### PR TITLE
Add CPU only tests to CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -69,3 +69,11 @@ jobs:
         run: |
           source "${HOME}/.cargo/env"
           cargo test --no-run
+
+      - name: CPU only tests
+        run: |
+          source "${HOME}/.cargo/env"
+
+          # FIXME: Temporary hack for runtime linking
+          export LD_LIBRARY_PATH="${CUDA_TILE_USE_LLVM_INSTALL_DIR}/lib"
+          ./scripts/run_cpu_tests.sh


### PR DESCRIPTION
Add the CPU only tests with a workaround for runtime linking to LLVM libraries. Also move the repeated env vars to the job level to avoid repetition.