### PR TITLE
Add interoperability guide for custom CUDA kernels

### DIFF
--- a/cutile-book/guide/async-execution.md
+++ b/cutile-book/guide/async-execution.md
@@ -492,4 +492,4 @@ launcher.grid((num_tiles as u32, 1, 1)).sync_on(&stream);
 
 ---
 
-Continue to [Performance Tuning](performance-tuning.md) for optimization techniques, or [Debugging](debugging.md) for troubleshooting.
+Continue to [Performance Tuning](performance-tuning.md) for optimization techniques, [Interoperability](interoperability.md) for integrating custom CUDA kernels into the `DeviceOperation` model, or [Debugging](debugging.md) for troubleshooting.

--- a/cutile-book/guide/debugging.md
+++ b/cutile-book/guide/debugging.md
@@ -381,5 +381,6 @@ The JIT kernel cache is in-memory per process. Restart the process to force reco
 ## Next Steps
 
 - See [Performance Tuning](performance-tuning.md) for optimization techniques
+- See [Interoperability](interoperability.md) for integrating custom CUDA kernels
 - Review [Syntax Reference](../appendix/syntax-reference.md) for the complete API
 - Try the [Tutorials](../tutorials/01-hello-world.md) for working examples

--- a/cutile-book/guide/execution-model.md
+++ b/cutile-book/guide/execution-model.md
@@ -184,3 +184,4 @@ Both use the same underlying compilation pipeline and generate equivalent GPU co
 - Learn about the [Data Model](data-model.md) for details on types and shapes
 - Explore [Memory Hierarchy](memory-hierarchy.md) for performance optimization
 - See [Async Execution](async-execution.md) for concurrent CPU/GPU work
+- See [Interoperability](interoperability.md) for integrating custom CUDA kernels into the `DeviceOperation` model

