### PR TITLE
fix: support negative literals in constant

### DIFF
--- a/cutile-compiler/src/compiler/compile_cuda_tile_op.rs
+++ b/cutile-compiler/src/compiler/compile_cuda_tile_op.rs
@@ -32,7 +32,7 @@ use std::collections::{BTreeMap, HashMap};
 use syn::parse::Parser;
 use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
-use syn::{Expr, ExprCall, ExprLit, ItemFn, Lit, Token, Type};
+use syn::{Expr, ExprCall, ExprLit, ItemFn, Lit, Token, Type, UnOp};
 
 impl<'m, 'c> CUDATileFunctionCompiler<'m> {
     pub fn compile_cuda_tile_op_call(
@@ -1986,6 +1986,37 @@ impl<'m, 'c> CUDATileFunctionCompiler<'m> {
                                 )
                             }
                         },
+                        Expr::Unary(unary_expr) => {
+                            let UnOp::Neg(_) = unary_expr.op else {
+                                return self.jit_error_result(
+                                    &call_expr.args[i].span(),
+                                    "Only unary negation is supported for constant values",
+                                );
+                            };
+                            match &*unary_expr.expr {
+                                Expr::Lit(lit_expr) => match &lit_expr.lit {
+                                    Lit::Int(int_lit) => {
+                                        (format!("-{}", int_lit.base10_digits()), "i32".to_string())
+                                    }
+                                    Lit::Float(float_lit) => (
+                                        format!("-{}", float_lit.base10_digits()),
+                                        "f32".to_string(),
+                                    ),
+                                    _ => {
+                                        return self.jit_error_result(
+                                            &call_expr.args[i].span(),
+                                            "Unsupported literal type for negation",
+                                        )
+                                    }
+                                },
+                                _ => {
+                                    return self.jit_error_result(
+                                        &call_expr.args[i].span(),
+                                        "Only literal negation is supported for constant values",
+                                    )
+                                }
+                            }
+                        }
                         Expr::Path(path_expr) => {
                             let path_expr_string = path_expr.to_token_stream().to_string();
                             let ty_val_split = path_expr_string.split(" :: ").collect::<Vec<_>>();

--- a/cutile/tests/basics_and_inlining.rs
+++ b/cutile/tests/basics_and_inlining.rs
@@ -114,6 +114,7 @@ mod basics_and_inlining_module {
         let _this_works: i32 = 1i32 + 2i32;
 
         let _multi_dim_const: Tile<f32, { [128, 64] }> = constant(0.0, x_shape);
+        let _neg_const: Tile<f32, { [128, 64] }> = constant(-1.0, x_shape);
 
         // Test tuples.
         let tuple: (i32, i32) = (1i32, 2i32);
@@ -210,6 +211,14 @@ mod basics_and_inlining_module {
             cuda_tile_assert!(shape_dim_1 == shape_dim_2, "Impossible");
         }
     }
+
+    #[cutile::entry()]
+    fn negative_constant_kernel<const S: [i32; 1]>(output: &mut Tensor<f32, S>) {
+        let shape = output.shape();
+        let _neg_float: Tile<f32, S> = constant(-1.0, shape);
+        let _neg_int: Tile<i32, S> = constant(-42i32, shape);
+        let _neg_suffixed: Tile<f32, S> = constant(-2.5f32, shape);
+    }
 }
 
 use basics_and_inlining_module::_module_asts;
@@ -267,6 +276,32 @@ fn compile_basics() -> () {
             .expect("Failed.")
             .as_operation()
             .to_string();
+        println!("{module_op_str}");
+    });
+}
+
+#[test]
+fn compile_negative_constant() -> () {
+    common::with_test_stack(|| {
+        let modules =
+            CUDATileModules::new(_module_asts()).expect("Failed to create CUDATileModules");
+        let gpu_name = get_gpu_name(0);
+        let compiler = CUDATileFunctionCompiler::new(
+            &modules,
+            "basics_and_inlining_module",
+            "negative_constant_kernel",
+            &[128.to_string()],
+            &[("output", &[1024])],
+            None,
+            gpu_name,
+        )
+        .expect("Failed.");
+        let module_op_str = compiler
+            .compile()
+            .expect("Failed to compile negative constant kernel.")
+            .as_operation()
+            .to_string();
+        assert!(module_op_str.contains("-1.0"));
         println!("{module_op_str}");
     });
 }


### PR DESCRIPTION
This is a small PR that resolves https://github.com/NVlabs/cutile-rs/issues/9

### tests 
```bash
cargo test --package cutile --test basics_and_inlining -- compile_negative_constant --exact --nocapture
```

```txt
cuda_tile.module @basics_and_inlining_module {
  entry @negative_constant_kernel_entry(%arg0: tile<ptr<f32>>, %arg1: tile<i32>, %arg2: tile<i32>, %arg3: tile<i32>, %arg4: tile<i32>) {
    %cst_128_i32 = constant <i32: 128> : tile<i32>
    %0 = make_token : token
    %blockId_x, %blockId_y, %blockId_z = get_tile_block_id : tile<i32>
    %assume_blockId_x = assume bounded<0, ?>, %blockId_x : tile<i32>
    %assume_blockId_y = assume bounded<0, ?>, %blockId_y : tile<i32>
    %assume_blockId_z = assume bounded<0, ?>, %blockId_z : tile<i32>
    %1 = muli %assume_blockId_x, %arg3 : tile<i32>
    %2 = muli %1, %arg2 : tile<i32>
    %3 = offset %arg0, %2 : tile<ptr<f32>>, tile<i32> -> tile<ptr<f32>>
    %tview = make_tensor_view %3, shape = [128], strides = [1024] : tensor_view<128xf32, strides=[1024]>
    %cst_128_i32_0 = constant <i32: 128> : tile<i32>
    %cst_128_i32_1 = constant <i32: 128> : tile<i32>
    %cst_f32 = constant <f32: -1.000000e+00> : tile<128xf32>
    %cst_-42_i32 = constant <i32: -42> : tile<128xi32>
    %cst_f32_2 = constant <f32: -2.500000e+00> : tile<128xf32>
    return
  }
}

test compile_negative_constant ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out; finished in 0.07s
```