### PR TITLE
Rename kernel launcher functions (breaking).

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ If everything works, you should see: `Hello, I am tile <0, 0, 0> in a kernel wit
 ```rust
 use cuda_async::device_operation::DeviceOperation;
 use cutile::{self, api, tile_kernel::IntoDeviceOperationPartition};
-use my_module::add_async as add;
+use my_module::add_op;
 
 #[cutile::module]
 mod my_module {
@@ -109,11 +109,12 @@ mod my_module {
     }
 }
 
-fn main() -> () {
+fn main() -> Result<(), cutile::tile_kernel::DeviceError> {
     let x = api::ones([32, 32]).arc();
     let y = api::ones([32, 32]).arc();
     let z = api::zeros([32, 32]).partition([4, 4]);
-    let (_z, _x, _y) = add(z, x, y).sync();
+    let (_z, _x, _y) = add_op(z, x, y).sync()?;
+    Ok(())
 }
 ```
 
@@ -126,7 +127,7 @@ The kernel indicates that `z` must be mutable. Since the same tile kernel execut
 any `&mut Tensor<...>` requires the host to pass a `Partition<Tensor<T>>` as the argument. Any `&Tensor<...>` requires the
 host to pass an `Arc<Tensor<...>>` as an argument.
 
-The expression `add(z, x, y)` constructs a representation of a _kernel launcher_: A structure which encodes how the GPU applies the kernel to the given arguments. By default, because we have partitioned `z` into a grid of `4x4` subtensors, the kernel launcher will pick a _launch grid_ of `(8, 8, 1)`. Each `(x, y, z)` coordinate in the launch grid corresponds to a _tile thread_.
+The expression `add_op(z, x, y)` constructs a representation of a _kernel launcher_: A structure which encodes how the GPU applies the kernel to the given arguments. By default, because we have partitioned `z` into a grid of `4x4` subtensors, the kernel launcher will pick a _launch grid_ of `(8, 8, 1)`. Each `(x, y, z)` coordinate in the launch grid corresponds to a _tile thread_.
 
 The `sync` method picks the default device on the system and synchronously JIT-compiles the kernel to the default device's architecture and immediately executes the kernel with the provided arguments.
 Before executing the user-defined kernel on the device-side, each tile thread is initialized by selecting 

--- a/cuda-async/src/device_operation.rs
+++ b/cuda-async/src/device_operation.rs
@@ -105,7 +105,7 @@ impl ExecutionContext {
 /// let op2 = op1.and_then(|x| value(x * 2));
 ///
 /// // Execute synchronously (blocks until GPU completes)
-/// let result = op2.sync(); // returns 84
+/// let result = op2.sync().expect("Device operation failed."); // returns 84
 /// ```
 ///
 /// ```rust,ignore
@@ -150,8 +150,19 @@ pub trait DeviceOperation:
     ) -> Result<DeviceFuture<<Self as DeviceOperation>::Output, Self>, DeviceError> {
         policy.schedule(self)
     }
