### PR TITLE
feat: add nix flake

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,29 @@ allowing for safe parallel mutable access.
 - Benchmarks: `cargo bench`
 - Everything: `./scripts/run_all_tests.sh` (or pipe to a log file: `./scripts/run_all_tests.sh 2>&1 | tee test_run.log`)
 
+# Via Nix
+
+We provide a Nix flake for easy setup and development. Flakes must be enabled in your Nix configuration, if not already, add to `~/.config/nix/nix.conf`:
+```
+experimental-features = nix-command flakes
+```
+
+Run a command directly:
+```bash
+nix develop -c cargo run -p cutile-examples --example add_basic
+```
+
+Or open an interactive shell:
+```bash
+nix develop
+# cutile-rs dev shell
+#  ✓ CUDA  /nix/store/...-cuda-toolkit-13.2
+#  ✓ LLVM  21.1.8
+#  ✓ Rust  1.90.0-nightly
+```
+
+The flake automatically locates host NVIDIA driver libraries on both NixOS and non-NixOS systems.
+
 # License
 The `cuda-bindings` crate is licensed under NVIDIA Software License: [LICENSE-NVIDIA](LICENSE-NVIDIA).
 All other crates are licensed under the Apache License, Version 2.0 http://www.apache.org/licenses/LICENSE-2.0

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1773389992,
-        "narHash": "sha256-wvfdLLWJ2I9oEpDd9PfMA8osfIZicoQ5MT1jIwNs9Tk=",
+        "lastModified": 1774106199,
+        "narHash": "sha256-US5Tda2sKmjrg2lNHQL3jRQ6p96cgfWh3J1QBliQ8Ws=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c06b4ae3d6599a672a6210b7021d699c351eebda",
+        "rev": "6c9a78c09ff4d6c21d0319114873508a6ec01655",
         "type": "github"
       },
       "original": {
@@ -48,11 +48,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773457417,
-        "narHash": "sha256-waABTSxPdbxml4BhcabHhyQF02Qnj27qRU4ard0mTQo=",
+        "lastModified": 1774235565,
+        "narHash": "sha256-D8OOwvq3zDDCtIhMcNueb9tGSZaZUanKpWDleRgQ80U=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "055977c30249484010750e03074c744dcdaa0d23",
+        "rev": "dc00324a2438762582b49954373112b8eab29cab",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -193,20 +193,43 @@
           MLIR_SYS_210_PREFIX = "${llvmInstall}";
           TABLEGEN_210_PREFIX = "${llvmInstall}";
 
-          # add cuda to env vars
           shellHook = ''
             export PATH="${cudaToolkit}/bin:${llvmInstall}/bin:$PATH"
             export CMAKE_PREFIX_PATH="${llvmInstall}:$CMAKE_PREFIX_PATH"
 
-            # NixOS OpenGL/GPU driver path
+            # GPU driver libs: NixOS provides /run/opengl-driver/lib; on other
+            # distros, symlink just the NVIDIA libs into a temp dir so we don't
+            # pull in the host glibc.
             if [ -d /run/opengl-driver/lib ]; then
               export LD_LIBRARY_PATH="/run/opengl-driver/lib:$LD_LIBRARY_PATH"
+            else
+              _nv_drv_dir=$(mktemp -d /tmp/nix-nvidia-driver.XXXXXX)
+              for d in /usr/lib/x86_64-linux-gnu /lib/x86_64-linux-gnu /usr/lib /usr/lib64; do
+                if [ -e "$d/libcuda.so.1" ]; then
+                  for lib in "$d"/libcuda.so* "$d"/libnvidia-ptxjitcompiler.so* "$d"/libnvidia-gpucomp.so*; do
+                    [ -e "$lib" ] && ln -sf "$lib" "$_nv_drv_dir/"
+                  done
+                  break
+                fi
+              done
+              if [ -n "$(ls -A "$_nv_drv_dir" 2>/dev/null)" ]; then
+                export LD_LIBRARY_PATH="$_nv_drv_dir:$LD_LIBRARY_PATH"
+              else
+                rm -rf "$_nv_drv_dir"
+              fi
             fi
 
             if [ ! -d cuda-tile-rs/cuda-tile/.git ] && [ ! -f cuda-tile-rs/cuda-tile/CMakeLists.txt ]; then
               echo "Initializing cuda-tile submodule..."
               git submodule update --init --recursive
             fi
+
+            echo ""
+            echo "cutile-rs dev shell"
+            echo " ✓ CUDA  $CUDA_TOOLKIT_PATH"
+            echo " ✓ LLVM  $(llvm-config --version 2>/dev/null)"
+            echo " ✓ Rust  $(rustc --version 2>/dev/null | awk '{print $2}')"
+            echo ""
           '';
         };
       }


### PR DESCRIPTION
This PR adds nix flake to ease running this repo. The flake pulls CUDA 13.2, LLVM 21 with MLIR and Rust nightly 2025-07-16.

You can drop into the development shell via

```bash
nix develop
```

or run commands in the dev shell directly like

```bash
nix develop -c cargo test
# ...
# test result: ok. 0 passed; 0 failed; 49 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

or

```bash
nix develop -c cargo run -p cutile-examples --example add_basic
# ...
#         2.0,
#         2.0,
#         2.0,
#         2.0,
#     ],
# )
```