--- a/cutile-book/guide/interoperability.md
+++ b/cutile-book/guide/interoperability.md
@@ -1,0 +1,251 @@
+# Interoperability with Custom CUDA Kernels
+
+The tile model handles dense tensor algebra well — GEMM, element-wise operations, reductions, convolutions — but some algorithms depend on **warp-level primitives** (`__shfl_sync`, `__ballot_sync`, `__reduce_sync`) for things like custom scan/prefix-sum, cooperative groups, or irregular data access patterns. For these, write the kernel in CUDA C++ and integrate it using the approach below.
+
+A custom CUDA kernel can participate in the same `DeviceOperation` execution model as your tile kernels — sharing streams, chaining with `.and_then()`, and avoiding unnecessary synchronization.
+
+## Step 1: Compile Your CUDA Kernel
+
+Compile your CUDA C++ kernel to PTX (portable) or a `.cubin` (architecture-specific):
+
+```bash
+# PTX — portable across GPU architectures, JIT-compiled at load time.
+nvcc -ptx -arch=compute_80 my_kernel.cu -o my_kernel.ptx
+
+# cubin — pre-compiled for a single architecture, no JIT overhead.
+nvcc -cubin -arch=sm_80 my_kernel.cu -o my_kernel.cubin
+```
+
+> **Architecture portability:** A `.cubin` file only runs on the exact SM architecture it was compiled for. Code compiled with `-arch=sm_80` will not load on an `sm_100` GPU. PTX avoids this problem — the CUDA driver JIT-compiles it for the target GPU at load time, at the cost of a one-time compilation delay. Prefer PTX unless you need to eliminate JIT overhead. If you must ship `.cubin` files, compile for each target architecture:
+>
+> ```bash
+> nvcc -cubin -gencode arch=compute_80,code=sm_80 \
+>              -gencode arch=compute_100,code=sm_100 \
+>              my_kernel.cu -o my_kernel.cubin
+> ```
+
+## Step 2: Load the Module and Function
+
+Use `cuda-async`'s module loading functions to load the compiled kernel:
+
+```rust
+use cuda_async::device_context::load_module_from_file;
+
+let module = load_module_from_file("my_kernel.cubin", device_id)?;
+let function = Arc::new(module.load_function("my_kernel_entry")?);
+```
+
+For PTX (JIT-compiled at runtime):
+
+```rust
+use cuda_async::device_context::load_module_from_ptx;
+
+let ptx_src = include_str!("my_kernel.ptx");
+let module = load_module_from_ptx(ptx_src, device_id)?;
+let function = Arc::new(module.load_function("my_kernel_entry")?);
+```
+
+## Step 3: Launch via AsyncKernelLaunch
+
+`AsyncKernelLaunch` is a `DeviceOperation` that wraps the CUDA driver's kernel launch API:
+
+```rust
+use cuda_async::launch::AsyncKernelLaunch;
+use cuda_core::LaunchConfig;
+
+let mut launcher = AsyncKernelLaunch::new(function.clone());
+launcher.push_arg(num_elements as u32);
+launcher.push_arg(scale);
+// SAFETY: input and output are valid device allocations with at least
+// num_elements f32 elements. output is exclusively written; input is
+// read-only. Both remain allocated until this operation completes.
+unsafe {
+    launcher
+        .push_device_ptr(input.cu_deviceptr())
+        .push_device_ptr(output.cu_deviceptr());
+}
+launcher.set_launch_config(LaunchConfig {
+    grid_dim: ((num_elements as u32 + 255) / 256, 1, 1),
+    block_dim: (256, 1, 1),
+    shared_mem_bytes: 0,
+});
+
+// Execute as a DeviceOperation — integrates with the async model.
+launcher.await?;
+```
+
+Scalar arguments (types implementing `DType`) can be pushed safely with `push_arg`. Device pointers must use `unsafe { push_device_ptr() }` — see [Safety: Device Pointer Arguments](#safety-device-pointer-arguments) below.
+
+## Safety: Device Pointer Arguments
+
+`push_device_ptr` passes a raw address to the CUDA driver. The Rust compiler has no visibility into GPU kernel code and cannot verify that:
+
+- The pointer refers to a valid device memory allocation on the correct GPU.
+- The allocation is large enough for the kernel's access pattern.
+- No other operation is concurrently reading or writing the same memory.
+- The argument order and types match the kernel's parameter signature.
+
+Neither the Rust compiler nor the CUDA driver validates these invariants — mistakes result in silent undefined behavior or hard-to-diagnose GPU faults. You must verify them manually.
+
+Scalar arguments (like `num_elements as u32`) are copied into the kernel's parameter space — the kernel reads the value, not an address. Any type implementing `DType` can be pushed safely with `push_arg`.
+
+To prevent data races, use stream ordering: operations chained with `.and_then()` on the same stream execute in order and see each other's writes. Operations on different streams require explicit synchronization.
+
+> **Why generated cuTile Rust kernels don't require `unsafe`:** When you write a tile kernel with `#[cutile::entry]`, the generated launcher uses the `KernelArgument` and `ArcKernelArgument` implementations for `Tensor<T>` and `Partition<Tensor<T>>`. These implementations call `push_device_ptr` internally, but can do so safely because the framework controls both sides: device pointers come from framework-managed allocations (guaranteed valid), and the ownership model — `Partition` for exclusive access, `Arc<Tensor>` for shared reads — prevents aliasing at the type level. Custom kernels bypass this: you are pushing pointers that the framework didn't allocate and can't track, so the safety burden falls on you.
+
+You can wrap a custom kernel launch in a struct that implements `DeviceOperation`. The struct's typed fields enforce the correct argument signature, and `unsafe` is confined to `execute`:
+
+```rust
+use cuda_async::device_context::with_default_device_policy;
+use cuda_async::device_future::DeviceFuture;
+use cuda_async::device_operation::{DeviceOperation, ExecutionContext};
+use cuda_async::error::DeviceError;
+use cuda_async::launch::AsyncKernelLaunch;
+use cuda_async::scheduling_policies::SchedulingPolicy;
+use cuda_core::{CudaFunction, LaunchConfig};
+use std::future::IntoFuture;
+
+pub struct ScaleKernel {
+    function: Arc<CudaFunction>,
+    n: u32,
+    scale: f32,
+    input: Arc<Tensor<f32>>,
+    output: Tensor<f32>,
+}
+
+impl DeviceOperation for ScaleKernel {
+    type Output = (Arc<Tensor<f32>>, Tensor<f32>);
+
+    // execute is unsafe because it enqueues async GPU work without
+    // synchronizing — the returned tensors may still be in-flight.
+    // Callers must synchronize (e.g. via DeviceFuture) before accessing
+    // the output.
+    unsafe fn execute(
+        self,
+        ctx: &ExecutionContext,
+    ) -> Result<<Self as DeviceOperation>::Output, DeviceError> {
+        let mut launcher = AsyncKernelLaunch::new(self.function);
+        launcher.push_arg(self.n);
+        launcher.push_arg(self.scale);
+        // SAFETY: input and output are framework-managed Tensor allocations.
+        // input is shared (Arc, read-only); output is exclusively written.
+        unsafe {
+            launcher
+                .push_device_ptr(self.input.cu_deviceptr())
+                .push_device_ptr(self.output.cu_deviceptr());
+        }
+        launcher.set_launch_config(LaunchConfig {
+            grid_dim: ((self.n + 255) / 256, 1, 1),
+            block_dim: (256, 1, 1),
+            shared_mem_bytes: 0,
+        });
+        unsafe { launcher.execute(ctx)? };
+        Ok((self.input, self.output))
+    }
+}
+
+// IntoFuture is a supertrait of DeviceOperation. Every custom DeviceOperation
+// needs this boilerplate to enable `.await` and `.sync()`.
+impl IntoFuture for ScaleKernel {
+    type Output = Result<(Arc<Tensor<f32>>, Tensor<f32>), DeviceError>;
+    type IntoFuture = DeviceFuture<(Arc<Tensor<f32>>, Tensor<f32>), ScaleKernel>;
+    fn into_future(self) -> Self::IntoFuture {
+        match with_default_device_policy(|policy| policy.schedule(self)) {
+            Ok(Ok(future)) => future,
+            Ok(Err(e)) | Err(e) => DeviceFuture::failed(e),
+        }
+    }
+}
+```
+
+This is the same pattern the `#[cutile::entry]` macro uses to generate safe launchers for tile kernels. No `unsafe` at the call site.
+
+## Step 4: Compose with Tile Kernels
+
+`AsyncKernelLaunch` implements `DeviceOperation`, so it chains with tile kernels. This pipeline runs a tile add (`z = x + y`), then the custom scale wrapper (`w = scale * z`):
+
+```rust
+// Run the tile add kernel — z = x + y.
+let (z_part, _x, _y) =
+    tile_add::add(z.partition([tile_size]), x.clone(), y.clone()).await?;
+let z: Tensor<f32> = z_part.unpartition();
+
+// Run the custom scale kernel — w = scale * z.
+let w: Tensor<f32> = zeros::<1, f32>([num_elements]).await?;
+let (_z, w) = ScaleKernel {
+    function: scale_function,
+    n: num_elements as u32,
+    scale,
+    input: Arc::new(z),
+    output: w,
+}
+.await?;
+```
+
+See [`interop.rs`](https://github.com/NVIDIA/cutile-rs/blob/main/cutile-examples/examples/interop.rs) for a complete, runnable version.
+
+---
+
+## Using `with_context` for Low-Level Control
+
+For more direct control, use `with_context` to access the CUDA stream and issue driver API calls directly:
+
+```rust
+use cuda_async::device_operation::{with_context, value, DeviceOperation};
+use cuda_async::device_operation::ExecutionContext;
+use cuda_core::{malloc_async, memcpy_htod_async, free_async};
+
+let host_data: Vec<f32> = vec![1.0; num_elements];
+let num_bytes = num_elements * std::mem::size_of::<f32>();
+
+// host_data is captured by reference — it must outlive the await so that
+// the async memcpy can read from it until the stream synchronizes.
+let op = with_context(|ctx: &ExecutionContext| {
+    let stream = ctx.get_cuda_stream();
+
+    let dptr = unsafe {
+        let dptr = malloc_async(num_bytes, stream);
+        memcpy_htod_async(dptr, host_data.as_ptr(), num_elements, stream);
+        dptr
+    };
+
+    value(dptr)
+});
+
+let dptr = op.await?;
+// host_data is safe to drop now — the await synchronized the stream.
+
+// Clean up: free the device memory on a stream.
+with_context(move |ctx: &ExecutionContext| {
+    unsafe { free_async(dptr, ctx.get_cuda_stream()) };
+    value(())
+})
+.await?;
+```
+
+This gives you full access to the CUDA driver API while participating in the `DeviceOperation` model. Everything inside the `unsafe` block is your responsibility to get right.
+
+---
+
+## Coming from Triton
+
+[Triton](https://triton-lang.org/) and cuTile Rust both let you write kernels in terms of tile-level operations. Many patterns that require explicit warp specialization in Triton (e.g., `warp_specialize` in `tl.range`) are handled implicitly by the cuTile Rust compiler:
+
+| Triton (manual) | cuTile Rust (automatic) |
+|-----------------|------------------------|
+| Assign producer warps to prefetch tiles from global → shared memory | Compiler generates shared memory staging for `load_tile` operations |
+| Assign consumer warps to compute on shared memory tiles | Compiler maps tile arithmetic to Tensor Cores and registers |
+| Software pipeline with `warp_specialize` in `tl.range` to overlap loads and compute | Compiler uses TMA for hardware-assisted pipelining on supported architectures |
+| Manual `tl.dot` placement across warps | `mma()` maps directly to Tensor Core instructions; thread/warp assignment is compiler-managed |
+| Tune `num_warps` and `num_stages` for occupancy | `occupancy` and `num_cta_in_cga` optimization hints guide the compiler |
+
+For patterns that don't map to the tile model, compile the kernel with Triton (or write it in CUDA C++) and integrate it via `AsyncKernelLaunch` as described above. Since Triton outputs PTX, you can load it directly:
+
+```rust
+let module = load_module_from_ptx(triton_generated_ptx, device_id)?;
+let function = Arc::new(module.load_function("gemm_kernel")?);
+```
+
+---
+
+Continue to [Debugging](debugging.md) for troubleshooting, or see [Performance Tuning](performance-tuning.md) for optimization techniques. This chapter builds on the `DeviceOperation` model introduced in [Async Execution](async-execution.md).

--- a/cutile-book/guide/introduction.md
+++ b/cutile-book/guide/introduction.md
@@ -173,6 +173,8 @@ This pattern is key to performance: global memory is slow compared to on-chip re
 - You need maximum portability across GPU *vendors*
 - Your team is deeply invested in the CUDA C++ ecosystem
 
+> **Note**: For algorithms requiring warp-level primitives or custom CUDA C++ kernels, cuTile Rust provides an [Interoperability](interoperability.md) that lets you integrate pre-compiled kernels into the same async execution model.
+
 ---
 
 ## Next Steps

--- a/cutile-book/guide/performance-tuning.md
+++ b/cutile-book/guide/performance-tuning.md
@@ -1,6 +1,6 @@
 # Performance Tuning
 
-This guide covers techniques for optimizing cuTile Rust kernel performance.
+This guide covers techniques for optimizing cuTile Rust kernel performance. For algorithms where peak performance requires warp-level control or integration with hand-tuned CUDA C++ kernels, see [Interoperability](interoperability.md).
 
 ## The Performance Mindset
 
@@ -389,4 +389,5 @@ fn fast_matmul<const S: [i32; 2]>(
 
 - See [Memory Hierarchy](memory-hierarchy.md) for detailed memory optimization
 - Learn about [Async Execution](async-execution.md) for overlapping operations
+- Read [Interoperability](interoperability.md) for integrating custom CUDA kernels when tile programming isn't enough
 - Check [Debugging](debugging.md) for troubleshooting performance issues

--- a/cutile-book/index.md
+++ b/cutile-book/index.md
@@ -98,6 +98,7 @@ guide/memory-hierarchy
 guide/operations
 guide/async-execution
 guide/performance-tuning
+guide/interoperability
 guide/debugging
 ```
 

--- a/cutile-book/tutorials/09-pointer-addition.md
+++ b/cutile-book/tutorials/09-pointer-addition.md
@@ -133,3 +133,9 @@ Modify the kernel to scale the output by a constant factor passed as an addition
 ### Exercise 3: Safe Wrapper
 
 Write a safe Rust wrapper function around the unsafe kernel that validates the pointer lengths at the host level before launching.
+
+---
+
+## See Also
+
+For a structured approach to integrating pre-compiled CUDA C++ kernels — using `AsyncKernelLaunch` instead of raw pointers — see the [Interoperability](../guide/interoperability.md) guide.

--- a/cutile-examples/examples/interop.rs
+++ b/cutile-examples/examples/interop.rs
@@ -1,0 +1,215 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Demonstrates integrating a custom CUDA kernel with cuTile tile kernels.
+//!
+//! Pipeline:
+//!   1. Tile kernel:   z = x + y       (element-wise add via cuTile)
+//!   2. Custom kernel: w = scale * z   (element-wise scale via hand-written PTX)
+//!
+//! Shows:
+//!   - Loading a kernel from inline PTX via `load_module_from_ptx`
+//!   - Launching with `AsyncKernelLaunch` (`push_arg` / `push_device_ptr`)
+//!   - Wrapping a custom kernel in a `DeviceOperation` struct for a safe call-site
+//!   - Chaining tile and custom kernels on the same stream with `and_then`
+
+use cuda_async::device_context::{load_module_from_ptx, with_default_device_policy};
+use cuda_async::device_future::DeviceFuture;
+use cuda_async::device_operation::DeviceOperation;
+use cuda_async::device_operation::ExecutionContext;
+use cuda_async::error::DeviceError;
+use cuda_async::launch::AsyncKernelLaunch;
+use cuda_async::scheduling_policies::SchedulingPolicy;
+use cuda_core::{CudaFunction, LaunchConfig};
+use cutile::api::{arange, zeros};
+use cutile::tensor::{IntoPartition, Tensor, ToHostVec};
+use std::future::IntoFuture;
+use std::sync::Arc;
+
+// ---------------------------------------------------------------------------
+// Tile kernel: element-wise add — z = x + y
+// ---------------------------------------------------------------------------
+
+#[cutile::module]
+mod tile_add {
+    use cutile::core::*;
+
+    #[cutile::entry()]
+    fn add<const S: [i32; 1]>(
+        z: &mut Tensor<f32, S>,
+        x: &Tensor<f32, { [-1] }>,
+        y: &Tensor<f32, { [-1] }>,
+    ) {
+        let tile_x = load_tile_like_1d(x, z);
+        let tile_y = load_tile_like_1d(y, z);
+        z.store(tile_x + tile_y);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Custom CUDA kernel: element-wise scale — out[i] = scale * in[i]
+//
+// Hand-written PTX targeting sm_52+ (JIT-compiled for the actual GPU at load
+// time). Each thread handles one element; the grid is sized to cover all
+// elements.
+// ---------------------------------------------------------------------------
+
+const SCALE_PTX: &str = "\
+.version 7.0
+.target sm_52
+.address_size 64
+
+.visible .entry scale_f32(
+    .param .u32 n,
+    .param .f32 scale,
+    .param .u64 in_ptr,
+    .param .u64 out_ptr
+)
+{
+    .reg .u32 %r<5>;
+    .reg .u64 %rd<4>;
+    .reg .f32 %f<3>;
+    .reg .pred %p;
+
+    ld.param.u32 %r0, [n];
+    ld.param.f32 %f0, [scale];
+    ld.param.u64 %rd0, [in_ptr];
+    ld.param.u64 %rd1, [out_ptr];
+
+    mov.u32 %r1, %tid.x;
+    mov.u32 %r2, %ctaid.x;
+    mov.u32 %r3, %ntid.x;
+    mad.lo.u32 %r4, %r2, %r3, %r1;
+
+    setp.ge.u32 %p, %r4, %r0;
+    @%p bra $done;
+
+    cvt.u64.u32 %rd2, %r4;
+    shl.b64 %rd2, %rd2, 2;
+    add.u64 %rd0, %rd0, %rd2;
+    add.u64 %rd1, %rd1, %rd2;
+
+    ld.global.f32 %f1, [%rd0];
+    mul.f32 %f2, %f1, %f0;
+    st.global.f32 [%rd1], %f2;
+
+$done:
+    ret;
+}
+";
+
+// ---------------------------------------------------------------------------
+// Safe DeviceOperation wrapper for the custom scale kernel.
+//
+// The struct's typed fields enforce the correct argument signature.  `unsafe`
+// is confined to the `execute` implementation where device pointers are
+// marshalled — callers construct and `.await` this type without `unsafe`.
+// ---------------------------------------------------------------------------
+
+struct ScaleKernel {
+    function: Arc<CudaFunction>,
+    n: u32,
+    scale: f32,
+    input: Arc<Tensor<f32>>,
+    output: Tensor<f32>,
+}
+
+impl DeviceOperation for ScaleKernel {
+    type Output = (Arc<Tensor<f32>>, Tensor<f32>);
+
+    // Safety: execute is unsafe because it enqueues work on a CUDA stream
+    // without synchronizing. The returned tensors may still be in-flight on
+    // the GPU. Callers must synchronize the stream (e.g. via DeviceFuture)
+    // before accessing the output.
+    unsafe fn execute(
+        self,
+        ctx: &ExecutionContext,
+    ) -> Result<<Self as DeviceOperation>::Output, DeviceError> {
+        let mut launcher = AsyncKernelLaunch::new(self.function);
+        launcher.push_arg(self.n);
+        launcher.push_arg(self.scale);
+        // Safety:
+        // Input okay since it's behind an Arc.
+        // Output okay since this struct owns the tensor we will be writing to.
+        // Pointer validity / sizing — both cu_deviceptr() values come from Tensor allocations that are at least self.n f32 elements.
+        // The kernel accesses elements 0..n, each at byte offset gid * 4, so both allocations are large enough.
+        unsafe {
+            launcher
+                .push_device_ptr(self.input.cu_deviceptr())
+                .push_device_ptr(self.output.cu_deviceptr());
+        }
+        launcher.set_launch_config(LaunchConfig {
+            grid_dim: (self.n.div_ceil(256), 1, 1),
+            block_dim: (256, 1, 1),
+            shared_mem_bytes: 0,
+        });
+        // Safety:
+        // Kernel impl needs to guarantee freedom from UB.
+        unsafe { launcher.execute(ctx)? };
+        Ok((self.input, self.output))
+    }
+}
+
+impl IntoFuture for ScaleKernel {
+    type Output = Result<(Arc<Tensor<f32>>, Tensor<f32>), DeviceError>;
+    type IntoFuture = DeviceFuture<(Arc<Tensor<f32>>, Tensor<f32>), ScaleKernel>;
+    fn into_future(self) -> Self::IntoFuture {
+        match with_default_device_policy(|policy| policy.schedule(self)) {
+            Ok(Ok(future)) => future,
+            Ok(Err(e)) | Err(e) => DeviceFuture::failed(e),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Main: run the tile add kernel, then the custom scale kernel, and verify.
+// ---------------------------------------------------------------------------
+
+#[tokio::main()]
+async fn main() -> Result<(), cutile::error::Error> {
+    let num_elements = 2usize.pow(5);
+    let tile_size = 4i32;
+    let scale = 3.0f32;
+    let device_id = 0;
+
+    // Step 1: Load the custom scale kernel from PTX.
+    let module = load_module_from_ptx(SCALE_PTX, device_id)?;
+    let scale_function = Arc::new(module.load_function("scale_f32")?);
+
+    // Step 2: Allocate input tensors.
+    let x: Arc<Tensor<f32>> = arange(num_elements).arc().await?;
+    let y: Arc<Tensor<f32>> = arange(num_elements).arc().await?;
+    let z: Tensor<f32> = zeros::<1, f32>([num_elements]).await?;
+
+    // Step 3: Run tile add kernel — z = x + y.
+    let (z_part, _x, _y) = tile_add::add(z.partition([tile_size]), x.clone(), y.clone()).await?;
+    let z: Tensor<f32> = z_part.unpartition();
+
+    // Step 4: Run custom scale kernel — w = scale * z.
+    let w: Tensor<f32> = zeros::<1, f32>([num_elements]).await?;
+    let (_z, w) = ScaleKernel {
+        function: scale_function,
+        n: num_elements as u32,
+        scale,
+        input: Arc::new(z),
+        output: w,
+    }
+    .await?;
+
+    // Step 5: Verify w[i] == scale * (x[i] + y[i]).
+    let x_host = x.to_host_vec().await?;
+    let y_host = y.to_host_vec().await?;
+    let w_host = w.to_host_vec().await?;
+    for i in 0..num_elements {
+        let expected = scale * (x_host[i] + y_host[i]);
+        println!(
+            "{} * ({} + {}) = {} (got {})",
+            scale, x_host[i], y_host[i], expected, w_host[i]
+        );
+        assert_eq!(expected, w_host[i]);
+    }
+    println!("Interop example passed.");
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- New guide chapter: **Interoperability with Custom CUDA Kernels**
- Documents when tile programming is the right fit vs. when warp-level primitives are needed
- Shows how to load and launch custom CUDA C++ kernels via `AsyncKernelLaunch`
- Demonstrates composing custom kernels with tile kernels using `and_then()` and `with_context`
- Added to the User Guide table of contents between Async Execution and Performance Tuning

Resolves #51

## Test plan
- [ ] Verify the book builds: `cd cutile-book && make livehtml`
- [ ] Review code examples for accuracy against current API