-    fn apply<O: Send, DO: DeviceOperation<Output = O>, F: Fn(Self) -> DO>(self, f: F) -> DO {
-        f(self)
+    /// Alias for [`DeviceOperation::and_then`].
+    ///
+    /// `apply` sequences on this operation's resolved output, rather than
+    /// transforming the operation object itself.
+    fn apply<O: Send, DO, F>(
+        self,
+        f: F,
+    ) -> AndThen<<Self as DeviceOperation>::Output, Self, O, DO, F>
+    where
+        DO: DeviceOperation<Output = O>,
+        F: FnOnce(<Self as DeviceOperation>::Output) -> DO,
+    {
+        self.and_then(f)
     }
     /// Chain a follow-up operation that runs **on the same stream** as `self`.
     ///

--- a/cutile-benchmarks/benches/fmha.rs
+++ b/cutile-benchmarks/benches/fmha.rs
@@ -240,7 +240,7 @@ fn ocean_fmha(c: &mut Criterion) {
                     let start = Instant::now();
                     for _i in 0..iters {
                         let (_, _, _, out_local, _, _) = unsafe {
-                            fmha_sync(
+                            fmha(
                                 q.clone(),
                                 k.clone(),
                                 v.clone(),

--- a/cutile-benchmarks/benches/fmha_causal.rs
+++ b/cutile-benchmarks/benches/fmha_causal.rs
@@ -250,7 +250,7 @@ fn ocean_fmha_causal(c: &mut Criterion) {
                     let start = Instant::now();
                     for _i in 0..iters {
                         let (_, _, _, out_local, _, _, _) = unsafe {
-                            fmha_causal_sync(
+                            fmha_causal(
                                 q.clone(),
                                 k.clone(),
                                 v.clone(),

--- a/cutile-benchmarks/benches/gemm.rs
+++ b/cutile-benchmarks/benches/gemm.rs
@@ -131,7 +131,7 @@ fn ocean_gemm(c: &mut Criterion) {
                 let start = Instant::now();
                 for _i in 0..iters {
                     unsafe {
-                        let (local_z, _, _, _) = gemm_sync(z, x.clone(), y.clone(), k as i32)
+                        let (local_z, _, _, _) = gemm(z, x.clone(), y.clone(), k as i32)
                             .generics(generics.clone())
                             .async_on(&stream)
                             .expect("Failed.");

--- a/cutile-benchmarks/benches/rmsnorm.rs
+++ b/cutile-benchmarks/benches/rmsnorm.rs
@@ -9,7 +9,7 @@ use cutile::api::{randn, zeros};
 use cutile::core::f16;
 use cutile::tensor::{IntoPartition, Partition, Tensor};
 use cutile::tile_kernel::TileKernel;
-use kernels::rms_norm_sync;
+use kernels::rms_norm;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -115,11 +115,10 @@ fn ocean_rmsnorm(c: &mut Criterion) {
                 let start = Instant::now();
                 for _i in 0..iters {
                     unsafe {
-                        let (_x, _w, local_out, _eps) =
-                            rms_norm_sync(x.clone(), w.clone(), out, eps)
-                                .generics(generics.clone())
-                                .async_on(&stream)
-                                .expect("Failed.");
+                        let (_x, _w, local_out, _eps) = rms_norm(x.clone(), w.clone(), out, eps)
+                            .generics(generics.clone())
+                            .async_on(&stream)
+                            .expect("Failed.");
                         out = local_out;
                     }
                 }

--- a/cutile-benchmarks/benches/softmax.rs
+++ b/cutile-benchmarks/benches/softmax.rs
@@ -83,7 +83,7 @@ fn softmax(c: &mut Criterion) {
                     let start = Instant::now();
                     for _i in 0..iters {
                         unsafe {
-                            let (_, local_out) = kernels::softmax_sync(x.clone(), out)
+                            let (_, local_out) = kernels::softmax(x.clone(), out)
                                 .generics(generics.clone())
                                 .async_on(&stream)
                                 .expect("Failed.");

--- a/cutile-book/conf.py
+++ b/cutile-book/conf.py
@@ -107,17 +107,3 @@ html_title = "cuTile Rust"
 
 # SEO
 html_baseurl = 'https://nvlabs.github.io/cutile-rs/'
-
-description = 'Write GPU kernels in safe, idiomatic Rust with tile-level abstractions.'
-
-html_meta = {
-    "description": description,
-    "author": author,
-    "og:title": project,
-    "og:description": description,
-    "og:type": "website",
-    "og:url": html_baseurl,
-    "og:site_name": project,
-}
-
-html_extra_path = ['robots.txt']

--- a/cutile-compiler/src/compiler/_function.rs
+++ b/cutile-compiler/src/compiler/_function.rs
@@ -22,6 +22,7 @@ use crate::error::JITError;
 use crate::error::SpannedJITError;
 use crate::generics::{GenericVars, TypeInstance};
 use crate::kernel_entry_generator::generate_entry_point;
+use crate::kernel_naming::KernelNaming;
 use crate::syn_utils::*;
 use crate::types::*;
 use cuda_async::device_context::Validator;
@@ -99,10 +100,11 @@ impl<'m, 'c> CUDATileFunctionCompiler<'m> {
                 "Undefined module: {module_name}"
             )));
         }
+        let kernel_naming = KernelNaming::new(function_name);
 
         let (_, function) = modules
             .functions
-            .get(function_name)
+            .get(kernel_naming.public_name())
             .with_context(|| format!("Undefined function: {function_name}"))?;
 
         let entry_attrs =
@@ -145,14 +147,14 @@ impl<'m, 'c> CUDATileFunctionCompiler<'m> {
 
         if modules
             .functions
-            .get(entry.sig.ident.to_string().as_str())
+            .get(kernel_naming.entry_name().as_str())
             .is_some()
         {
             return modules
                 .resolve_span(module_name, &function.span())
                 .jit_error_result(&format!(
                     "Entry point namespace collision: {}",
-                    entry.sig.ident.to_string()
+                    kernel_naming.entry_name()
                 ));
         }
 

--- a/cutile-compiler/src/compiler/_module.rs
+++ b/cutile-compiler/src/compiler/_module.rs
@@ -9,6 +9,7 @@
 use crate::ast::{Module, SourceLocation, SpanBase};
 use crate::error::{JITError, SpannedJITError};
 use crate::generics::{GenericVars, TypeInstance};
+use crate::kernel_naming::KernelNaming;
 use crate::syn_utils::*;
 use std::collections::HashMap;
 use syn::spanned::Spanned;
@@ -248,9 +249,14 @@ impl CUDATileModules {
         }
     }
 
+    pub fn get_function_by_name(&self, function_name: &str) -> Option<&(String, ItemFn)> {
+        let canonical_name = KernelNaming::canonical_public_name(function_name);
+        self.functions.get(canonical_name.as_str())
+    }
+
     pub fn get_cuda_tile_op_attrs(&self, ident: &str) -> Option<SingleMetaList> {
         // TODO (hme): This is slow but flexible.
-        match self.functions.get(ident) {
+        match self.get_function_by_name(ident) {
             Some((_, item_fn)) => get_meta_list("cuda_tile :: op", &item_fn.attrs),
             None => None,
         }
@@ -264,7 +270,7 @@ impl CUDATileModules {
         if !self.modules.contains_key(module_name) {
             return JITError::generic(&format!("undefined module: `{module_name}`"));
         }
-        match self.functions.get(function_name) {
+        match self.get_function_by_name(function_name) {
             Some(function) => Ok(function),
             None => JITError::generic(&format!("undefined function: `{function_name}`")),
         }

--- a/cutile-compiler/src/compiler/compile_cuda_tile_op.rs
+++ b/cutile-compiler/src/compiler/compile_cuda_tile_op.rs
@@ -54,8 +54,7 @@ impl<'m, 'c> CUDATileFunctionCompiler<'m> {
 
         let fn_item = self
             .modules
-            .functions
-            .get(rust_function_name.to_string().as_str());
+            .get_function_by_name(rust_function_name.as_str());
         if fn_item.is_none() {
             return self.jit_error_result(
                 &call_expr.func.span(),

--- a/cutile-compiler/src/compiler/compile_expression.rs
+++ b/cutile-compiler/src/compiler/compile_expression.rs
@@ -1102,8 +1102,9 @@ impl<'m, 'c> CUDATileFunctionCompiler<'m> {
                                     ctx,
                                     return_type,
                                 )?)
-                            } else if let Some((module_name, fn_item)) =
-                                self.modules.functions.get(ident.to_string().as_str())
+                            } else if let Some((module_name, fn_item)) = self
+                                .modules
+                                .get_function_by_name(ident.to_string().as_str())
                             {
                                 if let Some(compiler_op_attrs) =
                                     get_meta_list("cuda_tile :: compiler_op", &fn_item.attrs)

--- a/cutile-compiler/src/compiler/compile_type.rs
+++ b/cutile-compiler/src/compiler/compile_type.rs
@@ -473,7 +473,8 @@ impl<'m, 'c> CUDATileFunctionCompiler<'m> {
                 match &*call_expr.func {
                     Expr::Path(path_expr) => {
                         let ident = get_ident_from_path_expr(&path_expr);
-                        let Some((_, fn_item)) = self.modules.functions.get(&ident.to_string())
+                        let Some((_, fn_item)) =
+                            self.modules.get_function_by_name(&ident.to_string())
                         else {
                             return self.jit_error_result(
                                 &call_expr.func.span(),

--- a/cutile-compiler/src/kernel_entry_generator.rs
+++ b/cutile-compiler/src/kernel_entry_generator.rs
@@ -10,6 +10,7 @@ use crate::ast::SourceLocation;
 use crate::compiler::utils::OptimizationHints;
 use crate::error::{JITError, SpannedJITError};
 use crate::generics::{GenericVars, TypeInstance};
+use crate::kernel_naming::KernelNaming;
 use crate::syn_utils::{get_fn_arg_var_name, get_ident_from_path_expr, get_ident_generic_args};
 use crate::types::{get_primitives_attrs, get_type_mutability};
 use cuda_async::device_context::{
@@ -369,8 +370,10 @@ pub fn generate_entry_point(
 ) -> Result<(ItemFn, Validator), JITError> {
     // Construct an entry point which takes tile and pointer parameters, constructs tensors views, and calls the original function.
     let mut fn_entry = fn_item.clone();
-    let fn_name = fn_entry.sig.ident.to_string();
-    let fn_entry_name = format!("{}_entry", fn_name);
+    let kernel_naming = KernelNaming::new(fn_item.sig.ident.to_string().as_str());
+    let fn_name = kernel_naming.public_name().to_string();
+    let fn_impl_name = kernel_naming.user_impl_name();
+    let fn_entry_name = kernel_naming.entry_name();
     fn_entry.sig.ident = Ident::new(fn_entry_name.as_str(), fn_item.sig.ident.span());
     // Generate entry point parameters, entry point body statements, and call arguments for function call.
     fn_entry.sig.inputs.clear();
@@ -485,7 +488,7 @@ pub fn generate_entry_point(
     };
     let final_stmnt = syn::parse2::<syn::Stmt>(
         format!(
-            "{unsafety_str} {{ {fn_name}::<{generic_args}>({}) }};",
+            "{unsafety_str} {{ {fn_impl_name}::<{generic_args}>({}) }};",
             final_stmnt_args_str.join(",")
         )
         .parse()

--- a/cutile-compiler/src/kernel_naming.rs
+++ b/cutile-compiler/src/kernel_naming.rs
@@ -1,0 +1,88 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/// Centralized naming for user-facing kernel names and generated symbols.
+///
+/// `public_name` is always the kernel name written by the user in `#[cutile::entry]`.
+/// All other names are derived from it so the mapping between:
+///
+/// - the user-visible kernel API
+/// - the hidden Rust implementation symbol
+/// - the compiler-generated entry point
+/// - helper functions used by launcher codegen
+///
+/// lives in exactly one place.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct KernelNaming {
+    public_name: String,
+}
+
+impl KernelNaming {
+    const USER_IMPL_PREFIX: &'static str = "__cutile_user_impl_";
+
+    /// Creates naming metadata from the user-defined kernel function name.
+    pub fn new(public_name: &str) -> Self {
+        Self {
+            public_name: public_name.to_string(),
+        }
+    }
+
+    /// Returns the user-visible kernel name for either a public kernel name or
+    /// a generated user-implementation symbol.
+    pub fn canonical_public_name(name: &str) -> String {
+        match Self::public_name_from_user_impl_name(name) {
+            Some(public_name) => public_name,
+            None => name.to_string(),
+        }
+    }
+
+    /// If `name` is a generated user-implementation symbol, returns the
+    /// original user-visible kernel name.
+    pub fn public_name_from_user_impl_name(name: &str) -> Option<String> {
+        name.strip_prefix(Self::USER_IMPL_PREFIX)
+            .map(|s| s.to_string())
+    }
+
+    /// Returns the user-visible kernel name.
+    ///
+    /// This is the name callers pass to `CUDATileFunctionCompiler::new(...)`
+    /// and the unsuffixed launcher name exposed from `#[cutile::module]`.
+    pub fn public_name(&self) -> &str {
+        &self.public_name
+    }
+
+    /// Returns the public helper used with `.apply(...)`.
+    ///
+    /// Example: `zip!(...).apply(my_kernel_apply)`.
+    pub fn apply_name(&self) -> String {
+        format!("{}_apply", self.public_name)
+    }
+
+    /// Returns the launcher helper for separate `DeviceOperation` arguments.
+    ///
+    /// In other words:
+    /// - `<kernel>(...)` is the public ergonomic entry point
+    /// - `<kernel>_apply(...)` is the public composition hook
+    /// - `<kernel>_op(...)` is the public helper for separate lazy arguments
+    pub fn device_op_helper_name(&self) -> String {
+        format!("{}_op", self.public_name)
+    }
+
+    /// Returns the hidden Rust symbol for the user-authored kernel implementation.
+    ///
+    /// This avoids colliding with the public unsuffixed launcher while still
+    /// letting the compiler-generated entry point call the real kernel body.
+    pub fn user_impl_name(&self) -> String {
+        format!("{}{}", Self::USER_IMPL_PREFIX, self.public_name)
+    }
+
+    /// Returns the compiler-facing entry point name.
+    ///
+    /// This is the symbol emitted into the generated CUDA Tile module and later
+    /// loaded as the compiled kernel entry.
+    pub fn entry_name(&self) -> String {
+        format!("{}_entry", self.public_name)
+    }
+}

--- a/cutile-compiler/src/lib.rs
+++ b/cutile-compiler/src/lib.rs
@@ -22,6 +22,7 @@ pub mod cuda_tile_runtime_utils;
 pub mod error;
 pub mod generics;
 mod kernel_entry_generator;
+pub mod kernel_naming;
 pub mod syn_utils;
 pub mod train_map;
 pub mod types;

--- a/cutile-examples/examples/add_basic.rs
+++ b/cutile-examples/examples/add_basic.rs
@@ -3,13 +3,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use cuda_async::device_operation::DeviceOperation;
+use cuda_async::device_operation::{DeviceOperation, Zippable};
 use cutile::{
     self, api,
     tensor::Unpartition,
-    tile_kernel::{IntoDeviceOperationPartition, TensorDeviceOpToHostVec, TileKernel, Unzippable3},
+    tile_kernel::{
+        zip, IntoDeviceOperationPartition, TensorDeviceOpToHostVec, TileKernel, Unzippable3,
+    },
 };
-use my_module::add_async as add;
+use my_module::add;
 
 #[cutile::module]
 mod my_module {
@@ -31,8 +33,8 @@ fn main() -> () {
     let a = api::ones([32]).arc();
     let b = api::ones([32]).arc();
     let c = api::zeros([32]).partition([4]);
-    let c_host_vec = add(a, b, c)
-        .grid((8, 1, 1))
+    let c_host_vec = zip!(a, b, c)
+        .apply(|(a, b, c)| add(a, b, c).grid((8, 1, 1)))
         .unzip()
         .2
         .unpartition()

--- a/cutile-examples/examples/add_ptr.rs
+++ b/cutile-examples/examples/add_ptr.rs
@@ -36,7 +36,7 @@ mod my_module {
     }
 }
 
-use my_module::add_ptr_sync;
+use my_module::add_ptr;
 
 #[tokio::main(flavor = "multi_thread", worker_threads = 16)]
 async fn main() -> Result<(), cutile::error::Error> {
@@ -54,11 +54,8 @@ async fn main() -> Result<(), cutile::error::Error> {
     let y_ptr = y.device_pointer();
 
     // Prepare kernel launch. Note that, since we're passing in pointers, unsafe is required.
-    let op = unsafe { add_ptr_sync(z_ptr, x_ptr, y_ptr, len as i32) }.grid((
-        (len / tile_size) as u32,
-        1,
-        1,
-    ));
+    let op =
+        unsafe { add_ptr(z_ptr, x_ptr, y_ptr, len as i32) }.grid(((len / tile_size) as u32, 1, 1));
 
     // Spawn an asynchronous task to compute this operation.
     let op_handle = tokio::spawn(op.into_future());

--- a/cutile-examples/examples/async_add.rs
+++ b/cutile-examples/examples/async_add.rs
@@ -2,12 +2,12 @@
  * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-use cuda_async::device_operation::{DeviceOperation, IntoDeviceOperation};
+use cuda_async::device_operation::{DeviceOperation, IntoDeviceOperation, Zippable};
 use cutile;
 use cutile::api::{arange, ones, zeros};
 use cutile::tensor::ToHostVec;
-use cutile::tile_kernel::IntoDeviceOperationPartition;
-use my_module::{add_apply, add_async};
+use cutile::tile_kernel::{zip, IntoDeviceOperationPartition};
+use my_module::add_apply;
 use std::future::IntoFuture;
 
 #[cutile::module]
@@ -36,7 +36,7 @@ async fn main() -> Result<(), cuda_async::error::DeviceError> {
     let x = arange(len);
     let y = ones([len]);
     // Use function calling convention:
-    let add_op_1 = add_async(z.partition([2]), x.arc(), y.arc());
+    let add_op_1 = zip!(z.partition([2]), x.arc(), y.arc()).apply(add_apply);
     // or chain the invocation of the kernel via the DeviceOperation apply method:
     let add_op_2 = add_op_1.apply(add_apply);
     // Schedule the operation using the default scheduler.

--- a/cutile-examples/examples/async_gemm.rs
+++ b/cutile-examples/examples/async_gemm.rs
@@ -10,7 +10,7 @@ use cutile::half::f16;
 use cutile::num_traits::identities::*;
 use cutile::tensor::{Tensor, ToHostVec, Unpartition};
 use cutile::tile_kernel::{IntoDeviceOperationPartition, TileKernel};
-use my_module::gemm_apply;
+use my_module::gemm_op;
 use std::fmt::Debug;
 use std::sync::Arc;
 
@@ -64,13 +64,10 @@ fn gemm<T1: WithDType + Debug, T2: WithDType + Debug>(
         bk.to_string(),
         k.to_string(),
     ];
-    let z = api::zeros([m, n]); // impl DeviceOperation
-    let args = zip!(
-        z.partition([bm, bn]),
-        x.device_operation(),
-        y.device_operation()
-    );
-    let (z, _x, _y) = args.apply(gemm_apply).generics(generics.to_vec()).unzip();
+    let z = api::zeros([m, n]).partition([bm, bn]); // impl DeviceOperation
+    let (z, _x, _y) = gemm_op(z, x.device_operation(), y.device_operation())
+        .generics(generics.to_vec())
+        .unzip();
     z.unpartition()
 }
 

--- a/cutile-examples/examples/async_mlp.rs
+++ b/cutile-examples/examples/async_mlp.rs
@@ -120,14 +120,16 @@ async fn main() -> Result<(), Error> {
         let (w0, w1) = (w.0.clone(), w.1.clone());
         let data = load_data([dim, dim]).arc();
         let out0 = api::zeros::<2, f32>([dim, dim]).partition([block_dim, block_dim]);
-        let (out0, _, _) = gemm_async(out0, data, value(w0))
-            .generics(fully_connected_layer.to_vec())
+        let fully_connected_layer = fully_connected_layer.to_vec();
+        let (out0, _, _) = gemm_op(out0, data, value(w0))
+            .generics(fully_connected_layer)
             .unzip();
         let out1 = api::zeros::<1, f32>([dim]).partition([block_dim]);
-        let (out1, _, _) = matvec_async(out1, out0.unpartition().arc(), value(w1))
-            .generics(output_layer.to_vec())
+        let output_layer = output_layer.to_vec();
+        let (out1, _, _) = matvec_op(out1, out0.unpartition().arc(), value(w1))
+            .generics(output_layer)
             .unzip();
-        let (out1,) = relu_async(out1).unzip();
+        let (out1,) = relu_op(out1).unzip();
         futures.push(tokio::spawn(out1.schedule(&devices[i])?));
     }
 

--- a/cutile-examples/examples/batch_matmul.rs
+++ b/cutile-examples/examples/batch_matmul.rs
@@ -44,7 +44,7 @@ mod my_module {
     }
 }
 
-use my_module::batch_matmul_sync;
+use my_module::batch_matmul;
 
 fn main() -> Result<(), Error> {
     let ctx = CudaContext::new(0)?;
@@ -67,9 +67,7 @@ fn main() -> Result<(), Error> {
         bk.to_string(),
         k.to_string(),
     ];
-    let (_a, _b, c) = batch_matmul_sync(a, b, c)
-        .generics(generics)
-        .sync_on(&stream)?;
+    let (_a, _b, c) = batch_matmul(a, b, c).generics(generics).sync_on(&stream)?;
     let c_host: Vec<f32> = c.unpartition().to_host_vec().sync_on(&stream)?;
 
     let expected = k as f32;

--- a/cutile-examples/examples/dropout.rs
+++ b/cutile-examples/examples/dropout.rs
@@ -34,7 +34,7 @@ mod my_module {
     }
 }
 
-use my_module::dropout_sync;
+use my_module::dropout;
 
 fn main() -> Result<(), Error> {
     let ctx = CudaContext::new(0)?;
@@ -48,7 +48,7 @@ fn main() -> Result<(), Error> {
         .into();
     let x_keep: Arc<Tensor<f32>> = rand_f32([m], Some(seed)).sync_on(&stream)?.into();
     let out: Partition<Tensor<f32>> = zeros([m]).sync_on(&stream)?.partition([bm]);
-    let (_, _x, _x_keep, out) = dropout_sync(p, x, x_keep, out).sync_on(&stream)?;
+    let (_, _x, _x_keep, out) = dropout(p, x, x_keep, out).sync_on(&stream)?;
     let out_host: Vec<f32> = out.unpartition().to_host_vec().sync_on(&stream)?;
     for i in 0..out_host.len() {
         let x = out_host[i];

--- a/cutile-examples/examples/flash_attention.rs
+++ b/cutile-examples/examples/flash_attention.rs
@@ -142,7 +142,7 @@ mod my_module {
 
 use cutile::candle_core;
 use cutile_examples::fmha_ref_exec;
-use my_module::fmha_sync;
+use my_module::fmha as fmha_kernel;
 
 fn fmha(
     b: usize,   // batch size.
@@ -184,7 +184,7 @@ fn fmha(
     let query_group_size = num_heads / kv_num_heads;
 
     let generics = vec![bm.to_string(), bn.to_string(), d.to_string()];
-    let (_, _, _, out, _, _) = fmha_sync(
+    let (_, _, _, out, _, _) = fmha_kernel(
         q.clone(),
         k.clone(),
         v.clone(),

--- a/cutile-examples/examples/flash_attention_causal.rs
+++ b/cutile-examples/examples/flash_attention_causal.rs
@@ -139,7 +139,7 @@ mod my_module {
     }
 }
 
-use my_module::fmha_sync;
+use my_module::fmha;
 
 fn idx4(
     a: usize,
@@ -246,7 +246,7 @@ fn run_attention_fmha(causal: bool) -> Result<(), Error> {
         (even_k as i32).to_string(),
     ];
 
-    let (_, _, _, out, _, _, _): (_, _, _, Partition<Tensor<f32>>, _, _, _) = fmha_sync(
+    let (_, _, _, out, _, _, _): (_, _, _, Partition<Tensor<f32>>, _, _, _) = fmha(
         q.clone(),
         k.clone(),
         v.clone(),

--- a/cutile-examples/examples/gemm.rs
+++ b/cutile-examples/examples/gemm.rs
@@ -10,7 +10,7 @@ use cutile::candle_core::WithDType;
 use cutile::error::Error;
 use cutile::tensor::*;
 use cutile::tile_kernel::*;
-use my_module::gemm_sync;
+use my_module::gemm as gemm_kernel;
 use std::fmt::Debug;
 
 #[cutile::module]
@@ -57,7 +57,7 @@ fn gemm<T: WithDType + Debug>() -> Result<(), Error> {
     let z = api::zeros([m, n]).partition([bm, bn]).sync_on(&stream)?;
     let x = api::ones([m, k]).arc().sync_on(&stream)?;
     let y = api::ones([k, n]).arc().sync_on(&stream)?;
-    let launcher = gemm_sync(z, x.clone(), y.clone());
+    let launcher = gemm_kernel(z, x.clone(), y.clone());
     let (z, _x, _y) = launcher.generics(generics.clone()).sync_on(&stream)?;
     let z_host: Vec<T> = z.unpartition().to_host_vec().sync_on(&stream)?;
     for i in 0..10 {

--- a/cutile-examples/examples/gemm_static.rs
+++ b/cutile-examples/examples/gemm_static.rs
@@ -10,7 +10,7 @@ use cutile::candle_core::WithDType;
 use cutile::error::Error;
 use cutile::tensor::*;
 use cutile::tile_kernel::*;
-use my_module::gemm_sync;
+use my_module::gemm as gemm_kernel;
 use std::fmt::Debug;
 
 #[cutile::module]
@@ -75,7 +75,7 @@ fn gemm<T: WithDType + Debug>() -> Result<(), Error> {
         z.num_mb()
     );
     let grid = z.grid()?;
-    let (z, _x, _y) = gemm_sync(z, x, y)
+    let (z, _x, _y) = gemm_kernel(z, x, y)
         .const_grid(grid)
         .generics(generics)
         .sync_on(&stream)?;

--- a/cutile-examples/examples/hello_world.rs
+++ b/cutile-examples/examples/hello_world.rs
@@ -31,12 +31,12 @@ mod hello_world_module {
     }
 }
 
-use hello_world_module::hello_world_kernel_sync;
+use hello_world_module::hello_world_kernel;
 
 fn main() -> Result<(), Error> {
     let ctx = CudaContext::new(0)?;
     let stream = ctx.new_stream()?;
-    let launcher = hello_world_kernel_sync();
+    let launcher = hello_world_kernel();
     launcher.grid((1, 1, 1)).sync_on(&stream)?;
     Ok(())
 }

--- a/cutile-examples/examples/rms_norm.rs
+++ b/cutile-examples/examples/rms_norm.rs
@@ -61,7 +61,7 @@ mod my_module {
     }
 }
 
-use my_module::rms_norm_sync;
+use my_module::rms_norm;
 
 fn main() -> Result<(), Error> {
     // Create a context. Device 0 is associated with the context.
@@ -75,7 +75,7 @@ fn main() -> Result<(), Error> {
     let x: Arc<Tensor<f32>> = randn(0.0, 1.0, [m, n]).sync_on(&stream)?.into();
     let w: Arc<Tensor<f32>> = randn(0.0, 1.0, [n]).sync_on(&stream)?.into();
     let out: Partition<Tensor<f32>> = zeros([m, n]).sync_on(&stream)?.partition([1, n as i32]);
-    let (_x, _w, out, _eps) = rms_norm_sync(x, w, out, eps)
+    let (_x, _w, out, _eps) = rms_norm(x, w, out, eps)
         .generics(generics)
         .sync_on(&stream)?;
     let out_host: Vec<f32> = out.unpartition().to_host_vec().sync_on(&stream)?;

--- a/cutile-examples/examples/saxpy.rs
+++ b/cutile-examples/examples/saxpy.rs
@@ -23,7 +23,7 @@ mod my_module {
     }
 }
 
-use my_module::saxpy_sync;
+use my_module::saxpy;
 
 // TODO (hme): Answer question about whether main should return Result<(), ...>
 fn main() -> Result<(), Error> {
@@ -35,7 +35,7 @@ fn main() -> Result<(), Error> {
     let input: Arc<Tensor<f32>> = arange(2usize.pow(5)).sync_on(&stream)?.into();
     let x = input.copy_sync(&stream)?.reshape([4, 8]).into();
     let y = input.copy_sync(&stream)?.reshape([4, 8]).partition([2, 2]);
-    let (a, _x, y) = saxpy_sync(a, x, y).sync_on(&stream)?;
+    let (a, _x, y) = saxpy(a, x, y).sync_on(&stream)?;
     let y_host: Vec<f32> = y.unpartition().to_host_vec().sync_on(&stream)?;
     let input_host: Vec<f32> = input.to_host_vec().sync_on(&stream)?;
     for i in 0..input_host.len() {

--- a/cutile-examples/examples/softmax.rs
+++ b/cutile-examples/examples/softmax.rs
@@ -31,7 +31,7 @@ mod my_module {
 }
 
 use cutile::utils::Float;
-use my_module::softmax_sync;
+use my_module::softmax;
 
 fn main() -> Result<(), Error> {
     // Create a context. Device 0 is associated with the context.
@@ -46,7 +46,7 @@ fn main() -> Result<(), Error> {
         .copy_sync(&stream)?
         .reshape([m, n])
         .partition([bm, bn]);
-    let (_x, y) = softmax_sync(x, y).sync_on(&stream)?;
+    let (_x, y) = softmax(x, y).sync_on(&stream)?;
     let y_host: Vec<f32> = y.unpartition().to_host_vec().sync_on(&stream)?;
     for i in (0..y_host.len()).step_by(8) {
         let x = y_host[i..i + 8].to_vec();

--- a/cutile-examples/examples/tensor_permute.rs
+++ b/cutile-examples/examples/tensor_permute.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 
 use cutile::candle_core;
 use cutile::utils::pretty_print_matrix;
-use my_module::tensor_permute_sync;
+use my_module::tensor_permute;
 
 #[cutile::module]
 mod my_module {
@@ -111,7 +111,7 @@ fn main() -> Result<(), Error> {
     println!("out tile = {:?}", partition_shape_rank3);
     println!("grid = {:?}", grid);
     println!("generics: {:?}", generics);
-    let (src, dst) = unsafe { tensor_permute_sync(src.clone(), dst) }
+    let (src, dst) = unsafe { tensor_permute(src.clone(), dst) }
         .generics(generics.clone())
         .sync_on(&stream)?;
 

--- a/cutile-macro/src/_module.rs
+++ b/cutile-macro/src/_module.rs
@@ -16,7 +16,7 @@
 //! 2. **Validates** syntax and type constraints
 //! 3. **Transforms** items (functions, structs, traits, impls)
 //! 4. **Generates** MLIR AST builders
-//! 5. **Creates** async kernel launchers for entry points
+//! 5. **Creates** kernel launchers for entry points
 //! 6. **Emits** the expanded code
 //!
 //! ## Item Processing
@@ -48,10 +48,10 @@
 //!
 //! ## Kernel Launchers
 //!
-//! For each `#[entry]` function, an async launcher is generated that:
+//! For each `#[entry]` function, launchers are generated that:
 //! - Compiles the kernel to CUDA
 //! - Manages kernel invocation
-//! - Handles async execution
+//! - Support direct calls and `.apply(...)` composition
 //! - Provides type-safe parameter passing
 
 use convert_case::{Case, Casing};
@@ -73,6 +73,7 @@ use crate::error::{Error, SpannedError};
 use crate::kernel_launcher_generator::generate_kernel_launcher;
 use crate::rewrite_variadics::*;
 use crate::validate_dsl_syntax::validate_entry_point_parameters;
+use cutile_compiler::kernel_naming::KernelNaming;
 use cutile_compiler::syn_utils::*;
 
 fn line_column_to_offset(source: &str, loc: LineColumn) -> Option<usize> {
@@ -136,7 +137,7 @@ pub fn get_asts_ident() -> Ident {
 /// Transforms a Rust module containing GPU kernel code into:
 /// - Concrete Rust functions (possibly expanded from variadics)
 /// - MLIR AST builder functions
-/// - Async kernel launcher functions
+/// - Kernel launcher functions
 ///
 /// ## Processing Pipeline
 ///
@@ -146,7 +147,7 @@ pub fn get_asts_ident() -> Ident {
 ///    - Validate syntax (for functions)
 ///    - Generate AST representation
 ///    - Handle variadic expansion if needed
-///    - Generate kernel launcher if `#[entry]` function
+///    - Generate kernel launchers if `#[entry]` function
 /// 4. Generate module AST builder function
 /// 5. Emit expanded code with all dependencies
 ///
@@ -167,9 +168,11 @@ pub fn get_asts_ident() -> Ident {
 ///     pub fn _module_asts() -> Vec<Module> { ... }
 ///
 ///     // Concrete items (functions, structs, etc.)
-///     pub fn my_kernel(...) { ... }
+///     fn __cutile_user_impl_my_kernel(...) { ... }
 ///
 ///     // Kernel launchers (for #[entry] functions)
+///     pub fn my_kernel(...) -> impl DeviceOperation { ... }
+///     pub fn my_kernel_op(...) -> impl DeviceOperation { ... }
 ///     pub fn my_kernel_apply(...) -> impl DeviceOperation { ... }
 /// }
 /// ```
@@ -570,9 +573,10 @@ pub fn structure(mut item: ItemStruct) -> Result<TokenStream, Error> {
 ///
 /// ## Entry Points
 ///
-/// Functions marked with `#[entry]` are validated and have async launchers generated.
+/// Functions marked with `#[entry]` are validated and have launchers generated.
 pub fn function(mut item: ItemFn, tile_rust_crate_root: &Ident) -> Result<TokenStream2, Error> {
-    if get_meta_list_by_last_segment("entry", &item.attrs).is_some() {
+    let is_entry = get_meta_list_by_last_segment("entry", &item.attrs).is_some();
+    if is_entry {
         validate_entry_point_parameters(&item)?
     }
     let attributes = get_meta_list("cuda_tile :: variadic_op", &item.attrs);
@@ -588,6 +592,11 @@ pub fn function(mut item: ItemFn, tile_rust_crate_root: &Ident) -> Result<TokenS
         HashSet::from([format!("{} :: entry", tile_rust_crate_root).as_str()]),
         &mut item.attrs,
     );
+    if is_entry {
+        let kernel_naming = KernelNaming::new(item.sig.ident.to_string().as_str());
+        let internal_name = kernel_naming.user_impl_name();
+        item.sig.ident = Ident::new(internal_name.as_str(), item.sig.ident.span());
+    }
     let concrete_items = match attributes {
         Some(attributes) => match attributes.name_as_str().unwrap().as_str() {
             "cuda_tile :: variadic_op" => variadic_op(&attributes, item.clone())?,
@@ -601,10 +610,10 @@ pub fn function(mut item: ItemFn, tile_rust_crate_root: &Ident) -> Result<TokenS
     Ok(result)
 }
 
-/// Generates the complete async kernel launcher struct and implementations.
+/// Generates the complete kernel launcher struct and implementations.
 ///
 /// Creates a launcher struct that implements `TileKernel`, `DeviceOperation`, and
-/// `IntoFuture` for a kernel entry point. This enables the ergonomic async API
+/// `IntoFuture` for a kernel entry point. This enables the ergonomic launcher API
 /// for launching GPU kernels.
 ///
 /// ## Parameters
@@ -635,7 +644,8 @@ pub fn function(mut item: ItemFn, tile_rust_crate_root: &Ident) -> Result<TokenS
 pub fn kernel_launcher(module_ident: &Ident, item: &ItemFn) -> Result<TokenStream2, Error> {
     let module_name = module_ident.to_string();
     let function_name = item.sig.ident.to_string();
-    let function_entry_name = format!("{}_entry", function_name);
+    let kernel_naming = KernelNaming::new(function_name.as_str());
+    let function_entry_name = kernel_naming.entry_name();
     let launcher_name = function_name.to_case(Case::UpperCamel).to_string();
     let launcher_args_name = format!("{}Args", launcher_name);
     let unsafety = item.sig.unsafety;
@@ -645,7 +655,7 @@ pub fn kernel_launcher(module_ident: &Ident, item: &ItemFn) -> Result<TokenStrea
             item,
             &module_name,
             &function_name,
-            &function_entry_name,
+            function_entry_name.as_str(),
             &launcher_name,
             &launcher_args_name,
         )?;
@@ -733,7 +743,7 @@ pub fn kernel_launcher(module_ident: &Ident, item: &ItemFn) -> Result<TokenStrea
             }
         }
 
-        // Implements DeviceOperation, along with sync/async launcher functions.
+        // Implements DeviceOperation, along with the generated launcher functions.
         #device_op_impl
     };
 

--- a/cutile-macro/src/kernel_launcher_generator.rs
+++ b/cutile-macro/src/kernel_launcher_generator.rs
@@ -5,19 +5,24 @@
 //! Kernel launcher generation.
 //!
 //! This module generates launcher functions for GPU kernel entry points
-//! with support for both synchronous and asynchronous execution.
+//! with support for direct invocation and `.apply(...)`-based composition.
 //! These launchers provide a type-safe interface for invoking
 //! CUDA Tile kernels from Rust code.
 //!
 //! ## Overview
 //!
-//! For each function marked with `#[cutile::entry]`, this module generates
-//! an `_apply` function that:
+//! For each function marked with `#[cutile::entry]`, this module generates:
+//!
+//! - an unsuffixed launcher for materialized arguments
+//! - an `_apply` helper for `.apply(...)` composition
+//! - an internal helper for `DeviceOperation` arguments
+//!
+//! Together these helpers:
 //!
 //! 1. **Compiles** the kernel (with caching)
 //! 2. **Infers** generic parameters from input types
 //! 3. **Handles** tensor partitioning and grid inference
-//! 4. **Launches** the kernel asynchronously
+//! 4. **Launch** the kernel as a device operation
 //! 5. **Returns** results as device operations
 //!
 //! ## Generated Launcher Structure
@@ -30,11 +35,25 @@
 //!     input: &Tensor<T, {[-1]}>,
 //! ) { }
 //!
-//! // Generates this launcher:
+//! // Generates these launchers:
+//! pub fn my_kernel<T: Send + WithDType>(
+//!     output: Partition<Tensor<T>>,
+//!     input: Arc<Tensor<T>>,
+//! ) -> impl DeviceOperation<Output=(Partition<Tensor<T>>, Arc<Tensor<T>>)> + TileKernel<...> {
+//!     // Wraps materialized values and delegates to my_kernel_op
+//! }
+//!
+//! pub fn my_kernel_op<T: Send + WithDType>(
+//!     output: impl DeviceOperation<Output = Partition<Tensor<T>>>,
+//!     input: impl DeviceOperation<Output = Arc<Tensor<T>>>,
+//! ) -> impl DeviceOperation<Output=(Partition<Tensor<T>>, Arc<Tensor<T>>)> + TileKernel<...> {
+//!     // Launches from separate lazy arguments
+//! }
+//!
 //! pub fn my_kernel_apply<T: Send + WithDType>(
 //!     inputs: (Partition<Tensor<T>>, Arc<Tensor<T>>),
 //! ) -> impl DeviceOperation<Output=(Partition<Tensor<T>>, Arc<Tensor<T>>)> + TileKernel<...> {
-//!     // Compilation and launch logic
+//!     // Launches from one grouped lazy argument tuple
 //! }
 //! ```
 //!
@@ -59,6 +78,7 @@
 //! Launch grid dimensions are automatically inferred from partitioned tensors.
 //! If multiple partitions exist, their grids must match.
 
+use cutile_compiler::kernel_naming::KernelNaming;
 use cutile_compiler::syn_utils::*;
 use cutile_compiler::types::get_ptr_type;
 use proc_macro2::Ident;
@@ -216,10 +236,10 @@ pub fn join_as_cons_tuple(vals: &Vec<String>) -> String {
     cons
 }
 
-/// Wraps an expression in a `value()` call if needed for async combinators.
+/// Wraps an expression in a `value()` call if needed for device-operation combinators.
 ///
-/// Helper function used when building async launcher code. If `wrap_as_val` is true,
-/// wraps the expression in `value()` to create an async value.
+/// Helper function used when building launcher code. If `wrap_as_val` is true,
+/// wraps the expression in `value()` to create a device-operation value.
 ///
 /// ## Parameters
 ///
@@ -279,11 +299,11 @@ pub fn zip_cons(inputs: &Vec<String>, var_name: &str, wrap_as_val: bool) -> Expr
     zip_block
 }
 
-/// Generates async code to zip inputs, then flatten them into a flat tuple.
+/// Generates launcher code to zip inputs, then flatten them into a flat tuple.
 ///
 /// Similar to `zip_cons` but adds a final `and_then` step that flattens the
 /// nested cons-cell structure into a regular flat tuple. This is the standard
-/// approach used for async kernel launchers.
+/// approach used for op-based launcher helpers.
 ///
 /// ## Parameters
 ///
@@ -399,7 +419,7 @@ pub fn generate_launcher_arg_types(
 /// Converts a vector of strings into a flat tuple string representation.
 ///
 /// Helper function that formats argument names into a comma-separated tuple string.
-/// Used when generating async launcher code.
+/// Used when generating launcher code.
 ///
 /// ## Parameters
 ///
@@ -422,13 +442,14 @@ pub fn to_tuple_string(args: &Vec<String>) -> String {
     )
 }
 
-/// Generates the complete async launcher code for a GPU kernel.
+/// Generates the complete launcher code for a GPU kernel.
 ///
 /// This is the main function that transforms a kernel function (marked with `#[entry]`)
-/// into an async launcher that can be called from Rust code. It generates:
+/// into launcher helpers that can be called from Rust code. It generates:
 /// 1. Type aliases for kernel arguments
 /// 2. A launcher struct implementing `DeviceOperation`
-/// 3. An `execute` method that builds the kernel call and launches it
+/// 3. A direct launcher for materialized arguments
+/// 4. An `_apply` helper for `.apply(...)` composition
 ///
 /// ## Parameters
 ///
@@ -457,7 +478,7 @@ pub fn to_tuple_string(args: &Vec<String>) -> String {
 /// impl<T: WithDType> DeviceOperation for MyKernel<T> {
 ///     type Output = ();
 ///     unsafe fn execute(mut self, ctx: &ExecutionContext) -> Self::Output {
-///         // Async launcher logic here
+///         // Kernel launch logic here
 ///     }
 /// }
 /// ```
@@ -660,14 +681,12 @@ pub fn generate_kernel_launcher(
     let kernel_return_type = quote! {
         #launcher_ident #launch_output_type
     };
-    let apply_name = format!("{}_apply", function_name);
-    let launcher_apply_ident = Ident::new(
-        format!("{}_apply", function_name).as_str(),
-        Span::call_site(),
-    );
+    let kernel_naming = KernelNaming::new(function_name);
+    let apply_name = kernel_naming.apply_name();
+    let launcher_apply_ident = Ident::new(apply_name.as_str(), Span::call_site());
     let launcher_apply = syn::parse2::<ItemFn>(quote! {
-        pub #unsafety fn #launcher_apply_ident #struct_generics (input: DI) -> #kernel_return_type {
-            return #launcher_ident::launch(input);
+        pub #unsafety fn #launcher_apply_ident #generic_params (input: #launcher_args_type) -> #kernel_return_type {
+            return #launcher_ident::launch(value(input));
         }
     })
     .unwrap();
@@ -683,21 +702,21 @@ pub fn generate_kernel_launcher(
         r
     };
 
-    // Generate launcher async function. Uses apply function.
-    // This operates on and returns a flat tuple of arguments.
-    let async_name = format!("{}_async", function_name);
-    let launcher_async_ident = Ident::new(async_name.as_str(), Span::call_site());
-    let mut launcher_async = syn::parse2::<ItemFn>(quote! {
-        pub #unsafety fn #launcher_async_ident #generic_params() -> #kernel_return_type {}
+    // Generate internal op-based launcher. Uses the apply function and operates on
+    // a flat tuple of `DeviceOperation` arguments.
+    let op_name = kernel_naming.device_op_helper_name();
+    let launcher_op_ident = Ident::new(op_name.as_str(), Span::call_site());
+    let mut launcher_op = syn::parse2::<ItemFn>(quote! {
+        pub #unsafety fn #launcher_op_ident #generic_params() -> #kernel_return_type {}
     })
     .unwrap();
     let mut function_params = vec![];
-    launcher_async.sig.generics.make_where_clause();
+    launcher_op.sig.generics.make_where_clause();
     for (i, _arg_ty) in arg_types.iter().enumerate() {
         let function_param = format!("arg{}", i);
         let type_param = format!("DI{}", i);
         let type_bound = format!("DeviceOperation<Output={}>", arg_aliases[i]);
-        launcher_async.sig.inputs.push(FnArg::Typed(
+        launcher_op.sig.inputs.push(FnArg::Typed(
             syn::parse2::<PatType>(
                 format!("{}: {}", function_param, type_param)
                     .parse()
@@ -705,10 +724,10 @@ pub fn generate_kernel_launcher(
             )
             .unwrap(),
         ));
-        launcher_async.sig.generics.params.push(GenericParam::Type(
+        launcher_op.sig.generics.params.push(GenericParam::Type(
             syn::parse2::<TypeParam>(type_param.parse().unwrap()).unwrap(),
         ));
-        let where_clause = launcher_async
+        let where_clause = launcher_op
             .sig
             .generics
             .where_clause
@@ -723,25 +742,22 @@ pub fn generate_kernel_launcher(
         function_params.push(function_param);
     }
     let input_zips = zip_and_then_flatten(&function_params, "input", false);
-    launcher_async.block.stmts.extend(input_zips.block.stmts);
-    launcher_async
-        .block
-        .stmts
-        .push(parse_stmt(format!("return {}(input);", apply_name)));
+    launcher_op.block.stmts.extend(input_zips.block.stmts);
+    launcher_op.block.stmts.push(parse_stmt(format!(
+        "return {}::launch(input);",
+        launcher_ident
+    )));
 
-    // Generate launcher sync function. Uses async function.
-    let launcher_sync_ident = Ident::new(
-        format!("{}_sync", function_name).as_str(),
-        Span::call_site(),
-    );
-    let mut launcher_sync = syn::parse2::<ItemFn>(quote! {
-        pub #unsafety fn #launcher_sync_ident #generic_params() -> #kernel_return_type {}
+    // Generate the public launcher that accepts materialized arguments.
+    let launcher_direct_ident = Ident::new(kernel_naming.public_name(), Span::call_site());
+    let mut launcher_direct = syn::parse2::<ItemFn>(quote! {
+        pub #unsafety fn #launcher_direct_ident #generic_params() -> #kernel_return_type {}
     })
     .unwrap();
     for (i, _arg_ty) in arg_types.iter().enumerate() {
         let function_param = &function_params[i];
         let type_param = &arg_aliases[i];
-        launcher_sync.sig.inputs.push(FnArg::Typed(
+        launcher_direct.sig.inputs.push(FnArg::Typed(
             syn::parse2::<PatType>(
                 format!("{}: {}", function_param, type_param)
                     .parse()
@@ -751,7 +767,7 @@ pub fn generate_kernel_launcher(
         ));
     }
     let return_op = format!(
-        "return {async_name}({});",
+        "return {op_name}({});",
         function_params
             .iter()
             .map(|var| zippable(var, true))
@@ -759,7 +775,7 @@ pub fn generate_kernel_launcher(
             .join(", ")
     );
 
-    launcher_sync.block.stmts.push(parse_stmt(return_op));
+    launcher_direct.block.stmts.push(parse_stmt(return_op));
     Ok((
         required_generics,
         (launcher_args_type.clone(), launcher_arg_type_def),
@@ -769,8 +785,8 @@ pub fn generate_kernel_launcher(
                 #launcher_method
             }
             #launcher_apply
-            #launcher_async
-            #launcher_sync
+            #launcher_op
+            #launcher_direct
         },
     ))
 }
@@ -815,7 +831,7 @@ fn parse_expr(s: String) -> Expr {
 /// Code generation result for a tensor kernel parameter.
 ///
 /// Contains all the generated code components needed for a single tensor
-/// parameter in the async kernel launcher.
+/// parameter in the generated launcher.
 ///
 /// ## Fields
 ///

--- a/cutile-macro/src/lib.rs
+++ b/cutile-macro/src/lib.rs
@@ -16,7 +16,7 @@
 //! 1. **Syntax Validation** - Ensures kernel code follows DSL restrictions
 //! 2. **Variadic Expansion** - Generates specialized versions for different ranks (1D, 2D, 3D, 4D)
 //! 3. **Type System Integration** - Manages compile-time shape information and type metadata
-//! 4. **Launcher Generation** - Creates host-side async kernel launcher functions
+//! 4. **Launcher Generation** - Creates host-side kernel launcher functions
 //! 5. **AST Construction** - Builds intermediate representation for MLIR compilation
 //!
 //! ## Architecture
@@ -34,7 +34,7 @@
 //!       ↓
 //! [_module] ← Main orchestration
 //!       ↓
-//! [kernel_launcher_generator] ← Generate async launchers
+//! [kernel_launcher_generator] ← Generate kernel launchers
 //!       ↓
 //! Expanded Rust + AST builders
 //! ```
@@ -45,7 +45,7 @@
 //! - **[`validate_dsl_syntax`]** - Validates that kernel code follows DSL restrictions
 //! - **[`rewrite_variadics`]** - Handles variadic types and generates rank-specific versions
 //! - **[`types`]** - Type system including shape inference and metadata management
-//! - **[`kernel_launcher_generator`]** - Generates async kernel launcher functions
+//! - **[`kernel_launcher_generator`]** - Generates kernel launcher functions
 //!
 //! ## The `#[module]` Attribute
 //!
@@ -71,7 +71,8 @@
 //!
 //! The macro transforms this into:
 //! - An AST builder function for MLIR compilation
-//! - An async launcher function (`vector_add_apply`)
+//! - A direct launcher function (`vector_add`)
+//! - An `.apply(...)` helper (`vector_add_apply`)
 //! - Type metadata for shape inference
 //! - Proper handling of generic parameters
 //!
@@ -134,13 +135,14 @@ mod rewrite_variadics;
 mod types;
 mod validate_dsl_syntax;
 
-/// Transforms a Rust module into GPU kernel code with async launchers.
+/// Transforms a Rust module into GPU kernel code with kernel launchers.
 ///
 /// This procedural macro is the main entry point for writing GPU kernels in cuTile Rust.
 /// It processes a module containing kernel functions marked with `#[entry]` and generates:
 ///
 /// - MLIR AST builder functions for compilation to CUDA
-/// - Async launcher functions for host-side execution
+/// - Direct launcher functions for host-side execution
+/// - `.apply(...)` helpers for composing existing `DeviceOperation`s
 /// - Type metadata for shape inference and validation
 ///
 /// ## Basic Usage
@@ -157,7 +159,9 @@ mod validate_dsl_syntax;
 ///     }
 /// }
 ///
-/// // Generated: kernels::my_kernel_apply() async launcher function
+/// // Generated: kernels::my_kernel() direct launcher
+/// // Generated: kernels::my_kernel_op() helper for separate DeviceOperations
+/// // Generated: kernels::my_kernel_apply() composition helper
 /// ```
 ///
 /// ## Attributes
@@ -170,8 +174,9 @@ mod validate_dsl_syntax;
 /// For each `#[entry]` function, the macro generates:
 ///
 /// 1. **AST Builder** - `<function>_ast()` - Builds MLIR representation
-/// 2. **Async Launcher** - `<function>_apply()` - Host-side async execution wrapper
-/// 3. **Metadata** - Type information for shape inference
+/// 2. **Direct Launcher** - `<function>()` - Wraps materialized values as device operations
+/// 3. **Apply Helper** - `<function>_apply()` - Composition entry point for `.apply(...)`
+/// 4. **Metadata** - Type information for shape inference
 ///
 /// ## See Also
 ///

--- a/cutile/src/tile_kernel.rs
+++ b/cutile/src/tile_kernel.rs
@@ -361,7 +361,7 @@ pub fn infer_launch_grid(
 /// }
 ///
 /// // Launch with explicit grid
-/// my_module::hello_world_sync()
+/// my_module::hello_world()
 ///     .grid((4, 1, 1))
 ///     .sync_on(&stream);
 /// ```
@@ -396,6 +396,20 @@ pub fn infer_launch_grid(
 ///     .apply(add_apply)
 ///     .generics(vec!["f32".to_string(), "256".to_string()])
 ///     .await; // Automatically launches with grid (4, 1, 1)
+/// ```
+///
+/// When your inputs are already `DeviceOperation`s, prefer `.apply(...)`
+/// rather than a separate op-taking kernel wrapper:
+///
+/// ```rust,ignore
+/// let x = api::randn(0.0, 1.0, [256]);
+/// let y = api::randn(0.0, 1.0, [256]);
+/// let z = api::zeros([256]);
+///
+/// let result = zip!(z, x, y)
+///     .apply(add_apply)
+///     .generics(vec!["f32".to_string(), "256".to_string()])
+///     .await;
 /// ```
 ///
 /// ### Using with async composition

--- a/cutile/tests/control_flow_ops.rs
+++ b/cutile/tests/control_flow_ops.rs
@@ -146,7 +146,7 @@ mod control_flow_ops_module {
     }
 }
 
-use control_flow_ops_module::{_module_asts, break_test_kernel_sync, if_return_test_kernel_sync};
+use control_flow_ops_module::{_module_asts, break_test_kernel, if_return_test_kernel};
 
 #[test]
 fn compile_control_flow_test() -> () {
@@ -196,7 +196,7 @@ fn compile_if_result_test() -> () {
     common::with_test_stack(|| {
         let arg: Tensor<i64> = ones([16]).sync().expect("Failed.");
         // If true, double and add 2.
-        let (result, _) = if_return_test_kernel_sync(arg.partition([4]), true)
+        let (result, _) = if_return_test_kernel(arg.partition([4]), true)
             .sync()
             .expect("Failed.");
         let result: Vec<i64> = result.unpartition().to_host_vec().sync().expect("Failed.");
@@ -204,7 +204,7 @@ fn compile_if_result_test() -> () {
 
         // If false, triple and add 3.
         let arg: Tensor<i64> = ones([16]).sync().expect("Failed.");
-        let (result, _) = if_return_test_kernel_sync(arg.partition([4]), false)
+        let (result, _) = if_return_test_kernel(arg.partition([4]), false)
             .sync()
             .expect("Failed.");
         let result: Vec<i64> = result.unpartition().to_host_vec().sync().expect("Failed.");
@@ -218,7 +218,7 @@ fn execute_break_test() -> () {
         // break_test_kernel loads output, doubles it twice (loop runs 2 iterations then breaks),
         // and stores the result. Starting from 1.0, we expect 1.0 * 2 * 2 = 4.0.
         let arg: Tensor<f32> = ones([16]).sync().expect("Failed.");
-        let (result,) = break_test_kernel_sync(arg.partition([4]))
+        let (result,) = break_test_kernel(arg.partition([4]))
             .sync()
             .expect("Failed.");
         let result: Vec<f32> = result.unpartition().to_host_vec().sync().expect("Failed.");

--- a/cutile/tests/type_conversion_ops.rs
+++ b/cutile/tests/type_conversion_ops.rs
@@ -82,9 +82,9 @@ mod type_conversion_ops_module {
 }
 
 use type_conversion_ops_module::_module_asts;
-use type_conversion_ops_module::bf16_conversion_kernel_sync;
-use type_conversion_ops_module::bf16_to_f32_conversion_kernel_sync;
-use type_conversion_ops_module::f32_to_bf16_conversion_kernel_sync;
+use type_conversion_ops_module::bf16_conversion_kernel;
+use type_conversion_ops_module::bf16_to_f32_conversion_kernel;
+use type_conversion_ops_module::f32_to_bf16_conversion_kernel;
 
 #[test]
 fn compile_conversion_ops() -> () {
@@ -253,7 +253,7 @@ fn execute_bf16_f32_roundtrip() -> () {
         let input: Tensor<bf16> = copy_host_vec_to_device(&input_host)
             .sync()
             .expect("Failed.");
-        let (result,) = bf16_conversion_kernel_sync(input.partition([4]))
+        let (result,) = bf16_conversion_kernel(input.partition([4]))
             .sync()
             .expect("Failed.");
 
@@ -287,7 +287,7 @@ fn execute_bf16_to_f32_conversion() -> () {
         let input = Arc::new(input);
         let output: Tensor<f32> = zeros([input_host.len()]).sync().expect("Failed.");
 
-        let (result, _) = bf16_to_f32_conversion_kernel_sync(output.partition([4]), input)
+        let (result, _) = bf16_to_f32_conversion_kernel(output.partition([4]), input)
             .sync()
             .expect("Failed.");
 
@@ -312,7 +312,7 @@ fn execute_f32_to_bf16_conversion() -> () {
         let input = Arc::new(input);
         let output: Tensor<bf16> = zeros([input_host.len()]).sync().expect("Failed.");
 
-        let (result, _) = f32_to_bf16_conversion_kernel_sync(output.partition([4]), input)
+        let (result, _) = f32_to_bf16_conversion_kernel(output.partition([4]), input)
             .sync()
             .expect("Failed.");
 


### PR DESCRIPTION
## Summary                                                                                                              
                                                                                                                          
  - **Rename generated launcher functions** to a clearer, consistent naming scheme using the new `KernelNaming` helper:   
    - `my_kernel_sync(...)` → `my_kernel(...)` — direct launcher for materialized arguments
    - `my_kernel_async(...)` → `my_kernel_op(...)` — launcher accepting separate `DeviceOperation` arguments              
    - `my_kernel_apply(...)` — unchanged, now takes a materialized tuple and wraps it in `value()`                        
  - **Rename user kernel implementations** to `__cutile_user_impl_<name>` internally, freeing the unsuffixed name for the
  public launcher                                                                                                         
  - **Fix `DeviceOperation::apply`** to delegate to `and_then` and return the proper combinator type
  - **Update all examples and benchmarks** to use the new launcher names                                                  
                                                                                                                          
  ## Breaking changes
                                                                                                                          
  - `<kernel>_sync(...)` no longer exists — use `<kernel>(...)` instead
  - `<kernel>_async(...)` no longer exists — use `<kernel>_op(...)` instead
  - `<kernel>_apply(...)` signature changed: now takes a materialized tuple, not a `DeviceOperation`
                                                                                                                          
  ## Documentation
                                                                                                                          
  Documentation updates will follow in a separate PR.