### PR TITLE
Add support for dependabot.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,6 @@ updates:
     labels:
       - CI
     groups:
-      gha-all:
+      all-actions:
         patterns:
           - "*"


### PR DESCRIPTION
This will keep ci action usage up-to-date.