### PR TITLE
feat: updated DeviceOp, tensor references, CUDA graph scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,62 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/),
+and this project adheres to [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+### Added
+- **DeviceOp combinators**: `.then()`, `.map()`, `.inspect()`, `.first()`, `.last()`, `.shared()`, `.boxed()`, `zip!`/`.unzip()`, following `futures` crate conventions.
+- **Unified kernel launcher**: Single function per kernel via `IntoDeviceOp`. Accepts `Tensor<T>`, `Arc<Tensor<T>>`, `&Tensor<T>`, `DeviceOp`s, and scalars interchangeably.
+- **KernelInput trait**: `&Tensor` params accept `Tensor<T>`, `Arc<Tensor<T>>`, or `&Tensor<T>`. Same type in, same type out. `&Tensor<T>` inputs prevent `tokio::spawn` at compile time via Rust's lifetime system.
+- **KernelOutput trait**: `&mut Tensor` params accept `Partition<Tensor<T>>` or `Partition<&mut Tensor<T>>`. Borrowed partitions write in place: No `unpartition()` needed.
+- **CUDA graph capture**: `.graph()` / `.graph_on(stream)` captures any `DeviceOp` into a replayable `CudaGraph<T>`. `graph.update()` + `graph.launch()` for efficient replay.
+- **`CudaGraph::scope`**: Scoped graph capture with `&mut` borrows. `s.record(op)` records `GraphNode` ops as graph nodes, releasing borrows between calls.
+- **`GraphNode` trait**: Marker trait for operations safe to record in a CUDA graph (kernel launches, `memcpy`). Allocation ops are excluded at compile time.
+- **Thread-local execution lock**: Enforces "only one DeviceOp may be executing at a time per thread." Prevents cross-stream data races from nested execution (e.g., `sync_on` inside a `then` closure). `unsafe then_unchecked` opts out.
+- **TensorView**: Safe borrowed reshaped view via `tensor.view(&[usize])`. Replaces `unsafe fn view()`.
+- **SharedDeviceOp**: Cloneable, execute-once operations via `.shared()`.
+- **DeviceOpVec**: Heterogeneous collections of boxed operations.
+- **Scheduling**: Simplified `SchedulingPolicy` trait with single `fn next_stream()`. `StreamPoolRoundRobin` (default, 4 streams) and `SingleStream`.
+- **Prelude**: `use cutile::prelude::*` for common imports.
+- **New examples**: `cuda_graphs.rs` (scope-based), `cuda_graphs_deviceop.rs` (combinator-based), `add_refs.rs` (borrow pattern).
+- **cutile-book**: DeviceOp API reference, CUDA Graphs tutorial, tutorials 6-9 in book_examples.rs.
+
+### Changed
+- **`DeviceOperation` renamed to `DeviceOp`**: Shorter, consistent with `DeviceOp` combinators.
+- **`zeros`/`ones`/`full` take `&[usize]`**: Dynamic shape, no const-generic rank parameter.
+- **`randn`/`rand` are generic**: `randn::<T>(mean, std, shape, seed)` via `RandNormal`/`RandUniform` traits. Per-type functions (`randn_f32`, etc.) removed.
+- **`copy` renamed to `dup`**: Takes `&Tensor<T>` not `&Arc<Tensor<T>>`.
+- **Copy API consolidated**: `copy_from`/`copy_into`/`copy_data_into` replaced by `memcpy(&mut dst, &src)` + `dup(&tensor)`.
+- **Reshape unification**: `reshape(&[usize])` returns `Result`. Old variants (`reshape_dyn`, `try_view`, `view_dyn`, `flatten_view`, etc.) removed.
+- **Tensor fields**: `shape`/`strides` now `pub(crate)` with `shape()`/`strides()` accessors.
+- **Partition uses `[usize]`**: Partition shapes are `[usize; N]`, not `[i32; N]`.
+- **Output-first convention**: `&mut Tensor` is always the first kernel parameter.
+- **Extension trait renames**: `IntoDeviceOperationPartition` → `PartitionOp`, `TensorDeviceOpToHostVec` → `ToHostVecOp`.
+- **`.graph()` / `.graph_on(stream)`**: Follows `sync` / `sync_on` convention.
+
+### Fixed
+- **`sync_on` error propagation**: `stream.synchronize()` errors are now returned instead of panicking.
+- **Concurrent stream capture**: Removed `cuCtxSynchronize` call in `CudaContext::new_stream` that caused `DriverError(900)` when creating streams while another thread was capturing a CUDA graph.
+
+### Removed
+- `DeviceOperationArc`, `UnwrapArc` struct, `GlobalSchedulingPolicy` enum, `WithDeviceId` trait.
+- `_op()` generated launcher variant (unified launcher replaces it).
+- `num_mb()`, `num_gb()`, `copy_sync()` on Tensor.
+- `DeviceOperationReshape`, `DeviceOperationDynamicReshape`, `DeviceOperationCopyFrom` traits.
+- cudarc event-tracking infrastructure (`num_streams`, `event_tracking` on `CudaContext`). Unused; caused interference with concurrent captures.
+
+## [0.0.1] - 2026-04-07
+
+Initial tagged release. Pre-DeviceOp redesign baseline.
+
+### Features
+- Tile-based GPU programming model with `#[cutile::entry()]` kernels.
+- `DeviceOperation` trait with `.apply()`, `.and_then()`, `zip!`, `.unzip()`.
+- JIT compilation pipeline: Rust AST → MLIR → CUDA PTX.
+- Async execution via tokio with `DeviceFuture`.
+- `Arc<Tensor<T>>` for shared inputs, `Partition<Tensor<T>>` for mutable outputs.
+- Flash attention, GEMM, RMSNorm, softmax examples.
+- cuTile Rust Book with tutorials 1-9.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,9 +25,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anyhow"
@@ -213,9 +213,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -276,18 +276,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -295,9 +295,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cmake"
@@ -310,19 +310,19 @@ dependencies = [
 
 [[package]]
 name = "comrak"
-version = "0.50.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "321d20bf105b6871a49da44c5fbb93e90a7cd6178ea5a9fe6cbc1e6d4504bc5e"
+checksum = "9f07383e7799d964bf7ffa6fc4457d177c54a44614661c7458bb0bd91b108e32"
 dependencies = [
  "caseless",
  "entities",
+ "finl_unicode",
  "jetscii",
  "phf 0.13.1",
  "phf_codegen",
  "rustc-hash 2.1.1",
  "smallvec",
  "typed-arena",
- "unicode_categories",
 ]
 
 [[package]]
@@ -446,6 +446,7 @@ dependencies = [
  "anyhow",
  "cuda-core",
  "futures",
+ "half",
  "thiserror 1.0.69",
 ]
 
@@ -501,7 +502,6 @@ dependencies = [
  "cuda-core",
  "cutile",
  "cutile-compiler",
- "cutile-examples",
  "tokio",
 ]
 
@@ -554,9 +554,9 @@ dependencies = [
 
 [[package]]
 name = "dissimilar"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8975ffdaa0ef3661bfe02dbdcc06c9f829dfafe6a3c474de366a8d5e44276921"
+checksum = "aeda16ab4059c5fd2a83f2b9c9e9c981327b18aa8e3b313f7e6563799d4f093e"
 
 [[package]]
 name = "dyn-stack"
@@ -625,6 +625,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "finl_unicode"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
 
 [[package]]
 name = "float8"
@@ -865,19 +871,19 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -993,9 +999,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jetscii"
@@ -1005,9 +1011,9 @@ checksum = "47f142fe24a9c9944451e8349de0a56af5f3e7226dc46f3ed4d4ecc0b85af75e"
 
 [[package]]
 name = "js-sys"
-version = "0.3.87"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f0862381daaec758576dcc22eb7bbf4d7efd67328553f3b45a412a51a3fb21"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1033,9 +1039,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libloading"
@@ -1076,9 +1082,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "melior"
-version = "0.26.5"
+version = "0.26.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c49659ea7a2c612aa7b34fc0bd1baf5e691d051034616d3df624b912915bf81"
+checksum = "f5c38e8ea1f1bb22ebc7fe311b3adac0e9d3591e7c4d02a3b3b9c89d3e66899c"
 dependencies = [
  "melior-macro",
  "mlir-sys",
@@ -1086,9 +1092,9 @@ dependencies = [
 
 [[package]]
 name = "melior-macro"
-version = "0.19.1"
+version = "0.19.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e27917e84caba4296e487807dfa5c810418d67eadc5540aa8bfe20d4529b31"
+checksum = "0e156c0973fdaaf2930149766775d85ff451e229739562cf50b0453f08024d2a"
 dependencies = [
  "comrak",
  "convert_case 0.11.0",
@@ -1135,9 +1141,9 @@ dependencies = [
 
 [[package]]
 name = "mlir-sys"
-version = "210.0.1"
+version = "210.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d24c8c35df089fa46fff72a9e4d90beed3f8a4e7d07af633a2e5f5b0d11b7"
+checksum = "f376ddc92bf2bad0eba47e20f75923f76306e429273379cedb70eb7e664aab90"
 dependencies = [
  "bindgen 0.72.1",
 ]
@@ -1193,9 +1199,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "oorandom"
@@ -1315,9 +1321,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "plotters"
@@ -1410,9 +1416,9 @@ checksum = "40e24eee682d89fb193496edf918a7f407d30175b2e785fe057e4392dfd182e0"
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -1422,6 +1428,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -1546,9 +1558,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rustc-hash"
@@ -1670,9 +1682,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+checksum = "876ac351060d4f882bb1032b6369eb0aef79ad9df1ea8bc404874d8cc3d0cd98"
 dependencies = [
  "serde_core",
 ]
@@ -1713,12 +1725,12 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1784,9 +1796,9 @@ checksum = "591ef38edfb78ca4771ee32cf494cb8771944bee237a9b91fc9c1424ac4b777b"
 
 [[package]]
 name = "tblgen"
-version = "0.7.2"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7364c3b3e7036cebffcc65895bff60ca160e1c9d98a84fb24f723e8c90b02a60"
+checksum = "0c4e3abe8582a0bb8708d11142c45e8c622f013bc4936d918da42c2aade60e98"
 dependencies = [
  "bindgen 0.72.1",
  "cc",
@@ -1855,9 +1867,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -1870,9 +1882,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",
@@ -1887,9 +1899,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1898,9 +1910,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.0.3+spec-1.1.0"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7614eaf19ad818347db24addfa201729cf2a9b6fdfd9eb0ab870fcacc606c0c"
+checksum = "f8195ca05e4eb728f4ba94f3e3291661320af739c4e43779cbdfae82ab239fcc"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -1913,27 +1925,27 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.0.0+spec-1.1.0"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
+checksum = "97251a7c317e03ad83774a8752a7e81fb6067740609f75ea2b585b569a59198f"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.9+spec-1.1.0"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
 dependencies = [
  "winnow",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.0.6+spec-1.1.0"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
+checksum = "d282ade6016312faf3e41e57ebbba0c073e4056dab1232ab1cb624199648f8ed"
 
 [[package]]
 name = "trybuild"
@@ -1980,21 +1992,15 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "da36089a805484bcccfffe0739803392c8298778a2d2f09febf76fac5ad9025b"
 
 [[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "unicode_categories"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
 name = "unindent"
@@ -2004,11 +2010,11 @@ checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "uuid"
-version = "1.21.0"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
+checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
 dependencies = [
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -2055,9 +2061,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.110"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1de241cdc66a9d91bd84f097039eb140cdc6eec47e0cdbaf9d932a1dd6c35866"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2068,9 +2074,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.110"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12fdf6649048f2e3de6d7d5ff3ced779cdedee0e0baffd7dff5cdfa3abc8a52"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2078,9 +2084,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.110"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e63d1795c565ac3462334c1e396fd46dbf481c40f51f5072c310717bc4fb309"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2091,9 +2097,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.110"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f9cdac23a5ce71f6bf9f8824898a501e511892791ea2a0c6b8568c68b9cb53"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
 ]
@@ -2134,9 +2140,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.87"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2c7c5718134e770ee62af3b6b4a84518ec10101aad610c024b64d6ff29bb1ff"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2175,16 +2181,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2202,31 +2199,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -2236,22 +2216,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2260,22 +2228,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2284,22 +2240,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2308,28 +2252,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
-
-[[package]]
 name = "winnow"
-version = "0.7.14"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
 
 [[package]]
 name = "wit-bindgen"
@@ -2444,18 +2376,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.39"
+version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
+checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.39"
+version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
+checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/README.md
+++ b/README.md
@@ -124,13 +124,11 @@ If everything works, you should see: `Hello, I am tile <0, 0, 0> in a kernel wit
 # Quick Start
 
 ```rust
-use cuda_async::device_operation::DeviceOperation;
-use cutile::{self, api, tile_kernel::IntoDeviceOperationPartition};
-use my_module::add_op;
+use cutile::prelude::*;
+use my_module::add;
 
 #[cutile::module]
 mod my_module {
-
     use cutile::core::*;
 
     #[cutile::entry()]
@@ -145,33 +143,21 @@ mod my_module {
     }
 }
 
-fn main() -> Result<(), cutile::tile_kernel::DeviceError> {
-    let x = api::ones([32, 32]).arc();
-    let y = api::ones([32, 32]).arc();
-    let z = api::zeros([32, 32]).partition([4, 4]);
-    let (_z, _x, _y) = add_op(z, x, y).sync()?;
+fn main() -> Result<(), cuda_async::error::DeviceError> {
+    let x = api::ones::<f32>(&[32, 32]).sync()?;
+    let y = api::ones::<f32>(&[32, 32]).sync()?;
+    let mut z = api::zeros::<f32>(&[32, 32]).sync()?;
+
+    add((&mut z).partition([4, 4]), &x, &y).sync()?;
     Ok(())
 }
 ```
 
-The above example defines a _device-side_ module named `my_module`, which contains the _tile kernel_ `add`. 
-The `add` kernel is marked as an _entry point_, allowing it to be executed from the _host-side_ (e.g. the `main` function).
-Our kernel is defined such that `x` and `y` are input tensors, and `z` is an output tensor.
+The `#[cutile::module]` macro transforms the `add` function into a GPU kernel. On the host side, `add(...)` constructs a lazy kernel launcher that accepts borrowed tensors: `(&mut z).partition([4, 4])` borrows the output and partitions it into 4×4 sub-tensors, while `&x` and `&y` borrow the inputs.
 
-On the host-side, we allocate our device-side tensors `x`, `y` and `z`.
-The kernel indicates that `z` must be mutable. Since the same tile kernel executes in parallel by many tile threads, we will need a way to provide each tile thread exclusive access to `z`. It is enough to wrap `x` and `y` in an Arc (see [cuda-async](cuda-async) for details), however, the tensor `z` is partitioned into a grid of `4x4` sub-tensors. In cuTile Rust,
-any `&mut Tensor<...>` requires the host to pass a `Partition<Tensor<T>>` as the argument. Any `&Tensor<...>` requires the
-host to pass an `Arc<Tensor<...>>` as an argument.
+`.sync()` JIT-compiles the kernel (cached after first use) and executes it. The launch grid `(8, 8, 1)` is inferred from the partition: 32÷4 = 8 tiles per dimension.
 
-The expression `add_op(z, x, y)` constructs a representation of a _kernel launcher_: A structure which encodes how the GPU applies the kernel to the given arguments. By default, because we have partitioned `z` into a grid of `4x4` subtensors, the kernel launcher will pick a _launch grid_ of `(8, 8, 1)`. Each `(x, y, z)` coordinate in the launch grid corresponds to a _tile thread_.
-
-The `sync` method picks the default device on the system and synchronously JIT-compiles the kernel to the default device's architecture and immediately executes the kernel with the provided arguments.
-Before executing the user-defined kernel on the device-side, each tile thread is initialized by selecting 
-a distinct sub-tensor from the partitioning of `z` as the `&mut Tensor<...>` kernel parameter.
-Each tile thread has exclusive access to a distinct sub-tensor within the partition of `z`,
-allowing for safe parallel mutable access.
-
-- Run the above example via `cargo run -p cutile-examples --example add_basic`.
+- Run the above example via `cargo run -p cutile-examples --example add_refs`.
 - More kernels and usage examples of the host-side API can be found [here](cutile-examples/examples).
 
 # Tests

--- a/cuda-async/Cargo.toml
+++ b/cuda-async/Cargo.toml
@@ -11,6 +11,7 @@ description = "Safe Async CUDA support via Async Rust."
 
 [dependencies]
 cuda-core = { workspace = true }
+half = { workspace = true }
 futures = { workspace = true }
 anyhow = { workspace = true }
 thiserror = { workspace = true }

--- a/cuda-async/README.md
+++ b/cuda-async/README.md
@@ -1,145 +1,130 @@
 # CUDA Async
-CUDA Async lets programmers asynchronously compose DAGs of CUDA operations,
+
+CUDA Async lets programmers asynchronously compose DAGs of CUDA operations
 and execute them on multiple devices using any async Rust runtime (such as tokio).
 
 The design consists of three key pieces:
-- Device operations, which are composed using the `DeviceOperation` API.
-- Scheduling, which is done via an implementation of the `SchedulingPolicy` trait. The `schedule` operation maps instances of `DeviceOperation` to `DeviceFuture`.
-- Future submission/execution, which is carried out by awaiting on the `DeviceFuture` type within an async context.
+- **Device operations** — composed using the `DeviceOp` trait and combinators.
+- **Scheduling** — an implementation of `SchedulingPolicy` maps `DeviceOp`s to streams.
+- **Execution** — `.sync_on(&stream)`, `.sync()`, or `.await`.
 
 ## Device Operations
 
-The `DeviceOperation<Output=T>` trait exposes an API for composing device operations.
-A given implementation of `DeviceOperation` can be converted into `DeviceFuture`, which implements `Future<Output=T>`.
-The `DeviceFuture` type can either be spawned or awaited upon by any async runtime in Rust.
-All functions in the `api` module construct implementations of `DeviceOperation<Output=T>`.
+`DeviceOp<Output=T>` is a lazy, composable GPU operation. Nothing executes
+until `.sync()`, `.sync_on()`, or `.await` is called.
 
-If you do this:
 ```rust
-async fn main() {
-    let a = 2.0;
-    let x = api::ones::<f32>([16, 16]).arc(); // impl DeviceOperation
-    let y = api::ones::<f32>([16, 16]).partition([4, 4]); // impl DeviceOperation
-    let op = api::zip((a, x, y)).apply(my_kernels::saxpy); // impl DeviceOperation
-    let (a, x, y) = op.await; // Implicitly converts the impl DeviceOperation into a DeviceFuture, and submits it for execution.
-}
-```
-The `apply` operation applies the user-defined kernel operation `saxpy` on the arguments `(a, x, y)`.
-The `arc` operation converts `x` into an `Arc<Tensor<f32>>`, and the `partition` operation converts
-`y` into an `Partition<Tensor<f32>>`.
-The kernel launcher passes `Arc<Tensor<f32>>` and `Partition<Tensor<f32>>` to tile kernels as `&Tensor<f32>` and partitioned sub tensors `&mut Tensor<f32>`, respectively
-(see [Kernel Launch](#kernel-launch) for details on how user-defined kernel arguments are safely prepared).
+use cutile::prelude::*;
 
-`impl DeviceOperation` objects on which `await` is called are implicitly converted into futures.
-This implicit conversion schedules the operation to execute on the default global device,
-and `await` submits the resulting future for execution, blocking the current thread until execution is complete.
+fn main() -> Result<(), DeviceError> {
+    let ctx = cuda_core::CudaContext::new(0)?;
+    let stream = ctx.new_stream()?;
 
-The `unzip` operation is the inverse of `zip`:
-```rust
-async fn main() {
-    let a = 2.0;
-    let x = api::ones::<f32>([16, 16]).arc();
-    let y = api::ones::<f32>([16, 16]).partition([4, 4]);
-    let op = zip!(a, x, y).apply(my_kernels::saxpy);
-    let (a, x, y) = op.unzip(); // Unzip args after applying saxpy.
-    let y = y.unpartition().arc();
-    let y: Arc<Tensor<f32>> = y.await; // await just on y.
+    let mut z = api::zeros::<f32>(&[16, 16]).sync_on(&stream)?;
+    let x = api::ones::<f32>(&[16, 16]).sync_on(&stream)?;
+    let y = api::ones::<f32>(&[16, 16]).sync_on(&stream)?;
+
+    // Borrow-based: &mut z for output, &x and &y for inputs.
+    let _ = saxpy((&mut z).partition([4, 4]), 2.0, &x).sync_on(&stream)?;
+    // z already has the result.
+    Ok(())
 }
 ```
 
-The above example discards `a` and `x` after executing `saxpy` by awaiting on just `y`.
-`unpartition().arc()` can be used to convert a `Partition<Tensor<f32>>` into `Arc<Tensor<f32>>`,
-subsequently allowing `y` to be used as an argument to multiple device operations in parallel.
+### Kernel Input Modes
 
-An `Arc<Tensor<f32>>` can be converted into a `Tensor<f32>` in the usual way, which
-requires the reference count of the `Arc<Tensor<f32>>` to be 1.
+Kernel `&Tensor` params accept three input forms. You get back the same
+type you put in:
+
+| Input | Returned | `tokio::spawn`? |
+|---|---|---|
+| `Tensor<T>` | `Tensor<T>` | Yes |
+| `Arc<Tensor<T>>` | `Arc<Tensor<T>>` | Yes |
+| `&Tensor<T>` | `&Tensor<T>` | No (not `'static`) |
+
+Kernel `&mut Tensor` params accept two partition forms:
+
+| Input | Returned |
+|---|---|
+| `Partition<Tensor<T>>` (owned) | `Partition<Tensor<T>>` |
+| `Partition<&mut Tensor<T>>` (borrowed) | `Partition<&mut Tensor<T>>` |
+
+The borrowed form writes in place — no `unpartition()` needed.
+
+### Combinators
+
+Operations compose via combinators that follow `futures` crate conventions:
+
+```rust
+// Chain dependent work on the same stream.
+let result = allocate_buffer()
+    .then(|buf| fill_kernel(buf))
+    .then(|buf| process_kernel(buf))
+    .sync()?;
+
+// Combine independent operations.
+let (a, b) = zip!(op_a, op_b).sync()?;
+
+// Transform output without GPU work.
+let doubled = op.map(|x| x * 2);
+
+// Cloneable, execute-once.
+let shared = op.shared();
+```
 
 ## Scheduling
 
-The `DeviceFuture` struct represents a _scheduled_ device operation. A scheduled operation has resources assigned to it.
-You can use the `DeviceOperation::schedule` method to schedule a device operation on a particular device:
+The `SchedulingPolicy` trait decides which CUDA stream each operation
+runs on. The default `StreamPoolRoundRobin` rotates through 4 streams,
+enabling overlap of independent operations.
+
 ```rust
-async fn my_op<T>(z: impl DeviceOperation<Output=T>) {
-    let zf: DeviceFuture<Output=T> = z.schedule(global_policy(1));
-    let z: Tensor<f32> = zf.await;
+// Implicit: .sync() and .await use the default round-robin policy.
+let result = my_kernel(out, input).sync()?;
+
+// Explicit: pin to a specific stream.
+let result = my_kernel(out, input).sync_on(&stream)?;
+
+// Multi-device: schedule on a specific device's policy.
+let future = my_kernel(out, input).schedule(&policy)?;
+```
+
+Operations chained with `.then()` share a single stream and always
+execute in order. Operations on different streams may overlap.
+
+## CUDA Graphs
+
+`CudaGraph<T>` captures a `DeviceOp` into a replayable CUDA graph using
+[stream capture](https://docs.nvidia.com/cuda/cuda-programming-guide/04-special-topics/cuda-graphs.html#creating-a-graph-using-stream-capture):
+
+```rust
+// Capture: executes once, records all GPU work into a graph.
+let forward_op = build_forward(&cfg, &weights, input.clone(), buffers);
+let mut graph = forward_op.graph_on(stream.clone())?;
+let buffers = graph.take_output().unwrap();
+
+// Replay loop — single driver call per iteration.
+for token in tokens {
+    graph.update(api::memcpy(&mut input_buf, &token))?;
+    graph.launch()?;
 }
 ```
 
-The above invocation of `schedule` uses the global policy defined for device `1` to assign resources to `z`. 
-Actual execution is deferred until `await` is invoked.
+All device pointers are baked in at capture time. To vary inputs, copy
+new data into pre-allocated buffers via `graph.update(op)` before each
+`graph.launch()`.
 
-## Efficient Execution
+## API Argument Conventions
 
-Consider the following program:
-```rust
-async fn main() {
-    let x: Tensor<f32> = api::ones::<f32>([16, 16]).await;
-    let y: Tensor<f32> = api::ones::<f32>([16, 16]).await;
-    let z: Tensor<f32> = api::add(x.into(), y.into()).await;
-}
-```
+| Layer | Arguments | Return |
+|---|---|---|
+| **API functions** (`zeros`, `dup`, etc.) | Concrete values | `impl DeviceOp` |
+| **Extension traits** (`.reshape()`, `.to_host_vec()`, etc.) | Concrete values | `impl DeviceOp` |
+| **Kernel functions** (`rms_norm`, etc.) | `IntoDeviceOp` / `KernelInput` / `KernelOutput` args | `impl DeviceOp` |
 
-The above implementation is correct but inefficient: 
-Whenever we invoke `await` on a `DeviceOperation`, we require synchronization with the async runtime.
-We can instead submit a single future for execution, letting the scheduling policy order device operations
-and synchronize with the async runtime once:
-```rust
-async fn main() {
-    let xf = api::ones::<f32>([16, 16]);
-    let yf = api::ones::<f32>([16, 16]);
-    let z: Tensor<f32> = api::add(x, y).await;
-}
-```
-
-The default scheduling policy executes the above composition of operations on the same stream, 
-which executes operations in order without synchronization overhead.
-The runtime is notified when the computations are complete via a CUDA host callback, 
-which is placed on the stream after all operations are submitted to the stream.
-
-A similar procedure takes place when `join` is called on a tuple of operations prior to `await`.
-
-## Kernel Launch
-
-Consider the following saxpy kernel:
-```rust
-#[cutile::module]
-mod my_module {
-  use cutile::core::{*};
-  #[cutile::entry()]
-  fn saxpy<const S: [i32; 2]>(a: f32, x: &Tensor<f32, {[-1, -1]}>, y: &mut Tensor<f32, S>) {
-    let tile_a: Tile<f32, S> = broadcast_scalar(a, y.shape());
-    let tile_x: Tile<f32, S> = load_tile_like_2d(x, y);
-    let tile_y: Tile<f32, S> = load_tile_mut(y);
-    store_tile(tile_a * tile_x + tile_y, y);
-  }
-}
-```
-
-The kernel expects a reference to `x`, and a mutable reference to `y`.
-We provide a reference to `x` by wrapping it in an `Arc` on the host-side.
-The `arc` method can be called directly on a host-side tensor to obtain `Arc<Tensor<T>>`.
-
-To provide safe mutable access to `y`, it must be partitioned into sub-tensors on the host-side.
-The `partition` method can be called on a host-side tensor to obtain an `impl Partition<Tensor<T>>`.
-When an `impl Partition<Tensor<T>>` is passed to a kernel function, it provides mutable access to a disjoint sub-tensor
-in the tensor partition.
-
-Rules:
-- `arc` and `partition` can be called on an `impl DeviceOperation<Output=Tensor<T>>` or directly on a `Tensor<T>`.
-- If you have a `Partition<Tensor<T>>`, you can `unwrap` it into `Tensor<T>` or call `arc` on it to obtain an `Arc<Tensor<T>>`.
-- If you have an `Arc<Tensor<T>>`, you can only `unwrap` it into `Tensor<T>` and partition it if there is exactly
-one reference to it.
-
-For example, to partition a `16x16` matrix into `4x4` sub-matrices and pass it to the given saxpy function, we do:
-```rust
-async fn main() {
-    let x = api::ones::<f32>([16, 16]);
-    let y = api::ones::<f32>([16, 16]);
-    let (a, x, y) = saxpy(2.0, x.arc(), y.partition([4, 4])).await;
-}
-```
-
-For an in-depth example, check out the data-parallel MLP example [here](../cutile-examples/examples/async_mlp.rs).
+Kernel launchers accept `Tensor<T>`, `Arc<Tensor<T>>`, `&Tensor<T>`,
+`Partition<Tensor<T>>`, `Partition<&mut Tensor<T>>`, scalars, and lazy
+`DeviceOp`s interchangeably via trait-based dispatch.
 
 # Testing
 

--- a/cuda-async/src/cuda_graph.rs
+++ b/cuda-async/src/cuda_graph.rs
@@ -1,0 +1,525 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use crate::device_operation::{DeviceOp, ExecutionContext, GraphNode};
+use crate::error::DeviceError;
+use cuda_core::{stream, sys, CudaStream, IntoResult};
+use std::mem::MaybeUninit;
+use std::sync::Arc;
+
+const CU_STREAM_CAPTURE_MODE_RELAXED: sys::CUstreamCaptureMode = 2;
+
+/// A captured and instantiated CUDA graph, ready for replay.
+///
+/// Created via [`CudaGraph::capture`], which executes a [`DeviceOp`] once
+/// on a capture stream, recording all GPU work into a graph. The graph can then
+/// be replayed any number of times via [`launch`](CudaGraph::launch).
+///
+/// All device pointers used by the operation are baked into the graph at capture
+/// time. To vary inputs between replays, pre-allocate an input buffer, pass it
+/// into the operation, and memcpy new data into that buffer before each launch.
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// use cuda_async::prelude::*;
+///
+/// // Build a lazy operation (no GPU work yet).
+/// let forward_op = build_forward_pass(&model, &bufs);
+///
+/// // Capture: executes once, records into graph, synchronizes.
+/// let mut graph = CudaGraph::capture(stream.clone(), forward_op)?;
+/// let bufs = graph.take_output().unwrap();
+///
+/// // Replay loop.
+/// for _ in 0..n_tokens {
+///     // Optionally: copy new input into a pre-allocated buffer here.
+///     graph.launch()?;
+/// }
+/// ```
+pub struct CudaGraph<T> {
+    stream: Arc<CudaStream>,
+    cu_graph: sys::CUgraph,
+    cu_graph_exec: sys::CUgraphExec,
+    output: Option<T>,
+}
+
+impl<T: Send> CudaGraph<T> {
+    /// Capture a [`DeviceOp`] into a replayable CUDA graph.
+    ///
+    /// Executes `op` once on `stream` in capture mode. All GPU work (kernel
+    /// launches, memcpys, etc.) issued by the operation is recorded into a
+    /// graph. The graph is then instantiated, uploaded, and the stream is
+    /// synchronized so the output `T` is safe to read immediately.
+    ///
+    /// Retrieve the output via [`take_output`](CudaGraph::take_output).
+    pub fn capture(
+        stream: Arc<CudaStream>,
+        op: impl DeviceOp<Output = T>,
+    ) -> Result<Self, DeviceError> {
+        let ctx = stream.context().clone();
+        ctx.bind_to_thread()?;
+
+        // Begin capture.
+        unsafe {
+            stream::begin_capture(stream.cu_stream(), CU_STREAM_CAPTURE_MODE_RELAXED)?;
+        }
+
+        // Execute the operation on the capture stream.
+        let exec_ctx = ExecutionContext::new(stream.clone());
+        let op_result = unsafe { op.execute(&exec_ctx) };
+
+        // End capture — must happen regardless of op success.
+        let end_result = unsafe { stream::end_capture(stream.cu_stream()) };
+
+        // Handle the (op_result, end_result) matrix, cleaning up on failure.
+        let (output, cu_graph) = match (op_result, end_result) {
+            (Err(op_err), Ok(cu_graph)) => {
+                if !cu_graph.is_null() {
+                    unsafe {
+                        let _ = sys::cuGraphDestroy(cu_graph).result();
+                    }
+                }
+                return Err(op_err);
+            }
+            (Err(op_err), Err(_)) => {
+                return Err(op_err);
+            }
+            (Ok(_), Err(capture_err)) => {
+                return Err(DeviceError::Driver(capture_err));
+            }
+            (Ok(output), Ok(cu_graph)) => {
+                if cu_graph.is_null() {
+                    return Err(DeviceError::Internal(
+                        "cuStreamEndCapture returned null graph".into(),
+                    ));
+                }
+                (output, cu_graph)
+            }
+        };
+
+        // Instantiate.
+        let cu_graph_exec = unsafe {
+            let mut cu_graph_exec = MaybeUninit::<sys::CUgraphExec>::uninit();
+            match sys::cuGraphInstantiateWithFlags(cu_graph_exec.as_mut_ptr(), cu_graph, 0).result()
+            {
+                Ok(()) => cu_graph_exec.assume_init(),
+                Err(e) => {
+                    let _ = sys::cuGraphDestroy(cu_graph).result();
+                    return Err(DeviceError::Driver(e));
+                }
+            }
+        };
+
+        // Upload (pre-stages graph resources on the device).
+        if let Err(e) = unsafe { sys::cuGraphUpload(cu_graph_exec, stream.cu_stream()).result() } {
+            unsafe {
+                let _ = sys::cuGraphExecDestroy(cu_graph_exec).result();
+                let _ = sys::cuGraphDestroy(cu_graph).result();
+            }
+            return Err(DeviceError::Driver(e));
+        }
+
+        // Synchronize so the output is safe to read.
+        stream.synchronize()?;
+
+        Ok(Self {
+            stream,
+            cu_graph,
+            cu_graph_exec,
+            output: Some(output),
+        })
+    }
+
+    /// Take the output produced during the capture execution.
+    ///
+    /// Returns `Some(T)` on the first call, `None` thereafter. Use this to
+    /// recover intermediate buffers or inspect the initial result.
+    pub fn take_output(&mut self) -> Option<T> {
+        self.output.take()
+    }
+
+    /// Execute a [`DeviceOp`] on the graph's stream without synchronizing.
+    ///
+    /// Use this to update graph inputs before [`launch`](CudaGraph::launch).
+    /// The operation is issued on the same stream the graph will run on, so
+    /// stream ordering guarantees it completes before the graph's kernels
+    /// begin. Synchronization happens when `launch()` returns.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// // Copy a new embedding into the graph's pre-allocated input buffer.
+    /// graph.update(api::memcpy(&mut h_input, &new_embedding))?;
+    /// graph.launch()?;
+    /// ```
+    pub fn update<O: Send>(&self, op: impl DeviceOp<Output = O>) -> Result<O, DeviceError> {
+        let ctx = ExecutionContext::new(self.stream.clone());
+        unsafe { op.execute(&ctx) }
+    }
+
+    /// Replay the captured graph and synchronize.
+    ///
+    /// Launches the graph on the capture stream and blocks until the GPU
+    /// finishes. Any operations issued via [`update`](CudaGraph::update)
+    /// on the same stream are guaranteed to complete before the graph runs.
+    // TODO: Add `launch_on(&stream)` to support launching on a different
+    // stream than the capture stream (requested by Isaac Gelado).
+    pub fn launch(&self) -> Result<(), DeviceError> {
+        unsafe {
+            sys::cuGraphLaunch(self.cu_graph_exec, self.stream.cu_stream()).result()?;
+        }
+        self.stream.synchronize()?;
+        Ok(())
+    }
+
+    /// Returns a reference to the stream this graph was captured on.
+    pub fn stream(&self) -> &Arc<CudaStream> {
+        &self.stream
+    }
+}
+
+impl<T> Drop for CudaGraph<T> {
+    fn drop(&mut self) {
+        let ctx = self.stream.context();
+        ctx.record_err(ctx.bind_to_thread());
+
+        let cu_graph_exec = std::mem::replace(&mut self.cu_graph_exec, std::ptr::null_mut());
+        if !cu_graph_exec.is_null() {
+            ctx.record_err(unsafe { sys::cuGraphExecDestroy(cu_graph_exec).result() });
+        }
+
+        let cu_graph = std::mem::replace(&mut self.cu_graph, std::ptr::null_mut());
+        if !cu_graph.is_null() {
+            ctx.record_err(unsafe { sys::cuGraphDestroy(cu_graph).result() });
+        }
+    }
+}
+
+/// A scope for recording GPU operations into a CUDA graph.
+///
+/// Created by [`CudaGraph::scope`]. Each call to [`record`](Scope::record)
+/// records a [`GraphNode`] as a graph node. The op is consumed immediately,
+/// releasing any borrows it holds. This means a buffer written by one
+/// kernel can be read by the next — `record` releases the `&mut` borrow,
+/// allowing a subsequent `record` to take `&` on the same buffer.
+///
+/// ```rust,ignore
+/// let graph = CudaGraph::scope(&stream, |s| {
+///     s.record(rms_norm((&mut bufs.norm).partition([1, d]), &input, &w))?;
+///     // bufs.norm borrow released — can now read it:
+///     s.record(matvec((&mut bufs.q).partition([bn]), &bufs.norm, &wq))?;
+///     Ok(())
+/// })?;
+///
+/// graph.launch()?;
+/// ```
+///
+/// # Safety proof: why `record` is safe
+///
+/// A CUDA data race occurs when two accesses to the same device memory
+/// are unordered and at least one is a write. This is UB per both CUDA
+/// and Rust.
+///
+/// `record` is safe because of two complementary mechanisms:
+///
+/// ## Capture mode prevents concurrent GPU execution
+///
+/// The scope's stream is in **capture mode** during the closure (via
+/// `cuStreamBeginCapture`). In capture mode:
+///
+/// 1. **No GPU work executes.** `record` records operations as graph
+///    nodes — kernels are not launched, memcpys are not issued. There
+///    is no in-flight GPU work that could race with anything.
+///
+/// 2. **Same-stream ordering is preserved.** All `record` calls go to
+///    the same capture stream. When the graph is later launched via
+///    [`CudaGraph::launch`], the nodes execute in recorded order on a
+///    single stream. Sequential same-stream execution is ordered — no
+///    data races.
+///
+/// 3. **Cross-stream operations during capture are harmless.** If the
+///    user calls `op.sync_on(&other_stream)` inside the closure, that
+///    work executes eagerly on `other_stream` — but no captured work is
+///    executing concurrently (the capture stream is recording, not
+///    running). At graph launch time, the eagerly-executed work is long
+///    complete. No overlap, no race.
+///
+/// 4. **`sync_on` on the capture stream fails at runtime.** CUDA returns
+///    `CUDA_ERROR_STREAM_CAPTURE_UNSUPPORTED` if you try to synchronize
+///    a stream that is capturing.
+///
+/// 5. **Borrow checker enforces `&mut` exclusivity.** `record` consumes
+///    the op, releasing `&mut`. The next `record` can then borrow the
+///    same buffer as `&` for reading.
+///
+/// ## `GraphNode` prevents allocation during capture
+///
+/// `record` accepts [`GraphNode`] (not [`DeviceOp`]). `GraphNode` is only
+/// implemented by operations that do not allocate or free device memory
+/// (kernel launches, `memcpy`, `value`). This prevents:
+///
+/// - **Address instability:** `cuMemAllocAsync` during capture allocates
+///   memory, but on replay the allocation node may return a different
+///   address. Subsequent nodes bake in the capture-time pointer — UB.
+///
+/// - **Uninitialized reads:** An allocation during capture gives the user
+///   a tensor handle. The initialization (e.g., memset from `zeros`) was
+///   recorded, not executed. Passing the tensor to `sync_on(&other_stream)`
+///   reads uninitialized memory.
+///
+/// - **Invalid frees:** If a tensor allocated inside the scope is dropped,
+///   `cuMemFreeAsync` is recorded. On replay, it frees the capture-time
+///   address, which may no longer be valid.
+///
+/// Since no tensors can be allocated inside the scope, all buffers are
+/// pre-allocated and passed in via borrows. No tensor created inside
+/// the scope means no tensor dropped inside the scope.
+///
+/// # What happens if you call other operations inside the closure
+///
+/// While `s.record(op)` is the intended API, other operations inside
+/// the closure have well-defined behavior:
+///
+/// | Operation | What happens |
+/// |---|---|
+/// | `op.sync_on(&capture_stream)` | Runtime error from CUDA driver |
+/// | `op.sync_on(&other_stream)` | Executes eagerly outside the graph — no race (see point 3) |
+/// | `op.sync()` | May pick the capture stream (error) or another stream (executes eagerly) |
+///
+/// These are all defined behavior but serve no purpose inside a graph
+/// capture scope — use `s.record(op)` instead.
+///
+/// # Thread safety
+///
+/// `Scope` is `!Send` — it cannot escape to another thread.
+///
+/// See `.internal/cuda-graph-redesign/SAFETY_PROOF_CUDA_GRAPH.md` for the full
+/// formal proof.
+pub struct Scope {
+    ctx: ExecutionContext,
+    _not_send: std::marker::PhantomData<*const ()>,
+}
+
+impl Scope {
+    /// Record a [`GraphNode`] into the graph being captured.
+    ///
+    /// The op is consumed, recording its GPU work (kernel launch, memcpy)
+    /// as a graph node. Any borrows held by the op are released when this
+    /// call returns. The return value contains valid metadata (tensor
+    /// shapes, device pointers) but GPU data is not yet computed — the
+    /// actual computation happens when the graph is replayed via
+    /// [`CudaGraph::launch`].
+    ///
+    /// Only operations that implement [`GraphNode`] can be recorded.
+    /// This excludes allocation ops (`zeros`, `ones`, `dup`, etc.)
+    /// whose addresses may change on replay.
+    pub fn record<T: Send>(
+        &self,
+        op: impl GraphNode + DeviceOp<Output = T>,
+    ) -> Result<T, DeviceError> {
+        // SAFETY: The scope's stream is in capture mode. No GPU work
+        // executes — ops are recorded as graph nodes. The GraphNode bound
+        // ensures no alloc/free ops are recorded. See Scope docs for
+        // the full safety proof.
+        unsafe { op.execute(&self.ctx) }
+    }
+}
+
+impl CudaGraph<()> {
+    /// Capture a CUDA graph using a scoped closure.
+    ///
+    /// The closure receives a [`Scope`] for recording operations. Each
+    /// `s.record(op)` records a graph node and consumes the op, releasing
+    /// borrows. A buffer written by one `record` call can be read by the
+    /// next.
+    ///
+    /// Pre-allocate all buffers before calling this method — the graph
+    /// replays into the same device pointers.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// let mut output = api::zeros::<f32>(&[d]).sync_on(&stream)?;
+    /// let weights = api::ones::<f32>(&[d]).sync_on(&stream)?;
+    ///
+    /// let graph = CudaGraph::scope(&stream, |s| {
+    ///     s.record(kernel1((&mut output).partition([128]), &weights))?;
+    ///     s.record(kernel2((&mut output).partition([64]), &weights))?;
+    ///     Ok(())
+    /// })?;
+    ///
+    /// graph.launch()?;
+    /// ```
+    ///
+    /// See [`Scope`] for the safety proof and edge-case behavior.
+    pub fn scope<F>(stream: &Arc<CudaStream>, f: F) -> Result<Self, DeviceError>
+    where
+        F: FnOnce(&Scope) -> Result<(), DeviceError>,
+    {
+        crate::device_operation::acquire_execution_lock()?;
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            Self::scope_inner(stream, f)
+        }));
+
+        crate::device_operation::release_execution_lock();
+
+        match result {
+            Ok(inner) => inner,
+            Err(payload) => std::panic::resume_unwind(payload),
+        }
+    }
+
+    fn scope_inner<F>(stream: &Arc<CudaStream>, f: F) -> Result<Self, DeviceError>
+    where
+        F: FnOnce(&Scope) -> Result<(), DeviceError>,
+    {
+        let ctx = stream.context().clone();
+        ctx.bind_to_thread()?;
+
+        // Begin capture.
+        unsafe {
+            stream::begin_capture(stream.cu_stream(), CU_STREAM_CAPTURE_MODE_RELAXED)?;
+        }
+
+        let scope = Scope {
+            ctx: ExecutionContext::new(stream.clone()),
+            _not_send: std::marker::PhantomData,
+        };
+
+        // Run the closure. Catch panics so cuStreamEndCapture always runs.
+        let scope_result =
+            match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| f(&scope))) {
+                Ok(result) => result,
+                Err(panic_payload) => {
+                    let _ = unsafe { stream::end_capture(stream.cu_stream()) };
+                    std::panic::resume_unwind(panic_payload);
+                }
+            };
+
+        // End capture.
+        let end_result = unsafe { stream::end_capture(stream.cu_stream()) };
+
+        let cu_graph = match (scope_result, end_result) {
+            (Err(scope_err), Ok(cu_graph)) => {
+                if !cu_graph.is_null() {
+                    unsafe {
+                        let _ = sys::cuGraphDestroy(cu_graph).result();
+                    }
+                }
+                return Err(scope_err);
+            }
+            (Err(scope_err), Err(_)) => {
+                return Err(scope_err);
+            }
+            (Ok(_), Err(capture_err)) => {
+                return Err(DeviceError::Driver(capture_err));
+            }
+            (Ok(()), Ok(cu_graph)) => {
+                if cu_graph.is_null() {
+                    return Err(DeviceError::Internal(
+                        "cuStreamEndCapture returned null graph".into(),
+                    ));
+                }
+                cu_graph
+            }
+        };
+
+        // Instantiate.
+        let cu_graph_exec = unsafe {
+            let mut cu_graph_exec = MaybeUninit::<sys::CUgraphExec>::uninit();
+            match sys::cuGraphInstantiateWithFlags(cu_graph_exec.as_mut_ptr(), cu_graph, 0).result()
+            {
+                Ok(()) => cu_graph_exec.assume_init(),
+                Err(e) => {
+                    let _ = sys::cuGraphDestroy(cu_graph).result();
+                    return Err(DeviceError::Driver(e));
+                }
+            }
+        };
+
+        // Upload.
+        if let Err(e) = unsafe { sys::cuGraphUpload(cu_graph_exec, stream.cu_stream()).result() } {
+            unsafe {
+                let _ = sys::cuGraphExecDestroy(cu_graph_exec).result();
+                let _ = sys::cuGraphDestroy(cu_graph).result();
+            }
+            return Err(DeviceError::Driver(e));
+        }
+
+        // Synchronize.
+        stream.synchronize()?;
+
+        Ok(CudaGraph {
+            stream: stream.clone(),
+            cu_graph,
+            cu_graph_exec,
+            output: Some(()),
+        })
+    }
+}
+
+/// A graph-backed inference module.
+///
+/// Implementations own a [`CudaGraph`] captured at construction time.
+/// Each call to [`forward`](Module::forward) updates the input buffer and
+/// replays the graph, returning the result synchronously.
+///
+/// # Construction
+///
+/// Graph capture is model-specific and happens in the implementation's
+/// constructor — not in the trait. A typical pattern:
+///
+/// ```rust,ignore
+/// use cuda_async::prelude::*;
+///
+/// struct MyModel {
+///     graph: CudaGraph<Arc<Tensor<f32>>>,
+///     h_input: Tensor<f32>,
+///     output: Arc<Tensor<f32>>,
+/// }
+///
+/// impl MyModel {
+///     fn new(stream: Arc<CudaStream>) -> Result<Self, DeviceError> {
+///         let h_input = api::zeros(&[d]).sync_on(&stream)?;
+///         let forward_op = build_forward(h_input.clone().into());
+///         let mut graph = forward_op.graph_on(stream)?;
+///         let output = graph.take_output().unwrap();
+///         Ok(Self { graph, h_input, output })
+///     }
+/// }
+///
+/// impl Module for MyModel {
+///     type Input = Arc<Tensor<f32>>;
+///     type Output = Arc<Tensor<f32>>;
+///
+///     fn forward(&mut self, input: Self::Input)
+///         -> Result<Self::Output, DeviceError>
+///     {
+///         self.graph.update(
+///             api::memcpy(&mut self.h_input, &input)
+///         )?;
+///         self.graph.launch()?;
+///         Ok(self.output.clone())
+///     }
+/// }
+/// ```
+///
+/// # Future extensions
+///
+/// This trait covers the forward pass. Planned companion traits:
+/// - `Backward` — gradient computation for autodiff
+/// - `Parameterized` — access to learnable parameters for optimizers
+pub trait Module {
+    /// The input to the module (e.g., an embedding tensor).
+    type Input: Send;
+    /// The output of the module (e.g., logits or a hidden state).
+    type Output: Send;
+
+    /// Run the forward pass: update the input, launch the graph, return
+    /// the result.
+    fn forward(&mut self, input: Self::Input) -> Result<Self::Output, DeviceError>;
+}

--- a/cuda-async/src/device_context.rs
+++ b/cuda-async/src/device_context.rs
@@ -6,7 +6,7 @@
 //! Thread-local GPU device state, kernel cache, and scheduling policy management.
 
 use crate::error::{device_assert, device_error, DeviceError};
-use crate::scheduling_policies::{GlobalSchedulingPolicy, SchedulingPolicy, StreamPoolRoundRobin};
+use crate::scheduling_policies::{SchedulingPolicy, StreamPoolRoundRobin};
 use cuda_core::{CudaContext, CudaFunction, CudaModule, CudaStream};
 use std::cell::Cell;
 use std::collections::HashMap;
@@ -74,7 +74,7 @@ type DeviceFunctionValidators = HashMap<String, Arc<Validator>>;
 /// Each GPU device has one `AsyncDeviceContext` stored in a thread-local map. It holds:
 ///
 /// - A [`CudaContext`] for driver API calls.
-/// - A [`GlobalSchedulingPolicy`] that decides which stream each operation runs on.
+/// - A [`SchedulingPolicy`] that decides which stream each operation runs on.
 /// - A cache of already-compiled kernel functions (keyed by [`FunctionKey::get_hash_string()`]).
 ///
 /// The context is lazily initialized on first use with the default round-robin policy
@@ -87,7 +87,7 @@ pub struct AsyncDeviceContext {
     // TODO: (hme): This will hurt perf due to contention. This should at least be static (OnceLock?).
     context: Arc<CudaContext>,
     deallocator_stream: Arc<CudaStream>,
-    policy: Arc<GlobalSchedulingPolicy>,
+    policy: Arc<dyn SchedulingPolicy>,
     functions: DeviceFunctions,
     validators: DeviceFunctionValidators,
 }
@@ -154,17 +154,15 @@ pub fn init_device_contexts_default() -> Result<(), DeviceError> {
 /// runtime auto-initialize with the default policy.
 pub fn new_device_context(
     device_id: usize,
-    mut policy: GlobalSchedulingPolicy,
+    policy: Arc<dyn SchedulingPolicy>,
 ) -> Result<AsyncDeviceContext, DeviceError> {
-    // device_id is a usize, device_id >= 0 is always true.
     let context = CudaContext::new(device_id)?;
-    policy.init(&context)?;
     let deallocator_stream = context.new_stream()?;
     Ok(AsyncDeviceContext {
         device_id,
         context,
         deallocator_stream,
-        policy: Arc::new(policy),
+        policy,
         functions: HashMap::new(),
         validators: HashMap::new(),
     })
@@ -187,7 +185,7 @@ pub fn new_device_context(
 pub fn init_device(
     hashmap: &mut HashMap<usize, AsyncDeviceContext>,
     device_id: usize,
-    policy: GlobalSchedulingPolicy,
+    policy: Arc<dyn SchedulingPolicy>,
 ) -> Result<(), DeviceError> {
     let device_context = new_device_context(device_id, policy)?;
     let pred = hashmap.insert(device_id, device_context).is_none();
@@ -198,13 +196,19 @@ pub fn init_with_default_policy(
     hashmap: &mut HashMap<usize, AsyncDeviceContext>,
     device_id: usize,
 ) -> Result<(), DeviceError> {
-    let policy =
-        unsafe { StreamPoolRoundRobin::new(device_id, DEFAULT_ROUND_ROBIN_STREAM_POOL_SIZE) };
-    init_device(
-        hashmap,
+    let context = CudaContext::new(device_id)?;
+    let policy = StreamPoolRoundRobin::new(&context, DEFAULT_ROUND_ROBIN_STREAM_POOL_SIZE)?;
+    let deallocator_stream = context.new_stream()?;
+    let device_context = AsyncDeviceContext {
         device_id,
-        GlobalSchedulingPolicy::RoundRobin(policy),
-    )
+        context,
+        deallocator_stream,
+        policy: Arc::new(policy),
+        functions: HashMap::new(),
+        validators: HashMap::new(),
+    };
+    let pred = hashmap.insert(device_id, device_context).is_none();
+    device_assert(device_id, pred, "Device is already initialized.")
 }
 
 pub fn with_global_device_context<F, R>(device_id: usize, f: F) -> Result<R, DeviceError>
@@ -218,7 +222,7 @@ where
                 init_device_contexts_default()?;
                 ctx.devices
                     .take()
-                    .ok_or_else(|| device_error(device_id, "Failed to initialize context"))?
+                    .ok_or(device_error(device_id, "Failed to initialize context"))?
             }
         };
         if !hashmap.contains_key(&device_id) {
@@ -226,7 +230,7 @@ where
         }
         let device_context = hashmap
             .get(&device_id)
-            .ok_or_else(|| device_error(device_id, "Failed to get context"))?;
+            .ok_or(device_error(device_id, "Failed to get context"))?;
         let r = f(device_context);
         ctx.devices.replace(Some(hashmap));
         Ok(r)
@@ -244,7 +248,7 @@ where
                 init_device_contexts_default()?;
                 ctx.devices
                     .take()
-                    .ok_or_else(|| device_error(device_id, "Failed to initialize context"))?
+                    .ok_or(device_error(device_id, "Failed to initialize context"))?
             }
         };
         if !hashmap.contains_key(&device_id) {
@@ -252,7 +256,7 @@ where
         }
         let device_context = hashmap
             .get_mut(&device_id)
-            .ok_or_else(|| device_error(device_id, "Failed to get context"))?;
+            .ok_or(device_error(device_id, "Failed to get context"))?;
         let r = f(device_context);
         ctx.devices.replace(Some(hashmap));
         Ok(r)
@@ -262,7 +266,7 @@ where
 /// Run a closure with a reference to the scheduling policy for `device_id`.
 pub fn with_device_policy<F, R>(device_id: usize, f: F) -> Result<R, DeviceError>
 where
-    F: FnOnce(&Arc<GlobalSchedulingPolicy>) -> R,
+    F: FnOnce(&Arc<dyn SchedulingPolicy>) -> R,
 {
     with_global_device_context(device_id, |device_context| f(&device_context.policy))
 }
@@ -271,10 +275,8 @@ where
 ///
 /// Useful when you need to schedule operations on a specific device outside the
 /// default `.await` / `.sync()` path.
-pub fn global_policy(device_id: usize) -> Result<Arc<GlobalSchedulingPolicy>, DeviceError> {
-    with_global_device_context(device_id, |device_context| {
-        Arc::clone(&device_context.policy)
-    })
+pub fn global_policy(device_id: usize) -> Result<Arc<dyn SchedulingPolicy>, DeviceError> {
+    with_global_device_context(device_id, |device_context| device_context.policy.clone())
 }
 
 pub unsafe fn with_deallocator_stream<F, R>(device_id: usize, f: F) -> Result<R, DeviceError>
@@ -306,7 +308,7 @@ where
 /// ```rust,ignore
 /// // Thread dedicated to device 1:
 /// set_default_device(1);
-/// let tensor = api::zeros([1024, 1024]).await; // runs on GPU 1
+/// let tensor = api::zeros(&[1024, 1024]).await; // runs on GPU 1
 /// ```
 pub fn set_default_device(default_device_id: usize) {
     DEVICE_CONTEXTS.with(|ctx| {
@@ -316,11 +318,11 @@ pub fn set_default_device(default_device_id: usize) {
 
 /// Run a closure with the scheduling policy of the current thread's default device.
 ///
-/// This is the function called internally by [`DeviceOperation::sync()`] and by the
+/// This is the function called internally by [`DeviceOp::sync()`] and by the
 /// [`IntoFuture`] implementation to schedule operations when no explicit device is given.
 pub fn with_default_device_policy<F, R>(f: F) -> Result<R, DeviceError>
 where
-    F: FnOnce(&Arc<GlobalSchedulingPolicy>) -> R,
+    F: FnOnce(&Arc<dyn SchedulingPolicy>) -> R,
 {
     let default_device = get_default_device();
     with_global_device_context(default_device, |device_context| f(&device_context.policy))
@@ -359,7 +361,7 @@ pub fn insert_cuda_function(
 ) -> Result<(), DeviceError> {
     with_global_device_context_mut(device_id, |device_context| {
         let key = func_key.get_hash_string();
-        let res = device_context.functions.insert(key, value);
+        let res = device_context.functions.insert(key.clone(), value);
         device_assert(device_id, res.is_none(), "Unexpected cache key collision.")
     })?
 }
@@ -385,11 +387,11 @@ pub fn get_cuda_function(
 ) -> Result<Arc<CudaFunction>, DeviceError> {
     with_global_device_context(device_id, |device_context| {
         let key = func_key.get_hash_string();
-        let (_module, function) = device_context
+        let entry = device_context
             .functions
             .get(&key)
-            .ok_or_else(|| device_error(device_id, "Failed to get cuda function."))?;
-        Ok(Arc::clone(function))
+            .ok_or(device_error(device_id, "Failed to get cuda function."))?;
+        Ok(entry.1.clone())
     })?
 }
 
@@ -400,7 +402,7 @@ pub fn insert_function_validator(
 ) -> Result<(), DeviceError> {
     with_global_device_context_mut(device_id, |device_context| {
         let key = func_key.get_hash_string();
-        let res = device_context.validators.insert(key, value);
+        let res = device_context.validators.insert(key.clone(), value);
         device_assert(device_id, res.is_none(), "Unexpected cache key collision.")
     })?
 }
@@ -411,10 +413,10 @@ pub fn get_function_validator(
 ) -> Result<Arc<Validator>, DeviceError> {
     with_global_device_context(device_id, |device_context| {
         let key = func_key.get_hash_string();
-        let validator = device_context
+        let entry = device_context
             .validators
             .get(&key)
-            .ok_or_else(|| device_error(device_id, "Failed to get function validator."))?;
-        Ok(Arc::clone(validator))
+            .ok_or(device_error(device_id, "Failed to get function validator."))?;
+        Ok(entry.clone())
     })?
 }

--- a/cuda-async/src/device_future.rs
+++ b/cuda-async/src/device_future.rs
@@ -5,7 +5,7 @@
 
 //! Future type that bridges CUDA stream callbacks with Rust's async executor.
 
-use crate::device_operation::{DeviceOperation, ExecutionContext};
+use crate::device_operation::{DeviceOp, ExecutionContext};
 use crate::error::DeviceError;
 use futures::task::AtomicWaker;
 use std::future::Future;
@@ -15,14 +15,13 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 /// State machine for tracking the lifecycle of a device future.
-#[derive(Debug, Default, Eq, PartialEq, Copy, Clone)]
+#[derive(Debug, Eq, PartialEq, Copy, Clone)]
 pub enum DeviceFutureState {
     // The future was created with an error and will resolve immediately on first poll.
     /// The future was created with an error and will resolve immediately.
     Failed,
     // The stream operation has not yet been scheduled. No callback has been added.
     /// The stream operation has not yet been scheduled.
-    #[default]
     Idle,
     // The stream operation has been scheduled and a callback has been added to the stream.
     // The callback should be added such that it immediately succeeds the scheduled operation.
@@ -34,7 +33,7 @@ pub enum DeviceFutureState {
 }
 
 /// Shared state between a CUDA stream callback and the async waker.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct StreamCallbackState {
     pub(crate) waker: AtomicWaker,
     pub(crate) complete: AtomicBool,
@@ -43,7 +42,10 @@ pub struct StreamCallbackState {
 impl StreamCallbackState {
     /// Creates a new callback state with the completion flag unset.
     pub fn new() -> Self {
-        Self::default()
+        Self {
+            waker: AtomicWaker::new(),
+            complete: AtomicBool::new(false),
+        }
     }
     /// Marks the operation as complete and wakes the associated task.
     pub fn signal(&self) {
@@ -52,9 +54,9 @@ impl StreamCallbackState {
     }
 }
 
-/// A future that executes a [`DeviceOperation`] on a CUDA stream and resolves upon completion.
+/// A future that executes a [`DeviceOp`] on a CUDA stream and resolves upon completion.
 #[derive(Debug)]
-pub struct DeviceFuture<T: Send, DO: DeviceOperation<Output = T>> {
+pub struct DeviceFuture<T: Send, DO: DeviceOp<Output = T>> {
     pub(crate) device_operation: Option<DO>,
     pub(crate) execution_context: Option<ExecutionContext>,
     pub(crate) result: Option<T>,
@@ -63,10 +65,19 @@ pub struct DeviceFuture<T: Send, DO: DeviceOperation<Output = T>> {
     pub(crate) callback_state: Option<Arc<StreamCallbackState>>,
 }
 
-impl<T: Send, DO: DeviceOperation<Output = T>> DeviceFuture<T, DO> {
+impl<T: Send, DO: DeviceOp<Output = T>> DeviceFuture<T, DO> {
     /// Creates an idle device future with no operation or execution context set.
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Creates a device future scheduled on the given stream.
+    pub fn scheduled(op: DO, ctx: ExecutionContext) -> Self {
+        Self {
+            device_operation: Some(op),
+            execution_context: Some(ctx),
+            ..Default::default()
+        }
     }
 
     /// Create a future that is pre-loaded with an error.
@@ -93,11 +104,12 @@ impl<T: Send, DO: DeviceOperation<Output = T>> DeviceFuture<T, DO> {
         &self,
         waker_state: Arc<StreamCallbackState>,
     ) -> Result<(), DeviceError> {
-        let ctx = self.execution_context.as_ref().ok_or_else(|| {
-            DeviceError::Internal(
+        let ctx = self
+            .execution_context
+            .as_ref()
+            .ok_or(DeviceError::Internal(
                 "Cannot execute future without setting stream on which to execute.".to_string(),
-            )
-        })?;
+            ))?;
         ctx.get_cuda_stream().launch_host_function(move || {
             waker_state.signal();
         })?;
@@ -105,41 +117,40 @@ impl<T: Send, DO: DeviceOperation<Output = T>> DeviceFuture<T, DO> {
     }
     /// Executes the stored device operation on the associated stream.
     fn execute(&mut self) -> Result<(), DeviceError> {
-        let ctx = self.execution_context.as_ref().ok_or_else(|| {
-            DeviceError::Internal(
+        let ctx = self
+            .execution_context
+            .as_ref()
+            .ok_or(DeviceError::Internal(
                 "Cannot execute future without setting stream on which to execute.".to_string(),
-            )
-        })?;
+            ))?;
         // TODO (hme): We may need to hold a reference to device_operation,
         //  to ensure kernel launch structs (and their args) are dropped
         //  when the future completes vs. when this function completes.
-        let operation = self.device_operation.take().ok_or_else(|| {
-            DeviceError::Internal(
-                "Unable to execute future: No operation has been set.".to_string(),
-            )
-        })?;
+        let operation = self.device_operation.take().ok_or(DeviceError::Internal(
+            "Unable to execute future: No operation has been set.".to_string(),
+        ))?;
         let out = unsafe { operation.execute(ctx) }?;
         self.result = Some(out);
         Ok(())
     }
 }
 
-impl<T: Send, DO: DeviceOperation<Output = T>> Default for DeviceFuture<T, DO> {
+impl<T: Send, DO: DeviceOp<Output = T>> Default for DeviceFuture<T, DO> {
     fn default() -> Self {
         Self {
-            device_operation: Default::default(),
-            execution_context: Default::default(),
-            result: Default::default(),
-            error: Default::default(),
-            state: Default::default(),
-            callback_state: Default::default(),
+            device_operation: None,
+            execution_context: None,
+            result: None,
+            error: None,
+            state: DeviceFutureState::Idle,
+            callback_state: None,
         }
     }
 }
 
-impl<T: Send, DO: DeviceOperation<Output = T>> Unpin for DeviceFuture<T, DO> {}
+impl<T: Send, DO: DeviceOp<Output = T>> Unpin for DeviceFuture<T, DO> {}
 
-impl<T: Send, DO: DeviceOperation<Output = T>> Future for DeviceFuture<T, DO> {
+impl<T: Send, DO: DeviceOp<Output = T>> Future for DeviceFuture<T, DO> {
     type Output = Result<T, DeviceError>;
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         if self.state == DeviceFutureState::Failed {
@@ -155,26 +166,32 @@ impl<T: Send, DO: DeviceOperation<Output = T>> Future for DeviceFuture<T, DO> {
         if self.callback_state.is_none() {
             self.callback_state = Some(Arc::new(StreamCallbackState::new()));
         }
-        let waker_state = self
-            .callback_state
-            .as_ref()
-            .map(Arc::clone)
-            .expect("Impossible.");
+        let waker_state = self.callback_state.as_ref().cloned().expect("Impossible.");
         match self.state {
             DeviceFutureState::Idle => {
+                // Acquire the thread-local execution lock.
+                if let Err(e) = crate::device_operation::acquire_execution_lock() {
+                    self.state = DeviceFutureState::Complete;
+                    return Poll::Ready(Err(e));
+                }
                 // Initialize the waker.
                 waker_state.waker.register(cx.waker());
                 // Execute this future's operation.
                 if let Err(e) = self.execute() {
+                    crate::device_operation::release_execution_lock();
                     self.state = DeviceFutureState::Complete;
                     return Poll::Ready(Err(e));
                 }
                 // Add the callback. We only want to do this once.
-                if let Err(e) = unsafe { self.register_callback(Arc::clone(&waker_state)) } {
+                if let Err(e) = unsafe { self.register_callback(waker_state.clone()) } {
+                    crate::device_operation::release_execution_lock();
                     self.state = DeviceFutureState::Complete;
                     return Poll::Ready(Err(e));
                 }
                 // Transition the future's state to "Executing."
+                // Release the lock — the GPU work is submitted and the
+                // callback will signal completion asynchronously.
+                crate::device_operation::release_execution_lock();
                 self.state = DeviceFutureState::Executing;
                 Poll::Pending
             }

--- a/cuda-async/src/device_operation.rs
+++ b/cuda-async/src/device_operation.rs
@@ -10,12 +10,49 @@ use crate::device_future::DeviceFuture;
 use crate::error::{device_error, DeviceError};
 use crate::scheduling_policies::SchedulingPolicy;
 use cuda_core::{CudaContext, CudaStream};
-use std::cell::UnsafeCell;
+use std::cell::{Cell, UnsafeCell};
 use std::fmt::Debug;
 use std::future::IntoFuture;
 use std::marker::PhantomData;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+
+// ── Thread-local execution guard ───────────────────────────────────────────
+//
+// Invariant: On any given thread, only one DeviceOp may be executing at a time.
+//
+// This prevents CUDA data races from nested execution (e.g., calling
+// sync_on(&other_stream) inside a `then` closure with in-flight tensors).
+
+thread_local! {
+    static DEVICE_OP_EXECUTING: Cell<bool> = const { Cell::new(false) };
+}
+
+/// Acquire the thread-local execution lock. Returns an error if another
+/// DeviceOp is already executing on this thread.
+pub(crate) fn acquire_execution_lock() -> Result<(), DeviceError> {
+    DEVICE_OP_EXECUTING.with(|flag| {
+        if flag.get() {
+            Err(DeviceError::Internal(
+                "DeviceOp execution is non-reentrant: another DeviceOp is already \
+                 executing on this thread. If this is intentional and you have \
+                 verified there are no cross-stream data races, use \
+                 `then_unchecked`."
+                    .into(),
+            ))
+        } else {
+            flag.set(true);
+            Ok(())
+        }
+    })
+}
+
+/// Release the thread-local execution lock.
+pub(crate) fn release_execution_lock() {
+    DEVICE_OP_EXECUTING.with(|flag| {
+        flag.set(false);
+    });
+}
 
 pub type Device = usize;
 
@@ -28,7 +65,7 @@ pub struct ExecutionContext {
 
 impl ExecutionContext {
     pub fn new(cuda_stream: Arc<CudaStream>) -> Self {
-        let cuda_context = Arc::clone(cuda_stream.context());
+        let cuda_context = cuda_stream.context().clone();
         let device = cuda_context.ordinal();
         Self {
             cuda_stream,
@@ -49,10 +86,10 @@ impl ExecutionContext {
         dead_code,
         reason = "kept for direct synchronous execution in tests and future blocking APIs"
     )]
-    fn execute<T: Send>(&self, op: impl DeviceOperation<Output = T>) -> Result<T, DeviceError> {
+    fn execute<T: Send>(&self, op: impl DeviceOp<Output = T>) -> Result<T, DeviceError> {
         unsafe {
-            // Safety: ExecutionContext is only available within a DeviceOperation closure.
-            // DeviceOperation closures can only be converted into DeviceFuture
+            // Safety: ExecutionContext is only available within a DeviceOp closure.
+            // DeviceOp closures can only be converted into DeviceFuture
             // which synchronizes device operations with the host thread via a host callback.
             op.execute(self)
         }
@@ -61,7 +98,7 @@ impl ExecutionContext {
 
 /// A lazy, composable GPU operation that may be executed synchronously or asynchronously on a CUDA device.
 ///
-/// `DeviceOperation` represents a resource-agnostic computation that will be scheduled and executed.
+/// `DeviceOp` represents a resource-agnostic computation that will be scheduled and executed.
 /// The actual execution resource (stream, device, host machine, cluster, etc.) is determined when the
 /// operation is either executed or converted into a future.
 /// Device operations are lazy - they don't execute until synchronously executed, or a corresponding
@@ -82,7 +119,7 @@ impl ExecutionContext {
 ///
 /// With the default [`StreamPoolRoundRobin`] policy (4 streams), consecutive `.await` or
 /// `.sync()` calls rotate through streams, so independent operations can overlap on the GPU.
-/// Operations chained with [`.and_then()`](DeviceOperation::and_then) share a single stream
+/// Operations chained with [`.then()`](DeviceOp::then) share a single stream
 /// and always execute in order.
 ///
 /// See [`SchedulingPolicy`] for a full explanation of ordering guarantees.
@@ -90,32 +127,32 @@ impl ExecutionContext {
 /// # Safety
 ///
 /// The `execute` method is unsafe because it's asynchronous - the GPU may still be writing to
-/// memory allocated by the output after `execute` returns. Converting a `DeviceOperation` into
+/// memory allocated by the output after `execute` returns. Converting a `DeviceOp` into
 /// a `DeviceFuture` ensures memory operations complete before the output can be accessed.
 ///
 /// ## Examples
 ///
 /// ```rust,ignore
-/// use cuda_async::device_operation::{DeviceOperation, value};
+/// use cuda_async::device_operation::{DeviceOp, value};
 ///
 /// // Create a simple value operation
 /// let op1 = value(42);
 ///
 /// // Chain operations together
-/// let op2 = op1.and_then(|x| value(x * 2));
+/// let op2 = op1.then(|x| value(x * 2));
 ///
 /// // Execute synchronously (blocks until GPU completes)
 /// let result = op2.sync().expect("Device operation failed."); // returns 84
 /// ```
 ///
 /// ```rust,ignore
-/// use cuda_async::device_operation::{DeviceOperation, zip};
+/// use cuda_async::device_operation::{DeviceOp, zip};
 /// use cutile::api;
 ///
 /// // Compose multiple tensor operations
-/// let x = api::zeros([64, 64]);
-/// let y = api::ones([64, 64]);
-/// let combined = zip!(x, y).and_then(|(x, y)| {
+/// let x = api::zeros(&[64, 64]);
+/// let y = api::ones(&[64, 64]);
+/// let combined = zip!(x, y).then(|(x, y)| {
 ///     // Both tensors are ready here
 ///     value((x, y))
 /// });
@@ -126,95 +163,197 @@ impl ExecutionContext {
 /// Operations automatically implement `IntoFuture`, enabling use with `.await`:
 ///
 /// ```rust,ignore
-/// let x = api::randn(0.0, 1.0, [100, 100]).arc().await?;
-/// let y = some_kernel(Arc::clone(&x)).await;
+/// let x: Arc<Tensor<f32>> = api::randn(0.0, 1.0, &[100, 100]).await?.into();
+/// let y = some_kernel(x.clone()).await?;
 /// ```
-pub trait DeviceOperation:
-    Send + Sized + IntoFuture<Output = Result<<Self as DeviceOperation>::Output, DeviceError>>
+pub trait DeviceOp:
+    Send + Sized + IntoFuture<Output = Result<<Self as DeviceOp>::Output, DeviceError>>
 {
     type Output: Send;
 
-    // Consumes DeviceOperation and executes the implementing operation.
+    // Consumes DeviceOp and executes the implementing operation.
     // This is unsafe because it is asynchronous: A device may be writing to memory allocated
     // by the output.
-    // Converting DeviceOperation into a DeviceFuture ensures any memory operations are complete
+    // Converting DeviceOp into a DeviceFuture ensures any memory operations are complete
     // before the output can be accessed by the async runtime.
     unsafe fn execute(
         self,
         context: &ExecutionContext,
-    ) -> Result<<Self as DeviceOperation>::Output, DeviceError>;
+    ) -> Result<<Self as DeviceOp>::Output, DeviceError>;
     /// Schedule this operation on a specific policy and return a [`DeviceFuture`].
-    fn schedule<P: SchedulingPolicy>(
+    fn schedule(
         self,
-        policy: &P,
-    ) -> Result<DeviceFuture<<Self as DeviceOperation>::Output, Self>, DeviceError> {
-        policy.schedule(self)
-    }
-    /// Alias for [`DeviceOperation::and_then`].
-    ///
-    /// `apply` sequences on this operation's resolved output, rather than
-    /// transforming the operation object itself.
-    fn apply<O: Send, DO, F>(
-        self,
-        f: F,
-    ) -> AndThen<<Self as DeviceOperation>::Output, Self, O, DO, F>
-    where
-        DO: DeviceOperation<Output = O>,
-        F: FnOnce(<Self as DeviceOperation>::Output) -> DO,
-    {
-        self.and_then(f)
+        policy: &Arc<dyn SchedulingPolicy>,
+    ) -> Result<DeviceFuture<<Self as DeviceOp>::Output, Self>, DeviceError> {
+        let stream = policy.next_stream()?;
+        let mut future = DeviceFuture::new();
+        future.device_operation = Some(self);
+        future.execution_context = Some(ExecutionContext::new(stream));
+        Ok(future)
     }
     /// Chain a follow-up operation that runs **on the same stream** as `self`.
     ///
     /// Because both operations share a stream, `f` is guaranteed to see `self`'s output
     /// fully written. This is the recommended way to express data dependencies without
     /// manual synchronization.
-    fn and_then<O: Send, DO, F>(
-        self,
-        f: F,
-    ) -> AndThen<<Self as DeviceOperation>::Output, Self, O, DO, F>
+    ///
+    /// The closure must not execute other DeviceOps (e.g., via `sync_on` or `sync`).
+    /// This is enforced at runtime by the thread-local execution lock — attempting
+    /// nested execution will return a `DeviceError`.
+    fn then<O: Send, DO, F>(self, f: F) -> AndThen<<Self as DeviceOp>::Output, Self, O, DO, F>
     where
-        DO: DeviceOperation<Output = O>,
-        F: FnOnce(<Self as DeviceOperation>::Output) -> DO,
+        DO: DeviceOp<Output = O>,
+        F: FnOnce(<Self as DeviceOp>::Output) -> DO,
     {
         AndThen {
             op: self,
             closure: f,
         }
     }
+    /// Like [`then`](DeviceOp::then), but without the thread-local execution lock.
+    ///
+    /// # Safety
+    ///
+    /// The closure must not submit GPU work to any stream other than the
+    /// chain's stream using tensors from the output. Violating this causes
+    /// CUDA data races (undefined behavior).
+    unsafe fn then_unchecked<O: Send, DO, F>(
+        self,
+        f: F,
+    ) -> AndThen<<Self as DeviceOp>::Output, Self, O, DO, F>
+    where
+        DO: DeviceOp<Output = O>,
+        F: FnOnce(<Self as DeviceOp>::Output) -> DO,
+    {
+        AndThen {
+            op: self,
+            closure: f,
+        }
+    }
+    /// Transform the output of this operation without issuing new GPU work.
+    fn map<O: Send, F>(
+        self,
+        f: F,
+    ) -> AndThen<
+        <Self as DeviceOp>::Output,
+        Self,
+        O,
+        Value<O>,
+        impl FnOnce(<Self as DeviceOp>::Output) -> Value<O> + Send,
+    >
+    where
+        F: FnOnce(<Self as DeviceOp>::Output) -> O + Send,
+    {
+        self.then(move |x| value(f(x)))
+    }
+    /// Peek at the output for debugging without consuming or transforming it.
+    fn inspect<F>(
+        self,
+        f: F,
+    ) -> AndThen<
+        <Self as DeviceOp>::Output,
+        Self,
+        <Self as DeviceOp>::Output,
+        Value<<Self as DeviceOp>::Output>,
+        impl FnOnce(<Self as DeviceOp>::Output) -> Value<<Self as DeviceOp>::Output> + Send,
+    >
+    where
+        F: FnOnce(&<Self as DeviceOp>::Output) + Send,
+    {
+        self.map(move |x| {
+            f(&x);
+            x
+        })
+    }
     fn and_then_with_context<O: Send, DO, F>(
         self,
         f: F,
-    ) -> AndThenWithContext<<Self as DeviceOperation>::Output, Self, O, DO, F>
+    ) -> AndThenWithContext<<Self as DeviceOp>::Output, Self, O, DO, F>
     where
-        DO: DeviceOperation<Output = O>,
-        F: FnOnce(&ExecutionContext, <Self as DeviceOperation>::Output) -> DO,
+        DO: DeviceOp<Output = O>,
+        F: FnOnce(&ExecutionContext, <Self as DeviceOp>::Output) -> DO,
     {
         AndThenWithContext {
             op: self,
             closure: f,
         }
     }
-    fn arc(self) -> DeviceOperationArc<<Self as DeviceOperation>::Output, Self>
+    /// Type-erase this operation into a [`BoxedDeviceOp`].
+    ///
+    /// This allows heterogeneous collections of operations that share the same
+    /// output type but differ in their concrete type (e.g. mixing `Value`,
+    /// `SelectLeft`, etc. in a single `Vec`).
+    fn boxed(self) -> BoxedDeviceOp<<Self as DeviceOp>::Output>
     where
-        <Self as DeviceOperation>::Output: Sync,
+        Self: 'static,
     {
-        DeviceOperationArc { op: self }
+        BoxedDeviceOp {
+            inner: Box::new(move |ctx| unsafe { self.execute(ctx) }),
+        }
+    }
+    /// Convert into a cloneable, execute-once operation.
+    ///
+    /// The underlying op executes at most once; every clone gets `Arc::clone()`
+    /// of the cached result. Follows the `FutureExt::shared()` convention.
+    fn shared(self) -> SharedDeviceOp<<Self as DeviceOp>::Output>
+    where
+        Self: 'static,
+        <Self as DeviceOp>::Output: Sync,
+    {
+        SharedDeviceOp {
+            inner: Arc::new(SharedExec {
+                computed: AtomicBool::new(false),
+                op: UnsafeCell::new(Some(Box::new(move |ctx: &ExecutionContext| unsafe {
+                    self.execute(ctx)
+                }))),
+                result: UnsafeCell::new(None),
+            }),
+        }
+    }
+    /// Capture this operation into a replayable [`CudaGraph`](crate::cuda_graph::CudaGraph)
+    /// using the default device's scheduling policy to pick a stream.
+    fn graph(
+        self,
+    ) -> Result<crate::cuda_graph::CudaGraph<<Self as DeviceOp>::Output>, DeviceError> {
+        with_default_device_policy(|policy| {
+            let stream = policy.next_stream()?;
+            self.graph_on(stream)
+        })?
+    }
+    /// Capture this operation into a replayable [`CudaGraph`](crate::cuda_graph::CudaGraph)
+    /// on an **explicit stream**.
+    ///
+    /// Executes the operation once on `stream` in capture mode, recording
+    /// all GPU work. Returns a `CudaGraph<Self::Output>` containing the
+    /// replayable graph and the initial output.
+    fn graph_on(
+        self,
+        stream: Arc<CudaStream>,
+    ) -> Result<crate::cuda_graph::CudaGraph<<Self as DeviceOp>::Output>, DeviceError> {
+        crate::cuda_graph::CudaGraph::capture(stream, self)
     }
     /// Execute synchronously using the default device's scheduling policy.
     ///
     /// The policy picks a stream (round-robin by default), submits the work, and blocks
     /// until the GPU finishes. Equivalent to `.await` but blocking.
-    fn sync(self) -> Result<<Self as DeviceOperation>::Output, DeviceError> {
-        with_default_device_policy(|policy| policy.sync(self))?
+    fn sync(self) -> Result<<Self as DeviceOp>::Output, DeviceError> {
+        with_default_device_policy(|policy| {
+            let stream = policy.next_stream()?;
+            self.sync_on(&stream)
+        })?
     }
+    /// Execute on a stream without synchronizing. The GPU may still be
+    /// writing to the output when this returns.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure the stream is synchronized before accessing
+    /// GPU data from the output.
     unsafe fn async_on(
         self,
         stream: &Arc<CudaStream>,
-    ) -> Result<<Self as DeviceOperation>::Output, DeviceError> {
-        let ctx = ExecutionContext::new(Arc::clone(stream));
-        // This is okay since we synchronize immediately.
-
+    ) -> Result<<Self as DeviceOp>::Output, DeviceError> {
+        let ctx = ExecutionContext::new(stream.clone());
         unsafe { self.execute(&ctx) }
     }
     /// Execute on an **explicit stream** and block until the GPU finishes.
@@ -222,110 +361,255 @@ pub trait DeviceOperation:
     /// This bypasses the scheduling policy entirely. All operations `sync_on` the same
     /// stream are guaranteed to execute in call order. Use this when you need deterministic
     /// ordering or are debugging concurrency issues.
-    fn sync_on(
-        self,
-        stream: &Arc<CudaStream>,
-    ) -> Result<<Self as DeviceOperation>::Output, DeviceError> {
-        let ctx = ExecutionContext::new(Arc::clone(stream));
-        // This is okay since we synchronize immediately.
+    fn sync_on(self, stream: &Arc<CudaStream>) -> Result<<Self as DeviceOp>::Output, DeviceError> {
+        acquire_execution_lock()?;
+        let ctx = ExecutionContext::new(stream.clone());
         let res = unsafe { self.execute(&ctx) };
-        stream.synchronize().expect("Synchronize failed.");
+        let sync_res = stream.synchronize();
+        release_execution_lock();
+        sync_res?;
         res
     }
 }
 
+// ── GraphNode ────────────────────────────────────────────────────────────────
+
+/// Marker trait for [`DeviceOp`]s that are safe to record in a CUDA graph.
+///
+/// Only operations that do **not** allocate or free device memory should
+/// implement this trait. During CUDA graph capture, allocation nodes may
+/// return different addresses on replay, breaking baked-in pointers.
+///
+/// Implementors:
+/// - Macro-generated kernel launchers (kernel launch only)
+/// - [`Memcpy`](crate::Memcpy) (copy between pre-allocated buffers)
+/// - [`Value<T>`] (no GPU work)
+///
+/// Non-implementors (allocate device memory):
+/// - `api::zeros`, `api::ones`, `api::full`, `api::arange`
+/// - `api::randn`, `api::rand`
+/// - `dup`, `copy_host_vec_to_device`
+///
+/// See [`Scope`](crate::cuda_graph::Scope) for the full safety proof.
+pub trait GraphNode: DeviceOp {}
+
 // Arc
 
-// I has to be sync since we are wrapping it in Arc.
-pub struct DeviceOperationArc<I: Send + Sync, DI>
-where
-    DI: DeviceOperation<Output = I>,
-{
-    op: DI,
+// Boxed (type-erased) DeviceOp
+
+/// A type-erased [`DeviceOp`] that boxes the execution closure.
+///
+/// Created via [`DeviceOp::boxed()`].
+/// Useful when you need to store operations with different concrete types but
+/// the same `Output` in a homogeneous collection (e.g.
+/// `Vec<BoxedDeviceOp<'_, T>>`).
+pub struct BoxedDeviceOp<T: Send> {
+    inner: Box<dyn FnOnce(&ExecutionContext) -> Result<T, DeviceError> + Send>,
 }
 
-unsafe impl<I: Send + Sync, DI> Send for DeviceOperationArc<I, DI> where
-    DI: DeviceOperation<Output = I>
-{
-}
+impl<T: Send> DeviceOp for BoxedDeviceOp<T> {
+    type Output = T;
 
-impl<I: Send + Sync, DI> DeviceOperation for DeviceOperationArc<I, DI>
-where
-    DI: DeviceOperation<Output = I>,
-{
-    type Output = Arc<I>;
-
-    unsafe fn execute(
-        self,
-        context: &ExecutionContext,
-    ) -> Result<<Self as DeviceOperation>::Output, DeviceError> {
-        let val: I = self.op.execute(context)?;
-        Ok(Arc::new(val))
+    unsafe fn execute(self, context: &ExecutionContext) -> Result<T, DeviceError> {
+        (self.inner)(context)
     }
 }
 
-impl<I: Send + Sync, DI> IntoFuture for DeviceOperationArc<I, DI>
-where
-    DI: DeviceOperation<Output = I>,
-{
-    type Output = Result<Arc<I>, DeviceError>;
-    type IntoFuture = DeviceFuture<Arc<I>, DeviceOperationArc<I, DI>>;
+impl<T: Send> IntoFuture for BoxedDeviceOp<T> {
+    type Output = Result<T, DeviceError>;
+    type IntoFuture = DeviceFuture<T, Self>;
     fn into_future(self) -> Self::IntoFuture {
-        match with_default_device_policy(|policy| policy.schedule(self)) {
+        match with_default_device_policy(|policy| {
+            let stream = policy.next_stream()?;
+            let mut f = DeviceFuture::new();
+            f.device_operation = Some(self);
+            f.execution_context = Some(ExecutionContext::new(stream));
+            Ok(f)
+        }) {
             Ok(Ok(future)) => future,
-            Ok(Err(e)) | Err(e) => DeviceFuture::failed(e),
+            Ok(Err(e)) => DeviceFuture::failed(e),
+            Err(e) => DeviceFuture::failed(e),
         }
+    }
+}
+
+// Shared (cloneable, execute-once) DeviceOp
+
+struct SharedExec<T: Send + Sync> {
+    computed: AtomicBool,
+    op: UnsafeCell<Option<Box<dyn FnOnce(&ExecutionContext) -> Result<T, DeviceError> + Send>>>,
+    result: UnsafeCell<Option<Arc<T>>>,
+}
+
+// TODO (hme): document safety
+unsafe impl<T: Send + Sync> Send for SharedExec<T> {}
+unsafe impl<T: Send + Sync> Sync for SharedExec<T> {}
+
+/// A cloneable, execute-once [`DeviceOp`].
+///
+/// Created via [`DeviceOp::shared()`]. The underlying operation executes at most
+/// once; every clone gets `Arc::clone()` of the cached result. Follows the
+/// `FutureExt::shared()` convention from the `futures` crate.
+///
+/// Output is always `Arc<T>` — the result is wrapped on first execution and
+/// shared via refcount thereafter.
+pub struct SharedDeviceOp<T: Send + Sync> {
+    inner: Arc<SharedExec<T>>,
+}
+
+impl<T: Send + Sync> Clone for SharedDeviceOp<T> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+impl<T: Send + Sync> DeviceOp for SharedDeviceOp<T> {
+    type Output = Arc<T>;
+
+    unsafe fn execute(self, context: &ExecutionContext) -> Result<Arc<T>, DeviceError> {
+        if !self.inner.computed.load(Ordering::Acquire) {
+            let op = unsafe { (&mut *self.inner.op.get()).take() }.ok_or(DeviceError::Internal(
+                "SharedDeviceOp: operation already taken".to_string(),
+            ))?;
+            let result = op(context)?;
+            unsafe {
+                *self.inner.result.get() = Some(Arc::new(result));
+            }
+            self.inner.computed.store(true, Ordering::Release);
+        }
+        Ok(unsafe { (&*self.inner.result.get()).as_ref().unwrap().clone() })
+    }
+}
+
+impl<T: Send + Sync> IntoFuture for SharedDeviceOp<T> {
+    type Output = Result<Arc<T>, DeviceError>;
+    type IntoFuture = DeviceFuture<Arc<T>, SharedDeviceOp<T>>;
+    fn into_future(self) -> Self::IntoFuture {
+        match with_default_device_policy(|policy| {
+            let stream = policy.next_stream()?;
+            let mut f = DeviceFuture::new();
+            f.device_operation = Some(self);
+            f.execution_context = Some(ExecutionContext::new(stream));
+            Ok(f)
+        }) {
+            Ok(Ok(future)) => future,
+            Ok(Err(e)) => DeviceFuture::failed(e),
+            Err(e) => DeviceFuture::failed(e),
+        }
+    }
+}
+
+/// Create a pre-computed [`SharedDeviceOp`] from an existing `Arc<T>`.
+///
+/// The returned op is already "executed" — cloning it just bumps the refcount.
+pub fn shared<T: Send + Sync>(val: Arc<T>) -> SharedDeviceOp<T> {
+    SharedDeviceOp {
+        inner: Arc::new(SharedExec {
+            computed: AtomicBool::new(true),
+            op: UnsafeCell::new(None),
+            result: UnsafeCell::new(Some(val)),
+        }),
+    }
+}
+
+// IntoDeviceOp — convert plain values or existing DeviceOps into DeviceOp
+
+/// Conversion trait that accepts both plain values and existing [`DeviceOp`]s.
+///
+/// The blanket impl covers all `DeviceOp` types (pass-through). Specific impls
+/// cover plain data types (`f32`, `Arc<Tensor<T>>`, etc.) that wrap via [`Value`].
+pub trait IntoDeviceOp<T: Send> {
+    type Op: DeviceOp<Output = T>;
+    fn into_op(self) -> Self::Op;
+}
+
+impl<T: Send, DO: DeviceOp<Output = T>> IntoDeviceOp<T> for DO {
+    type Op = DO;
+    fn into_op(self) -> DO {
+        self
+    }
+}
+
+// IntoDeviceOp impls for Arc<T> and &Arc<T> — wraps in Value.
+impl<T: Send + Sync + 'static> IntoDeviceOp<Arc<T>> for Arc<T> {
+    type Op = Value<Arc<T>>;
+    fn into_op(self) -> Value<Arc<T>> {
+        value(self)
+    }
+}
+
+impl<T: Send + Sync + 'static> IntoDeviceOp<Arc<T>> for &Arc<T> {
+    type Op = Value<Arc<T>>;
+    fn into_op(self) -> Value<Arc<T>> {
+        value(self.clone())
+    }
+}
+
+// Scalar IntoDeviceOp impls — wraps the value in Value<T>.
+macro_rules! impl_into_device_op_scalar {
+    ($($ty:ty),*) => {
+        $(
+            impl IntoDeviceOp<$ty> for $ty {
+                type Op = Value<$ty>;
+                fn into_op(self) -> Value<$ty> { value(self) }
+            }
+        )*
+    };
+}
+impl_into_device_op_scalar!(
+    f32,
+    f64,
+    i8,
+    i16,
+    i32,
+    i64,
+    u8,
+    u16,
+    u32,
+    u64,
+    usize,
+    bool,
+    half::f16,
+    half::bf16
+);
+
+// DevicePointer impl — for unsafe kernel pointer arguments.
+impl<T: cuda_core::DType + Send> IntoDeviceOp<crate::device_buffer::DevicePointer<T>>
+    for crate::device_buffer::DevicePointer<T>
+{
+    type Op = Value<crate::device_buffer::DevicePointer<T>>;
+    fn into_op(self) -> Value<crate::device_buffer::DevicePointer<T>> {
+        value(self)
     }
 }
 
 // Unwrap Arc
-pub struct UnwrapArc<I: Send + Sync, DI>
-where
-    DI: DeviceOperation<Output = Arc<I>>,
-{
-    op: DI,
-}
-
-unsafe impl<I: Send + Sync, DI> Send for UnwrapArc<I, DI> where DI: DeviceOperation<Output = Arc<I>> {}
-
-impl<I: Send + Sync + Debug, DI> DeviceOperation for UnwrapArc<I, DI>
-where
-    DI: DeviceOperation<Output = Arc<I>>,
-{
-    type Output = I;
-
-    unsafe fn execute(
+/// Extension trait: `.unwrap_arc()` on `DeviceOp<Output = Arc<T>>`.
+///
+/// Unwraps the Arc at execution time. Fails if the Arc has multiple owners.
+pub trait DeviceOpUnwrapArc<T: Send + Sync>: DeviceOp<Output = Arc<T>> + Sized {
+    fn unwrap_arc(
         self,
-        context: &ExecutionContext,
-    ) -> Result<<Self as DeviceOperation>::Output, DeviceError> {
-        let val = self.op.execute(context)?;
-        match Arc::try_unwrap(val) {
-            Ok(inner) => Ok(inner),
-            Err(_) => Err(DeviceError::Internal("Arc unwrap failed.".to_string())),
-        }
+    ) -> AndThen<Arc<T>, Self, T, Value<T>, impl FnOnce(Arc<T>) -> Value<T> + Send> {
+        self.then(|arc| {
+            value(
+                Arc::try_unwrap(arc)
+                    .unwrap_or_else(|_| panic!("unwrap_arc: Arc has multiple owners")),
+            )
+        })
     }
 }
 
-impl<I: Send + Sync + Debug, DI> IntoFuture for UnwrapArc<I, DI>
-where
-    DI: DeviceOperation<Output = Arc<I>>,
-{
-    type Output = Result<I, DeviceError>;
-    type IntoFuture = DeviceFuture<I, UnwrapArc<I, DI>>;
-    fn into_future(self) -> Self::IntoFuture {
-        match with_default_device_policy(|policy| policy.schedule(self)) {
-            Ok(Ok(future)) => future,
-            Ok(Err(e)) | Err(e) => DeviceFuture::failed(e),
-        }
-    }
-}
+impl<T: Send + Sync, DI: DeviceOp<Output = Arc<T>>> DeviceOpUnwrapArc<T> for DI {}
 
 // AndThen
 
 pub struct AndThen<I: Send, DI, O: Send, DO, F>
 where
-    DI: DeviceOperation<Output = I>,
-    DO: DeviceOperation<Output = O>,
+    DI: DeviceOp<Output = I>,
+    DO: DeviceOp<Output = O>,
     F: FnOnce(I) -> DO,
 {
     op: DI,
@@ -334,16 +618,16 @@ where
 
 unsafe impl<I: Send, DI, O: Send, DO, F> Send for AndThen<I, DI, O, DO, F>
 where
-    DI: DeviceOperation<Output = I>,
-    DO: DeviceOperation<Output = O>,
+    DI: DeviceOp<Output = I>,
+    DO: DeviceOp<Output = O>,
     F: FnOnce(I) -> DO + Send,
 {
 }
 
-impl<I: Send, DI, O: Send, DO, F> DeviceOperation for AndThen<I, DI, O, DO, F>
+impl<I: Send, DI, O: Send, DO, F> DeviceOp for AndThen<I, DI, O, DO, F>
 where
-    DI: DeviceOperation<Output = I>,
-    DO: DeviceOperation<Output = O>,
+    DI: DeviceOp<Output = I>,
+    DO: DeviceOp<Output = O>,
     F: FnOnce(I) -> DO + Send,
 {
     type Output = O;
@@ -351,7 +635,7 @@ where
     unsafe fn execute(
         self,
         context: &ExecutionContext,
-    ) -> Result<<Self as DeviceOperation>::Output, DeviceError> {
+    ) -> Result<<Self as DeviceOp>::Output, DeviceError> {
         let input: I = self.op.execute(context)?;
         let output_device_op: DO = (self.closure)(input);
         output_device_op.execute(context)
@@ -360,16 +644,23 @@ where
 
 impl<I: Send, DI, O: Send, DO, F> IntoFuture for AndThen<I, DI, O, DO, F>
 where
-    DI: DeviceOperation<Output = I>,
-    DO: DeviceOperation<Output = O>,
+    DI: DeviceOp<Output = I>,
+    DO: DeviceOp<Output = O>,
     F: FnOnce(I) -> DO + Send,
 {
     type Output = Result<O, DeviceError>;
     type IntoFuture = DeviceFuture<O, AndThen<I, DI, O, DO, F>>;
     fn into_future(self) -> Self::IntoFuture {
-        match with_default_device_policy(|policy| policy.schedule(self)) {
+        match with_default_device_policy(|policy| {
+            let stream = policy.next_stream()?;
+            let mut f = DeviceFuture::new();
+            f.device_operation = Some(self);
+            f.execution_context = Some(ExecutionContext::new(stream));
+            Ok(f)
+        }) {
             Ok(Ok(future)) => future,
-            Ok(Err(e)) | Err(e) => DeviceFuture::failed(e),
+            Ok(Err(e)) => DeviceFuture::failed(e),
+            Err(e) => DeviceFuture::failed(e),
         }
     }
 }
@@ -385,24 +676,33 @@ impl<T> Value<T> {
     }
 }
 
-impl<T: Send> DeviceOperation for Value<T> {
+impl<T: Send> DeviceOp for Value<T> {
     type Output = T;
 
     unsafe fn execute(
         self,
         _context: &ExecutionContext,
-    ) -> Result<<Self as DeviceOperation>::Output, DeviceError> {
+    ) -> Result<<Self as DeviceOp>::Output, DeviceError> {
         Ok(self.0)
     }
 }
+
+impl<T: Send> GraphNode for Value<T> {}
 
 impl<T: Send> IntoFuture for Value<T> {
     type Output = Result<T, DeviceError>;
     type IntoFuture = DeviceFuture<T, Value<T>>;
     fn into_future(self) -> Self::IntoFuture {
-        match with_default_device_policy(|policy| policy.schedule(self)) {
+        match with_default_device_policy(|policy| {
+            let stream = policy.next_stream()?;
+            let mut f = DeviceFuture::new();
+            f.device_operation = Some(self);
+            f.execution_context = Some(ExecutionContext::new(stream));
+            Ok(f)
+        }) {
             Ok(Ok(future)) => future,
-            Ok(Err(e)) | Err(e) => DeviceFuture::failed(e),
+            Ok(Err(e)) => DeviceFuture::failed(e),
+            Err(e) => DeviceFuture::failed(e),
         }
     }
 }
@@ -411,15 +711,6 @@ pub fn value<T: Send>(x: T) -> Value<T> {
     Value::new(x)
 }
 
-// Use value to impl into for any T.
-pub trait IntoDeviceOperation<T: Send> {
-    fn device_operation(self) -> Value<T>;
-}
-impl<T: Send> IntoDeviceOperation<T> for T {
-    fn device_operation(self) -> Value<T> {
-        value(self)
-    }
-}
 impl From<f32> for Value<f32> {
     fn from(val: f32) -> Self {
         Value::new(val)
@@ -428,26 +719,24 @@ impl From<f32> for Value<f32> {
 
 // Empty (closure)
 
-pub struct Empty<O: Send, DO: DeviceOperation<Output = O>, F: FnOnce() -> DO> {
+pub struct Empty<O: Send, DO: DeviceOp<Output = O>, F: FnOnce() -> DO> {
     closure: F,
 }
 
-pub fn empty<O: Send, DO: DeviceOperation<Output = O>, F: FnOnce() -> DO>(
-    closure: F,
-) -> Empty<O, DO, F> {
+pub fn empty<O: Send, DO: DeviceOp<Output = O>, F: FnOnce() -> DO>(closure: F) -> Empty<O, DO, F> {
     Empty { closure }
 }
 
 unsafe impl<O: Send, DO, F> Send for Empty<O, DO, F>
 where
-    DO: DeviceOperation<Output = O>,
+    DO: DeviceOp<Output = O>,
     F: FnOnce() -> DO,
 {
 }
 
-impl<O: Send, DO, F> DeviceOperation for Empty<O, DO, F>
+impl<O: Send, DO, F> DeviceOp for Empty<O, DO, F>
 where
-    DO: DeviceOperation<Output = O>,
+    DO: DeviceOp<Output = O>,
     F: FnOnce() -> DO,
 {
     type Output = O;
@@ -455,38 +744,44 @@ where
     unsafe fn execute(
         self,
         context: &ExecutionContext,
-    ) -> Result<<Self as DeviceOperation>::Output, DeviceError> {
+    ) -> Result<<Self as DeviceOp>::Output, DeviceError> {
         let out_device_op = (self.closure)();
         out_device_op.execute(context)
     }
 }
 
-impl<O: Send, DO: DeviceOperation<Output = O>, F: FnOnce() -> DO> IntoFuture for Empty<O, DO, F> {
+impl<O: Send, DO: DeviceOp<Output = O>, F: FnOnce() -> DO> IntoFuture for Empty<O, DO, F> {
     type Output = Result<O, DeviceError>;
     type IntoFuture = DeviceFuture<O, Empty<O, DO, F>>;
     fn into_future(self) -> Self::IntoFuture {
-        match with_default_device_policy(|policy| policy.schedule(self)) {
+        match with_default_device_policy(|policy| {
+            let stream = policy.next_stream()?;
+            let mut f = DeviceFuture::new();
+            f.device_operation = Some(self);
+            f.execution_context = Some(ExecutionContext::new(stream));
+            Ok(f)
+        }) {
             Ok(Ok(future)) => future,
-            Ok(Err(e)) | Err(e) => DeviceFuture::failed(e),
+            Ok(Err(e)) => DeviceFuture::failed(e),
+            Err(e) => DeviceFuture::failed(e),
         }
     }
 }
 
 // Zip
 
-pub struct Zip<T1: Send, T2: Send, A: DeviceOperation<Output = T1>, B: DeviceOperation<Output = T2>>
-{
+pub struct Zip<T1: Send, T2: Send, A: DeviceOp<Output = T1>, B: DeviceOp<Output = T2>> {
     phantom: PhantomData<(T1, T2)>,
     a: A,
     b: B,
 }
 
-unsafe impl<T1: Send, T2: Send, A: DeviceOperation<Output = T1>, B: DeviceOperation<Output = T2>>
-    Send for Zip<T1, T2, A, B>
+unsafe impl<T1: Send, T2: Send, A: DeviceOp<Output = T1>, B: DeviceOp<Output = T2>> Send
+    for Zip<T1, T2, A, B>
 {
 }
 
-fn _zip<T1: Send, T2: Send, A: DeviceOperation<Output = T1>, B: DeviceOperation<Output = T2>>(
+fn _zip<T1: Send, T2: Send, A: DeviceOp<Output = T1>, B: DeviceOp<Output = T2>>(
     a: A,
     b: B,
 ) -> Zip<T1, T2, A, B> {
@@ -497,42 +792,49 @@ fn _zip<T1: Send, T2: Send, A: DeviceOperation<Output = T1>, B: DeviceOperation<
     }
 }
 
-impl<T1: Send, T2: Send, A: DeviceOperation<Output = T1>, B: DeviceOperation<Output = T2>>
-    DeviceOperation for Zip<T1, T2, A, B>
+impl<T1: Send, T2: Send, A: DeviceOp<Output = T1>, B: DeviceOp<Output = T2>> DeviceOp
+    for Zip<T1, T2, A, B>
 {
     type Output = (T1, T2);
 
     unsafe fn execute(
         self,
         context: &ExecutionContext,
-    ) -> Result<<Self as DeviceOperation>::Output, DeviceError> {
+    ) -> Result<<Self as DeviceOp>::Output, DeviceError> {
         let a: T1 = self.a.execute(context)?;
         let b: T2 = self.b.execute(context)?;
         Ok((a, b))
     }
 }
 
-impl<T1: Send, T2: Send, A: DeviceOperation<Output = T1>, B: DeviceOperation<Output = T2>>
-    IntoFuture for Zip<T1, T2, A, B>
+impl<T1: Send, T2: Send, A: DeviceOp<Output = T1>, B: DeviceOp<Output = T2>> IntoFuture
+    for Zip<T1, T2, A, B>
 {
     type Output = Result<(T1, T2), DeviceError>;
     type IntoFuture = DeviceFuture<(T1, T2), Zip<T1, T2, A, B>>;
     fn into_future(self) -> Self::IntoFuture {
-        match with_default_device_policy(|policy| policy.schedule(self)) {
+        match with_default_device_policy(|policy| {
+            let stream = policy.next_stream()?;
+            let mut f = DeviceFuture::new();
+            f.device_operation = Some(self);
+            f.execution_context = Some(ExecutionContext::new(stream));
+            Ok(f)
+        }) {
             Ok(Ok(future)) => future,
-            Ok(Err(e)) | Err(e) => DeviceFuture::failed(e),
+            Ok(Err(e)) => DeviceFuture::failed(e),
+            Err(e) => DeviceFuture::failed(e),
         }
     }
 }
 
 pub trait Zippable<I, O: Send> {
-    fn zip(self) -> impl DeviceOperation<Output = O>;
+    fn zip(self) -> impl DeviceOp<Output = O>;
 }
 
-impl<T0: Send, T1: Send, DI0: DeviceOperation<Output = T0>, DI1: DeviceOperation<Output = T1>>
+impl<T0: Send, T1: Send, DI0: DeviceOp<Output = T0>, DI1: DeviceOp<Output = T1>>
     Zippable<(DI0, DI1), (T0, T1)> for (DI0, DI1)
 {
-    fn zip(self) -> impl DeviceOperation<Output = (T0, T1)> {
+    fn zip(self) -> impl DeviceOp<Output = (T0, T1)> {
         _zip(self.0, self.1)
     }
 }
@@ -541,15 +843,84 @@ impl<
         T0: Send,
         T1: Send,
         T2: Send,
-        DI0: DeviceOperation<Output = T0>,
-        DI1: DeviceOperation<Output = T1>,
-        DI2: DeviceOperation<Output = T2>,
+        DI0: DeviceOp<Output = T0>,
+        DI1: DeviceOp<Output = T1>,
+        DI2: DeviceOp<Output = T2>,
     > Zippable<(DI0, DI1, DI2), (T0, T1, T2)> for (DI0, DI1, DI2)
 {
-    fn zip(self) -> impl DeviceOperation<Output = (T0, T1, T2)> {
+    fn zip(self) -> impl DeviceOp<Output = (T0, T1, T2)> {
         let cons = _zip(self.1, self.2);
         let cons = _zip(self.0, cons);
-        cons.and_then(|(arg0, (arg1, arg2))| value((arg0, arg1, arg2)))
+        cons.then(|(arg0, (arg1, arg2))| value((arg0, arg1, arg2)))
+    }
+}
+
+impl<
+        T0: Send,
+        T1: Send,
+        T2: Send,
+        T3: Send,
+        DI0: DeviceOp<Output = T0>,
+        DI1: DeviceOp<Output = T1>,
+        DI2: DeviceOp<Output = T2>,
+        DI3: DeviceOp<Output = T3>,
+    > Zippable<(DI0, DI1, DI2, DI3), (T0, T1, T2, T3)> for (DI0, DI1, DI2, DI3)
+{
+    fn zip(self) -> impl DeviceOp<Output = (T0, T1, T2, T3)> {
+        let cons = _zip(self.2, self.3);
+        let cons = _zip(self.1, cons);
+        let cons = _zip(self.0, cons);
+        cons.then(|(arg0, (arg1, (arg2, arg3)))| value((arg0, arg1, arg2, arg3)))
+    }
+}
+
+impl<
+        T0: Send,
+        T1: Send,
+        T2: Send,
+        T3: Send,
+        T4: Send,
+        DI0: DeviceOp<Output = T0>,
+        DI1: DeviceOp<Output = T1>,
+        DI2: DeviceOp<Output = T2>,
+        DI3: DeviceOp<Output = T3>,
+        DI4: DeviceOp<Output = T4>,
+    > Zippable<(DI0, DI1, DI2, DI3, DI4), (T0, T1, T2, T3, T4)> for (DI0, DI1, DI2, DI3, DI4)
+{
+    fn zip(self) -> impl DeviceOp<Output = (T0, T1, T2, T3, T4)> {
+        let cons = _zip(self.3, self.4);
+        let cons = _zip(self.2, cons);
+        let cons = _zip(self.1, cons);
+        let cons = _zip(self.0, cons);
+        cons.then(|(arg0, (arg1, (arg2, (arg3, arg4))))| value((arg0, arg1, arg2, arg3, arg4)))
+    }
+}
+
+impl<
+        T0: Send,
+        T1: Send,
+        T2: Send,
+        T3: Send,
+        T4: Send,
+        T5: Send,
+        DI0: DeviceOp<Output = T0>,
+        DI1: DeviceOp<Output = T1>,
+        DI2: DeviceOp<Output = T2>,
+        DI3: DeviceOp<Output = T3>,
+        DI4: DeviceOp<Output = T4>,
+        DI5: DeviceOp<Output = T5>,
+    > Zippable<(DI0, DI1, DI2, DI3, DI4, DI5), (T0, T1, T2, T3, T4, T5)>
+    for (DI0, DI1, DI2, DI3, DI4, DI5)
+{
+    fn zip(self) -> impl DeviceOp<Output = (T0, T1, T2, T3, T4, T5)> {
+        let cons = _zip(self.4, self.5);
+        let cons = _zip(self.3, cons);
+        let cons = _zip(self.2, cons);
+        let cons = _zip(self.1, cons);
+        let cons = _zip(self.0, cons);
+        cons.then(|(arg0, (arg1, (arg2, (arg3, (arg4, arg5)))))| {
+            value((arg0, arg1, arg2, arg3, arg4, arg5))
+        })
     }
 }
 
@@ -564,6 +935,15 @@ macro_rules! zip {
     ($arg0:expr, $arg1:expr, $arg2:expr) => {
         ($arg0, $arg1, $arg2).zip()
     };
+    ($arg0:expr, $arg1:expr, $arg2:expr, $arg3:expr) => {
+        ($arg0, $arg1, $arg2, $arg3).zip()
+    };
+    ($arg0:expr, $arg1:expr, $arg2:expr, $arg3:expr, $arg4:expr) => {
+        ($arg0, $arg1, $arg2, $arg3, $arg4).zip()
+    };
+    ($arg0:expr, $arg1:expr, $arg2:expr, $arg3:expr, $arg4:expr, $arg5:expr) => {
+        ($arg0, $arg1, $arg2, $arg3, $arg4, $arg5).zip()
+    };
 }
 pub use zip;
 
@@ -571,7 +951,7 @@ pub use zip;
 
 fn _unzip<T1: Send, T2: Send, DI>(input: DI) -> (SelectLeft<T1, T2, DI>, SelectRight<T1, T2, DI>)
 where
-    DI: DeviceOperation<Output = (T1, T2)>,
+    DI: DeviceOp<Output = (T1, T2)>,
 {
     let select = Select {
         computed: AtomicBool::new(false),
@@ -579,11 +959,11 @@ where
         left: UnsafeCell::new(None),
         right: UnsafeCell::new(None),
     };
-    let select = Arc::new(select);
+    let select_arc = Arc::new(select);
     let out1 = SelectLeft {
-        select: Arc::clone(&select),
+        select: select_arc.clone(),
     };
-    let out2 = SelectRight { select };
+    let out2 = SelectRight { select: select_arc };
     (out1, out2)
 }
 
@@ -591,7 +971,7 @@ where
 
 pub struct Select<T1: Send, T2: Send, DI>
 where
-    DI: DeviceOperation<Output = (T1, T2)>,
+    DI: DeviceOp<Output = (T1, T2)>,
 {
     computed: AtomicBool,
     input: UnsafeCell<Option<DI>>,
@@ -601,18 +981,16 @@ where
 
 impl<T1: Send, T2: Send, DI> Select<T1, T2, DI>
 where
-    DI: DeviceOperation<Output = (T1, T2)>,
+    DI: DeviceOp<Output = (T1, T2)>,
 {
     unsafe fn execute(self: &Arc<Self>, context: &ExecutionContext) -> Result<(), DeviceError> {
         if !self.computed.load(Ordering::Acquire) {
             // Safety: This block is guaranteed to execute at most once.
             // Put the input in a box so the pointer is dropped when this block exits.
-            let input = self.input.get();
-            let input = unsafe { input.as_mut() };
-            let input = input
-                .unwrap()
-                .take()
-                .ok_or_else(|| device_error(context.get_device_id(), "Select operation failed."))?;
+            let input = unsafe { (&mut *self.input.get()).take() }.ok_or(device_error(
+                context.get_device_id(),
+                "Select operation failed.",
+            ))?;
             let (left, right) = input.execute(context)?;
             // Update internal state.
             unsafe {
@@ -624,14 +1002,12 @@ where
         Ok(())
     }
     unsafe fn left(&self) -> T1 {
-        let cell = self.left.get();
-        let cell = unsafe { cell.as_mut() };
-        cell.unwrap().take().unwrap()
+        let left = unsafe { (&mut *self.left.get()).take() }.unwrap();
+        left
     }
     unsafe fn right(&self) -> T2 {
-        let cell = self.right.get();
-        let cell = unsafe { cell.as_mut() };
-        cell.unwrap().take().unwrap()
+        let right = unsafe { (&mut *self.right.get()).take() }.unwrap();
+        right
     }
 }
 
@@ -639,40 +1015,44 @@ where
 
 pub struct SelectLeft<T1: Send, T2: Send, DI>
 where
-    DI: DeviceOperation<Output = (T1, T2)>,
+    DI: DeviceOp<Output = (T1, T2)>,
 {
     select: Arc<Select<T1, T2, DI>>,
 }
 
-unsafe impl<T1: Send, T2: Send, DI: DeviceOperation<Output = (T1, T2)>> Send
-    for SelectLeft<T1, T2, DI>
-{
-}
+unsafe impl<T1: Send, T2: Send, DI: DeviceOp<Output = (T1, T2)>> Send for SelectLeft<T1, T2, DI> {}
 
 impl<T1: Send, T2: Send, DI> IntoFuture for SelectLeft<T1, T2, DI>
 where
-    DI: DeviceOperation<Output = (T1, T2)>,
+    DI: DeviceOp<Output = (T1, T2)>,
 {
     type Output = Result<T1, DeviceError>;
     type IntoFuture = DeviceFuture<T1, SelectLeft<T1, T2, DI>>;
     fn into_future(self) -> Self::IntoFuture {
-        match with_default_device_policy(|policy| policy.schedule(self)) {
+        match with_default_device_policy(|policy| {
+            let stream = policy.next_stream()?;
+            let mut f = DeviceFuture::new();
+            f.device_operation = Some(self);
+            f.execution_context = Some(ExecutionContext::new(stream));
+            Ok(f)
+        }) {
             Ok(Ok(future)) => future,
-            Ok(Err(e)) | Err(e) => DeviceFuture::failed(e),
+            Ok(Err(e)) => DeviceFuture::failed(e),
+            Err(e) => DeviceFuture::failed(e),
         }
     }
 }
 
-impl<T1: Send, T2: Send, DI> DeviceOperation for SelectLeft<T1, T2, DI>
+impl<T1: Send, T2: Send, DI> DeviceOp for SelectLeft<T1, T2, DI>
 where
-    DI: DeviceOperation<Output = (T1, T2)>,
+    DI: DeviceOp<Output = (T1, T2)>,
 {
     type Output = T1;
 
     unsafe fn execute(
         self,
         context: &ExecutionContext,
-    ) -> Result<<Self as DeviceOperation>::Output, DeviceError> {
+    ) -> Result<<Self as DeviceOp>::Output, DeviceError> {
         self.select.execute(context)?;
         Ok(self.select.left())
     }
@@ -682,40 +1062,44 @@ where
 
 pub struct SelectRight<T1: Send, T2: Send, DI>
 where
-    DI: DeviceOperation<Output = (T1, T2)>,
+    DI: DeviceOp<Output = (T1, T2)>,
 {
     select: Arc<Select<T1, T2, DI>>,
 }
 
-unsafe impl<T1: Send, T2: Send, DI: DeviceOperation<Output = (T1, T2)>> Send
-    for SelectRight<T1, T2, DI>
-{
-}
+unsafe impl<T1: Send, T2: Send, DI: DeviceOp<Output = (T1, T2)>> Send for SelectRight<T1, T2, DI> {}
 
 impl<T1: Send, T2: Send, DI> IntoFuture for SelectRight<T1, T2, DI>
 where
-    DI: DeviceOperation<Output = (T1, T2)>,
+    DI: DeviceOp<Output = (T1, T2)>,
 {
     type Output = Result<T2, DeviceError>;
     type IntoFuture = DeviceFuture<T2, SelectRight<T1, T2, DI>>;
     fn into_future(self) -> Self::IntoFuture {
-        match with_default_device_policy(|policy| policy.schedule(self)) {
+        match with_default_device_policy(|policy| {
+            let stream = policy.next_stream()?;
+            let mut f = DeviceFuture::new();
+            f.device_operation = Some(self);
+            f.execution_context = Some(ExecutionContext::new(stream));
+            Ok(f)
+        }) {
             Ok(Ok(future)) => future,
-            Ok(Err(e)) | Err(e) => DeviceFuture::failed(e),
+            Ok(Err(e)) => DeviceFuture::failed(e),
+            Err(e) => DeviceFuture::failed(e),
         }
     }
 }
 
-impl<T1: Send, T2: Send, DI> DeviceOperation for SelectRight<T1, T2, DI>
+impl<T1: Send, T2: Send, DI> DeviceOp for SelectRight<T1, T2, DI>
 where
-    DI: DeviceOperation<Output = (T1, T2)>,
+    DI: DeviceOp<Output = (T1, T2)>,
 {
     type Output = T2;
 
     unsafe fn execute(
         self,
         context: &ExecutionContext,
-    ) -> Result<<Self as DeviceOperation>::Output, DeviceError> {
+    ) -> Result<<Self as DeviceOp>::Output, DeviceError> {
         self.select.execute(context)?;
         Ok(self.select.right())
     }
@@ -723,48 +1107,194 @@ where
 
 pub trait Unzippable1<T0: Send>
 where
-    Self: DeviceOperation<Output = (T0,)>,
+    Self: DeviceOp<Output = (T0,)>,
 {
-    fn unzip(self) -> (impl DeviceOperation<Output = T0>,) {
-        (self.and_then(|(r,)| value(r)),)
+    fn unzip(self) -> (impl DeviceOp<Output = T0>,) {
+        (self.then(|(r,)| value(r)),)
     }
 }
-impl<T0: Send, DI: DeviceOperation<Output = (T0,)>> Unzippable1<T0> for DI {}
+impl<T0: Send, DI: DeviceOp<Output = (T0,)>> Unzippable1<T0> for DI {}
 
 pub trait Unzippable2<T0: Send, T1: Send>
 where
-    Self: DeviceOperation<Output = (T0, T1)>,
+    Self: DeviceOp<Output = (T0, T1)>,
 {
-    fn unzip(
-        self,
-    ) -> (
-        impl DeviceOperation<Output = T0>,
-        impl DeviceOperation<Output = T1>,
-    ) {
+    fn unzip(self) -> (impl DeviceOp<Output = T0>, impl DeviceOp<Output = T1>) {
         _unzip(self)
     }
+    fn first(self) -> impl DeviceOp<Output = T0>
+    where
+        Self: Sized,
+    {
+        self.then(|(first, _)| value(first))
+    }
+    fn last(self) -> impl DeviceOp<Output = T1>
+    where
+        Self: Sized,
+    {
+        self.then(|(_, last)| value(last))
+    }
 }
-impl<T0: Send, T1: Send, DI: DeviceOperation<Output = (T0, T1)>> Unzippable2<T0, T1> for DI {}
+impl<T0: Send, T1: Send, DI: DeviceOp<Output = (T0, T1)>> Unzippable2<T0, T1> for DI {}
 
 pub trait Unzippable3<T0: Send, T1: Send, T2: Send>
 where
-    Self: DeviceOperation<Output = (T0, T1, T2)>,
+    Self: DeviceOp<Output = (T0, T1, T2)>,
 {
     fn unzip(
         self,
     ) -> (
-        impl DeviceOperation<Output = T0>,
-        impl DeviceOperation<Output = T1>,
-        impl DeviceOperation<Output = T2>,
+        impl DeviceOp<Output = T0>,
+        impl DeviceOp<Output = T1>,
+        impl DeviceOp<Output = T2>,
     ) {
-        let cons = self.and_then(|(arg0, arg1, arg2)| value((arg0, (arg1, arg2))));
+        let cons = self.then(|(arg0, arg1, arg2)| value((arg0, (arg1, arg2))));
         let (car, cdr) = _unzip(cons);
         let (cdr_car, cdr_cdr) = _unzip(cdr);
         (car, cdr_car, cdr_cdr)
     }
+    fn first(self) -> impl DeviceOp<Output = T0>
+    where
+        Self: Sized,
+    {
+        self.then(|(first, _, _)| value(first))
+    }
+    fn last(self) -> impl DeviceOp<Output = T2>
+    where
+        Self: Sized,
+    {
+        self.then(|(_, _, last)| value(last))
+    }
 }
-impl<T0: Send, T1: Send, T2: Send, DI: DeviceOperation<Output = (T0, T1, T2)>>
-    Unzippable3<T0, T1, T2> for DI
+impl<T0: Send, T1: Send, T2: Send, DI: DeviceOp<Output = (T0, T1, T2)>> Unzippable3<T0, T1, T2>
+    for DI
+{
+}
+
+pub trait Unzippable4<T0: Send, T1: Send, T2: Send, T3: Send>
+where
+    Self: DeviceOp<Output = (T0, T1, T2, T3)>,
+{
+    fn unzip(
+        self,
+    ) -> (
+        impl DeviceOp<Output = T0>,
+        impl DeviceOp<Output = T1>,
+        impl DeviceOp<Output = T2>,
+        impl DeviceOp<Output = T3>,
+    ) {
+        let cons = self.then(|(a0, a1, a2, a3)| value((a0, (a1, (a2, a3)))));
+        let (car, cdr) = _unzip(cons);
+        let (cdr0, cdr1) = _unzip(cdr);
+        let (cdr1_0, cdr1_1) = _unzip(cdr1);
+        (car, cdr0, cdr1_0, cdr1_1)
+    }
+    fn first(self) -> impl DeviceOp<Output = T0>
+    where
+        Self: Sized,
+    {
+        self.then(|(first, _, _, _)| value(first))
+    }
+    fn last(self) -> impl DeviceOp<Output = T3>
+    where
+        Self: Sized,
+    {
+        self.then(|(_, _, _, last)| value(last))
+    }
+}
+impl<T0: Send, T1: Send, T2: Send, T3: Send, DI: DeviceOp<Output = (T0, T1, T2, T3)>>
+    Unzippable4<T0, T1, T2, T3> for DI
+{
+}
+
+pub trait Unzippable5<T0: Send, T1: Send, T2: Send, T3: Send, T4: Send>
+where
+    Self: DeviceOp<Output = (T0, T1, T2, T3, T4)>,
+{
+    fn unzip(
+        self,
+    ) -> (
+        impl DeviceOp<Output = T0>,
+        impl DeviceOp<Output = T1>,
+        impl DeviceOp<Output = T2>,
+        impl DeviceOp<Output = T3>,
+        impl DeviceOp<Output = T4>,
+    ) {
+        let cons = self.then(|(a0, a1, a2, a3, a4)| value((a0, (a1, (a2, (a3, a4))))));
+        let (car, cdr) = _unzip(cons);
+        let (cdr0, cdr1) = _unzip(cdr);
+        let (cdr1_0, cdr1_1) = _unzip(cdr1);
+        let (cdr2_0, cdr2_1) = _unzip(cdr1_1);
+        (car, cdr0, cdr1_0, cdr2_0, cdr2_1)
+    }
+    fn first(self) -> impl DeviceOp<Output = T0>
+    where
+        Self: Sized,
+    {
+        self.then(|(first, _, _, _, _)| value(first))
+    }
+    fn last(self) -> impl DeviceOp<Output = T4>
+    where
+        Self: Sized,
+    {
+        self.then(|(_, _, _, _, last)| value(last))
+    }
+}
+impl<
+        T0: Send,
+        T1: Send,
+        T2: Send,
+        T3: Send,
+        T4: Send,
+        DI: DeviceOp<Output = (T0, T1, T2, T3, T4)>,
+    > Unzippable5<T0, T1, T2, T3, T4> for DI
+{
+}
+
+pub trait Unzippable6<T0: Send, T1: Send, T2: Send, T3: Send, T4: Send, T5: Send>
+where
+    Self: DeviceOp<Output = (T0, T1, T2, T3, T4, T5)>,
+{
+    fn unzip(
+        self,
+    ) -> (
+        impl DeviceOp<Output = T0>,
+        impl DeviceOp<Output = T1>,
+        impl DeviceOp<Output = T2>,
+        impl DeviceOp<Output = T3>,
+        impl DeviceOp<Output = T4>,
+        impl DeviceOp<Output = T5>,
+    ) {
+        let cons = self.then(|(a0, a1, a2, a3, a4, a5)| value((a0, (a1, (a2, (a3, (a4, a5)))))));
+        let (car, cdr) = _unzip(cons);
+        let (cdr0, cdr1) = _unzip(cdr);
+        let (cdr1_0, cdr1_1) = _unzip(cdr1);
+        let (cdr2_0, cdr2_1) = _unzip(cdr1_1);
+        let (cdr3_0, cdr3_1) = _unzip(cdr2_1);
+        (car, cdr0, cdr1_0, cdr2_0, cdr3_0, cdr3_1)
+    }
+    fn first(self) -> impl DeviceOp<Output = T0>
+    where
+        Self: Sized,
+    {
+        self.then(|(first, _, _, _, _, _)| value(first))
+    }
+    fn last(self) -> impl DeviceOp<Output = T5>
+    where
+        Self: Sized,
+    {
+        self.then(|(_, _, _, _, _, last)| value(last))
+    }
+}
+impl<
+        T0: Send,
+        T1: Send,
+        T2: Send,
+        T3: Send,
+        T4: Send,
+        T5: Send,
+        DI: DeviceOp<Output = (T0, T1, T2, T3, T4, T5)>,
+    > Unzippable6<T0, T1, T2, T3, T4, T5> for DI
 {
 }
 
@@ -780,21 +1310,21 @@ pub use unzip;
 
 pub struct StreamOperation<
     O: Send,
-    DO: DeviceOperation<Output = O>,
+    DO: DeviceOp<Output = O>,
     F: FnOnce(&ExecutionContext) -> DO + Send,
 > {
     f: F,
 }
 
-impl<O: Send, DO: DeviceOperation<Output = O>, F: FnOnce(&ExecutionContext) -> DO + Send>
-    DeviceOperation for StreamOperation<O, DO, F>
+impl<O: Send, DO: DeviceOp<Output = O>, F: FnOnce(&ExecutionContext) -> DO + Send> DeviceOp
+    for StreamOperation<O, DO, F>
 {
     type Output = O;
 
     unsafe fn execute(
         self,
         context: &ExecutionContext,
-    ) -> Result<<Self as DeviceOperation>::Output, DeviceError> {
+    ) -> Result<<Self as DeviceOp>::Output, DeviceError> {
         let dop_out: DO = (self.f)(context);
         dop_out.execute(context)
     }
@@ -802,23 +1332,30 @@ impl<O: Send, DO: DeviceOperation<Output = O>, F: FnOnce(&ExecutionContext) -> D
 
 pub fn with_context<
     O: Send,
-    DO: DeviceOperation<Output = O>,
+    DO: DeviceOp<Output = O>,
     F: FnOnce(&ExecutionContext) -> DO + Send,
 >(
     f: F,
-) -> impl DeviceOperation<Output = O> {
+) -> impl DeviceOp<Output = O> {
     StreamOperation { f }
 }
 
-impl<O: Send, DO: DeviceOperation<Output = O>, F: FnOnce(&ExecutionContext) -> DO + Send> IntoFuture
+impl<O: Send, DO: DeviceOp<Output = O>, F: FnOnce(&ExecutionContext) -> DO + Send> IntoFuture
     for StreamOperation<O, DO, F>
 {
     type Output = Result<O, DeviceError>;
     type IntoFuture = DeviceFuture<O, StreamOperation<O, DO, F>>;
     fn into_future(self) -> Self::IntoFuture {
-        match with_default_device_policy(|policy| policy.schedule(self)) {
+        match with_default_device_policy(|policy| {
+            let stream = policy.next_stream()?;
+            let mut f = DeviceFuture::new();
+            f.device_operation = Some(self);
+            f.execution_context = Some(ExecutionContext::new(stream));
+            Ok(f)
+        }) {
             Ok(Ok(future)) => future,
-            Ok(Err(e)) | Err(e) => DeviceFuture::failed(e),
+            Ok(Err(e)) => DeviceFuture::failed(e),
+            Err(e) => DeviceFuture::failed(e),
         }
     }
 }
@@ -827,8 +1364,8 @@ impl<O: Send, DO: DeviceOperation<Output = O>, F: FnOnce(&ExecutionContext) -> D
 
 pub struct AndThenWithContext<I: Send, DI, O: Send, DO, F>
 where
-    DI: DeviceOperation<Output = I>,
-    DO: DeviceOperation<Output = O>,
+    DI: DeviceOp<Output = I>,
+    DO: DeviceOp<Output = O>,
     F: FnOnce(&ExecutionContext, I) -> DO,
 {
     op: DI,
@@ -837,16 +1374,16 @@ where
 
 unsafe impl<I: Send, DI, O: Send, DO, F> Send for AndThenWithContext<I, DI, O, DO, F>
 where
-    DI: DeviceOperation<Output = I>,
-    DO: DeviceOperation<Output = O>,
+    DI: DeviceOp<Output = I>,
+    DO: DeviceOp<Output = O>,
     F: FnOnce(&ExecutionContext, I) -> DO + Send,
 {
 }
 
-impl<I: Send, DI, O: Send, DO, F> DeviceOperation for AndThenWithContext<I, DI, O, DO, F>
+impl<I: Send, DI, O: Send, DO, F> DeviceOp for AndThenWithContext<I, DI, O, DO, F>
 where
-    DI: DeviceOperation<Output = I>,
-    DO: DeviceOperation<Output = O>,
+    DI: DeviceOp<Output = I>,
+    DO: DeviceOp<Output = O>,
     F: FnOnce(&ExecutionContext, I) -> DO + Send,
 {
     type Output = O;
@@ -854,7 +1391,7 @@ where
     unsafe fn execute(
         self,
         context: &ExecutionContext,
-    ) -> Result<<Self as DeviceOperation>::Output, DeviceError> {
+    ) -> Result<<Self as DeviceOp>::Output, DeviceError> {
         let input: I = self.op.execute(context)?;
         let output_device_op: DO = (self.closure)(context, input);
         output_device_op.execute(context)
@@ -863,16 +1400,100 @@ where
 
 impl<I: Send, DI, O: Send, DO, F> IntoFuture for AndThenWithContext<I, DI, O, DO, F>
 where
-    DI: DeviceOperation<Output = I>,
-    DO: DeviceOperation<Output = O>,
+    DI: DeviceOp<Output = I>,
+    DO: DeviceOp<Output = O>,
     F: FnOnce(&ExecutionContext, I) -> DO + Send,
 {
     type Output = Result<O, DeviceError>;
     type IntoFuture = DeviceFuture<O, AndThenWithContext<I, DI, O, DO, F>>;
     fn into_future(self) -> Self::IntoFuture {
-        match with_default_device_policy(|policy| policy.schedule(self)) {
+        match with_default_device_policy(|policy| {
+            let stream = policy.next_stream()?;
+            let mut f = DeviceFuture::new();
+            f.device_operation = Some(self);
+            f.execution_context = Some(ExecutionContext::new(stream));
+            Ok(f)
+        }) {
             Ok(Ok(future)) => future,
-            Ok(Err(e)) | Err(e) => DeviceFuture::failed(e),
+            Ok(Err(e)) => DeviceFuture::failed(e),
+            Err(e) => DeviceFuture::failed(e),
         }
     }
 }
+
+// DeviceOpVec — execute a Vec of boxed operations, sync once.
+
+/// A [`DeviceOp`] that executes a vector of [`BoxedDeviceOp`]s
+/// sequentially on the same stream and collects their outputs into a `Vec<T>`.
+///
+/// This avoids per-element stream synchronization: the caller can issue a
+/// single `.sync_on(&stream)` after all operations have been submitted.
+pub struct DeviceOpVec<T: Send> {
+    ops: Vec<BoxedDeviceOp<T>>,
+}
+
+impl<T: Send + 'static> DeviceOpVec<T> {
+    pub fn empty() -> Self {
+        Self { ops: Vec::new() }
+    }
+
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            ops: Vec::with_capacity(capacity),
+        }
+    }
+
+    pub fn new(ops: Vec<BoxedDeviceOp<T>>) -> Self {
+        Self { ops }
+    }
+
+    pub fn push<DO: DeviceOp<Output = T> + 'static>(&mut self, op: DO) {
+        self.ops.push(op.boxed());
+    }
+
+    pub fn remove(&mut self, index: usize) -> BoxedDeviceOp<T> {
+        self.ops.remove(index)
+    }
+
+    pub fn last(&self) -> Option<&BoxedDeviceOp<T>> {
+        self.ops.last()
+    }
+}
+
+impl<T: Send> DeviceOp for DeviceOpVec<T> {
+    type Output = Vec<T>;
+
+    unsafe fn execute(self, context: &ExecutionContext) -> Result<Vec<T>, DeviceError> {
+        let mut results = Vec::with_capacity(self.ops.len());
+        for op in self.ops {
+            results.push(op.execute(context)?);
+        }
+        Ok(results)
+    }
+}
+
+impl<T: Send> IntoFuture for DeviceOpVec<T> {
+    type Output = Result<Vec<T>, DeviceError>;
+    type IntoFuture = DeviceFuture<Vec<T>, Self>;
+    fn into_future(self) -> Self::IntoFuture {
+        match with_default_device_policy(|policy| {
+            let stream = policy.next_stream()?;
+            let mut f = DeviceFuture::new();
+            f.device_operation = Some(self);
+            f.execution_context = Some(ExecutionContext::new(stream));
+            Ok(f)
+        }) {
+            Ok(Ok(future)) => future,
+            Ok(Err(e)) => DeviceFuture::failed(e),
+            Err(e) => DeviceFuture::failed(e),
+        }
+    }
+}
+
+impl<T: Send + 'static> From<Vec<BoxedDeviceOp<T>>> for DeviceOpVec<T> {
+    fn from(ops: Vec<BoxedDeviceOp<T>>) -> Self {
+        Self::new(ops)
+    }
+}
+
+// New names — old names kept as re-exports for backwards compatibility.

--- a/cuda-async/src/launch.rs
+++ b/cuda-async/src/launch.rs
@@ -7,9 +7,8 @@
 
 use crate::device_context::with_default_device_policy;
 use crate::device_future::DeviceFuture;
-use crate::device_operation::{DeviceOperation, ExecutionContext};
+use crate::device_operation::{DeviceOp, ExecutionContext};
 use crate::error::DeviceError;
-use crate::scheduling_policies::SchedulingPolicy;
 use anyhow::{Context, Result};
 use cuda_core::sys::CUdeviceptr;
 use cuda_core::{launch_kernel, CudaFunction, CudaStream, DType, LaunchConfig};
@@ -34,9 +33,9 @@ impl Drop for AsyncKernelLaunch {
         let _ = self
             .args
             .iter()
-            .map(|&arg| {
+            .map(|arg| {
                 // Reconstruct the boxes. Pointers will be dropped when they go out of scope.
-                unsafe { Box::from_raw(arg as *mut usize) }
+                unsafe { Box::from_raw(*arg) }
             })
             .collect::<Vec<_>>();
     }
@@ -90,9 +89,9 @@ impl AsyncKernelLaunch {
     /// # Safety
     /// The caller must ensure the kernel arguments and launch config are valid.
     unsafe fn launch(mut self, stream: &Arc<CudaStream>) -> Result<(), DeviceError> {
-        let cfg = self.cfg.ok_or_else(|| {
-            DeviceError::Launch("Await called before launching the kernel.".to_string())
-        })?;
+        let cfg = self.cfg.ok_or(DeviceError::Launch(
+            "Await called before launching the kernel.".to_string(),
+        ))?;
         launch_kernel(
             self.func.cu_function(),
             cfg.grid_dim,
@@ -138,13 +137,13 @@ impl<T: DType> KernelArgument for T {
     }
 }
 
-impl DeviceOperation for AsyncKernelLaunch {
+impl DeviceOp for AsyncKernelLaunch {
     type Output = ();
 
     unsafe fn execute(
         self,
         ctx: &ExecutionContext,
-    ) -> Result<<Self as DeviceOperation>::Output, DeviceError> {
+    ) -> Result<<Self as DeviceOp>::Output, DeviceError> {
         self.launch(ctx.get_cuda_stream())
     }
 }
@@ -153,9 +152,16 @@ impl IntoFuture for AsyncKernelLaunch {
     type Output = Result<(), DeviceError>;
     type IntoFuture = DeviceFuture<(), AsyncKernelLaunch>;
     fn into_future(self) -> Self::IntoFuture {
-        match with_default_device_policy(|policy| policy.schedule(self)) {
+        match with_default_device_policy(|policy| {
+            let stream = policy.next_stream()?;
+            let mut f = DeviceFuture::new();
+            f.device_operation = Some(self);
+            f.execution_context = Some(ExecutionContext::new(stream));
+            Ok(f)
+        }) {
             Ok(Ok(future)) => future,
-            Ok(Err(e)) | Err(e) => DeviceFuture::failed(e),
+            Ok(Err(e)) => DeviceFuture::failed(e),
+            Err(e) => DeviceFuture::failed(e),
         }
     }
 }

--- a/cuda-async/src/lib.rs
+++ b/cuda-async/src/lib.rs
@@ -6,12 +6,14 @@
 //! Async runtime for CUDA device operations, providing futures-based kernel launching
 //! and device memory management.
 
+pub mod cuda_graph;
 pub mod device_buffer;
 pub mod device_context;
 pub mod device_future;
 pub mod device_operation;
 pub mod error;
 pub mod launch;
+pub mod prelude;
 pub mod scheduling_policies;
 
 pub use futures;

--- a/cuda-async/src/prelude.rs
+++ b/cuda-async/src/prelude.rs
@@ -1,0 +1,46 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Convenience re-exports for common `cuda-async` types and traits.
+//!
+//! ```rust,ignore
+//! use cuda_async::prelude::*;
+//! ```
+
+// Core traits + execution context
+pub use crate::device_operation::DeviceOp;
+pub use crate::device_operation::ExecutionContext;
+pub use crate::device_operation::GraphNode;
+
+// Constructors and helpers
+pub use crate::device_operation::value;
+pub use crate::device_operation::with_context;
+pub use crate::device_operation::DeviceOpUnwrapArc;
+pub use crate::device_operation::IntoDeviceOp;
+
+// Composition traits
+pub use crate::device_operation::Unzippable1;
+pub use crate::device_operation::Unzippable2;
+pub use crate::device_operation::Unzippable3;
+pub use crate::device_operation::Unzippable4;
+pub use crate::device_operation::Unzippable5;
+pub use crate::device_operation::Unzippable6;
+pub use crate::device_operation::Zippable;
+
+// Macros
+pub use crate::unzip;
+pub use crate::zip;
+
+// Concrete types users commonly name
+pub use crate::device_operation::BoxedDeviceOp;
+pub use crate::device_operation::DeviceOpVec;
+pub use crate::device_operation::SharedDeviceOp;
+pub use crate::device_operation::Value;
+
+// CUDA graph capture
+pub use crate::cuda_graph::{CudaGraph, Scope};
+
+// Error type
+pub use crate::error::DeviceError;

--- a/cuda-async/src/scheduling_policies.rs
+++ b/cuda-async/src/scheduling_policies.rs
@@ -5,302 +5,83 @@
 
 //! Stream scheduling policies that control how operations are assigned to CUDA streams.
 
-use crate::device_future::DeviceFuture;
-use crate::device_operation::{DeviceOperation, ExecutionContext};
-use crate::error::{device_error, DeviceError};
+use crate::error::DeviceError;
 use cuda_core::{CudaContext, CudaStream};
 use std::sync::atomic::AtomicUsize;
 use std::sync::Arc;
 
-/// The active scheduling policy for a device context.
+/// A strategy for selecting which CUDA stream to run the next operation on.
 ///
-/// A scheduling policy decides **which CUDA stream** each [`DeviceOperation`] runs on.
-/// This single decision controls whether consecutive operations can overlap on the GPU:
+/// This is the only decision a policy makes — which stream. The `DeviceOp` trait
+/// handles the rest (constructing futures, synchronizing, etc.).
 ///
-/// - **Same stream** → operations execute in order (serialized).
-/// - **Different streams** → operations *may* execute concurrently.
-///
-/// The default policy is [`RoundRobin`](GlobalSchedulingPolicy::RoundRobin), which
-/// distributes operations across a pool of streams.
-///
-/// # Choosing a Policy
-///
-/// | Policy          | Behavior                 | When to use                                  |
-/// |-----------------|--------------------------|----------------------------------------------|
-/// | `RoundRobin(N)` | Cycles through N streams | Default; enables overlap for independent ops |
-/// | `SingleStream`  | All ops on one stream    | Strict ordering without manual sync          |
-///
-/// See [`StreamPoolRoundRobin`] and [`SingleStream`] for details.
-pub enum GlobalSchedulingPolicy {
-    /// Round-robin scheduling across a pool of CUDA streams.
-    RoundRobin(StreamPoolRoundRobin),
-}
-
-impl GlobalSchedulingPolicy {
-    pub fn as_scheduling_policy(&self) -> Result<&impl SchedulingPolicy, DeviceError> {
-        match self {
-            GlobalSchedulingPolicy::RoundRobin(roundrobin) => Ok(roundrobin),
-        }
-    }
-}
-
-impl WithDeviceId for GlobalSchedulingPolicy {
-    fn get_device_id(&self) -> usize {
-        match self {
-            GlobalSchedulingPolicy::RoundRobin(roundrobin) => roundrobin.get_device_id(),
-        }
-    }
-}
-
-impl SchedulingPolicy for GlobalSchedulingPolicy {
-    fn init(&mut self, ctx: &Arc<CudaContext>) -> Result<(), DeviceError> {
-        match self {
-            GlobalSchedulingPolicy::RoundRobin(roundrobin) => roundrobin.init(ctx),
-        }
-    }
-    fn schedule<T: Send, O: DeviceOperation<Output = T>>(
-        &self,
-        op: O,
-    ) -> Result<DeviceFuture<T, O>, DeviceError> {
-        match self {
-            GlobalSchedulingPolicy::RoundRobin(roundrobin) => roundrobin.schedule(op),
-        }
-    }
-    fn sync<T: Send, O: DeviceOperation<Output = T>>(&self, op: O) -> Result<T, DeviceError> {
-        match self {
-            GlobalSchedulingPolicy::RoundRobin(roundrobin) => roundrobin.sync(op),
-        }
-    }
-}
-
-impl SchedulingPolicy for Arc<GlobalSchedulingPolicy> {
-    fn init(&mut self, _ctx: &Arc<CudaContext>) -> Result<(), DeviceError> {
-        Err(DeviceError::Scheduling(
-            "Cannot initialize scheduling policy inside an Arc.".to_string(),
-        ))
-    }
-    fn schedule<T: Send, O: DeviceOperation<Output = T>>(
-        &self,
-        op: O,
-    ) -> Result<DeviceFuture<T, O>, DeviceError> {
-        match self.as_ref() {
-            GlobalSchedulingPolicy::RoundRobin(roundrobin) => roundrobin.schedule(op),
-        }
-    }
-    fn sync<T: Send, O: DeviceOperation<Output = T>>(&self, op: O) -> Result<T, DeviceError> {
-        match self.as_ref() {
-            GlobalSchedulingPolicy::RoundRobin(roundrobin) => roundrobin.sync(op),
-        }
-    }
-}
-
-/// Trait for types that are bound to a specific GPU device.
-pub trait WithDeviceId {
-    fn get_device_id(&self) -> usize;
-}
-
-/// A strategy for assigning [`DeviceOperation`]s to CUDA streams.
-///
-/// Every operation submitted through `.await`, `.sync()`, or `.schedule()` passes through
-/// a `SchedulingPolicy`. The policy picks a stream and returns a [`DeviceFuture`] bound to
-/// that stream.
+/// Object-safe: no generic methods. Stored as `Arc<dyn SchedulingPolicy>` in the
+/// thread-local device context.
 ///
 /// # Stream Ordering Guarantees
 ///
 /// CUDA guarantees that work items on the **same stream** execute in submission order.
-/// Work on **different streams** has no ordering guarantee — the GPU hardware scheduler
-/// is free to interleave or overlap them.
-///
-/// This means the policy directly affects concurrency behavior:
-///
-/// ```text
-/// ┌──────────────────────────────────────────────────-┐
-/// │  RoundRobin(4)        op1 ─► Stream 0             │
-/// │                       op2 ─► Stream 1  (overlap!) │
-/// │                       op3 ─► Stream 2  (overlap!) │
-/// │                       op4 ─► Stream 3  (overlap!) │
-/// │                       op5 ─► Stream 0  (waits for │
-/// │                                         op1)      │
-/// ├──────────────────────────────────────────────────-┤
-/// │  SingleStream         op1 ─► Stream 0             │
-/// │                       op2 ─► Stream 0  (waits)    │
-/// │                       op3 ─► Stream 0  (waits)    │
-/// └──────────────────────────────────────────────────-┘
-/// ```
-///
-/// # Safety
-///
-/// Implementations must be `Sync` because the policy is shared across async tasks.
-///
-// TODO (hme): Isaac's feedback:
-//  - Schedule op takes multiple deviceOps + meta data per policy*.
-//  - Metadata type per policy impl.
-pub trait SchedulingPolicy: Sync {
-    /// Create the underlying CUDA streams. Called once during device initialization.
-    fn init(&mut self, ctx: &Arc<CudaContext>) -> Result<(), DeviceError>;
-
-    /// Assign `op` to a stream and return a [`DeviceFuture`] that will execute it.
-    ///
-    /// The operation is **not** executed yet — execution happens when the returned
-    /// future is first polled.
-    fn schedule<T: Send, O: DeviceOperation<Output = T>>(
-        &self,
-        op: O,
-    ) -> Result<DeviceFuture<T, O>, DeviceError>;
-
-    /// Execute `op` synchronously: submit to a stream, then block until the GPU finishes.
-    fn sync<T: Send, O: DeviceOperation<Output = T>>(&self, op: O) -> Result<T, DeviceError>;
+/// Work on **different streams** has no ordering guarantee.
+pub trait SchedulingPolicy: Send + Sync {
+    /// Select the next CUDA stream for an operation.
+    fn next_stream(&self) -> Result<Arc<CudaStream>, DeviceError>;
 }
 
 /// Distributes operations across a fixed-size pool of CUDA streams using round-robin assignment.
 ///
-/// This is the **default scheduling policy**. Each call to [`schedule`](SchedulingPolicy::schedule)
-/// or [`sync`](SchedulingPolicy::sync) picks the next stream in the pool (wrapping around),
-/// so consecutive operations typically land on **different streams** and may run concurrently
-/// on the GPU.
-///
-/// # Default Configuration
-///
-/// The default pool size is **4 streams**
-/// ([`DEFAULT_ROUND_ROBIN_STREAM_POOL_SIZE`](crate::device_context::DEFAULT_ROUND_ROBIN_STREAM_POOL_SIZE)).
-///
-/// # Overlap and Dependencies
-///
-/// Because consecutive operations usually go to different streams, they can overlap:
-///
-/// ```text
-/// .await (op A) ─► Stream 0 ──▶ ████████          (GPU work A)
-/// .await (op B) ─► Stream 1 ──▶    ████████       (GPU work B, overlaps A)
-/// .await (op C) ─► Stream 2 ──▶       ████████    (GPU work C, overlaps B)
-/// ```
-#[derive(Debug)]
+/// This is the **default scheduling policy**. Each call to `next_stream()` picks the
+/// next stream in the pool (wrapping around), so consecutive operations typically land
+/// on **different streams** and may run concurrently on the GPU.
 pub struct StreamPoolRoundRobin {
-    device_id: usize,
     next_stream_idx: AtomicUsize,
-    pub(crate) num_streams: usize,
-    pub(crate) stream_pool: Option<Vec<Arc<CudaStream>>>,
+    stream_pool: Vec<Arc<CudaStream>>,
 }
 
 impl StreamPoolRoundRobin {
-    // This has to be unsafe, because we cannot otherwise guarantee correct ordering of operations.
-    pub unsafe fn new(device_id: usize, num_streams: usize) -> Self {
-        Self {
-            device_id,
-            num_streams,
-            stream_pool: None,
-            next_stream_idx: AtomicUsize::new(0),
+    /// Creates a round-robin pool with `num_streams` streams on the given context.
+    pub fn new(ctx: &Arc<CudaContext>, num_streams: usize) -> Result<Self, DeviceError> {
+        let mut stream_pool = Vec::with_capacity(num_streams);
+        for _ in 0..num_streams {
+            stream_pool.push(ctx.new_stream()?);
         }
+        Ok(Self {
+            stream_pool,
+            next_stream_idx: AtomicUsize::new(0),
+        })
     }
 }
 
 impl SchedulingPolicy for StreamPoolRoundRobin {
-    fn init(&mut self, ctx: &Arc<CudaContext>) -> Result<(), DeviceError> {
-        let mut stream_pool = vec![];
-        for _ in 0..self.num_streams {
-            let stream = ctx.new_stream()?;
-            stream_pool.push(stream);
-        }
-        self.stream_pool = Some(stream_pool);
-        Ok(())
-    }
-    fn sync<T: Send, O: DeviceOperation<Output = T>>(&self, op: O) -> Result<T, DeviceError> {
-        let non_wrapping_idx = self
+    fn next_stream(&self) -> Result<Arc<CudaStream>, DeviceError> {
+        let idx = self
             .next_stream_idx
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        let stream_idx = non_wrapping_idx % self.num_streams;
-        let stream_pool = self
-            .stream_pool
-            .as_ref()
-            .ok_or_else(|| device_error(self.device_id, "Stream pool not initialized."))?;
-        let stream = &stream_pool[stream_idx];
-        op.sync_on(stream)
-    }
-    fn schedule<T: Send, O: DeviceOperation<Output = T>>(
-        &self,
-        op: O,
-    ) -> Result<DeviceFuture<T, O>, DeviceError> {
-        let non_wrapping_idx = self
-            .next_stream_idx
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        let stream_idx = non_wrapping_idx % self.num_streams;
-        let stream_pool = self
-            .stream_pool
-            .as_ref()
-            .ok_or_else(|| device_error(self.device_id, "Stream pool not initialized."))?;
-        let stream = &stream_pool[stream_idx];
-        let future = DeviceFuture {
-            device_operation: Some(op),
-            execution_context: Some(ExecutionContext::new(Arc::clone(stream))),
-            ..Default::default()
-        };
-        Ok(future)
-    }
-}
-
-impl WithDeviceId for StreamPoolRoundRobin {
-    fn get_device_id(&self) -> usize {
-        self.device_id
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+            % self.stream_pool.len();
+        Ok(Arc::clone(&self.stream_pool[idx]))
     }
 }
 
 /// Routes every operation to a single CUDA stream, guaranteeing strict sequential execution.
-///
-/// All operations submitted through this policy execute in exactly the order they are
-/// scheduled — no overlap, no reordering. This is the simplest mental model but leaves
-/// GPU concurrency on the table.
-///
-/// # When to Use
-///
-/// - Debugging: eliminates concurrency as a source of bugs.
-/// - Strict pipelines: when every operation depends on the previous one and you want
-///   to avoid explicit synchronization.
-///
-/// For most workloads, [`StreamPoolRoundRobin`] is preferred because it allows the GPU
-/// to overlap independent operations.
-#[derive(Debug)]
 pub struct SingleStream {
-    #[expect(dead_code, reason = "unsure what this is for")]
-    device_id: usize,
-    pub stream: Option<Arc<CudaStream>>,
+    stream: Arc<CudaStream>,
 }
 
 impl SingleStream {
-    // This has to be unsafe, because we cannot otherwise guarantee correct ordering of operations.
-    pub unsafe fn new(device_id: usize) -> Self {
-        Self {
-            device_id,
-            stream: None,
-        }
+    /// Creates a single-stream policy on the given context.
+    pub fn new(ctx: &Arc<CudaContext>) -> Result<Self, DeviceError> {
+        Ok(Self {
+            stream: ctx.new_stream()?,
+        })
     }
-    pub fn schedule_single<T: Send, O: DeviceOperation<Output = T>>(
-        &self,
-        op: O,
-    ) -> DeviceFuture<T, O> {
-        let stream = self.stream.as_ref().unwrap();
-        DeviceFuture {
-            device_operation: Some(op),
-            execution_context: Some(ExecutionContext::new(Arc::clone(stream))),
-            ..Default::default()
-        }
+
+    /// Returns a reference to the underlying stream.
+    pub fn stream(&self) -> &Arc<CudaStream> {
+        &self.stream
     }
 }
 
 impl SchedulingPolicy for SingleStream {
-    fn init(&mut self, ctx: &Arc<CudaContext>) -> Result<(), DeviceError> {
-        self.stream = Some(
-            ctx.new_stream()
-                .expect("Failed to create dedicated stream."),
-        );
-        Ok(())
-    }
-    fn schedule<T: Send, O: DeviceOperation<Output = T>>(
-        &self,
-        op: O,
-    ) -> Result<DeviceFuture<T, O>, DeviceError> {
-        Ok(self.schedule_single(op))
-    }
-    fn sync<T: Send, O: DeviceOperation<Output = T>>(&self, op: O) -> Result<T, DeviceError> {
-        let stream = self.stream.as_ref().unwrap();
-        op.sync_on(stream)
+    fn next_stream(&self) -> Result<Arc<CudaStream>, DeviceError> {
+        Ok(Arc::clone(&self.stream))
     }
 }

--- a/cuda-async/tests/concurrent_capture.rs
+++ b/cuda-async/tests/concurrent_capture.rs
@@ -1,0 +1,102 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Tests for concurrent CUDA stream capture behavior.
+
+use cuda_async::cuda_graph::CudaGraph;
+use cuda_async::device_operation::value;
+use cuda_async::error::DeviceError;
+
+fn has_gpu() -> bool {
+    cuda_core::CudaContext::device_count()
+        .map(|n| n > 0)
+        .unwrap_or(false)
+}
+
+/// Two threads capture simultaneously on different streams from
+/// the same CUDA context.
+#[test]
+fn concurrent_capture_same_context() {
+    if !has_gpu() {
+        return;
+    }
+
+    let ctx = cuda_core::CudaContext::new(0).unwrap();
+    let stream_a = ctx.new_stream().unwrap();
+    let stream_b = ctx.new_stream().unwrap();
+
+    let handle_a = std::thread::spawn(move || -> Result<(), DeviceError> {
+        CudaGraph::scope(&stream_a, |s| {
+            s.record(value(1))?;
+            std::thread::sleep(std::time::Duration::from_millis(50));
+            s.record(value(2))?;
+            Ok(())
+        })?;
+        Ok(())
+    });
+
+    let handle_b = std::thread::spawn(move || -> Result<(), DeviceError> {
+        CudaGraph::scope(&stream_b, |s| {
+            s.record(value(3))?;
+            std::thread::sleep(std::time::Duration::from_millis(50));
+            s.record(value(4))?;
+            Ok(())
+        })?;
+        Ok(())
+    });
+
+    let result_a = handle_a.join().expect("thread A panicked");
+    let result_b = handle_b.join().expect("thread B panicked");
+
+    assert!(
+        result_a.is_ok() && result_b.is_ok(),
+        "Concurrent capture failed: A={result_a:?}, B={result_b:?}"
+    );
+}
+
+/// Thread A captures while thread B creates a new stream from a
+/// fresh CudaContext::new(0). Previously this failed because
+/// new_stream called cuCtxSynchronize (for event tracking init),
+/// which conflicted with A's active capture.
+#[test]
+fn new_stream_during_capture_on_another_thread() {
+    if !has_gpu() {
+        return;
+    }
+
+    let ctx_a = cuda_core::CudaContext::new(0).unwrap();
+    let stream_a = ctx_a.new_stream().unwrap();
+
+    let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
+    let barrier_a = barrier.clone();
+    let barrier_b = barrier.clone();
+
+    let handle_a = std::thread::spawn(move || -> Result<(), DeviceError> {
+        CudaGraph::scope(&stream_a, |s| {
+            s.record(value(1))?;
+            barrier_a.wait();
+            std::thread::sleep(std::time::Duration::from_millis(100));
+            s.record(value(2))?;
+            Ok(())
+        })?;
+        Ok(())
+    });
+
+    let handle_b = std::thread::spawn(move || -> Result<(), DeviceError> {
+        barrier_b.wait();
+        let ctx_b = cuda_core::CudaContext::new(0).unwrap();
+        let _stream = ctx_b.new_stream()?;
+        Ok(())
+    });
+
+    let result_a = handle_a.join().expect("thread A panicked");
+    let result_b = handle_b.join().expect("thread B panicked");
+
+    assert!(result_a.is_ok(), "Capture should succeed: {result_a:?}");
+    assert!(
+        result_b.is_ok(),
+        "new_stream should succeed during concurrent capture: {result_b:?}"
+    );
+}

--- a/cuda-async/tests/cuda_graph.rs
+++ b/cuda-async/tests/cuda_graph.rs
@@ -1,0 +1,165 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Tests for `CudaGraph::scope` — scoped CUDA graph capture.
+
+use cuda_async::cuda_graph::CudaGraph;
+use cuda_async::device_operation::{value, DeviceOp};
+use cuda_async::error::DeviceError;
+
+fn has_gpu() -> bool {
+    cuda_core::CudaContext::device_count()
+        .map(|n| n > 0)
+        .unwrap_or(false)
+}
+
+fn on_fresh_thread<F: FnOnce() + Send + 'static>(f: F) {
+    std::thread::spawn(f).join().expect("test thread panicked");
+}
+
+#[test]
+fn scope_empty_closure() {
+    if !has_gpu() {
+        return;
+    }
+    on_fresh_thread(|| {
+        let ctx = cuda_core::CudaContext::new(0).unwrap();
+        let stream = ctx.new_stream().unwrap();
+
+        let graph = CudaGraph::scope(&stream, |_s| Ok(())).unwrap();
+        graph.launch().unwrap();
+    });
+}
+
+#[test]
+fn scope_records_value_ops() {
+    if !has_gpu() {
+        return;
+    }
+    on_fresh_thread(|| {
+        let ctx = cuda_core::CudaContext::new(0).unwrap();
+        let stream = ctx.new_stream().unwrap();
+
+        let mut recorded = Vec::new();
+        let graph = CudaGraph::scope(&stream, |s| {
+            let a = s.record(value(42))?;
+            let b = s.record(value("hello"))?;
+            recorded.push(a);
+            recorded.push(b.len() as i32);
+            Ok(())
+        })
+        .unwrap();
+
+        assert_eq!(recorded, vec![42, 5]);
+        graph.launch().unwrap();
+    });
+}
+
+#[test]
+fn scope_error_propagation() {
+    if !has_gpu() {
+        return;
+    }
+    on_fresh_thread(|| {
+        let ctx = cuda_core::CudaContext::new(0).unwrap();
+        let stream = ctx.new_stream().unwrap();
+
+        let result = CudaGraph::scope(&stream, |_s| {
+            Err(DeviceError::Internal("test error".into()))
+        });
+
+        assert!(result.is_err());
+        match result {
+            Err(DeviceError::Internal(msg)) => {
+                assert!(
+                    msg.contains("test error"),
+                    "Expected test error, got: {msg}"
+                );
+            }
+            Err(e) => panic!("Expected Internal error, got: {e}"),
+            Ok(_) => panic!("Expected error, got Ok"),
+        }
+    });
+}
+
+#[test]
+fn scope_panic_safety() {
+    if !has_gpu() {
+        return;
+    }
+    let result = std::thread::spawn(|| {
+        let ctx = cuda_core::CudaContext::new(0).unwrap();
+        let stream = ctx.new_stream().unwrap();
+
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            CudaGraph::scope(&stream, |_s| {
+                panic!("intentional panic in scope");
+            })
+        }));
+
+        // Stream should still be usable after the panic.
+        stream.synchronize().unwrap();
+    })
+    .join();
+
+    assert!(
+        result.is_ok(),
+        "Thread should not panic after scope cleanup"
+    );
+}
+
+#[test]
+fn scope_multiple_launches() {
+    if !has_gpu() {
+        return;
+    }
+    on_fresh_thread(|| {
+        let ctx = cuda_core::CudaContext::new(0).unwrap();
+        let stream = ctx.new_stream().unwrap();
+
+        let graph = CudaGraph::scope(&stream, |_s| Ok(())).unwrap();
+
+        for _ in 0..10 {
+            graph.launch().unwrap();
+        }
+    });
+}
+
+#[test]
+fn scope_nested_execution_rejected() {
+    // Any attempt to execute a DeviceOp inside the scope closure
+    // (via sync_on, sync, etc.) is rejected by the thread-local
+    // execution lock — enforcing the invariant that only one
+    // DeviceOp may be executing at a time per thread.
+    if !has_gpu() {
+        return;
+    }
+    on_fresh_thread(|| {
+        let ctx = cuda_core::CudaContext::new(0).unwrap();
+        let stream = ctx.new_stream().unwrap();
+        let other_stream = ctx.new_stream().unwrap();
+
+        // sync_on capture stream — rejected by execution lock.
+        let result = CudaGraph::scope(&stream, |_s| {
+            let _ = value(42).sync_on(&stream)?;
+            Ok(())
+        });
+        assert!(result.is_err(), "nested sync_on should fail");
+
+        // sync_on other stream — also rejected by execution lock.
+        let result = CudaGraph::scope(&stream, |_s| {
+            let _ = value(42).sync_on(&other_stream)?;
+            Ok(())
+        });
+        assert!(result.is_err(), "nested sync_on (other stream) should fail");
+
+        // sync — also rejected.
+        let result = CudaGraph::scope(&stream, |_s| {
+            value(42).sync()?;
+            Ok(())
+        });
+        assert!(result.is_err(), "nested sync should fail");
+    });
+}

--- a/cuda-async/tests/error_handling.rs
+++ b/cuda-async/tests/error_handling.rs
@@ -12,13 +12,11 @@
 //! start from a clean `DEVICE_CONTEXTS`.
 
 use cuda_async::device_context::{
-    get_default_device, init_device_contexts, new_device_context, set_default_device,
-    DEFAULT_DEVICE_ID, DEFAULT_ROUND_ROBIN_STREAM_POOL_SIZE,
+    get_default_device, init_device_contexts, set_default_device, DEFAULT_DEVICE_ID,
 };
 use cuda_async::device_future::DeviceFuture;
 use cuda_async::device_operation::Value;
 use cuda_async::error::{device_assert, device_error, DeviceError};
-use cuda_async::scheduling_policies::{GlobalSchedulingPolicy, StreamPoolRoundRobin};
 use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
@@ -176,8 +174,10 @@ fn set_default_device_changes_value() {
 #[test]
 fn new_device_context_with_invalid_device_returns_driver_error() {
     // Device ordinal 9999 should not exist on any reasonable system.
-    let policy = unsafe { StreamPoolRoundRobin::new(9999, DEFAULT_ROUND_ROBIN_STREAM_POOL_SIZE) };
-    let result = new_device_context(9999, GlobalSchedulingPolicy::RoundRobin(policy));
+    // CudaContext::new(9999) will fail with a driver error, which propagates
+    // through new_device_context.
+    let result = cuda_core::CudaContext::new(9999);
+    let result = result.map_err(DeviceError::Driver);
     match result {
         Err(DeviceError::Driver(_)) => { /* expected */ }
         Err(other) => panic!("expected Driver variant, got: {other:?}"),

--- a/cuda-async/tests/execute_once.rs
+++ b/cuda-async/tests/execute_once.rs
@@ -1,0 +1,315 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Tests verifying that `unzip`, `zip`, and `shared` execute ancestor
+//! operations exactly once, regardless of how many downstream branches
+//! consume the results.
+
+use cuda_async::device_context::init_device_contexts;
+use cuda_async::device_operation::{
+    value, BoxedDeviceOp, DeviceOp, SharedDeviceOp, Unzippable2, Unzippable3, Zippable,
+};
+use cuda_async::zip;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+/// Run `f` on a fresh thread so thread-local `DEVICE_CONTEXTS` starts clean.
+fn on_fresh_thread<F: FnOnce() + Send + 'static>(f: F) {
+    std::thread::spawn(f).join().expect("test thread panicked");
+}
+
+/// Helper: create a `BoxedDeviceOp` that increments `counter` on each execution.
+fn counted_op<T: Send + 'static>(counter: &Arc<AtomicUsize>, val: T) -> BoxedDeviceOp<T> {
+    let c = counter.clone();
+    value(())
+        .then(move |()| {
+            c.fetch_add(1, Ordering::SeqCst);
+            value(val)
+        })
+        .boxed()
+}
+
+// ---------------------------------------------------------------------------
+// .shared() — cloneable, execute-once operations
+// ---------------------------------------------------------------------------
+
+#[test]
+fn shared_executes_ancestor_exactly_once() {
+    on_fresh_thread(|| {
+        init_device_contexts(0, 1).expect("init failed (requires GPU)");
+
+        let counter = Arc::new(AtomicUsize::new(0));
+        let op = counted_op(&counter, 42u64);
+
+        let shared = op.shared();
+        let a = shared.clone().sync().expect("first failed");
+        let b = shared.sync().expect("second failed");
+
+        assert_eq!(counter.load(Ordering::SeqCst), 1);
+        assert_eq!(*a, 42);
+        assert_eq!(*b, 42);
+        assert!(Arc::ptr_eq(&a, &b));
+    });
+}
+
+#[test]
+fn shared_n_way_clone() {
+    on_fresh_thread(|| {
+        init_device_contexts(0, 1).expect("init failed (requires GPU)");
+
+        let counter = Arc::new(AtomicUsize::new(0));
+        let shared = counted_op(&counter, 99u64).shared();
+
+        let results: Vec<Arc<u64>> = (0..5)
+            .map(|_| shared.clone().sync().expect("clone failed"))
+            .collect();
+
+        assert_eq!(counter.load(Ordering::SeqCst), 1);
+        for r in &results {
+            assert_eq!(**r, 99);
+            assert!(Arc::ptr_eq(r, &results[0]));
+        }
+    });
+}
+
+#[test]
+fn shared_into_zip() {
+    on_fresh_thread(|| {
+        init_device_contexts(0, 1).expect("init failed (requires GPU)");
+
+        let counter = Arc::new(AtomicUsize::new(0));
+        let shared = counted_op(&counter, 42u64).shared();
+
+        let (a, b) = zip!(shared.clone(), shared).sync().expect("sync failed");
+
+        assert_eq!(counter.load(Ordering::SeqCst), 1);
+        assert_eq!(*a, 42);
+        assert_eq!(*b, 42);
+        assert!(Arc::ptr_eq(&a, &b));
+    });
+}
+
+#[test]
+fn shared_pre_computed() {
+    on_fresh_thread(|| {
+        init_device_contexts(0, 1).expect("init failed (requires GPU)");
+
+        let val = Arc::new(7u64);
+        let shared: SharedDeviceOp<u64> = cuda_async::device_operation::shared(val.clone());
+
+        let a = shared.clone().sync().expect("first failed");
+        let b = shared.sync().expect("second failed");
+
+        assert_eq!(*a, 7);
+        assert!(Arc::ptr_eq(&a, &b));
+        assert!(Arc::ptr_eq(&a, &val));
+    });
+}
+
+// ---------------------------------------------------------------------------
+// unzip (2-tuple)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn unzip2_executes_ancestor_exactly_once() {
+    on_fresh_thread(|| {
+        init_device_contexts(0, 1).expect("init failed (requires GPU)");
+
+        let counter = Arc::new(AtomicUsize::new(0));
+        let c = counter.clone();
+        let op = value(()).then(move |()| {
+            c.fetch_add(1, Ordering::SeqCst);
+            value((1u64, 2u64))
+        });
+
+        let (left, right) = op.unzip();
+        let a = left.sync().expect("left failed");
+        let b = right.sync().expect("right failed");
+
+        assert_eq!(counter.load(Ordering::SeqCst), 1);
+        assert_eq!(a, 1);
+        assert_eq!(b, 2);
+    });
+}
+
+#[test]
+fn unzip2_right_before_left() {
+    on_fresh_thread(|| {
+        init_device_contexts(0, 1).expect("init failed (requires GPU)");
+
+        let counter = Arc::new(AtomicUsize::new(0));
+        let c = counter.clone();
+        let op = value(()).then(move |()| {
+            c.fetch_add(1, Ordering::SeqCst);
+            value((1u64, 2u64))
+        });
+
+        let (left, right) = op.unzip();
+        let b = right.sync().expect("right failed");
+        let a = left.sync().expect("left failed");
+
+        assert_eq!(counter.load(Ordering::SeqCst), 1);
+        assert_eq!(a, 1);
+        assert_eq!(b, 2);
+    });
+}
+
+// ---------------------------------------------------------------------------
+// unzip (3-tuple — exercises nested _unzip chain)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn unzip3_executes_ancestor_exactly_once() {
+    on_fresh_thread(|| {
+        init_device_contexts(0, 1).expect("init failed (requires GPU)");
+
+        let counter = Arc::new(AtomicUsize::new(0));
+        let c = counter.clone();
+        let op = value(()).then(move |()| {
+            c.fetch_add(1, Ordering::SeqCst);
+            value((1u64, 2u64, 3u64))
+        });
+
+        let (a, b, c_op) = op.unzip();
+        let a = a.sync().expect("a failed");
+        let b = b.sync().expect("b failed");
+        let c_val = c_op.sync().expect("c failed");
+
+        assert_eq!(counter.load(Ordering::SeqCst), 1);
+        assert_eq!(a, 1);
+        assert_eq!(b, 2);
+        assert_eq!(c_val, 3);
+    });
+}
+
+#[test]
+fn unzip3_reversed_execution_order() {
+    on_fresh_thread(|| {
+        init_device_contexts(0, 1).expect("init failed (requires GPU)");
+
+        let counter = Arc::new(AtomicUsize::new(0));
+        let c = counter.clone();
+        let op = value(()).then(move |()| {
+            c.fetch_add(1, Ordering::SeqCst);
+            value((1u64, 2u64, 3u64))
+        });
+
+        let (a, b, c_op) = op.unzip();
+        let c_val = c_op.sync().expect("c failed");
+        let b = b.sync().expect("b failed");
+        let a = a.sync().expect("a failed");
+
+        assert_eq!(counter.load(Ordering::SeqCst), 1);
+        assert_eq!(a, 1);
+        assert_eq!(b, 2);
+        assert_eq!(c_val, 3);
+    });
+}
+
+// ---------------------------------------------------------------------------
+// zip then unzip (round-trip)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn zip2_then_unzip2_executes_each_input_once() {
+    on_fresh_thread(|| {
+        init_device_contexts(0, 1).expect("init failed (requires GPU)");
+
+        let counter_a = Arc::new(AtomicUsize::new(0));
+        let counter_b = Arc::new(AtomicUsize::new(0));
+
+        let op_a = counted_op(&counter_a, 10u64);
+        let op_b = counted_op(&counter_b, 20u64);
+
+        let (a, b) = zip!(op_a, op_b).unzip();
+        let a = a.sync().expect("a failed");
+        let b = b.sync().expect("b failed");
+
+        assert_eq!(counter_a.load(Ordering::SeqCst), 1);
+        assert_eq!(counter_b.load(Ordering::SeqCst), 1);
+        assert_eq!(a, 10);
+        assert_eq!(b, 20);
+    });
+}
+
+#[test]
+fn zip3_then_unzip3_executes_each_input_once() {
+    on_fresh_thread(|| {
+        init_device_contexts(0, 1).expect("init failed (requires GPU)");
+
+        let counter_a = Arc::new(AtomicUsize::new(0));
+        let counter_b = Arc::new(AtomicUsize::new(0));
+        let counter_c = Arc::new(AtomicUsize::new(0));
+
+        let op_a = counted_op(&counter_a, 1u64);
+        let op_b = counted_op(&counter_b, 2u64);
+        let op_c = counted_op(&counter_c, 3u64);
+
+        let (a, b, c_op) = zip!(op_a, op_b, op_c).unzip();
+        let a = a.sync().expect("a failed");
+        let b = b.sync().expect("b failed");
+        let c_val = c_op.sync().expect("c failed");
+
+        assert_eq!(counter_a.load(Ordering::SeqCst), 1);
+        assert_eq!(counter_b.load(Ordering::SeqCst), 1);
+        assert_eq!(counter_c.load(Ordering::SeqCst), 1);
+        assert_eq!(a, 1);
+        assert_eq!(b, 2);
+        assert_eq!(c_val, 3);
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Fan-out then fan-in (unzip → re-zip)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn unzip_then_rezip_executes_ancestor_once() {
+    on_fresh_thread(|| {
+        init_device_contexts(0, 1).expect("init failed (requires GPU)");
+
+        let counter = Arc::new(AtomicUsize::new(0));
+        let c = counter.clone();
+        let op = value(()).then(move |()| {
+            c.fetch_add(1, Ordering::SeqCst);
+            value((1u64, 2u64))
+        });
+
+        let (left, right) = op.unzip();
+        let rezipped = zip!(left, right);
+        let (a, b) = rezipped.sync().expect("sync failed");
+
+        assert_eq!(counter.load(Ordering::SeqCst), 1);
+        assert_eq!(a, 1);
+        assert_eq!(b, 2);
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Diamond: zip two inputs, unzip, transform each branch, re-zip
+// ---------------------------------------------------------------------------
+
+#[test]
+fn diamond_graph_executes_each_leaf_once() {
+    on_fresh_thread(|| {
+        init_device_contexts(0, 1).expect("init failed (requires GPU)");
+
+        let counter_a = Arc::new(AtomicUsize::new(0));
+        let counter_b = Arc::new(AtomicUsize::new(0));
+
+        let op_a = counted_op(&counter_a, 10u64);
+        let op_b = counted_op(&counter_b, 20u64);
+
+        // zip → unzip (fan-out) → transform each branch → re-zip (fan-in)
+        let (a, b) = zip!(op_a, op_b).unzip();
+        let a = a.then(|v| value(v + 1));
+        let b = b.then(|v| value(v + 2));
+        let result = zip!(a, b).sync().expect("sync failed");
+
+        assert_eq!(counter_a.load(Ordering::SeqCst), 1);
+        assert_eq!(counter_b.load(Ordering::SeqCst), 1);
+        assert_eq!(result, (11, 22));
+    });
+}

--- a/cuda-core/src/api.rs
+++ b/cuda-core/src/api.rs
@@ -258,6 +258,48 @@ pub mod curand {
             unsafe { assert!(curandDestroyGenerator(self.curand_gen) == 0) };
         }
     }
+
+    /// Trait for types that support cuRAND normal distribution generation.
+    pub trait RandNormal: Sized + Send {
+        /// Generate normally distributed values into device memory.
+        ///
+        /// # Safety
+        /// `dptr` must be valid device memory with capacity for `len` elements.
+        unsafe fn generate_normal(rng: &RNG, dptr: CUdeviceptr, len: usize, mean: Self, std: Self);
+    }
+
+    impl RandNormal for f32 {
+        unsafe fn generate_normal(rng: &RNG, dptr: CUdeviceptr, len: usize, mean: f32, std: f32) {
+            rng.generate_normal_f32(dptr, len, mean, std);
+        }
+    }
+
+    impl RandNormal for f64 {
+        unsafe fn generate_normal(rng: &RNG, dptr: CUdeviceptr, len: usize, mean: f64, std: f64) {
+            rng.generate_normal_f64(dptr, len, mean, std);
+        }
+    }
+
+    /// Trait for types that support cuRAND uniform distribution generation.
+    pub trait RandUniform: Sized + Send {
+        /// Generate uniformly distributed values in `[0, 1)` into device memory.
+        ///
+        /// # Safety
+        /// `dptr` must be valid device memory with capacity for `len` elements.
+        unsafe fn generate_uniform(rng: &RNG, dptr: CUdeviceptr, len: usize);
+    }
+
+    impl RandUniform for f32 {
+        unsafe fn generate_uniform(rng: &RNG, dptr: CUdeviceptr, len: usize) {
+            rng.generate_uniform_f32(dptr, len);
+        }
+    }
+
+    impl RandUniform for f64 {
+        unsafe fn generate_uniform(rng: &RNG, dptr: CUdeviceptr, len: usize) {
+            rng.generate_uniform_f64(dptr, len);
+        }
+    }
 }
 
 /// Queries a device attribute value for the given device.

--- a/cuda-core/src/cudarc_shim.rs
+++ b/cuda-core/src/cudarc_shim.rs
@@ -11,7 +11,7 @@
 
 use std::ffi::{c_int, c_uint, c_void, CString};
 use std::sync::{
-    atomic::{AtomicBool, AtomicU32, AtomicUsize, Ordering},
+    atomic::{AtomicU32, Ordering},
     Arc,
 };
 
@@ -40,8 +40,6 @@ pub struct CudaContext {
         reason = "cached device capability for future async memory pool decisions"
     )]
     pub(crate) has_async_alloc: bool,
-    pub(crate) num_streams: AtomicUsize,
-    pub(crate) event_tracking: AtomicBool,
     pub(crate) error_state: AtomicU32,
 }
 
@@ -85,8 +83,6 @@ impl CudaContext {
             cu_ctx,
             ordinal,
             has_async_alloc,
-            num_streams: AtomicUsize::new(0),
-            event_tracking: AtomicBool::new(true),
             error_state: AtomicU32::new(0),
         });
         ctx.bind_to_thread()?;
@@ -161,39 +157,15 @@ impl CudaContext {
         ctx::set_flags(flags)
     }
 
-    /// Returns `true` if more than one stream has been created on this context.
-    pub fn is_in_multi_stream_mode(&self) -> bool {
-        self.num_streams.load(Ordering::Relaxed) > 0
-    }
-
-    /// Returns `true` if event tracking is enabled.
-    pub fn is_event_tracking(&self) -> bool {
-        self.event_tracking.load(Ordering::Relaxed)
-    }
-
-    /// Enables event tracking for stream synchronization on multi-stream transitions.
-    ///
-    /// # Safety
-    /// Caller must ensure no concurrent stream creation races with this call.
-    pub unsafe fn enable_event_tracking(&self) {
-        self.event_tracking.store(true, Ordering::Relaxed);
-    }
-
-    /// Disables event tracking.
-    ///
-    /// # Safety
-    /// Caller must ensure disabling tracking does not introduce data races.
-    pub unsafe fn disable_event_tracking(&self) {
-        self.event_tracking.store(false, Ordering::Relaxed);
-    }
-
     /// Checks and clears the context's recorded error state.
     pub fn check_err(&self) -> Result<(), DriverError> {
         let error_state = self.error_state.swap(0, Ordering::Relaxed);
         if error_state == 0 {
             Ok(())
         } else {
-            Err(DriverError(error_state))
+            Err(DriverError(unsafe {
+                std::mem::transmute::<u32, cuda_bindings::cudaError_enum>(error_state)
+            }))
         }
     }
 
@@ -219,7 +191,6 @@ impl Drop for CudaStream {
     fn drop(&mut self) {
         self.ctx.record_err(self.ctx.bind_to_thread());
         if !self.cu_stream.is_null() {
-            self.ctx.num_streams.fetch_sub(1, Ordering::Relaxed);
             self.ctx
                 .record_err(unsafe { stream::destroy(self.cu_stream) });
         }
@@ -237,10 +208,6 @@ impl CudaContext {
     /// Creates a new non-blocking CUDA stream on this context.
     pub fn new_stream(self: &Arc<Self>) -> Result<Arc<CudaStream>, DriverError> {
         self.bind_to_thread()?;
-        let prev_num_streams = self.num_streams.fetch_add(1, Ordering::Relaxed);
-        if prev_num_streams == 0 && self.is_event_tracking() {
-            self.synchronize()?;
-        }
         let cu_stream = stream::create(stream::StreamKind::NonBlocking)?;
         Ok(Arc::new(CudaStream {
             cu_stream,
@@ -253,7 +220,6 @@ impl CudaStream {
     /// Creates a new stream that waits on this stream's current work before proceeding.
     pub fn fork(&self) -> Result<Arc<Self>, DriverError> {
         self.ctx.bind_to_thread()?;
-        self.ctx.num_streams.fetch_add(1, Ordering::Relaxed);
         let cu_stream = stream::create(stream::StreamKind::NonBlocking)?;
         let stream = Arc::new(CudaStream {
             cu_stream,

--- a/cutile-benchmarks/Cargo.toml
+++ b/cutile-benchmarks/Cargo.toml
@@ -35,6 +35,10 @@ name = "rmsnorm"
 harness = false
 
 [[bench]]
+name = "execution_lock"
+harness = false
+
+[[bench]]
 name = "launch_overhead"
 harness = false
 
@@ -44,4 +48,3 @@ cutile-compiler = { workspace = true }
 cuda-async = { workspace = true }
 cuda-core = { workspace = true }
 cutile = { workspace = true }
-cutile-examples = { workspace = true }

--- a/cutile-benchmarks/benches/execution_lock.rs
+++ b/cutile-benchmarks/benches/execution_lock.rs
@@ -1,0 +1,60 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Benchmark: thread-local execution lock overhead.
+//!
+//! Compares the cost of `sync_on` (with lock) vs `async_on` + manual
+//! synchronize (without lock) to measure the overhead of the thread-local
+//! execution guard.
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use cuda_async::device_operation::{value, DeviceOp};
+use std::time::Duration;
+
+fn has_gpu() -> bool {
+    cuda_core::CudaContext::device_count()
+        .map(|n| n > 0)
+        .unwrap_or(false)
+}
+
+fn bench_execution_lock(c: &mut Criterion) {
+    if !has_gpu() {
+        eprintln!("No GPU available, skipping execution_lock benchmark.");
+        return;
+    }
+
+    // Run on a fresh thread to get a clean CUDA context.
+    let (stream,) = std::thread::spawn(|| {
+        let ctx = cuda_core::CudaContext::new(0).unwrap();
+        let stream = ctx.new_stream().unwrap();
+        (stream,)
+    })
+    .join()
+    .unwrap();
+
+    let mut group = c.benchmark_group("execution_lock");
+    group.warm_up_time(Duration::from_millis(500));
+    group.measurement_time(Duration::from_secs(3));
+
+    // Baseline: value(42).sync_on(&stream) — includes lock acquire/release.
+    group.bench_function("sync_on_with_lock", |b| {
+        b.iter(|| {
+            value(42).sync_on(&stream).unwrap();
+        });
+    });
+
+    // Comparison: unsafe async_on + manual synchronize — no lock.
+    group.bench_function("async_on_no_lock", |b| {
+        b.iter(|| {
+            unsafe { value(42).async_on(&stream).unwrap() };
+            stream.synchronize().unwrap();
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_execution_lock);
+criterion_main!(benches);

--- a/cutile-benchmarks/benches/fmha.rs
+++ b/cutile-benchmarks/benches/fmha.rs
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
-use cuda_async::device_operation::DeviceOperation;
+use cuda_async::device_operation::DeviceOp;
 use cuda_core::CudaContext;
 use cutile::api::{randn_f16, zeros};
 use cutile::core::f16;
@@ -158,7 +158,7 @@ fn ocean_fmha(c: &mut Criterion) {
         let m = (1024 * scale,);
         context_lengths.push(m)
     }
-    const TILE_SHAPE: (i32, i32) = (128, 64);
+    const TILE_SHAPE: (usize, usize) = (128, 64);
     let hyper_params = vec![
         [TILE_SHAPE].as_slice(),
         [TILE_SHAPE].as_slice(),
@@ -210,11 +210,11 @@ fn ocean_fmha(c: &mut Criterion) {
             .expect("Failed.")
             .into();
 
-        let qk_scale = f16::from_f32(1.0 / f32::sqrt(q.shape[3] as f32));
+        let qk_scale = f16::from_f32(1.0 / f32::sqrt(q.shape()[3] as f32));
 
         // This is always 1.
-        let num_heads = q.shape[1];
-        let kv_num_heads = k.shape[1];
+        let num_heads = q.shape()[1];
+        let kv_num_heads = k.shape()[1];
         assert_eq!(num_heads % kv_num_heads, 0);
         let query_group_size = num_heads / kv_num_heads;
         let generics = vec![bm.to_string(), bn.to_string(), d.to_string()];
@@ -228,13 +228,13 @@ fn ocean_fmha(c: &mut Criterion) {
             |bencher, _size_mb| {
                 bencher.iter_custom(|iters| {
                     // launch grid = (b*h, m/bm, 1)
-                    let mut out: Partition<Tensor<f16>> = zeros([b * h, m, d])
+                    let mut out: Partition<Tensor<f16>> = zeros(&[b * h, m, d])
                         .sync_on(&stream)
                         .expect("Failed.")
-                        .partition([bbh, bm, d as i32]);
+                        .partition([bbh, bm, d]);
                     assert_eq!(
                         out.grid().expect("Invalid grid."),
-                        ((b * h) as u32, (m / bm as usize) as u32, 1)
+                        ((b * h) as u32, (m / bm) as u32, 1)
                     );
                     stream.synchronize().expect("Failed to synchronize.");
                     let start = Instant::now();

--- a/cutile-benchmarks/benches/fmha_causal.rs
+++ b/cutile-benchmarks/benches/fmha_causal.rs
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
-use cuda_async::device_operation::DeviceOperation;
+use cuda_async::device_operation::DeviceOp;
 use cuda_core::CudaContext;
 use cutile::api::{randn_f16, zeros};
 use cutile::core::f16;
@@ -157,7 +157,7 @@ fn ocean_fmha_causal(c: &mut Criterion) {
         let m = (1024 * scale,);
         context_lengths.push(m)
     }
-    const TILE_SHAPE: (i32, i32) = (128, 64);
+    const TILE_SHAPE: (usize, usize) = (128, 64);
     let hyper_params = vec![
         [TILE_SHAPE].as_slice(),
         [TILE_SHAPE].as_slice(),
@@ -197,7 +197,7 @@ fn ocean_fmha_causal(c: &mut Criterion) {
 
         let causal: bool = true;
         let input_pos: i32 = 0;
-        let even_k = (m as i32) % bn == 0;
+        let even_k = m % bn == 0;
 
         let seed = 123;
         let q: Arc<Tensor<f16>> = randn_f16(f16::ZERO, f16::ONE, [b, h, m, d], Some(seed))
@@ -213,11 +213,11 @@ fn ocean_fmha_causal(c: &mut Criterion) {
             .expect("Failed.")
             .into();
 
-        let qk_scale = f16::from_f32(1.0 / f32::sqrt(q.shape[3] as f32));
+        let qk_scale = f16::from_f32(1.0 / f32::sqrt(q.shape()[3] as f32));
 
         // This is always 1.
-        let num_heads = q.shape[1];
-        let kv_num_heads = k.shape[1];
+        let num_heads = q.shape()[1];
+        let kv_num_heads = k.shape()[1];
         assert_eq!(num_heads % kv_num_heads, 0);
         let query_group_size = num_heads / kv_num_heads;
         let generics = vec![
@@ -238,13 +238,13 @@ fn ocean_fmha_causal(c: &mut Criterion) {
             |bencher, _size_mb| {
                 bencher.iter_custom(|iters| {
                     // launch grid = (b*h, m/bm, 1)
-                    let mut out: Partition<Tensor<f16>> = zeros([b * h, m, d])
+                    let mut out: Partition<Tensor<f16>> = zeros(&[b * h, m, d])
                         .sync_on(&stream)
                         .expect("Failed.")
-                        .partition([bbh, bm, d as i32]);
+                        .partition([bbh, bm, d]);
                     assert_eq!(
                         out.grid().expect("Invalid grid."),
-                        ((b * h) as u32, (m / bm as usize) as u32, 1)
+                        ((b * h) as u32, (m / bm) as u32, 1)
                     );
                     stream.synchronize().expect("Failed to synchronize.");
                     let start = Instant::now();

--- a/cutile-benchmarks/benches/gemm.rs
+++ b/cutile-benchmarks/benches/gemm.rs
@@ -3,13 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
-use cuda_async::device_operation::DeviceOperation;
+use cuda_async::device_operation::{value, DeviceOp};
 use cuda_core::CudaContext;
 use cutile::api;
 use cutile::core::f16;
-use cutile::tile_kernel::{IntoDeviceOperationPartition, TileKernel};
+use cutile::tile_kernel::{PartitionOp, TileKernel};
 use kernels::*;
 use std::iter::zip;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 #[cutile::module]
@@ -114,8 +115,14 @@ fn ocean_gemm(c: &mut Criterion) {
             bn.to_string(),
             bk.to_string(),
         ];
-        let x = api::ones([m, k]).arc().sync_on(&stream).expect("Failed.");
-        let y = api::ones([k, n]).arc().sync_on(&stream).expect("Failed.");
+        let x = api::ones(&[m, k])
+            .then(|t| value(Arc::new(t)))
+            .sync_on(&stream)
+            .expect("Failed.");
+        let y = api::ones(&[k, n])
+            .then(|t| value(Arc::new(t)))
+            .sync_on(&stream)
+            .expect("Failed.");
 
         let num_ops = (2 * m * n * k) as f64;
         let label = n.to_string();
@@ -123,8 +130,8 @@ fn ocean_gemm(c: &mut Criterion) {
         group.throughput(Throughput::Elements(num_ops as u64));
         group.bench_with_input(BenchmarkId::new("N", &label), &label, |b, _size_mb| {
             b.iter_custom(|iters| {
-                let mut z = api::zeros::<2, f16>([m, n])
-                    .partition([bm as i32, bn as i32])
+                let mut z = api::zeros::<f16>(&[m, n])
+                    .partition([bm, bn])
                     .sync_on(&stream)
                     .expect("Failed.");
                 stream.synchronize().expect("Failed to synchronize.");

--- a/cutile-benchmarks/benches/launch_overhead.rs
+++ b/cutile-benchmarks/benches/launch_overhead.rs
@@ -14,11 +14,12 @@
 //! is a measurable fraction of total time.
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
-use cuda_async::device_operation::DeviceOperation;
+use cuda_async::device_operation::DeviceOp;
 use cuda_core::CudaContext;
 use cutile::api;
 use cutile::core::f16;
-use cutile::tile_kernel::{IntoDeviceOperationPartition, TileKernel};
+use cutile::tensor::{IntoPartition, Partition, Tensor};
+use cutile::tile_kernel::TileKernel;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -67,15 +68,21 @@ fn launch_overhead(c: &mut Criterion) {
         bk.to_string(),
     ];
 
-    let x: Arc<_> = api::ones([n, n]).arc().sync_on(&stream).expect("Failed.");
-    let y: Arc<_> = api::ones([n, n]).arc().sync_on(&stream).expect("Failed.");
+    let x: Arc<Tensor<f16>> = api::ones::<f16>(&[n, n])
+        .sync_on(&stream)
+        .expect("Failed.")
+        .into();
+    let y: Arc<Tensor<f16>> = api::ones::<f16>(&[n, n])
+        .sync_on(&stream)
+        .expect("Failed.")
+        .into();
 
     // JIT warmup + steady-state warmup for sync_on path.
     {
-        let mut z = api::zeros::<2, f16>([n, n])
-            .partition([bm as i32, bn as i32])
+        let mut z: Partition<Tensor<f16>> = api::zeros::<f16>(&[n, n])
             .sync_on(&stream)
-            .expect("Failed.");
+            .expect("Failed.")
+            .partition([bm, bn]);
         for _ in 0..WARMUP_ITERS {
             let (local_z, _, _, _) = unsafe {
                 kernels::gemm(z, x.clone(), y.clone(), n as i32)
@@ -92,10 +99,10 @@ fn launch_overhead(c: &mut Criterion) {
     // 1. sync_on: execute + stream.synchronize(), no callbacks.
     group.bench_function(BenchmarkId::new("mode", "sync_on"), |b| {
         b.iter_custom(|iters| {
-            let mut z = api::zeros::<2, f16>([n, n])
-                .partition([bm as i32, bn as i32])
+            let mut z: Partition<Tensor<f16>> = api::zeros::<f16>(&[n, n])
                 .sync_on(&stream)
-                .expect("Failed.");
+                .expect("Failed.")
+                .partition([bm, bn]);
             stream.synchronize().expect("Failed.");
             let start = Instant::now();
             for _ in 0..iters {
@@ -118,10 +125,10 @@ fn launch_overhead(c: &mut Criterion) {
         .expect("Failed to build tokio runtime.");
     {
         rt.block_on(async {
-            let mut z = api::zeros::<2, f16>([n, n])
-                .partition([bm as i32, bn as i32])
+            let mut z: Partition<Tensor<f16>> = api::zeros::<f16>(&[n, n])
                 .sync_on(&stream)
-                .expect("Failed.");
+                .expect("Failed.")
+                .partition([bm, bn]);
             for _ in 0..WARMUP_ITERS {
                 let (local_z, _, _, _) = unsafe {
                     kernels::gemm(z, x.clone(), y.clone(), n as i32).generics(generics.clone())
@@ -139,10 +146,10 @@ fn launch_overhead(c: &mut Criterion) {
     group.bench_function(BenchmarkId::new("mode", "await"), |b| {
         b.iter_custom(|iters| {
             rt.block_on(async {
-                let mut z = api::zeros::<2, f16>([n, n])
-                    .partition([bm as i32, bn as i32])
+                let mut z: Partition<Tensor<f16>> = api::zeros::<f16>(&[n, n])
                     .sync_on(&stream)
-                    .expect("Failed.");
+                    .expect("Failed.")
+                    .partition([bm, bn]);
                 stream.synchronize().expect("Failed.");
                 let start = Instant::now();
                 for _ in 0..iters {
@@ -160,10 +167,10 @@ fn launch_overhead(c: &mut Criterion) {
 
     // Steady-state warmup for async_on path.
     {
-        let mut z = api::zeros::<2, f16>([n, n])
-            .partition([bm as i32, bn as i32])
+        let mut z: Partition<Tensor<f16>> = api::zeros::<f16>(&[n, n])
             .sync_on(&stream)
-            .expect("Failed.");
+            .expect("Failed.")
+            .partition([bm, bn]);
         for _ in 0..WARMUP_ITERS {
             unsafe {
                 let (local_z, _, _, _) = kernels::gemm(z, x.clone(), y.clone(), n as i32)
@@ -180,10 +187,10 @@ fn launch_overhead(c: &mut Criterion) {
     // 3. async_on: execute only, single synchronize at end.
     group.bench_function(BenchmarkId::new("mode", "async_on"), |b| {
         b.iter_custom(|iters| {
-            let mut z = api::zeros::<2, f16>([n, n])
-                .partition([bm as i32, bn as i32])
+            let mut z: Partition<Tensor<f16>> = api::zeros::<f16>(&[n, n])
                 .sync_on(&stream)
-                .expect("Failed.");
+                .expect("Failed.")
+                .partition([bm, bn]);
             stream.synchronize().expect("Failed.");
             let start = Instant::now();
             for _ in 0..iters {

--- a/cutile-benchmarks/benches/rmsnorm.rs
+++ b/cutile-benchmarks/benches/rmsnorm.rs
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
-use cuda_async::device_operation::DeviceOperation;
+use cuda_async::device_operation::DeviceOp;
 use cuda_core::CudaContext;
 use cutile::api::{randn_f16, zeros};
 use cutile::core::f16;
@@ -107,10 +107,10 @@ fn ocean_rmsnorm(c: &mut Criterion) {
         group.throughput(Throughput::BytesDecimal(total_bytes as u64));
         group.bench_with_input(BenchmarkId::new("N", &label), &label, |b, _size_mb| {
             b.iter_custom(|iters| {
-                let mut out: Partition<Tensor<f16>> = zeros([m, n])
+                let mut out: Partition<Tensor<f16>> = zeros(&[m, n])
                     .sync_on(&stream)
                     .expect("Failed.")
-                    .partition([1, n as i32]);
+                    .partition([1, n]);
                 stream.synchronize().expect("Failed to synchronize.");
                 let start = Instant::now();
                 for _i in 0..iters {

--- a/cutile-benchmarks/benches/softmax.rs
+++ b/cutile-benchmarks/benches/softmax.rs
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
-use cuda_async::device_operation::DeviceOperation;
+use cuda_async::device_operation::DeviceOp;
 use cuda_core::CudaContext;
 use cutile::api::{randn_f16, zeros};
 use cutile::core::f16;
@@ -75,7 +75,7 @@ fn softmax(c: &mut Criterion) {
             &label.1,
             |b, _size_mb| {
                 b.iter_custom(|iters| {
-                    let mut out: Partition<Tensor<f16>> = zeros([m, n])
+                    let mut out: Partition<Tensor<f16>> = zeros(&[m, n])
                         .sync_on(&stream)
                         .expect("Failed.")
                         .partition([bm, bn]);

--- a/cutile-book/_static/images/async-mlp-pipeline.svg
+++ b/cutile-book/_static/images/async-mlp-pipeline.svg
@@ -51,7 +51,7 @@
       <rect width="100" height="70" rx="8" fill="#79c0ff"/>
       <text x="50" y="28" text-anchor="middle" font-size="13" font-weight="700" fill="#ffffff">Input</text>
       <text x="50" y="46" text-anchor="middle" font-size="12" font-weight="600" fill="#ffffff">[16, 32]</text>
-      <text x="50" y="62" text-anchor="middle" font-size="11" font-weight="600" fill="#ffffff">DeviceOperation</text>
+      <text x="50" y="62" text-anchor="middle" font-size="11" font-weight="600" fill="#ffffff">DeviceOp</text>
     </g>
     
     <!-- Arrow -->
@@ -63,7 +63,7 @@
       <rect width="140" height="70" rx="8" fill="none" stroke="#d2a8ff" stroke-width="2"/>
       <text x="70" y="24" text-anchor="middle" font-size="13" font-weight="700" fill="#d2a8ff">Linear (GEMM)</text>
       <text x="70" y="42" text-anchor="middle" font-size="12" font-weight="600" fill="#ffffff">input @ weights</text>
-      <text x="70" y="60" text-anchor="middle" font-family="'RobotoMono', monospace" font-size="11" font-weight="500" fill="#d2a8ff">.apply(gemm_apply)</text>
+      <text x="70" y="60" text-anchor="middle" font-family="'RobotoMono', monospace" font-size="11" font-weight="500" fill="#d2a8ff">gemm(out, data, w)</text>
     </g>
     
     <!-- Arrow -->
@@ -75,7 +75,7 @@
       <rect width="120" height="70" rx="8" fill="none" stroke="#ffa657" stroke-width="2"/>
       <text x="60" y="24" text-anchor="middle" font-size="13" font-weight="700" fill="#ffa657">ReLU</text>
       <text x="60" y="42" text-anchor="middle" font-size="12" font-weight="600" fill="#ffffff">max(0, x)</text>
-      <text x="60" y="60" text-anchor="middle" font-family="'RobotoMono', monospace" font-size="11" font-weight="500" fill="#ffa657">relu_apply</text>
+      <text x="60" y="60" text-anchor="middle" font-family="'RobotoMono', monospace" font-size="11" font-weight="500" fill="#ffa657">relu</text>
     </g>
     
     <!-- Arrow -->

--- a/cutile-book/_static/images/computation-graph.svg
+++ b/cutile-book/_static/images/computation-graph.svg
@@ -34,7 +34,7 @@
   <!-- Main Title -->
   <text x="475" y="38" text-anchor="middle" font-size="24" font-weight="700" fill="#ffffff" letter-spacing="-0.5">Lazy Computation Graph</text>
   <line x1="325" y1="50" x2="625" y2="50" stroke="#76B900" stroke-width="2" opacity="0.6"/>
-  <text x="475" y="72" text-anchor="middle" font-size="14" font-weight="500" fill="#8b949e">DeviceOperations compose into graphs that run on .await</text>
+  <text x="475" y="72" text-anchor="middle" font-size="14" font-weight="500" fill="#8b949e">DeviceOps compose into graphs that run on .await</text>
 
   <!-- Input nodes (stacked vertically on left) -->
   <g transform="translate(40, 115)">

--- a/cutile-book/_static/images/execution-flow.svg
+++ b/cutile-book/_static/images/execution-flow.svg
@@ -41,9 +41,9 @@
   <rect width="920" height="660" fill="url(#grid)" opacity="0.5"/>
   
   <!-- Main Title -->
-  <text x="400" y="38" text-anchor="middle" font-size="24" font-weight="700" fill="#ffffff" letter-spacing="-0.5">DeviceOperation Execution Flow</text>
+  <text x="400" y="38" text-anchor="middle" font-size="24" font-weight="700" fill="#ffffff" letter-spacing="-0.5">DeviceOp Execution Flow</text>
   <line x1="230" y1="50" x2="570" y2="50" stroke="#76B900" stroke-width="2" opacity="0.6"/>
-  <text x="400" y="72" text-anchor="middle" font-size="14" font-weight="500" fill="#8b949e">What happens when you .await a DeviceOperation</text>
+  <text x="400" y="72" text-anchor="middle" font-size="14" font-weight="500" fill="#8b949e">What happens when you .await a DeviceOp</text>
 
   <!-- Column Headers -->
   <g transform="translate(0, 95)">

--- a/cutile-book/appendix/definitions.md
+++ b/cutile-book/appendix/definitions.md
@@ -42,7 +42,7 @@ An alias for [Tile Block](#tile-block), used throughout this book to emphasize t
 
 Multiple tile blocks making progress over a period of time by being scheduled onto available Streaming Multiprocessors (SMs). This aligns with Rust's definition of concurrency — different parts of a program executing *independently*, not necessarily at the exact same instant — extended to the GPU context: when a kernel is launched with more tile blocks than there are SMs, the GPU's hardware scheduler assigns tile blocks to SMs as resources become available. Some tile blocks execute in parallel while others are pending, but from the programmer's perspective all tile blocks are logically concurrent — their relative order of execution is unspecified and they are independent of one another.
 
-On the host side, concurrency also arises through CUDA streams and async/await: multiple `DeviceOperation`s submitted to different streams can overlap in time, and the async runtime schedules them without requiring the programmer to specify an exact execution order.
+On the host side, concurrency also arises through CUDA streams and async/await: multiple `DeviceOp`s submitted to different streams can overlap in time, and the async runtime schedules them without requiring the programmer to specify an exact execution order.
 
 ## Parallel Execution
 
@@ -99,13 +99,13 @@ Tensor shape dimensions specified as `-1` in the kernel signature (e.g., `Tensor
 
 cuTile Rust compiles kernels at first invocation through a multi-stage pipeline: Rust AST → MLIR → cubin. The compiled binary is cached in memory (in a thread-local `HashMap`) so subsequent launches with the same generics are instant. A new combination of const generics or type parameters produces a new compilation.
 
-## DeviceOperation
+## DeviceOp
 
-A lazy description of GPU work — allocation, kernel launch, or data transfer — that is not executed until either `.sync_on(&stream)`, `.await`, or `tokio::spawn()` is invoked. `DeviceOperation`s can be composed with `zip!`, `.apply()`, and `.and_then()` to build dataflow graphs before submitting GPU work.
+A lazy description of GPU work — allocation, kernel launch, or data transfer — that is not executed until either `.sync_on(&stream)`, `.sync()`, or `.await` is invoked. `DeviceOp`s can be composed with `zip!`, `.then()`, `.map()`, `.shared()`, and `.first()`/`.last()` to build dataflow graphs before submitting GPU work. Kernel launchers accept `Tensor<T>`, `Arc<Tensor<T>>`, `&Tensor<T>`, scalars, and `DeviceOp` arguments directly via `IntoDeviceOp` and `KernelInput`. The return type matches the input type — you get back what you put in.
 
 ## DeviceFuture
 
-A `DeviceFuture` is a future that has been assigned resources — specifically, a device stream on which to execute — but has not yet started GPU work. A `DeviceFuture` is created when a `DeviceOperation` is scheduled (e.g., via `into_future()`), at which point the scheduling policy selects a stream. The actual GPU work is not submitted until the `DeviceFuture` is polled for the first time, which happens when you `.await` it or `tokio::spawn` it.
+A `DeviceFuture` is a future that has been assigned resources — specifically, a device stream on which to execute — but has not yet started GPU work. A `DeviceFuture` is created when a `DeviceOp` is scheduled (e.g., via `into_future()`), at which point the scheduling policy selects a stream. The actual GPU work is not submitted until the `DeviceFuture` is polled for the first time, which happens when you `.await` it or `tokio::spawn` it.
 
 ## Broadcasting
 

--- a/cutile-book/appendix/syntax-reference.md
+++ b/cutile-book/appendix/syntax-reference.md
@@ -271,7 +271,7 @@ let shifted = tile + 1.0f32;
 let result = fma(x, y, z);
 
 // x * y + z with explicit rounding mode
-let result = fma_op(x, y, z, "nearest_even");
+let result = fma(x, y, z, "nearest_even");
 ```
 
 ---
@@ -810,6 +810,19 @@ acc = true_div(acc, l_i.broadcast(const_shape![BM, D]));
 
 ## Host-Side API
 
+### Kernel Parameter Types
+
+| Kernel param | Host input | Return type |
+|---|---|---|
+| `&Tensor<T, S>` | `Tensor<T>`, `Arc<Tensor<T>>`, or `&Tensor<T>` | Same as input |
+| `&mut Tensor<T, S>` | `Partition<Tensor<T>>` or `Partition<&mut Tensor<T>>` | Same as input |
+| Scalar (`f32`, `i32`, etc.) | Same scalar | Same scalar |
+| `*mut T` (unsafe only) | `DevicePointer<T>` | `DevicePointer<T>` |
+
+Borrowed forms (`&Tensor<T>`, `Partition<&mut Tensor<T>>`) introduce a
+lifetime that prevents `tokio::spawn` at compile time — use `Arc` and
+owned partitions for spawned tasks.
+
 ### Launching Kernels (Sync)
 
 ```rust
@@ -818,30 +831,34 @@ use my_module::kernel;
 let ctx = CudaContext::new(0)?;
 let stream = ctx.new_stream()?;
 
-// Create tensors
-let x: Arc<Tensor<f32>> = ones([32, 32]).arc().sync_on(&stream)?;
-let z = zeros([32, 32]).partition([4, 4]).sync_on(&stream)?;
+// Borrow-based: no Arc, no unpartition, no return capture.
+let x = ones::<f32>(&[32, 32]).sync_on(&stream)?;
+let mut z = zeros::<f32>(&[32, 32]).sync_on(&stream)?;
 
-// Launch with generics
-let generics = vec!["f32".to_string(), "16".to_string()];
-let (z, _x) = kernel(z, x)
-    .generics(generics)
-    .grid((8, 8, 1))  // Optional: explicit grid
+let _ = kernel((&mut z).partition([4, 4]), &x)
+    .generics(vec!["f32".to_string(), "16".to_string()])
     .sync_on(&stream)?;
+// z already has the result.
 
-// Get results
+// Owned variant (useful when building lazy graphs):
+let x: Arc<Tensor<f32>> = ones(&[32, 32]).sync_on(&stream)?.into();
+let z = zeros(&[32, 32]).partition([4, 4]).sync_on(&stream)?;
+
+let (z, _x) = kernel(z, x)
+    .generics(vec!["f32".to_string(), "16".to_string()])
+    .sync_on(&stream)?;
 let z_host: Vec<f32> = z.unpartition().to_host_vec().sync_on(&stream)?;
 ```
 
 ### Launching Kernels (Async)
 
 ```rust
-use my_module::kernel_op;
+use my_module::kernel;
 
-let x = ones([32, 32]).arc();
-let z = zeros::<2, f32>([32, 32]).partition([4, 4]);
+let x = ones(&[32, 32]).map(Into::into);
+let z = zeros(&[32, 32]).partition([4, 4]);
 
-let (z, _x) = kernel_op(z, x).unzip();
+let (z, _x) = kernel(z, x).unzip();
 
 let z_host: Vec<f32> = z.unpartition().await?.to_host_vec().await?;
 ```

--- a/cutile-book/conf.py
+++ b/cutile-book/conf.py
@@ -4,7 +4,7 @@
 # -- Project information -----------------------------------------------------
 project = 'cuTile Rust'
 copyright = '2025, NVIDIA Corporation'
-author = 'Nihal Pasham, NVIDIA Corporation'
+author = 'Nihal Pasham'
 release = '0.1.0'
 
 # -- General configuration ---------------------------------------------------
@@ -12,7 +12,6 @@ extensions = [
     'myst_parser',           # Markdown support
     'sphinx_copybutton',     # Copy button on code blocks
     'sphinx_design',         # Cards, grids, tabs
-    'sphinx_sitemap',        # Generate sitemap.xml for SEO
 ]
 
 # Markdown configuration
@@ -104,6 +103,3 @@ html_show_sourcelink = False
 
 # Title in sidebar
 html_title = "cuTile Rust"
-
-# SEO
-html_baseurl = 'https://nvlabs.github.io/cutile-rs/'

--- a/cutile-book/guide/async-execution.md
+++ b/cutile-book/guide/async-execution.md
@@ -31,16 +31,16 @@ Key properties of streams:
 
 ---
 
-## DeviceOperations: Lazy Computation Graphs
+## DeviceOps: Lazy Computation Graphs
 
-The core abstraction is `DeviceOperation` — a lazy operation that describes GPU work without executing it.
+The core abstraction is `DeviceOp` — a lazy operation that describes GPU work without executing it.
 
-### What's a DeviceOperation?
+### What's a DeviceOp?
 
 Think of it as a recipe that hasn't been cooked yet:
 
 ```rust
-let z = api::zeros([64, 64]);  // DeviceOperation<Output=Tensor<f32>>
+let z = api::zeros(&[64, 64]);  // DeviceOp<Output=Tensor<f32>>
 // Nothing happened yet! Just built a description of what to do.
 
 let result = z.await;  // NOW it executes: allocates GPU memory, fills with zeros
@@ -49,19 +49,19 @@ let result = z.await;  // NOW it executes: allocates GPU memory, fills with zero
 ### The Key Trait
 
 ```rust
-pub trait DeviceOperation: Send + Sized + IntoFuture
+pub trait DeviceOp: Send + Sized + IntoFuture
 where Self::Output: Send {
     // ...
 }
 ```
 
-Every `DeviceOperation` implements `IntoFuture`, which means every operation is awaitable.
+Every `DeviceOp` implements `IntoFuture`, which means every operation is awaitable.
 
 ---
 
 ## The Execution Flow
 
-When you `.await` a DeviceOperation, here's what happens:
+When you `.await` a DeviceOp, here's what happens:
 
 ```{raw} html
 <style>
@@ -141,91 +141,223 @@ When you `.await` a DeviceOperation, here's what happens:
 Consider the following snippet:
 
 ```rust
-let x = api::randn(0.0f32, 1.0f32, [m, k]).arc().await;
+let x: Tensor<f32> = api::randn(0.0f32, 1.0f32, &[m, k]).await?;
 ```
 
 This is what each method does:
 
 | Step | Code | GPU Work? |
 |------|------|-----------|
-| 1 | `api::randn(...)` | ❌ Allocates CPU memory, creates DeviceOperation |
-| 2 | `.arc()` | ❌ Wraps in Arc, still lazy |
-| 3 | `.await` | ❌ Creates DeviceFuture |
-| 4 | First poll | ✅ **NOW** executes the GPU copy |
-| 5 | Completion | Returns tensor |
+| 1 | `api::randn(...)` | ❌ Creates lazy DeviceOp |
+| 2 | `.await` | ❌ Creates DeviceFuture |
+| 3 | First poll | ✅ **NOW** allocates GPU memory, generates random values |
+| 4 | Completion | Returns tensor |
 
 GPU work happens during the **first poll**, not when you call `.await`!
 
 ---
 
-## Synchronous vs Asynchronous Execution
+## Starting with `.sync()`
 
-### Synchronous Pattern
-
-```rust
-let launcher = kernel(args...);
-let result = launcher
-    .grid((x, y, z))
-    .sync_on(&stream);  // Launch AND wait
-```
-
-The `sync_on` method:
-1. Launches the kernel
-2. **Blocks** until completion
-3. Returns the result
-
-Use this for:
-- Simple scripts
-- When you need results immediately
-- Debugging
-
-### Asynchronous Pattern
+The simplest way to run a kernel is `.sync()`:
 
 ```rust
-let op = kernel_op(args...);
-let fut = op.into_future();
-let result = fut.await;  // Non-blocking in async context
+let x = api::ones::<f32>(&[1024]).sync()?;
+let y = api::ones::<f32>(&[1024]).sync()?;
+let mut z = api::zeros::<f32>(&[1024]).sync()?;
+
+add((&mut z).partition([128]), &x, &y).sync()?;
 ```
 
-Or, if the inputs are already grouped into one `DeviceOperation`:
+This is the right choice for scripts, debugging, and learning. Each `.sync()` call launches work on the GPU and blocks the CPU until it finishes.
+
+### Why sync-per-op is expensive
+
+In a multi-layer model, calling `.sync()` after every kernel creates a gap where *both* the CPU and GPU are idle — the CPU is waiting for the GPU, and the GPU has nothing queued:
+
+```text
+CPU:  [launch] [wait......] [launch] [wait......] [launch] [wait......]
+GPU:           [kernel████]          [kernel████]          [kernel████]
+                          ↑                      ↑
+                     idle gap                idle gap
+```
+
+For inference, this overhead dominates — kernels are fast (microseconds), but sync round-trips are not. A 22-layer transformer with 6 kernels per layer means 132 sync gaps per token.
+
+### The fix: compose first, sync once
+
+Build the entire operation graph lazily, then execute in one shot:
 
 ```rust
-let args = zip!(z_op, x_op, y_op);
-let (z, x, y) = args.apply(kernel_apply).await;
+// No GPU work yet — just building the graph.
+let result = rms_norm(out1, hidden.clone(), weight.clone(), eps)
+    .first()
+    .unpartition()
+    .shared();
+
+let q = matvec(out2, result.clone(), wq.clone())
+    .first()
+    .unpartition()
+    .shared();
+
+// NOW execute everything on one stream, no gaps.
+let output = q.sync_on(&stream)?;
 ```
 
-Use this for:
-- Production code
-- Overlapping computation and I/O
-- Building complex pipelines
+```text
+CPU:  [build graph...] [launch all]  [wait]
+GPU:                    [norm████][mv████][add████]
+                         no gaps — work is pipelined
+```
+
+The rest of this guide explains the tools for building these graphs:
+`.then()`, `zip!`, `.shared()`, `.await`, and stream scheduling.
+
+### Synchronous: `.sync()` / `.sync_on()`
+
+```rust
+kernel(args...).sync()?;          // default device, default stream policy
+kernel(args...).sync_on(&stream)?; // explicit stream
+```
+
+### Asynchronous: `.await`
+
+```rust
+let result = kernel(args...).await?;  // non-blocking in async context
+```
+
+Or compose lazily and await the final result:
+
+```rust
+let result = step1(args)
+    .then(|out| step2(out))
+    .then(|out| step3(out))
+    .await?;
+```
 
 ---
 
 ## Building Computation Graphs
 
-DeviceOperations compose into computation graphs:
+DeviceOps compose into computation graphs:
 
 ```rust
-// Build lazy computation graph
-let x = api::randn(0.0, 1.0, [m, k]);
-let y = api::randn(0.0, 1.0, [k, n]);
-let z = api::zeros([m, n]).partition([bm, bn]);
+// Build lazy computation graph — no GPU work yet
+let z = api::zeros(&[m, n]).partition([bm, bn]);
+let x = api::randn(0.0, 1.0, &[m, k]);
+let y = api::randn(0.0, 1.0, &[k, n]);
 
-// Chain kernel invocations
-let result = matmul_op(z, x.arc(), y.arc())
-    .and_then(|(z, _x, _y)| activation_op(z))
-    .and_then(|(z,)| normalize_op(z));
+// Chain kernel invocations — output-first convention, direct calls
+let result = matmul(z, x, y)
+    .then(|(z, _x, _y)| activation(z))
+    .then(|(z,)| normalize(z));
 
-// Execute entire graph
-let output = result.await;
+// Execute entire graph in one shot
+let output = result.await?;
 ```
 
-![Lazy computation graph showing how DeviceOperations compose](../_static/images/computation-graph.svg)
+![Lazy computation graph showing how DeviceOps compose](../_static/images/computation-graph.svg)
 
 **Benefits:**
 - Operations can be fused
 - Memory can be reused
 - Scheduling can be optimized
+
+---
+
+## Splitting and Sharing Operations
+
+`zip!` combines multiple `DeviceOp`s into one. But what about the reverse — taking a single operation's output and feeding it into multiple downstream branches? That's what `unzip` and `.shared()` are for.
+
+### unzip: Fan-Out from a Tuple
+
+`unzip` takes an operation that produces a tuple and splits it into independent operations, one per element:
+
+```rust
+// A kernel returns (output, weight, bias) as a 3-tuple.
+let (output, weight, bias) = kernel(args).unzip();
+
+// Each is now an independent DeviceOp.
+let result = output.unpartition().await?;
+let w = weight.await?;
+```
+
+`unzip` is the inverse of `zip!`:
+
+```text
+  zip! (fan-in)                     unzip (fan-out)
+
+    op_a ─┐                           ┌── branch_a
+           ├─ zip! ─── (a, b)    (a, b) ── unzip ──┤
+    op_b ─┘                           └── branch_b
+```
+
+### The Execute-Once Guarantee
+
+When you `unzip`, the ancestor operation that produces the tuple is **executed at most once**, regardless of how many branches consume it. Internally, `unzip` uses a shared gate (`Select`) that runs the ancestor on the first branch to execute and caches the results for the remaining branches:
+
+```text
+                                      ┌── SelectLeft ── .sync()  ─── runs ancestor,
+  ancestor_op ────── Select (shared) ─┤                               caches both results
+                                      └── SelectRight ── .sync() ─── finds cached result,
+                                                                      no re-execution
+```
+
+This means fan-out patterns like "compute once, use in two places" are safe and efficient:
+
+```rust
+let (z, x, y) = zip!(z_op, x_op, y_op)
+    .then(my_kernel)
+    .unzip();
+
+// The kernel runs once. z, x, and y each take their portion of the result.
+let output = z.unpartition().to_host_vec().sync()?;
+```
+
+### .shared(): Cloneable, Execute-Once Operations
+
+`.shared()` converts any `DeviceOp` into a `SharedDeviceOp<T>` that implements `Clone`. The underlying operation executes at most once — every clone gets `Arc::clone()` of the cached result. This follows the `FutureExt::shared()` convention from the `futures` crate.
+
+```rust
+// Create a shared operation — cloneable, execute-once.
+let x = api::ones(&[32, 32]).shared();
+
+// Pass to multiple consumers without consuming the original.
+let a = kernel_a(x.clone()).sync()?;  // x executes here (once)
+let b = kernel_b(x.clone()).sync()?;  // Uses the cached Arc — no re-execution
+let c = kernel_c(x).sync()?;          // Also uses the cached result
+```
+
+Unlike `unzip` (which splits a fixed tuple), `.shared()` supports unlimited consumers. The result is always `Arc<T>`, so shared reads are cheap.
+
+For pre-computed values (e.g., weight tensors already in `Arc`), use the `shared()` constructor:
+
+```rust
+let w: SharedDeviceOp<Tensor<f32>> = cuda_async::device_operation::shared(weight_arc);
+```
+
+### Common Patterns
+
+```text
+Diamond (fan-out then fan-in):
+
+  op_a ─┐              ┌─ transform_a ─┐
+         ├── zip! ── unzip              ├── zip! ── result
+  op_b ─┘              └─ transform_b ─┘
+
+Broadcast (.shared() into parallel kernels):
+
+                     ┌── kernel_a ── result_a
+  x.shared() ──────┤
+                     ├── kernel_b ── result_b
+                     └── kernel_c ── result_c
+```
+
+### Limitations
+
+The execute-once mechanism relies on **sequential execution** — the normal mode for `cuda-async`, where operations are `.sync()`'d or `.await`'d one at a time from a single thread. Under this model, the shared gate is guaranteed to see only one caller at a time.
+
+If two branches of an `unzip` were somehow executed **concurrently on different OS threads** (e.g., via `tokio::spawn` on a multi-threaded runtime), the gate is not safe — it uses a non-atomic check-then-act pattern internally. In practice, this is not triggerable because device contexts are thread-local, so scheduling an operation from a thread that hasn't initialized its device context will fail before reaching the gate. However, avoid designs that would poll both sides of an `unzip` from different threads.
 
 ---
 
@@ -240,25 +372,56 @@ You need synchronization when:
 
 ```rust
 // Bad: No sync before reading
-let z = kernel_op(x, y).sync_on(&stream);
+let z = kernel(x, y).sync_on(&stream);
 let data = z.to_host_vec();  // ❌ May read incomplete data!
 
 // Good: Sync before reading
-let z = kernel_op(x, y).sync_on(&stream);
+let z = kernel(x, y).sync_on(&stream);
 let data = z.to_host_vec().sync_on(&stream);  // ✅ Waits for completion
 ```
 
-### Arc for Shared Data
+### Passing Tensors to Kernels
 
-Use `Arc` to share tensors across operations:
+Kernel `&Tensor` params accept three input forms, and `&mut Tensor` params
+accept two partition forms. You get back the same type you put in.
+
+**Inputs (`&Tensor`):**
 
 ```rust
-let x: Arc<Tensor<f32>> = ones([32, 32]).sync_on(&stream).into();
+// Owned — single use, no Arc overhead.
+let x: Tensor<f32> = ones(&[32, 32]).sync_on(&stream)?;
+let (_, x) = kernel(out, x).sync_on(&stream)?;  // x is Tensor<f32>
 
-// x can be used multiple times
-let z1 = kernel1(x.clone()).sync_on(&stream);
-let z2 = kernel2(x.clone()).sync_on(&stream);
+// Shared — use the same tensor in multiple kernels.
+let x: Arc<Tensor<f32>> = ones(&[32, 32]).sync_on(&stream)?.into();
+let z1 = kernel1(out1, x.clone()).sync_on(&stream)?;
+let z2 = kernel2(out2, x.clone()).sync_on(&stream)?;
+
+// Borrowed — no allocation, borrow checker enforces lifetime.
+let x: Tensor<f32> = ones(&[32, 32]).sync_on(&stream)?;
+let _ = kernel(out, &x).sync_on(&stream)?;  // x still available
 ```
+
+**Outputs (`&mut Tensor`):**
+
+```rust
+// Owned partition — must unpartition() to get the tensor back.
+let z = zeros(&[32, 32]).sync_on(&stream)?.partition([4, 4]);
+let (z, ..) = kernel(z, &x).sync_on(&stream)?;
+let tensor = z.unpartition();
+
+// Borrowed partition — writes in place, no unpartition() needed.
+let mut z = zeros(&[32, 32]).sync_on(&stream)?;
+let _ = kernel((&mut z).partition([4, 4]), &x).sync_on(&stream)?;
+// z already has the result.
+```
+
+Borrowed inputs (`&Tensor<T>`) and borrowed partitions (`Partition<&mut Tensor<T>>`)
+are not `'static`, so `tokio::spawn` rejects them at compile time — use `Arc`
+and owned partitions for spawned tasks.
+
+See the [DeviceOp API Reference](deviceop-reference.md#ownership-model)
+for the full ownership model.
 
 ---
 
@@ -309,14 +472,14 @@ Stream 2:       ████████ (op_c)
 Stream 3:          ████████ (op_d)
 ```
 
-**2. Chained with `.and_then()`**
+**2. Chained with `.then()`**
 
-Operations composed with `.and_then()` share a single stream, so the second operation always sees the first one's output:
+Operations composed with `.then()` share a single stream, so the second operation always sees the first one's output:
 
 ```rust
 let result = allocate_tensor()
-    .and_then(|tensor| fill_with_ones(tensor))  // same stream → ordered
-    .and_then(|tensor| run_kernel(tensor))       // same stream → ordered
+    .then(|tensor| fill_with_ones(tensor))  // same stream → ordered
+    .then(|tensor| run_kernel(tensor))       // same stream → ordered
     .await;
 ```
 
@@ -346,20 +509,19 @@ let b = op_b.await;  // op_b submitted after op_a is confirmed done
 
 Overlap requires two things: (1) operations land on different streams, and (2) they are submitted to the GPU before waiting for each other.
 
-**Building a lazy graph with `zip!` + `apply`:**
+**Building a lazy graph — direct kernel call:**
 
 ```rust
-// These three allocations form a single DeviceOperation graph.
-// When awaited, the policy submits them to the GPU in quick succession.
-let args = zip!(
-    zeros([1024, 1024]).partition([64, 64]),
-    x.device_operation(),
-    y.device_operation(),
-);
-let (z, _x, _y) = args.apply(kernel_apply).unzip();
-
-// All three inputs were submitted together — they can overlap.
-let result = z.unpartition().await;
+// The unified launcher accepts both DeviceOps and plain values.
+// No need for zip! or value() wrapping.
+let result = my_kernel(
+    zeros(&[1024, 1024]).partition([64, 64]),
+    x,
+    y,
+)
+.first()
+.unpartition()
+.await?;
 ```
 
 **Using `tokio::join!` for independent work:**
@@ -380,9 +542,9 @@ The round-robin policy does **not** track data dependencies. If operation B read
 **Safe patterns for dependent operations:**
 
 ```rust
-// Pattern 1: Chain with .and_then() — same stream, automatic ordering
+// Pattern 1: Chain with .then() — same stream, automatic ordering
 let result = create_tensor()
-    .and_then(|t| process(t))
+    .then(|t| process(t))
     .await;
 
 // Pattern 2: Await sequentially — host ensures ordering
@@ -409,11 +571,11 @@ let (a, b) = tokio::join!(future_a, future_b);
 
 | Method               | Stream assignment           | Ordering guarantee          | Best for                           |
 |----------------------|-----------------------------|-----------------------------|------------------------------------|
-| `.and_then()`        | Shares parent's stream      | **Strict** — same stream    | Dependent operations               |
+| `.then()`        | Shares parent's stream      | **Strict** — same stream    | Dependent operations               |
 | `.sync_on(&stream)`  | Your explicit stream        | **Strict** — if same stream | Debugging, deterministic pipelines |
 | `.sync()`            | Policy picks (round-robin)  | **None** between calls      | Quick scripts                      |
 | `.await`             | Policy picks (round-robin)  | **None** between awaits     | Async code (see note below)        |
-| `zip!` + `.apply()`  | Single stream for the graph | **Strict** within the graph | Kernel launch patterns             |
+| `zip!` + `.then()`  | Single stream for the graph | **Strict** within the graph | Kernel launch patterns             |
 
 :::{tip}
 Sequential `.await` calls *appear* ordered from the host's perspective (each waits before the next starts), but the GPU work for each `.await` runs on whichever stream the policy assigns. For truly independent operations you want to overlap, use `zip!` or `tokio::join!`.
@@ -428,11 +590,11 @@ Sequential `.await` calls *appear* ordered from the host's perspective (each wai
 ```rust
 // Bad: Many small syncs
 for i in 0..1000 {
-    let result = kernel_op(data[i]).sync_on(&stream);
+    let result = kernel(data[i]).sync_on(&stream);
 }
 
 // Good: Build graph, sync once
-let ops: Vec<_> = (0..1000).map(|i| kernel_op(data[i])).collect();
+let ops: Vec<_> = (0..1000).map(|i| kernel(data[i])).collect();
 let results = join_all(ops).await;
 ```
 
@@ -443,7 +605,7 @@ The default round-robin policy already enables this — consecutive operations l
 ```rust
 // These naturally overlap with the default 4-stream pool:
 let compute_op = heavy_kernel(input.clone());
-let transfer_op = api::zeros([next_batch_size, dim]);
+let transfer_op = api::zeros(&[next_batch_size, dim]);
 
 // Submit both before waiting for either:
 let (result, next_buffer) = tokio::join!(compute_op, transfer_op);
@@ -473,23 +635,28 @@ launcher.grid((num_tiles as u32, 1, 1)).sync_on(&stream);
 
 | Concept                   | What it is                                                  |
 |---------------------------|-------------------------------------------------------------|
-| **DeviceOperation**       | Lazy computation description                                |
+| **DeviceOp**       | Lazy computation description                                |
 | **Stream**                | Ordered queue of GPU work                                   |
 | **SchedulingPolicy**      | Decides which stream each operation uses                    |
 | **Round-Robin (default)** | Rotates across 4 streams — enables overlap                  |
 | **SingleStream**          | All ops on one stream — strict ordering                     |
 | **sync_on()**             | Execute on an explicit stream and wait                      |
 | **await**                 | Execute via the default device's scheduling policy (async)  |
-| **.and_then()**           | Chain operations on the same stream                         |
-| **Arc**                   | Share data across operations                                |
+| **.then()**           | Chain operations on the same stream                         |
+| **zip!**                  | Combine multiple operations into one (fan-in)               |
+| **unzip**                 | Split a tuple operation into independent branches (fan-out) |
+| **.shared()**             | Cloneable, execute-once operation — share data across N branches |
+| **.map(f)**               | Transform output without new GPU work                       |
+| **.first()** / **.last()**| Extract first/last element from tuple output                |
+| **.boxed()**              | Type-erase an operation for heterogeneous collections       |
 
 **Key takeaways:**
 
 1. The default policy distributes work across **4 streams** — consecutive operations can overlap.
 2. Operations on the **same stream** are always ordered; operations on **different streams** are not.
-3. Use `.and_then()`, sequential `.await`, or `.sync_on()` with a shared stream to enforce ordering between dependent operations.
-4. Use `zip!`, `.apply()`, or `tokio::join!` to enable overlap for independent operations.
+3. Use `.then()`, sequential `.await`, or `.sync_on()` with a shared stream to enforce ordering between dependent operations.
+4. Use `zip!`, `.then()`, or `tokio::join!` to enable overlap for independent operations.
 
 ---
 
-Continue to [Performance Tuning](performance-tuning.md) for optimization techniques, [Interoperability](interoperability.md) for integrating custom CUDA kernels into the `DeviceOperation` model, or [Debugging](debugging.md) for troubleshooting.
+Continue to [Performance Tuning](performance-tuning.md) for optimization techniques, [Interoperability](interoperability.md) for integrating custom CUDA kernels into the `DeviceOp` model, or [Debugging](debugging.md) for troubleshooting.

--- a/cutile-book/guide/data-model.md
+++ b/cutile-book/guide/data-model.md
@@ -200,17 +200,22 @@ On the host, you allocate tensors, partition them, and pass them to kernel launc
 
 ```rust
 // Host-side Tensor<T> — parameterized by element type only
-let tensor: Tensor<f32> = zeros([1024, 1024]).sync_on(&stream)?;
+let mut tensor: Tensor<f32> = zeros(&[1024, 1024]).sync_on(&stream)?;
 
-// Host-side Partition<Tensor<T>> — wraps a tensor with a partition_shape
+// Owned partition — moves the tensor into the partition
 let partitioned: Partition<Tensor<f32>> = tensor.partition([16, 16]);
-// 64×64 = 4096 sub-tensors, each 16×16
 
-// Shared reference for read-only inputs
-let shared: Arc<Tensor<f32>> = ones([1024, 1024]).arc().sync_on(&stream)?;
+// Borrowed partition — borrows mutably, tensor written in place
+let partitioned_ref = (&mut tensor).partition([16, 16]);
+
+// Read-only inputs: borrow, Arc, or owned
+let input: &Tensor<f32> = &tensor;           // borrow
+let shared: Arc<Tensor<f32>> = Arc::new(tensor);  // shared ownership
 ```
 
-The generated launcher accepts `Partition<Tensor<T>>` for every `&mut Tensor` parameter and `Arc<Tensor<T>>` for every `&Tensor` parameter.
+The generated launcher accepts multiple forms for each parameter type.
+`&Tensor` params accept `&Tensor<T>`, `Arc<Tensor<T>>`, or `Tensor<T>`.
+`&mut Tensor` params accept `Partition<Tensor<T>>` or `Partition<&mut Tensor<T>>`.
 
 ### Device-Side Types
 

--- a/cutile-book/guide/debugging.md
+++ b/cutile-book/guide/debugging.md
@@ -42,8 +42,8 @@ Transfer results to the CPU to inspect them after kernel execution:
 let ctx = CudaContext::new(0)?;
 let stream = ctx.new_stream()?;
 
-let x: Arc<Tensor<f32>> = ones([32, 32]).arc().sync_on(&stream)?;
-let z = zeros([32, 32]).sync_on(&stream)?.partition([4, 4]);
+let x: Arc<Tensor<f32>> = ones(&[32, 32]).map(Into::into).sync_on(&stream)?;
+let z = zeros(&[32, 32]).sync_on(&stream)?.partition([4, 4]);
 
 let (z, _x) = my_kernel(z, x).sync_on(&stream)?;
 
@@ -221,7 +221,7 @@ Fix: ensure the CUDA toolkit version is compatible with the installed driver, an
 
 ```rust
 // WRONG: tensor dropped while kernel is still running
-let z: Tensor<f32> = zeros([len]).await?;
+let z: Tensor<f32> = zeros(&[len]).await?;
 let z_ptr = z.device_pointer();
 drop(z);  // Frees GPU memory!
 unsafe { add_ptr(z_ptr, ...) }.sync_on(&stream)?;  // Segfault or corruption

--- a/cutile-book/guide/deviceop-reference.md
+++ b/cutile-book/guide/deviceop-reference.md
@@ -1,0 +1,420 @@
+# DeviceOp API Reference
+
+Quick-reference for the `DeviceOp` trait and its combinators. For a
+tutorial-style introduction, see [Async Execution](async-execution.md).
+
+---
+
+## The Futures Analogy
+
+`DeviceOp` is to GPU work what `Future` is to async I/O. Both are lazy
+descriptions of work that don't execute until driven:
+
+| Concept | `std::future::Future` | `DeviceOp` |
+|---|---|---|
+| What it represents | Async computation | GPU computation |
+| When it runs | On `.await` or `poll()` | On `.sync()`, `.sync_on()`, or `.await` |
+| Chaining | `.then()`, `.map()` via `FutureExt` | `.then()`, `.map()` on `DeviceOp` |
+| Fan-in | `join!` | `zip!` |
+| Fan-out | N/A (single consumer) | `.unzip()` |
+| Shared access | `FutureExt::shared()` | `.shared()` |
+| Type erasure | `BoxFuture` | `.boxed()` → `BoxedDeviceOp` |
+| Output wrapper | `Poll<T>` | `Result<T, DeviceError>` |
+
+The key difference: a `Future` is pulled by an async runtime via `poll()`,
+while a `DeviceOp` is pushed to the GPU via `execute()`. When you convert
+a `DeviceOp` to a `Future` (via `.await` or `.into_future()`), cuTile bridges
+the two models — the runtime polls a `DeviceFuture` that checks whether the
+GPU has finished.
+
+---
+
+## Combinator Reference
+
+All combinators follow established Rust conventions. The "Precedent" column
+shows which standard library or `futures` crate method inspired the design.
+
+### Composition
+
+| Combinator | Signature | Precedent | What it does |
+|---|---|---|---|
+| `zip!(a, b, …)` | `(impl DeviceOp, …) → impl DeviceOp<Output=(A, B, …)>` | `Iterator::zip` | Combine N operations into a single tuple-producing operation |
+| `.unzip()` | `impl DeviceOp<Output=(A, B, …)> → (impl DeviceOp<Output=A>, …)` | `Iterator::unzip` | Split a tuple operation into independent per-element operations |
+| `.then(f)` | `self → f(Self::Output) → impl DeviceOp<Output=O>` | `FutureExt::then` | Chain follow-up GPU work **on the same stream** |
+| `.map(f)` | `self → f(Self::Output) → O` (no GPU work) | `FutureExt::map` | Transform output without issuing GPU work |
+| `.inspect(f)` | `self → f(&Self::Output)` (passthrough) | `FutureExt::inspect` | Peek at output for debugging; returns it unchanged |
+
+### Selection
+
+| Combinator | Signature | Precedent | What it does |
+|---|---|---|---|
+| `.first()` | `impl DeviceOp<Output=(A, B, …)> → impl DeviceOp<Output=A>` | `slice::first` | Extract the first element of a tuple output |
+| `.last()` | `impl DeviceOp<Output=(A, B, …)> → impl DeviceOp<Output=Z>` | `slice::last` | Extract the last element of a tuple output |
+
+### Sharing and Erasure
+
+| Combinator | Signature | Precedent | What it does |
+|---|---|---|---|
+| `.shared()` | `self → SharedDeviceOp<Self::Output>` | `FutureExt::shared` | Cloneable, execute-once; output is `Arc<T>` |
+| `shared(arc)` | `Arc<T> → SharedDeviceOp<T>` | — | Wrap an existing `Arc` as a pre-computed `SharedDeviceOp` |
+| `.boxed()` | `self → BoxedDeviceOp<Self::Output>` | `FutureExt::boxed` | Type-erase for heterogeneous collections |
+
+### Execution
+
+| Method | Stream chosen by | Blocks? | Use case |
+|---|---|---|---|
+| `.sync()` | Default policy (round-robin) | Yes | Quick scripts |
+| `.sync_on(&stream)` | The explicit stream | Yes | Deterministic ordering, debugging |
+| `.await` | Default policy (round-robin) | No (suspends task) | Async production code |
+| `.into_future()` | Default policy | No (returns `DeviceFuture`) | Manual future handling |
+| `.schedule(policy)` | The policy you provide | No (returns `DeviceFuture`) | Multi-device dispatch |
+| `.graph()` | Default policy (round-robin) | Yes (captures + syncs) | CUDA graph capture |
+| `.graph_on(stream)` | The explicit stream | Yes (captures + syncs) | CUDA graph capture on specific stream |
+
+:::{note}
+If any kernel input is `&Tensor<T>` (borrowed), the operation is not
+`'static` and cannot be used with `tokio::spawn`. Use `.sync_on()` or
+`.await` in the same scope, or switch to `Arc<Tensor<T>>` for spawned tasks.
+:::
+
+---
+
+## Supported Kernel Parameter Types
+
+| Kernel param | Host type | Return type |
+|---|---|---|
+| `&Tensor<T, S>` | `Tensor<T>`, `Arc<Tensor<T>>`, or `&Tensor<T>` | Same as input |
+| `&mut Tensor<T, S>` | `Partition<Tensor<T>>` or `Partition<&mut Tensor<T>>` | Same as input |
+| Scalar (`f32`, `i32`, etc.) | Same scalar | Same scalar |
+| `*mut T` (unsafe only) | `DevicePointer<T>` | `DevicePointer<T>` |
+
+The borrowed partition form (`Partition<&mut Tensor<T>>`) writes in place — no
+`unpartition()` needed. Create it with `(&mut tensor).partition(shape)`.
+
+---
+
+## Ownership Model
+
+The core invariant: **you get back what you put in**.
+
+### Read-only inputs (`&Tensor` params)
+
+| Input | Returned | `tokio::spawn`? |
+|---|---|---|
+| `Tensor<T>` | `Tensor<T>` | Yes |
+| `Arc<Tensor<T>>` | `Arc<Tensor<T>>` | Yes |
+| `&'a Tensor<T>` | `&'a Tensor<T>` | No (not `'static`) |
+
+### Mutable outputs (`&mut Tensor` params)
+
+| Input | Returned | `unpartition()` needed? |
+|---|---|---|
+| `Partition<Tensor<T>>` (owned) | `Partition<Tensor<T>>` | Yes |
+| `Partition<&'a mut Tensor<T>>` (borrowed) | `Partition<&'a mut Tensor<T>>` | No — tensor is written in place |
+
+The borrowed form is created with `(&mut tensor).partition(shape)`:
+
+### Owned: `Tensor<T>`
+
+Pass a tensor directly — the launcher wraps it in `Arc` internally for the
+kernel, then unwraps it back afterward (safe because refcount is 1):
+
+```rust
+let output = my_kernel(
+    api::zeros(&[1024]).partition([128]),
+    api::ones::<f32>(&[1024]),  // DeviceOp<Output=Tensor<f32>>
+)
+.first()
+.unpartition()
+.sync_on(&stream)?;
+```
+
+Use this for single-use tensors where you don't need shared access.
+
+### Shared: `Arc<Tensor<T>>`
+
+Wrap in `Arc` when the same tensor is passed to multiple kernels:
+
+```rust
+let x: Arc<Tensor<f32>> = api::ones(&[1024]).sync_on(&stream)?.into();
+
+let a = kernel_a(out_a, x.clone()).sync_on(&stream)?;
+let b = kernel_b(out_b, x.clone()).sync_on(&stream)?;
+```
+
+This is the most common pattern in existing code.
+
+### Borrowed: `&Tensor<T>`
+
+Pass a reference when you want to retain ownership and avoid `Arc` overhead.
+The borrow checker ensures the tensor outlives the kernel:
+
+```rust
+let weights: Tensor<f32> = api::ones(&[1024]).sync_on(&stream)?;
+
+// Borrow — no Arc allocation, no refcount.
+let result = my_kernel(out_partition, &weights).sync_on(&stream)?;
+
+// weights is still available here.
+```
+
+**Key safety property**: because `&Tensor<T>` is not `'static`,
+`tokio::spawn` rejects operations that borrow tensors:
+
+```rust
+let op = my_kernel(out, &weights);  // borrows weights
+tokio::spawn(op);                    // ← compile error: not 'static
+```
+
+This is enforced at compile time by Rust's lifetime system — no runtime
+checks needed.
+
+### `.shared()`: Clone + Execute-Once
+
+`.shared()` converts a `DeviceOp` into a `SharedDeviceOp<T>` that is
+`Clone`. The underlying operation runs **at most once**; every clone
+receives `Arc::clone()` of the cached result:
+
+```rust
+let x = api::ones::<f32>(&[32, 32]).shared();
+
+let a = kernel_a(x.clone()).sync()?;  // x executes here (first clone to run)
+let b = kernel_b(x.clone()).sync()?;  // uses cached Arc<Tensor<f32>>
+```
+
+Output type changes: `DeviceOp<Output=T>` becomes
+`SharedDeviceOp` with `Output=Arc<T>`.
+
+For pre-computed values (e.g., weight tensors), use the
+`shared()` free function to wrap an `Arc<T>` directly:
+
+```rust
+use cuda_async::device_operation::shared;
+
+let w: Arc<Tensor<f32>> = /* loaded weights */;
+let w_op: SharedDeviceOp<Tensor<f32>> = shared(w);
+```
+
+### `.unwrap_arc()`
+
+`.shared()` and `unzip` produce `Arc<T>` outputs. When you need owned `T`
+back (e.g., to partition a tensor), use `.unwrap_arc()`:
+
+```rust
+let x: Arc<Tensor<f32>> = api::ones(&[1024]).shared().sync()?;
+
+let owned: Tensor<f32> = value(x).unwrap_arc().sync()?;
+let partitioned = owned.partition([128]);
+```
+
+Panics if the Arc has multiple owners.
+
+### IntoDeviceOp: Automatic Wrapping
+
+The `IntoDeviceOp` trait lets kernel launchers accept both `DeviceOp`s and
+plain values:
+
+| Type | Wraps as |
+|---|---|
+| Any `impl DeviceOp<Output=T>` | Pass-through |
+| `Tensor<T>` | `Value<Tensor<T>>` |
+| `Arc<T>` | `Value<Arc<T>>` |
+| `&'a Tensor<T>` | `Value<&'a Tensor<T>>` |
+| `&Arc<T>` | `Value<Arc<T>>` (clones the Arc) |
+| `f32`, `f64`, `i32`, `i64`, `u32`, `u64`, `usize` | `Value<T>` |
+| `Partition<Tensor<T>>` | `Value<Partition<Tensor<T>>>` |
+
+```rust
+// All of these work as inputs to a &Tensor kernel param:
+my_kernel(out, tensor);              // Tensor<T>
+my_kernel(out, arc_tensor);          // Arc<Tensor<T>>
+my_kernel(out, &tensor);             // &Tensor<T>
+my_kernel(out, api::ones(&[1024]));  // DeviceOp<Output=Tensor<T>>
+```
+
+---
+
+## Scheduling Model
+
+### How Streams Are Chosen
+
+When you call `.sync()` or `.await`, the operation asks the **default
+device's scheduling policy** for a stream. The default policy is
+`StreamPoolRoundRobin` with 4 streams:
+
+```text
+op_a.sync()  →  Stream 0
+op_b.sync()  →  Stream 1
+op_c.sync()  →  Stream 2
+op_d.sync()  →  Stream 3
+op_e.sync()  →  Stream 0  (wraps around)
+```
+
+Consecutive independent operations land on different streams, enabling GPU
+overlap. Operations chained with `.then()` share the parent's stream,
+preserving data-dependency ordering.
+
+### Explicit Stream: `.sync_on()`
+
+Bypasses the policy entirely. All operations given the same stream execute
+in call order:
+
+```rust
+let stream = ctx.new_stream()?;
+let a = op_a.sync_on(&stream)?;  // Stream X
+let b = op_b.sync_on(&stream)?;  // Stream X — guaranteed after op_a
+```
+
+### Available Policies
+
+| Policy | Behavior |
+|---|---|
+| `StreamPoolRoundRobin` (default) | Rotates through N streams (default 4) |
+| `SingleStream` | All operations on one stream — strict ordering |
+| Custom `impl SchedulingPolicy` | Implement `fn next_stream()` for your own strategy |
+
+### `.then()` Guarantees
+
+`.then()` is the recommended way to express data dependencies. Both
+operations share a single stream, so the second is guaranteed to see the
+first's output fully written — no manual synchronization needed:
+
+```rust
+let result = allocate_buffer()
+    .then(|buf| fill_kernel(buf))      // same stream
+    .then(|buf| process_kernel(buf))   // same stream
+    .sync()?;
+```
+
+**Non-reentrancy:** On any given thread, only one DeviceOp may be
+executing at a time. Calling `sync_on`, `sync`, or `.await` inside a
+`then` closure will return a runtime error. This prevents CUDA data
+races from cross-stream access to in-flight tensors. If you need
+nested execution and have verified there are no cross-stream data
+races, use `unsafe then_unchecked`.
+
+---
+
+## Error Propagation
+
+All execution methods return `Result<T, DeviceError>`. Errors propagate
+through combinators: if any operation in a `.then()` chain fails, the
+error short-circuits to the caller.
+
+### DeviceError Variants
+
+| Variant | When it occurs |
+|---|---|
+| `Driver(DriverError)` | CUDA driver call failed (OOM, invalid argument, etc.) |
+| `Context { device_id, message }` | Device context assertion failed |
+| `KernelCache(String)` | Kernel compilation or cache lookup failed |
+| `Scheduling(String)` | No stream available or policy misconfigured |
+| `Launch(String)` | Kernel launch precondition violated |
+| `Internal(String)` | Bug in cuda-async internals |
+| `Anyhow(String)` | Converted from `anyhow::Error` |
+
+### Error Handling Patterns
+
+```rust
+// Pattern 1: Propagate with ?
+let x = api::zeros(&[1024]).sync_on(&stream)?;
+
+// Pattern 2: Match specific errors
+match my_kernel(args).sync_on(&stream) {
+    Ok(result) => { /* use result */ }
+    Err(DeviceError::Launch(msg)) => {
+        eprintln!("kernel launch failed: {msg}");
+    }
+    Err(e) => return Err(e.into()),
+}
+```
+
+### cutile::error::Error vs DeviceError
+
+`cutile::error::Error` is the top-level error type that wraps
+`DeviceError` alongside other error categories (I/O, shape mismatches,
+etc.). Functions that only do GPU work return `DeviceError`; functions
+that mix host and device work (like the examples) return
+`cutile::error::Error`.
+
+---
+
+## CUDA Graph Integration
+
+### Combinator approach: `.graph_on(stream)`
+
+Any `DeviceOp` can be captured into a replayable CUDA graph:
+
+```rust
+let forward_op = build_forward(&cfg, &weights, input, buffers);
+let mut graph = forward_op.graph_on(stream.clone())?;
+let output = graph.take_output().unwrap();
+
+// Replay loop — no graph rebuilding, no kernel re-compilation.
+for token in tokens {
+    graph.update(api::memcpy(&mut input_buf, &token))?;
+    graph.launch()?;
+}
+```
+
+This requires `Arc<Tensor<T>>` + `try_partition` for shared buffers.
+
+### Scope approach: `CudaGraph::scope`
+
+`CudaGraph::scope` provides an imperative alternative using `&mut` borrows
+instead of `Arc`. Each `s.record(op)` records a graph node and releases
+borrows immediately. A buffer written by one `record` call can be read
+by the next:
+
+```rust
+let mut output = api::zeros::<f32>(&[d]).sync_on(&stream)?;
+let weights = api::ones::<f32>(&[d]).sync_on(&stream)?;
+
+let graph = CudaGraph::scope(&stream, |s| {
+    s.record(kernel1((&mut output).partition([128]), &weights))?;
+    s.record(kernel2((&mut output).partition([64]), &weights))?;
+    Ok(())
+})?;
+
+graph.launch()?;
+```
+
+`record` only accepts operations that implement `GraphNode` — kernel
+launches and `memcpy`. Allocation ops (`zeros`, `ones`, `dup`) are
+rejected at compile time because their addresses may change on replay.
+
+### `GraphNode` trait
+
+`GraphNode` is a marker trait for operations safe to record in a CUDA
+graph. Only operations that do not allocate or free device memory
+implement it:
+
+| Implements `GraphNode` | Why safe |
+|---|---|
+| Macro-generated kernel launchers | Kernel launch only — no alloc/free |
+| `Memcpy` (`api::memcpy`) | Copy between pre-allocated buffers |
+| `Value<T>` (`value(x)`) | No GPU work |
+
+### CudaGraph methods
+
+| Method | What it does |
+|---|---|
+| `.graph()` / `.graph_on(stream)` | Capture a `DeviceOp` into a `CudaGraph<T>` |
+| `CudaGraph::scope(&stream, \|s\| { … })` | Scoped capture with `&mut` borrows |
+| `s.record(op: impl GraphNode)` | Record a graph node inside a scope |
+| `graph.take_output()` | Retrieve the output from the capture execution |
+| `graph.update(op)` | Run a `DeviceOp` on the graph's stream (e.g., copy new input) |
+| `graph.launch()` | Replay the captured graph and synchronize |
+
+All device pointers are baked in at capture time. To vary inputs, pre-allocate
+a buffer, pass it into the operation, and `memcpy` new data before each
+launch. See [Tutorial 10: CUDA Graphs](../tutorials/10-cuda-graphs.md) for a
+complete walkthrough.
+
+---
+
+## See Also
+
+- [Async Execution](async-execution.md) — tutorial-style guide to streams, scheduling, and composition patterns
+- [Tutorial 10: CUDA Graphs](../tutorials/10-cuda-graphs.md) — end-to-end CUDA graph example
+- [Interoperability](interoperability.md) — integrating custom CUDA C++ kernels into the DeviceOp model

--- a/cutile-book/guide/execution-model.md
+++ b/cutile-book/guide/execution-model.md
@@ -38,9 +38,9 @@ fn main() -> Result<(), Error> {
     let ctx = CudaContext::new(0)?;
     let stream = ctx.new_stream()?;
 
-    let x: Arc<Tensor<f32>> = ones([1024, 1024]).arc().sync_on(&stream)?;
-    let y: Arc<Tensor<f32>> = ones([1024, 1024]).arc().sync_on(&stream)?;
-    let z = zeros([1024, 1024]).sync_on(&stream)?.partition([64, 64]);
+    let x: Arc<Tensor<f32>> = ones(&[1024, 1024]).map(Into::into).sync_on(&stream)?;
+    let y: Arc<Tensor<f32>> = ones(&[1024, 1024]).map(Into::into).sync_on(&stream)?;
+    let z = zeros(&[1024, 1024]).sync_on(&stream)?.partition([64, 64]);
 
     let (z, _x, _y) = add(z, x, y).sync_on(&stream)?;
     Ok(())
@@ -184,4 +184,4 @@ Both use the same underlying compilation pipeline and generate equivalent GPU co
 - Learn about the [Data Model](data-model.md) for details on types and shapes
 - Explore [Memory Hierarchy](memory-hierarchy.md) for performance optimization
 - See [Async Execution](async-execution.md) for concurrent CPU/GPU work
-- See [Interoperability](interoperability.md) for integrating custom CUDA kernels into the `DeviceOperation` model
+- See [Interoperability](interoperability.md) for integrating custom CUDA kernels into the `DeviceOp` model

--- a/cutile-book/guide/interoperability.md
+++ b/cutile-book/guide/interoperability.md
@@ -2,7 +2,7 @@
 
 The tile model handles dense tensor algebra well — GEMM, element-wise operations, reductions, convolutions — but some algorithms depend on **warp-level primitives** (`__shfl_sync`, `__ballot_sync`, `__reduce_sync`) for things like custom scan/prefix-sum, cooperative groups, or irregular data access patterns. For these, write the kernel in CUDA C++ and integrate it using the approach below.
 
-A custom CUDA kernel can participate in the same `DeviceOperation` execution model as your tile kernels — sharing streams, chaining with `.and_then()`, and avoiding unnecessary synchronization.
+A custom CUDA kernel can participate in the same `DeviceOp` execution model as your tile kernels — sharing streams, chaining with `.then()`, and avoiding unnecessary synchronization.
 
 ## Step 1: Compile Your CUDA Kernel
 
@@ -41,7 +41,7 @@ let function = Arc::new(module.load_function("my_kernel_entry")?);
 
 ## Step 3: Launch via AsyncKernelLaunch
 
-`AsyncKernelLaunch` is a `DeviceOperation` that wraps the CUDA driver's kernel launch API:
+`AsyncKernelLaunch` is a `DeviceOp` that wraps the CUDA driver's kernel launch API:
 
 ```rust
 use cuda_async::launch::AsyncKernelLaunch;
@@ -64,7 +64,7 @@ launcher.set_launch_config(LaunchConfig {
     shared_mem_bytes: 0,
 });
 
-// Execute as a DeviceOperation — integrates with the async model.
+// Execute as a DeviceOp — integrates with the async model.
 launcher.await?;
 ```
 
@@ -83,16 +83,16 @@ Neither the Rust compiler nor the CUDA driver validates these invariants — mis
 
 Scalar arguments (like `num_elements as u32`) are copied into the kernel's parameter space — the kernel reads the value, not an address. Any type implementing `DType` can be pushed safely with `push_arg`.
 
-To prevent data races, use stream ordering: operations chained with `.and_then()` on the same stream execute in order and see each other's writes. Operations on different streams require explicit synchronization.
+To prevent data races, use stream ordering: operations chained with `.then()` on the same stream execute in order and see each other's writes. Operations on different streams require explicit synchronization.
 
 > **Why generated cuTile Rust kernels don't require `unsafe`:** When you write a tile kernel with `#[cutile::entry]`, the generated launcher uses the `KernelArgument` and `ArcKernelArgument` implementations for `Tensor<T>` and `Partition<Tensor<T>>`. These implementations call `push_device_ptr` internally, but can do so safely because the framework controls both sides: device pointers come from framework-managed allocations (guaranteed valid), and the ownership model — `Partition` for exclusive access, `Arc<Tensor>` for shared reads — prevents aliasing at the type level. Custom kernels bypass this: you are pushing pointers that the framework didn't allocate and can't track, so the safety burden falls on you.
 
-You can wrap a custom kernel launch in a struct that implements `DeviceOperation`. The struct's typed fields enforce the correct argument signature, and `unsafe` is confined to `execute`:
+You can wrap a custom kernel launch in a struct that implements `DeviceOp`. The struct's typed fields enforce the correct argument signature, and `unsafe` is confined to `execute`:
 
 ```rust
 use cuda_async::device_context::with_default_device_policy;
 use cuda_async::device_future::DeviceFuture;
-use cuda_async::device_operation::{DeviceOperation, ExecutionContext};
+use cuda_async::device_operation::{DeviceOp, ExecutionContext};
 use cuda_async::error::DeviceError;
 use cuda_async::launch::AsyncKernelLaunch;
 use cuda_async::scheduling_policies::SchedulingPolicy;
@@ -107,7 +107,7 @@ pub struct ScaleKernel {
     output: Tensor<f32>,
 }
 
-impl DeviceOperation for ScaleKernel {
+impl DeviceOp for ScaleKernel {
     type Output = (Arc<Tensor<f32>>, Tensor<f32>);
 
     // execute is unsafe because it enqueues async GPU work without
@@ -117,7 +117,7 @@ impl DeviceOperation for ScaleKernel {
     unsafe fn execute(
         self,
         ctx: &ExecutionContext,
-    ) -> Result<<Self as DeviceOperation>::Output, DeviceError> {
+    ) -> Result<<Self as DeviceOp>::Output, DeviceError> {
         let mut launcher = AsyncKernelLaunch::new(self.function);
         launcher.push_arg(self.n);
         launcher.push_arg(self.scale);
@@ -138,7 +138,7 @@ impl DeviceOperation for ScaleKernel {
     }
 }
 
-// IntoFuture is a supertrait of DeviceOperation. Every custom DeviceOperation
+// IntoFuture is a supertrait of DeviceOp. Every custom DeviceOp
 // needs this boilerplate to enable `.await` and `.sync()`.
 impl IntoFuture for ScaleKernel {
     type Output = Result<(Arc<Tensor<f32>>, Tensor<f32>), DeviceError>;
@@ -156,7 +156,7 @@ This is the same pattern the `#[cutile::entry]` macro uses to generate safe laun
 
 ## Step 4: Compose with Tile Kernels
 
-`AsyncKernelLaunch` implements `DeviceOperation`, so it chains with tile kernels. This pipeline runs a tile add (`z = x + y`), then the custom scale wrapper (`w = scale * z`):
+`AsyncKernelLaunch` implements `DeviceOp`, so it chains with tile kernels. This pipeline runs a tile add (`z = x + y`), then the custom scale wrapper (`w = scale * z`):
 
 ```rust
 // Run the tile add kernel — z = x + y.
@@ -165,7 +165,7 @@ let (z_part, _x, _y) =
 let z: Tensor<f32> = z_part.unpartition();
 
 // Run the custom scale kernel — w = scale * z.
-let w: Tensor<f32> = zeros::<1, f32>([num_elements]).await?;
+let w: Tensor<f32> = zeros(&[num_elements]).await?;
 let (_z, w) = ScaleKernel {
     function: scale_function,
     n: num_elements as u32,
@@ -185,7 +185,7 @@ See [`interop.rs`](https://github.com/NVlabs/cutile-rs/blob/main/cutile-examples
 For more direct control, use `with_context` to access the CUDA stream and issue driver API calls directly:
 
 ```rust
-use cuda_async::device_operation::{with_context, value, DeviceOperation};
+use cuda_async::device_operation::{with_context, value, DeviceOp};
 use cuda_async::device_operation::ExecutionContext;
 use cuda_core::{malloc_async, memcpy_htod_async, free_async};
 
@@ -217,7 +217,7 @@ with_context(move |ctx: &ExecutionContext| {
 .await?;
 ```
 
-This gives you full access to the CUDA driver API while participating in the `DeviceOperation` model. Everything inside the `unsafe` block is your responsibility to get right.
+This gives you full access to the CUDA driver API while participating in the `DeviceOp` model. Everything inside the `unsafe` block is your responsibility to get right.
 
 ---
 
@@ -242,4 +242,4 @@ let function = Arc::new(module.load_function("gemm_kernel")?);
 
 ---
 
-Continue to [Debugging](debugging.md) for troubleshooting, or see [Performance Tuning](performance-tuning.md) for optimization techniques. This chapter builds on the `DeviceOperation` model introduced in [Async Execution](async-execution.md).
+Continue to [Debugging](debugging.md) for troubleshooting, or see [Performance Tuning](performance-tuning.md) for optimization techniques. This chapter builds on the `DeviceOp` model introduced in [Async Execution](async-execution.md).

--- a/cutile-book/guide/introduction.md
+++ b/cutile-book/guide/introduction.md
@@ -10,9 +10,7 @@ cuTile Rust kernels are GPU programs that execute concurrently across a logical 
 The `#[cutile::entry()]` attribute marks a Rust function as an *entry point*: a function you can call from your Rust program that executes on the GPU.
 
 ```rust
-use cuda_async::device_operation::DeviceOperation;
-use cuda_async::error::DeviceError;
-use cutile::{self, api, tile_kernel::IntoDeviceOperationPartition};
+use cutile::prelude::*;
 use my_module::add;
 
 #[cutile::module]
@@ -31,16 +29,20 @@ mod my_module {
     }
 }
 
-fn main() -> Result<(), DeviceError> {
-    let z = api::zeros([32, 32]).partition([4, 4]).sync()?;
-    let x = api::ones([32, 32]).arc().sync()?;
-    let y = api::ones([32, 32]).arc().sync()?;
-    let (_z, _x, _y) = add(z, x, y).sync()?;
+fn main() -> Result<(), cuda_async::error::DeviceError> {
+    let ctx = cuda_core::CudaContext::new(0)?;
+    let stream = ctx.new_stream()?;
+
+    let x = api::ones::<f32>(&[32, 32]).sync_on(&stream)?;
+    let y = api::ones::<f32>(&[32, 32]).sync_on(&stream)?;
+    let mut z = api::zeros::<f32>(&[32, 32]).sync_on(&stream)?;
+
+    let _ = add((&mut z).partition([4, 4]), &x, &y).sync_on(&stream)?;
     Ok(())
 }
 ```
 
-Here, `main` is host Rust code: it runs on the CPU, allocates tensors, and launches work. The `add` function is device Rust code because it is marked with `#[cutile::entry()]`; when `main` first calls `add(z, x, y)`, cuTile Rust JIT-compiles that function into optimized GPU code. The `#[cutile::module]` macro makes `my_module` expose the generated host-side APIs for launching `add`.
+Here, `main` is host Rust code: it runs on the CPU, allocates tensors, and launches work. The `add` function is device Rust code because it is marked with `#[cutile::entry()]`; when `main` first calls `add(...)`, cuTile Rust JIT-compiles that function into optimized GPU code. The `#[cutile::module]` macro makes `my_module` expose the generated host-side APIs for launching `add`.
 
 ---
 
@@ -52,59 +54,51 @@ Here, `main` is host Rust code: it runs on the CPU, allocates tensors, and launc
 
 ## How Kernel Arguments Map
 
-On the host side, immutable tensor arguments are typically passed as `Arc<Tensor<_>>`, which the generated kernel API maps to `&Tensor<...>` in device Rust code. Mutable tensor arguments are typically passed as `Partition<Tensor<_>>`, which the generated kernel API maps to `&mut Tensor<...>` for one tile-shaped region of the output.
+On the host side, the generated launcher accepts several forms for each kernel parameter:
+
+| Kernel param | Host input | What the kernel sees |
+|---|---|---|
+| `&Tensor<T, S>` | `&Tensor<T>`, `Arc<Tensor<T>>`, or `Tensor<T>` | `&Tensor<T, S>` (read-only) |
+| `&mut Tensor<T, S>` | `Partition<&mut Tensor<T>>` or `Partition<Tensor<T>>` | `&mut Tensor<T, S>` (one tile-shaped region) |
+| Scalar (`f32`, etc.) | Same scalar | Same scalar |
 
 Partitioning splits a tensor into disjoint regions with a fixed tile shape, such as `partition([4, 4])` for a 2D tensor. Each tile block receives one partition element, which is how cuTile Rust gives the kernel mutable access to one region at a time while keeping writes non-overlapping.
+
+The borrow-based form (`&Tensor`, `Partition<&mut Tensor>`) lets you pass tensors without moving them. The kernel writes through the borrow — no `unpartition()` or return capture needed.
 
 ---
 
 ## Launching Kernels
 
-Use `add(...)` when your arguments are already resolved:
+The simplest pattern borrows everything:
 
 ```rust
-let z = api::zeros([32, 32]).partition([4, 4]).sync()?;
-let x = api::ones([32, 32]).arc().sync()?;
-let y = api::ones([32, 32]).arc().sync()?;
+let x = api::ones::<f32>(&[32, 32]).sync_on(&stream)?;
+let y = api::ones::<f32>(&[32, 32]).sync_on(&stream)?;
+let mut z = api::zeros::<f32>(&[32, 32]).sync_on(&stream)?;
 
-let (_z, _x, _y) = add(z, x, y)
-    .sync()
-    .expect("Failed to launch add kernel.");
+// Borrow-based: z is written in place.
+let _ = add((&mut z).partition([4, 4]), &x, &y).sync_on(&stream)?;
 ```
 
-Use `add_op(...)` when each argument is still its own `DeviceOperation`:
+The launcher also accepts lazy `DeviceOp` arguments — everything stays lazy until `.sync()` or `.await`:
 
 ```rust
-use my_module::add_op;
+let z = api::zeros(&[32, 32]).partition([4, 4]);
+let x = api::ones::<f32>(&[32, 32]);
+let y = api::ones::<f32>(&[32, 32]);
 
-let z = api::zeros([32, 32]).partition([4, 4]);
-let x = api::ones([32, 32]).arc();
-let y = api::ones([32, 32]).arc();
-
-let (_z, _x, _y) = add_op(z, x, y)
-    .sync()
-    .expect("Failed to launch add kernel.");
+let (_z, _x, _y) = add(z, x, y).sync()?;
 ```
 
-If your arguments are already grouped into one `DeviceOperation`, use `.apply(...)` to launch `add(...)` inside that device operation context:
+For chaining, use `.then()` to compose operations on the same stream:
 
 ```rust
-use cuda_async::device_operation::*;
-
-let z = api::zeros([32, 32]).partition([4, 4]);
-let x = api::ones([32, 32]).arc();
-let y = api::ones([32, 32]).arc();
-
-let args = zip!(z, x, y);
-let (_z, _x, _y) = args
-    .apply(|(z, x, y)| add(z, x, y))
-    .sync()
-    .expect("Failed to launch add kernel.");
+let result = allocate()
+    .then(|buf| fill_kernel(buf))
+    .then(|buf| process_kernel(buf))
+    .sync()?;
 ```
-
-Conceptually, `apply` builds a new `DeviceOperation` from the output of `args`. The closure does not execute immediately on the host. Instead, it describes how to construct the next deferred operation once `args` produces `(z, x, y)`, and the whole composed operation runs only when you call `.sync()` or `.await`.
-
-These are the main generated kernel-launch APIs you should work with.
 
 ---
 

--- a/cutile-book/guide/memory-hierarchy.md
+++ b/cutile-book/guide/memory-hierarchy.md
@@ -20,7 +20,7 @@ Modern NVIDIA GPUs (H100 shown) have a multi-level memory hierarchy:
 
 ```rust
 // Tensors live in global memory
-let x: Arc<Tensor<f32>> = ones([1024, 1024]).arc().sync_on(&stream)?;
+let x: Arc<Tensor<f32>> = ones(&[1024, 1024]).map(Into::into).sync_on(&stream)?;
 ```
 
 **Best practices:**
@@ -102,7 +102,7 @@ Partitioning logically divides a tensor into a grid of equally sized sub-regions
 
 ```rust
 // 1024×1024 tensor, processed as 16×16 tiles
-let output = zeros([1024, 1024])
+let output = zeros(&[1024, 1024])
     .partition([16, 16]);  // Creates 64×64 = 4096 tiles
 
 // Each tile knows its position

--- a/cutile-book/guide/operations.md
+++ b/cutile-book/guide/operations.md
@@ -68,7 +68,7 @@ let result = a * x + y;
 let result = fma(a, x, y);
 
 // Fused multiply-add with rounding mode
-let result = fma_op(a, x, y, rounding_mode);
+let result = fma(a, x, y, rounding_mode);
 ```
 
 ---

--- a/cutile-book/guide/tile-programming-model.md
+++ b/cutile-book/guide/tile-programming-model.md
@@ -58,7 +58,7 @@ To process a large tensor, you **partition** it — dividing the tensor into a g
 Mutable tensors must be partitioned on the host side before kernel launch:
 
 ```rust
-let tensor = zeros([1024, 1024]).sync_on(&stream)?;
+let tensor = zeros(&[1024, 1024]).sync_on(&stream)?;
 let partitioned = tensor.partition([64, 64]);  // 16×16 = 256 sub-tensors
 ```
 
@@ -128,7 +128,7 @@ At kernel launch time, the launcher calls `.grid()` on each `&mut Tensor` parame
 
 ```rust
 // Grid is inferred from z's partition: (16, 16, 1)
-let z = zeros([1024, 1024]).sync_on(&stream)?.partition([64, 64]);
+let z = zeros(&[1024, 1024]).sync_on(&stream)?.partition([64, 64]);
 let (z, _x, _y) = add(z, x, y).sync_on(&stream)?;
 ```
 

--- a/cutile-book/index.md
+++ b/cutile-book/index.md
@@ -14,9 +14,7 @@ We encourage early experimentation and welcome feedback to help validate design 
 ## 🚀 Get Started in 5 Minutes
 
 ```rust
-use cuda_async::device_operation::DeviceOperation;
-use cuda_async::error::DeviceError;
-use cutile::{self, api, tile_kernel::IntoDeviceOperationPartition};
+use cutile::prelude::*;
 use my_module::add;
 
 #[cutile::module]
@@ -34,11 +32,12 @@ mod my_module {
     }
 }
 
-fn main() -> Result<(), DeviceError> {
-    let z = api::zeros([32, 32]).partition([4, 4]).sync()?;
-    let x = api::ones([32, 32]).arc().sync()?;
-    let y = api::ones([32, 32]).arc().sync()?;
-    let (_z, _x, _y) = add(z, x, y).sync()?;
+fn main() -> Result<(), cuda_async::error::DeviceError> {
+    let x = api::ones::<f32>(&[1024, 1024]).sync()?;
+    let y = api::ones::<f32>(&[1024, 1024]).sync()?;
+    let mut z = api::zeros::<f32>(&[1024, 1024]).sync()?;
+
+    add((&mut z).partition([64, 64]), &x, &y).sync()?;
     Ok(())
 }
 ```
@@ -83,6 +82,7 @@ tutorials/06-flash-attention
 tutorials/07-intro-to-async
 tutorials/08-data-parallel-mlp
 tutorials/09-pointer-addition
+tutorials/10-cuda-graphs
 ```
 
 ```{toctree}
@@ -97,6 +97,7 @@ guide/execution-model
 guide/memory-hierarchy
 guide/operations
 guide/async-execution
+guide/deviceop-reference
 guide/performance-tuning
 guide/interoperability
 guide/debugging

--- a/cutile-book/requirements.txt
+++ b/cutile-book/requirements.txt
@@ -4,6 +4,5 @@ pydata-sphinx-theme>=0.14
 myst-parser>=2.0
 sphinx-copybutton>=0.5
 sphinx-design>=0.5
-sphinx-sitemap>=2.5
 sphinx-autobuild>=2024.0  # Live reload for local development
 

--- a/cutile-book/tutorials/01-hello-world.md
+++ b/cutile-book/tutorials/01-hello-world.md
@@ -11,7 +11,7 @@ Tile kernels are functions which run as `N` copies concurrently and in parallel 
 Here is a kernel that prints "hello" from the GPU:
 
 ```rust
-use cuda_async::device_operation::DeviceOperation;
+use cuda_async::device_operation::DeviceOp;
 use cuda_core::CudaContext;
 use cutile;
 use cutile::error::Error;

--- a/cutile-book/tutorials/02-vector-addition.md
+++ b/cutile-book/tutorials/02-vector-addition.md
@@ -7,7 +7,7 @@ In cutile, tile threads run concurrently and each tile knows its coordinates via
 ---
 
 ```rust
-use cuda_async::device_operation::DeviceOperation;
+use cuda_async::device_operation::DeviceOp;
 use cuda_core::CudaContext;
 use std::sync::Arc;
 use cutile;
@@ -39,11 +39,11 @@ fn main() -> Result<(), Error> {
     let stream = ctx.new_stream()?;
     
     // Create input tensors: 32×32 matrices filled with 1.0
-    let x: Arc<Tensor<f32>> = ones([32, 32]).sync_on(&stream)?.into();
-    let y: Arc<Tensor<f32>> = ones([32, 32]).sync_on(&stream)?.into();
+    let x: Arc<Tensor<f32>> = ones(&[32, 32]).sync_on(&stream)?.into();
+    let y: Arc<Tensor<f32>> = ones(&[32, 32]).sync_on(&stream)?.into();
     
     // Create output tensor, PARTITIONED into 4×4 sub-tensors.
-    let z = zeros([32, 32]).sync_on(&stream)?.partition([4, 4]);
+    let z = zeros(&[32, 32]).sync_on(&stream)?.partition([4, 4]);
     
     // Run the kernel — one tile thread per sub-tensor, for a total of 64 threads.
     let (z, _x, _y) = add(z, x, y).sync_on(&stream)?;
@@ -71,7 +71,7 @@ Partitioning divides a tensor into a grid of sub-regions, each processed by one 
 ### Host-Side Partitioning (Required for `&mut Tensor`)
 
 ```rust
-let z = zeros([32, 32]).sync_on(&stream)?.partition([4, 4]);
+let z = zeros(&[32, 32]).sync_on(&stream)?.partition([4, 4]);
 ```
 
 1. Creates a 32×32 output tensor initialized to zeros.
@@ -177,7 +177,7 @@ fn my_kernel(...) {
 Modify the partition to `[8, 8]`:
 
 ```rust
-let z = zeros([32, 32]).sync_on(&stream)?.partition([8, 8]);
+let z = zeros(&[32, 32]).sync_on(&stream)?.partition([8, 8]);
 ```
 
 - How many tile threads are launched?

--- a/cutile-book/tutorials/03-saxpy.md
+++ b/cutile-book/tutorials/03-saxpy.md
@@ -21,7 +21,7 @@ Broadcasting is conceptual — the GPU doesn't actually allocate memory for all 
 ---
 
 ```rust
-use cuda_async::device_operation::DeviceOperation;
+use cuda_async::device_operation::DeviceOp;
 use cuda_core::CudaContext;
 use std::sync::Arc;
 use cutile;
@@ -56,8 +56,8 @@ fn main() -> Result<(), Error> {
     
     // Create x and y as [0, 1, 2, ..., 31] reshaped to 4×8
     let input: Arc<Tensor<f32>> = arange(32usize).sync_on(&stream)?.into();
-    let x: Arc<Tensor<f32>> = input.copy_sync(&stream)?.reshape([4, 8]).into();
-    let y = input.copy_sync(&stream)?.reshape([4, 8]).partition([2, 2]);
+    let x: Arc<Tensor<f32>> = input.dup().sync_on(&stream)?.reshape([4, 8]).into();
+    let y = input.dup().sync_on(&stream)?.reshape([4, 8]).partition([2, 2]);
     
     // Run: y = 2.0 * x + y = 2*x + x = 3*x
     let (a, _x, y) = saxpy(a, x, y).sync_on(&stream)?;

--- a/cutile-book/tutorials/04-matrix-multiplication.md
+++ b/cutile-book/tutorials/04-matrix-multiplication.md
@@ -52,7 +52,7 @@ Each element of A is used BN times. Each element of B is used BM times. This **d
 ## The Code
 
 ```rust
-use cuda_async::device_operation::DeviceOperation;
+use cuda_async::device_operation::DeviceOp;
 use cuda_core::CudaContext;
 use std::sync::Arc;
 use cutile;
@@ -101,14 +101,15 @@ fn main() -> Result<(), Error> {
         bm.to_string(), bn.to_string(), bk.to_string(), k.to_string()
     ];
 
-    let z = api::zeros([m, n]).partition([bm, bn]).sync_on(&stream)?;
-    let x: Arc<Tensor<f32>> = api::ones([m, k]).arc().sync_on(&stream)?;
-    let y: Arc<Tensor<f32>> = api::ones([k, n]).arc().sync_on(&stream)?;
+    let z = api::zeros(&[m, n]).partition([bm, bn]).sync_on(&stream)?;
+    let x: Arc<Tensor<f32>> = api::ones(&[m, k]).map(Into::into).sync_on(&stream)?;
+    let y: Arc<Tensor<f32>> = api::ones(&[k, n]).map(Into::into).sync_on(&stream)?;
 
     let (z, _x, _y) = gemm(z, x, y).generics(generics).sync_on(&stream)?;
 
     let z_host: Vec<f32> = z.unpartition().to_host_vec().sync_on(&stream)?;
     println!("z[0] = {} (expected {})", z_host[0], k);
+
 
     Ok(())
 }
@@ -225,7 +226,7 @@ fn gemm<E: ElementType, const BM: i32, const BN: i32, const BK: i32, const K: i3
 | `E` | `z`, `x`, `y` | `z.dtype()` | Yes |
 | `BM` | `z` (`&mut`) | `z.partition_shape[0]` | Yes |
 | `BN` | `z` (`&mut`) | `z.partition_shape[1]` | Yes |
-| `K` | `x`, `y` | `x.shape[1]` | Yes |
+| `K` | `x`, `y` | `x.shape()[1]` | Yes |
 | `BK` | — | — | No |
 
 `BM` and `BN` are known at kernel launch time because they are embedded in the `Partition` created by `.partition([bm, bn])`. `K` is known because it appears as a dimension of the input tensors `x` and `y`. But `BK` does not appear in the type of any kernel argument — it is only used *inside* the kernel body when partitioning `x` and `y` into tiles:

--- a/cutile-book/tutorials/05-fused-softmax.md
+++ b/cutile-book/tutorials/05-fused-softmax.md
@@ -43,7 +43,7 @@ exp(x_i - max) / Σ exp(x_j - max)
 ## The Code
 
 ```rust
-use cuda_async::device_operation::DeviceOperation;
+use cuda_async::device_operation::DeviceOp;
 use cuda_core::CudaContext;
 use cutile;
 use cutile::api::arange;
@@ -89,8 +89,8 @@ fn main() -> Result<(), Error> {
     let (bm, bn) = (2i32, n as i32);
 
     let input: Arc<Tensor<f32>> = arange(m * n).sync_on(&stream)?.into();
-    let x: Arc<Tensor<f32>> = input.copy_sync(&stream)?.reshape([m, n]).into();
-    let y = input.copy_sync(&stream)?.reshape([m, n]).partition([bm, bn]);
+    let x: Arc<Tensor<f32>> = input.dup().sync_on(&stream)?.reshape([m, n]).into();
+    let y = input.dup().sync_on(&stream)?.reshape([m, n]).partition([bm, bn]);
 
     let (_x, y) = softmax(x, y).sync_on(&stream)?;
     let y_host: Vec<f32> = y.unpartition().to_host_vec().sync_on(&stream)?;

--- a/cutile-book/tutorials/06-flash-attention.md
+++ b/cutile-book/tutorials/06-flash-attention.md
@@ -121,14 +121,14 @@ For each Q tile (row block of the output):
 ## The Code
 
 ```rust
-use cuda_async::device_operation::DeviceOperation;
+use cuda_async::device_operation::DeviceOp;
 use cuda_core::CudaContext;
 use std::sync::Arc;
 use cutile;
-use cutile::api::{randn_f32, zeros};
+use cutile::api::{randn, zeros};
 use cutile::error::Error;
-use cutile::tensor::{CopyToHost, IntoPartition, Partition, Tensor, Unpartition};
-use cutile::tile_kernel::TileKernel;
+use cutile::tensor::{IntoPartition, Partition, Tensor, ToHostVec, Unpartition};
+use cutile::tile_kernel::{PartitionOp, TileKernel, ToHostVecOp};
 
 #[cutile::module]
 mod fmha_module {
@@ -227,16 +227,16 @@ fn main() -> Result<(), Error> {
     let (bm, bn) = (64, 32);
 
     let seed = 42u64;
-    let q: Arc<Tensor<f32>> = randn_f32(0., 1., [batch, heads, seq_len, head_dim], Some(seed))
+    let q: Arc<Tensor<f32>> = randn(0., 1., [batch, heads, seq_len, head_dim], Some(seed))
         .sync_on(&stream)?.into();
-    let k: Arc<Tensor<f32>> = randn_f32(0., 1., [batch, heads, seq_len, head_dim], Some(seed + 1))
+    let k: Arc<Tensor<f32>> = randn(0., 1., [batch, heads, seq_len, head_dim], Some(seed + 1))
         .sync_on(&stream)?.into();
-    let v: Arc<Tensor<f32>> = randn_f32(0., 1., [batch, heads, seq_len, head_dim], Some(seed + 2))
+    let v: Arc<Tensor<f32>> = randn(0., 1., [batch, heads, seq_len, head_dim], Some(seed + 2))
         .sync_on(&stream)?.into();
 
-    let out: Partition<Tensor<f32>> = zeros([batch * heads, seq_len, head_dim])
+    let out = zeros(&[batch * heads, seq_len, head_dim])
         .sync_on(&stream)?
-        .partition([1, bm, head_dim as i32]);
+        .partition([1, bm, head_dim]);
 
     let qk_scale = 1.0 / f32::sqrt(head_dim as f32);
     let generics = vec![bm.to_string(), bn.to_string(), head_dim.to_string()];
@@ -245,8 +245,8 @@ fn main() -> Result<(), Error> {
         .generics(generics)
         .sync_on(&stream)?;
 
-    let out_host = out.unpartition().copy_to_host().sync_on(&stream)?;
-    println!("Output shape: {:?}", out_host.shape());
+    let out_host: Vec<f32> = out.unpartition().to_host_vec().sync_on(&stream)?;
+    println!("Output length: {}", out_host.len());
 
     Ok(())
 }
@@ -255,7 +255,7 @@ fn main() -> Result<(), Error> {
 **Output:**
 
 ```text
-Output shape: [8, 128, 64]
+Output length: 65536
 ```
 
 ---

--- a/cutile-book/tutorials/07-intro-to-async.md
+++ b/cutile-book/tutorials/07-intro-to-async.md
@@ -21,16 +21,16 @@ With async, the CPU can do other work while the GPU computes:
 
 ---
 
-## DeviceOperation
+## DeviceOp
 
-In cutile, GPU work is represented as a `DeviceOperation` — a description of work to be done, not yet executed:
+In cutile, GPU work is represented as a `DeviceOp` — a description of work to be done, not yet executed:
 
-- `DeviceOperation` describes the work.
+- `DeviceOp` describes the work.
 - `.await`, `tokio::spawn(.)`, or `.sync_on(.)` executes it.
 
 ```rust
-// This creates a DeviceOperation, but doesn't execute yet!
-let tensor_op = api::ones([1024, 1024]);  // Returns impl DeviceOperation
+// This creates a DeviceOp, but doesn't execute yet!
+let tensor_op = api::ones(&[1024, 1024]);  // Returns impl DeviceOp
 
 // Nothing has happened on the GPU yet...
 
@@ -44,7 +44,7 @@ let tensor: Tensor<f32> = tensor_op.await;             // Async API
 
 ## Sync vs Async APIs
 
-In cutile, a `DeviceOperation` can be executed with either sync or async APIs. Given a particular operation `op`:
+In cutile, a `DeviceOp` can be executed with either sync or async APIs. Given a particular operation `op`:
 
 | API | Description |
 |----------|-------------|
@@ -62,7 +62,7 @@ In cutile, a `DeviceOperation` can be executed with either sync or async APIs. G
 ```rust
 use cutile::api::{ones, zeros};
 use cutile::tensor::{Tensor, ToHostVec, Unpartition};
-use cutile::tile_kernel::{IntoDeviceOperationPartition, TileKernel, TensorDeviceOpToHostVec};
+use cutile::tile_kernel::{PartitionOp, TileKernel, ToHostVecOp};
 use cuda_async::device_operation::*;
 use std::sync::Arc;
 
@@ -82,23 +82,25 @@ mod async_add_module {
     }
 }
 
-use async_add_module::add_apply;
+use async_add_module::add;
 
 #[tokio::main]
-async fn main() {
-    let x: Arc<Tensor<f32>> = ones([32, 32]).arc().await?;
-    let y: Arc<Tensor<f32>> = ones([32, 32]).arc().await?;
+async fn main() -> Result<(), DeviceError> {
+    let x: Arc<Tensor<f32>> = ones(&[32, 32]).map(Into::into).await?;
+    let y: Arc<Tensor<f32>> = ones(&[32, 32]).map(Into::into).await?;
 
-    let z_op = zeros::<2, f32>([32, 32]);
-    let args = zip!(
-        z_op.partition([4, 4]),           // Output, partitioned into tiles
-        x.device_operation(),             // Input x as DeviceOperation
-        y.device_operation()              // Input y as DeviceOperation
-    );
-    let (z, _x, _y) = args.apply(add_apply).unzip();
-
-    let z_host: Vec<f32> = z.unpartition().to_host_vec().await?;
+    // Unified launcher: pass output partition and inputs directly.
+    let z_host: Vec<f32> = add(
+        zeros(&[32, 32]).partition([4, 4]),  // Output, partitioned into tiles
+        x,                                    // Input x (Arc<Tensor> via IntoDeviceOp)
+        y,                                    // Input y
+    )
+    .first()
+    .unpartition()
+    .to_host_vec()
+    .await?;
     println!("z[0] = {} (expected 2.0)", z_host[0]);
+    Ok(())
 }
 ```
 
@@ -116,58 +118,50 @@ z[0] = 2 (expected 2.0)
 
 ```rust
 #[tokio::main]
-async fn main() {
-    let batch1_op = prepare_batch(1);  // Returns DeviceOperation
-    let batch2_op = prepare_batch(2);  // Returns DeviceOperation
+async fn main() -> Result<(), DeviceError> {
+    let batch1_op = prepare_batch(1);  // Returns DeviceOp
+    let batch2_op = prepare_batch(2);  // Returns DeviceOp
 
-    let batch1 = batch1_op.await;
+    let batch1 = batch1_op.await?;
 
     let result1_op = process_kernel(batch1);
     let result1_handle = tokio::spawn(result1_op);  // Non-blocking
 
     // batch 2 data can be prepared while batch 1's kernel runs
-    let batch2 = batch2_op.await;
+    let batch2 = batch2_op.await?;
 
-    let result2 = process_kernel(batch2).await;
+    let result2 = process_kernel(batch2).await?;
 
-    let result1 = result1_handle.await;
+    let result1 = result1_handle.await?;
+    Ok(())
 }
 ```
 
 ---
 
-## Composing DeviceOperations
+## Composing DeviceOps
 
-### `zip!` — Combine Operations for Kernels
+### Unified Kernel Launcher
 
-`zip!` combines multiple DeviceOperations into a tuple that can be passed to kernels:
+The kernel launcher accepts both `DeviceOp` and plain values directly — no `zip!` needed:
+
+```rust
+// Pass output partition and inputs directly.
+let result = kernel(output_op.partition([4, 4]), input1, input2)
+    .first()           // Extract the output
+    .unpartition()
+    .await?;
+```
+
+### `zip!` — Combine Operations Manually
+
+For cases where you need explicit control, `zip!` combines multiple DeviceOps into a tuple:
 
 ```rust
 use cuda_async::device_operation::*;
 
-let args = zip!(
-    output_op.partition([4, 4]),   // Partitioned output
-    input1.device_operation(),     // Input as DeviceOperation
-    input2.device_operation()      // Another input
-);
-
-let (out, _in1, _in2) = args.apply(kernel_apply).unzip();
-```
-
-### `apply` — Run Kernels on DeviceOperations
-
-```rust
-let args = zip!(output_op, input_op);
-let (output, _input) = args.apply(some_kernel_apply).unzip();
-
-let result = output.await;
-```
-
-Use `kernel_op(...)` instead when the arguments are still separate `DeviceOperation`s rather than already grouped with `zip!`:
-
-```rust
-let output_op = kernel_op(z_op, input_op);
-let output = output_op.await;
+let combined = zip!(op_a, op_b, op_c);
+let (a, b, c) = combined.await?;
 ```
 
 ---
@@ -187,16 +181,46 @@ Start with sync for learning, move to async for production.
 
 ---
 
+## Borrowed Inputs and Spawn Safety
+
+Kernel `&Tensor` params accept three input forms: `Tensor<T>`, `Arc<Tensor<T>>`,
+and `&Tensor<T>`. Borrowed inputs (`&Tensor<T>`) work with `.sync_on()` and
+`.await`, but the compiler rejects them with `tokio::spawn`:
+
+```rust
+let weights: Tensor<f32> = api::ones(&[1024]).sync_on(&stream)?;
+
+// OK — borrow is contained in the sync call.
+let result = my_kernel(out, &weights).sync_on(&stream)?;
+
+// OK — borrow checker ensures weights outlives the await.
+let result = my_kernel(out, &weights).await?;
+
+// COMPILE ERROR — &weights is not 'static, so the future can't be spawned.
+let handle = tokio::spawn(my_kernel(out, &weights));
+//                                       ^^^^^^^^ borrowed value does not live long enough
+```
+
+This is enforced at compile time by Rust's lifetime system. If you need to
+spawn, use `Arc<Tensor<T>>` instead:
+
+```rust
+let weights: Arc<Tensor<f32>> = api::ones(&[1024]).sync_on(&stream)?.into();
+let handle = tokio::spawn(my_kernel(out, weights));  // OK — Arc is 'static
+```
+
+---
+
 ## Key Takeaways
 
 | Concept | What It Means |
 |---------|---------------|
-| **DeviceOperation** | A description of GPU work, not yet executed |
+| **DeviceOp** | A description of GPU work, not yet executed |
 | **.await** | Execute the operation and get the result |
 | **Async enables overlap** | CPU can do work while GPU computes |
-| **zip!** | Combine multiple operations for kernel input |
-| **apply** | Launch a kernel from one grouped `DeviceOperation` |
-| **`*_op`** | Launch a kernel from separate `DeviceOperation` arguments |
+| **Unified launcher** | Kernel functions accept DeviceOps and plain values directly |
+| **zip!** | Combine multiple operations into a tuple |
+| **.then()** | Chain follow-up work on the same stream |
 
 ---
 
@@ -211,10 +235,10 @@ Use `zip!` to create 4 tensors in parallel.
 :::{dropdown} Answer
 ```rust
 let (a, b, c, d) = zip!(
-    ones([100, 100]).arc(),
-    zeros([100, 100]).arc(),
-    randn(0.0, 1.0, [100, 100]).arc(),
-    arange(10000).arc()
+    ones(&[100, 100]).map(Into::into),
+    zeros(&[100, 100]).map(Into::into),
+    randn(0.0, 1.0, [100, 100]).map(Into::into),
+    arange(10000).map(Into::into)
 ).await?;
 ```
 :::

--- a/cutile-book/tutorials/08-data-parallel-mlp.md
+++ b/cutile-book/tutorials/08-data-parallel-mlp.md
@@ -70,18 +70,18 @@ mod data_parallel_module {
     }
 }
 
-use data_parallel_module::{gemm_apply, relu_apply, matvec_apply};
+use data_parallel_module::{gemm, relu, matvec};
 
 #[tokio::main]
-async fn main() {
+async fn main() -> Result<(), DeviceError> {
 
     use cuda_async::device_operation::*;
-    use data_parallel_module::{gemm_apply, relu_apply, matvec_apply};
+    use data_parallel_module::{gemm, relu, matvec};
     use cutile::api;
     use cutile::tensor::{Unpartition, Partition, Tensor, ToHostVec};
-    use cutile::tile_kernel::{IntoDeviceOperationPartition, TileKernel};
+    use cutile::tile_kernel::{PartitionOp, TileKernel};
     use cuda_async::device_context::global_policy;
-    use cutile::api::copy;
+    use cutile::api::dup;
     use tokio::task::JoinHandle;
 
     // Get device scheduling policies.
@@ -109,12 +109,12 @@ async fn main() {
         block_dim.to_string(),
         dim.to_string(),
     ];
-    let w0 = api::randn(0.0f32, 1.0, [dim, dim]); // impl DeviceOperation
-    let w1 = api::randn(0.0f32, 1.0, [dim]); // impl DeviceOperation
-    let w = zip!(w0.arc(), w1.arc()).schedule(&devices[0])?.await?;
+    let w0 = api::randn(0.0f32, 1.0, [dim, dim]); // impl DeviceOp
+    let w1 = api::randn(0.0f32, 1.0, [dim]); // impl DeviceOp
+    let w = zip!(w0.map(Into::into), w1.map(Into::into)).schedule(&devices[0])?.await?;
     let mut joins = vec![];
     for i in 1..num_devices {
-        let w_copy = tokio::spawn(zip!(copy(&w.0).arc(), copy(&w.1).arc()).schedule(&devices[i])?);
+        let w_copy = tokio::spawn(zip!(dup(&w.0).map(Into::into), dup(&w.1).map(Into::into)).schedule(&devices[i])?);
         joins.push(w_copy);
     }
     let mut model_weights = vec![w];
@@ -127,16 +127,19 @@ async fn main() {
     for i in 0..num_devices {
         let w = &model_weights[i];
         let (w0, w1) = (w.0.clone(), w.1.clone());
-        let data = api::randn(0.0, 1.0, [dim, dim]).arc();
-        let out0 = api::zeros::<2, f32>([dim, dim]).partition([block_dim, block_dim]);
-        let (out0, _, _) = zip!(out0, data, value(w0))
-            .apply(|args| gemm_apply(args).generics(fully_connected_layer.to_vec()))
-            .unzip();
-        let out1 = api::zeros::<1, f32>([dim]).partition([block_dim]);
-        let (out1, _, _) = zip!(out1, out0.unpartition().arc(), value(w1))
-            .apply(|args| matvec_apply(args).generics(output_layer.to_vec()))
-            .unzip();
-        let (out1,) = out1.and_then(|out1| value((out1,))).apply(relu_apply).unzip();
+        let data = api::randn(0.0, 1.0, [dim, dim]).map(Into::into);
+        // Unified launcher: pass output partition and inputs directly.
+        let out0 = api::zeros(&[dim, dim]).partition([block_dim, block_dim]);
+        let out0 = gemm(out0, data, w0)
+            .generics(fully_connected_layer.to_vec())
+            .first()
+            .unpartition();
+        let out1 = api::zeros(&[dim]).partition([block_dim]);
+        let out1 = matvec(out1, out0.map(Into::into), w1)
+            .generics(output_layer.to_vec())
+            .first()
+            .unpartition();
+        let (out1,) = relu(out1.partition([block_dim])).unzip();
         futures.push(tokio::spawn(out1.schedule(&devices[i])?));
     }
 
@@ -150,6 +153,7 @@ async fn main() {
         println!("{:?}", output.to_host_vec().await?);
     }
 
+    Ok(())
 }
 ```
 
@@ -167,22 +171,21 @@ for i in 0..num_devices {
     let (w0, w1) = (w.0.clone(), w.1.clone());
     // Sample random data. Although the sampling procedure is a simulation,
     // this can be replaced with a procedure that actually samples a batch of data.
-    let data = api::randn(0.0, 1.0, [dim, dim]).arc();
-    // Construct the intermediate output buffer and partition, since we'll be writing to it.
-    let out0 = api::zeros::<2, f32>([dim, dim]).partition([block_dim, block_dim]);
-    // Execute GEMM.
-    let (out0, _, _) = zip!(out0, data, value(w0))
-        .apply(|args| gemm_apply(args).generics(fully_connected_layer.to_vec()))
-        .unzip();
-    // Construct the final output buffer and partition.
-    let out1 = api::zeros::<1, f32>([dim]).partition([block_dim]);
-    // Execute MatVec.
-    let (out1, _, _) = zip!(out1, out0.unpartition().arc(), value(w1))
-        .apply(|args| matvec_apply(args).generics(output_layer.to_vec()))
-        .unzip();
-    // Apply ReLU and unzip. We need to unzip here since arguments to kernels
-    // are always packed into a tuple.
-    let (out1,) = out1.and_then(|out1| value((out1,))).apply(relu_apply).unzip();
+    let data = api::randn(0.0, 1.0, [dim, dim]).map(Into::into);
+    // Unified launcher: pass output partition and inputs directly.
+    let out0 = api::zeros(&[dim, dim]).partition([block_dim, block_dim]);
+    let out0 = gemm(out0, data, w0)
+        .generics(fully_connected_layer.to_vec())
+        .first()
+        .unpartition();
+    // Final output: matvec + relu.
+    let out1 = api::zeros(&[dim]).partition([block_dim]);
+    let out1 = matvec(out1, out0.map(Into::into), w1)
+        .generics(output_layer.to_vec())
+        .first()
+        .unpartition();
+    // Apply ReLU. Partition for tile-level dispatch, then unzip the result.
+    let (out1,) = relu(out1.partition([block_dim])).unzip();
     // out1 now contains the work we would like to schedule on device i.
     // By invoking schedule on device i, we generate a device future which is
     // ready to execute on device i. By spawning a task for the device future,

--- a/cutile-book/tutorials/09-pointer-addition.md
+++ b/cutile-book/tutorials/09-pointer-addition.md
@@ -48,9 +48,9 @@ async fn async_main() -> Result<(), cutile::error::Error> {
     let tile_size = 4usize;
 
     // Initialize tensors.
-    let z: Tensor<f32> = zeros([len]).await?;
-    let x: Tensor<f32> = ones([len]).await?;
-    let y: Tensor<f32> = ones([len]).await?;
+    let z: Tensor<f32> = zeros(&[len]).await?;
+    let x: Tensor<f32> = ones(&[len]).await?;
+    let y: Tensor<f32> = ones(&[len]).await?;
 
     // Extract device pointers.
     let z_ptr = z.device_pointer();

--- a/cutile-book/tutorials/10-cuda-graphs.md
+++ b/cutile-book/tutorials/10-cuda-graphs.md
@@ -1,0 +1,428 @@
+# Tutorial 10: CUDA Graphs
+
+CUDA graphs let you capture an entire GPU workload once and replay it
+many times, eliminating per-launch overhead. This tutorial builds a
+multi-layer forward pass using DeviceOp combinators, captures it as
+a CUDA graph, and replays it in a token loop.
+
+---
+
+## Why CUDA Graphs?
+
+Every kernel launch involves CPU-side work: selecting a stream, setting up
+arguments, invoking the driver. For workloads that repeat the same graph of
+operations (e.g., the forward pass of a transformer), this per-launch
+overhead can dominate — especially at small batch sizes where kernels are
+fast relative to their launch cost.
+
+A CUDA graph records the entire sequence of operations once, then replays
+it with a single driver call. The GPU sees the full graph up front and can
+schedule internal work more aggressively.
+
+```text
+Without graphs:                     With graphs:
+
+  CPU: launch → wait → launch →      CPU: launch_graph → wait
+       wait → launch → wait               (single call)
+  GPU: ████   ████   ████            GPU: ████████████████
+       gaps between kernels                no gaps
+```
+
+---
+
+## The Model
+
+We'll build a minimal transformer-style layer stack: each layer performs
+RMSNorm → Q projection (matvec) → O projection (matvec) → residual add.
+The hidden state flows through all layers sequentially.
+
+```text
+input
+  │
+  ├─ Layer 0: RMSNorm → Q MatVec → O MatVec → Add(residual, hidden)
+  │
+  ├─ Layer 1: RMSNorm → Q MatVec → O MatVec → Add(residual, hidden)
+  │
+  └─ … (n_layers)
+```
+
+### Kernels
+
+Three cutile kernels handle the compute. Each follows the output-first
+convention (`&mut Tensor` as the first parameter):
+
+```rust
+#[cutile::module]
+mod kernels {
+    use cutile::core::*;
+
+    /// RMS normalization: out = rms_norm(x) * w
+    #[cutile::entry()]
+    pub fn rms_norm<const D: i32, const BS: i32>(
+        out: &mut Tensor<f32, { [1, D] }>,
+        x: &Tensor<f32, { [-1, D] }>,
+        w: &Tensor<f32, { [D] }>,
+        eps: f32,
+    ) { /* tile-level implementation */ }
+
+    /// Matrix-vector multiply: out = x @ w^T
+    #[cutile::entry()]
+    pub fn matvec<const BN: i32, const BK: i32, const K: i32>(
+        out: &mut Tensor<f32, { [BN] }>,
+        x: &Tensor<f32, { [-1, K] }>,
+        w: &Tensor<f32, { [-1, K] }>,
+    ) { /* tile-level implementation */ }
+
+    /// Element-wise add: out = a + b
+    #[cutile::entry()]
+    pub fn add<const B: i32>(
+        out: &mut Tensor<f32, { [B] }>,
+        a: &Tensor<f32, { [-1] }>,
+        b: &Tensor<f32, { [-1] }>,
+    ) { /* tile-level implementation */ }
+}
+```
+
+### Model State
+
+Weights are shared across all forward calls. Buffers are pre-allocated once
+and reused every token — the graph replays into the same memory:
+
+```rust
+struct LayerWeights {
+    norm_w: Arc<Tensor<f32>>,
+    wq: Arc<Tensor<f32>>,
+    wo: Arc<Tensor<f32>>,
+}
+
+struct LayerBuffers {
+    norm: Arc<Tensor<f32>>,
+    q: Arc<Tensor<f32>>,
+    o: Arc<Tensor<f32>>,
+    residual: Arc<Tensor<f32>>,
+}
+```
+
+---
+
+## Building the Lazy Graph
+
+The core of the approach: build the entire forward pass as a `DeviceOp`
+without executing anything. This is the graph that will be captured.
+
+```rust
+fn build_forward(
+    cfg: &Config,
+    weights: &[LayerWeights],
+    input: Arc<Tensor<f32>>,
+    buffers: Vec<LayerBuffers>,
+) -> DeviceOpVec<LayerBuffers> {
+    let mut result = Vec::with_capacity(buffers.len());
+    let mut hidden: SharedDeviceOp<Tensor<f32>> = shared(input);
+
+    for (w, bufs) in weights.iter().zip(buffers) {
+        // RMSNorm: hidden(1,d) × norm_w → norm(1,d)
+        let norm = rms_norm(
+            bufs.norm.try_partition([1, cfg.d]).expect("sole buffer owner"),
+            hidden.clone().reshape(&[1, cfg.d]),
+            w.norm_w.clone(),
+            cfg.eps,
+        )
+        .generics(cfg.rms_generics())
+        .first()
+        .unpartition()
+        .shared();
+
+        // Q projection: norm @ wq^T → q
+        let q = matvec(
+            bufs.q.try_partition([cfg.bn]).expect("sole buffer owner"),
+            norm.clone(),
+            w.wq.clone(),
+        )
+        .generics(cfg.mv_generics())
+        .first()
+        .unpartition()
+        .shared();
+
+        // O projection: q @ wo^T → o
+        let o = matvec(
+            bufs.o.try_partition([cfg.bn]).expect("sole buffer owner"),
+            q.clone().reshape(&[1, cfg.d]),
+            w.wo.clone(),
+        )
+        .generics(cfg.mv_generics())
+        .first()
+        .unpartition()
+        .shared();
+
+        // Residual add: hidden + o → residual
+        let residual = add(
+            bufs.residual.try_partition([cfg.block]).expect("sole buffer owner"),
+            hidden.clone().reshape(&[cfg.d]),
+            o.clone(),
+        )
+        .first()
+        .unpartition()
+        .shared();
+
+        hidden = residual.clone();
+
+        // Collect buffers for this layer.
+        result.push(
+            zip!(norm, q, o, residual)
+                .map(|(norm, q, o, residual)| LayerBuffers { norm, q, o, residual })
+                .boxed(),
+        );
+    }
+
+    DeviceOpVec::new(result)
+}
+```
+
+Key patterns to notice:
+
+- **`.shared()`** — Each intermediate result is shared so it can feed into
+  both the next kernel and the final buffer collection. The underlying
+  computation runs once; downstream consumers get `Arc::clone()`.
+- **`.first()`** — Kernel launches return a tuple of all arguments.
+  `.first()` extracts just the output (the `&mut Tensor` parameter).
+- **`try_partition`** — Converts `Arc<Tensor<T>>` into a `Partition` by
+  proving sole ownership (Arc refcount == 1).
+- **`DeviceOpVec`** — Collects boxed ops for heterogeneous layer outputs.
+- **No GPU work yet** — Everything above is pure graph construction.
+
+---
+
+## Capturing the Graph
+
+`.graph_on(stream)` executes the operation once in CUDA's stream capture mode,
+recording all GPU work into a replayable graph:
+
+```rust
+let input: Arc<Tensor<f32>> = api::rand([cfg.d], None).sync_on(&stream)?.into();
+let buffers: Vec<_> = (0..cfg.n_layers)
+    .map(|_| LayerBuffers::allocate(cfg.d, &stream))
+    .collect::<Result<_, _>>()?;
+stream.synchronize()?;
+
+// Build lazy graph (no GPU work).
+let forward_op = build_forward(&cfg, &weights, input.clone(), buffers);
+
+// Capture: executes once, records everything, returns CudaGraph.
+let mut graph = forward_op.graph_on(stream.clone())?;
+
+// Retrieve the output from the capture execution.
+let buffers = graph.take_output().unwrap();
+let output = buffers.last().unwrap().residual.clone();
+```
+
+After capture:
+- `graph` holds the recorded CUDA graph, ready for replay.
+- `buffers` holds the tensors that the graph writes into — these are the
+  same device pointers baked into the graph.
+- `output` points to the final layer's residual buffer.
+
+---
+
+## The Module Pattern
+
+Wrap the graph in a `Module` trait for clean inference:
+
+```rust
+trait Module {
+    type Input: Send;
+    type Output: Send;
+    fn forward(&mut self, input: Self::Input) -> Result<Self::Output, DeviceError>;
+}
+
+struct GraphModel {
+    graph: CudaGraph<Vec<LayerBuffers>>,
+    input: Arc<Tensor<f32>>,
+    output: Arc<Tensor<f32>>,
+    _buffers: Vec<LayerBuffers>,
+}
+
+impl Module for GraphModel {
+    type Input = Arc<Tensor<f32>>;
+    type Output = Arc<Tensor<f32>>;
+
+    fn forward(&mut self, input: Self::Input) -> Result<Self::Output, DeviceError> {
+        // Copy new embedding into the baked-in input buffer.
+        self.graph.update(api::memcpy(&mut self.input, &input))?;
+        // Replay the entire forward pass with a single driver call.
+        self.graph.launch()?;
+        Ok(self.output.clone())
+    }
+}
+```
+
+Each `forward` call:
+
+1. **`graph.update(memcpy(…))`** — Copies new input data into the
+   pre-allocated input buffer. This runs on the graph's stream, so it
+   completes before the graph launches.
+2. **`graph.launch()`** — Replays all captured kernels. The GPU sees the
+   full operation sequence and can schedule aggressively.
+3. **Returns `output.clone()`** — The output `Arc` points to the same
+   device memory the graph wrote into. No copy needed.
+
+---
+
+## Putting It Together
+
+```rust
+fn main() -> Result<(), Error> {
+    let ctx = CudaContext::new(0)?;
+    let stream = ctx.new_stream()?;
+
+    let cfg = Config { d: 2048, n_layers: 22, block: 128, bn: 16, bk: 16, eps: 1e-5 };
+
+    // Allocate weights (random for this example).
+    let weights: Vec<LayerWeights> = (0..cfg.n_layers)
+        .map(|_| Ok(LayerWeights {
+            norm_w: api::rand([cfg.d], None).sync_on(&stream)?.into(),
+            wq: api::rand([cfg.d, cfg.d], None).sync_on(&stream)?.into(),
+            wo: api::rand([cfg.d, cfg.d], None).sync_on(&stream)?.into(),
+        }))
+        .collect::<Result<_, Error>>()?;
+
+    // Build and capture.
+    let mut model = GraphModel::new(&cfg, &weights, &stream)?;
+
+    // Inference loop — each call is a single graph launch.
+    let n_tokens = 512;
+    for _ in 0..n_tokens {
+        let embedding: Arc<Tensor<f32>> = api::rand([cfg.d], None).sync_on(&stream)?.into();
+        let _output = model.forward(embedding)?;
+    }
+
+    Ok(())
+}
+```
+
+---
+
+## Alternative: `CudaGraph::scope`
+
+The combinator approach above requires `Arc<Tensor<T>>` + `try_partition`
+for pre-allocated buffers. `CudaGraph::scope` provides an imperative
+alternative using `&mut` borrows:
+
+```rust
+let mut input: Tensor<f32> = api::ones::<f32>(&[cfg.d]).sync_on(&stream)?;
+let mut buffers: Vec<LayerBuffers> = /* pre-allocate */;
+
+let graph = CudaGraph::scope(&stream, |s| {
+    for (w, bufs) in weights.iter().zip(buffers.iter_mut()) {
+        let hidden_2d = input.view(&[1, cfg.d])?;
+
+        s.record(rms_norm(
+            (&mut bufs.norm).partition([1, cfg.d]),
+            &hidden_2d,
+            &w.norm_w,
+            cfg.eps,
+        ).generics(cfg.rms_generics()))?;
+
+        s.record(matvec(
+            (&mut bufs.q).partition([cfg.bn]),
+            &bufs.norm,
+            &w.wq,
+        ).generics(cfg.mv_generics()))?;
+
+        let q_2d = bufs.q.view(&[1, cfg.d])?;
+        s.record(matvec(
+            (&mut bufs.o).partition([cfg.bn]),
+            &q_2d,
+            &w.wo,
+        ).generics(cfg.mv_generics()))?;
+
+        s.record(add(
+            (&mut bufs.residual).partition([cfg.block]),
+            &input,
+            &bufs.o,
+        ))?;
+
+        s.record(api::memcpy(&mut input, &bufs.residual))?;
+    }
+    Ok(())
+})?;
+
+graph.launch()?;
+```
+
+Key differences from the combinator approach:
+
+| | Combinator (`.graph()`) | Scope (`CudaGraph::scope`) |
+|---|---|---|
+| Buffer ownership | `Arc<Tensor<T>>` + `try_partition` | `&mut Tensor<T>` borrows |
+| Write-then-read | Via `.shared()` + cloning | Via `record()` releasing borrows |
+| Failure mode | Runtime panic (refcount != 1) | Compile error (borrow conflict) |
+| Composability | Chains with `.then()`, `.map()` | Imperative sequential code |
+
+`s.record(op)` only accepts operations that implement `GraphNode` — kernel
+launches and `memcpy`. Allocation ops (`api::zeros`, `dup`, etc.) are rejected
+at compile time because their addresses may change on graph replay.
+
+---
+
+## When to Use CUDA Graphs
+
+| Scenario | Use CUDA graphs? | Why |
+|---|---|---|
+| Repeat the same operation graph many times | **Yes** | Amortizes capture cost; eliminates per-launch overhead |
+| Dynamic shapes per iteration | No | Captured graphs bake in tensor dimensions |
+| Dynamic control flow per iteration | No | Captured graphs bake in the branch structure |
+| Small number of iterations | Maybe | Capture cost (~1 execution) must be amortized |
+| Profiling individual kernels | No | Graph replay shows as a single event |
+
+---
+
+## Key Takeaways
+
+| Concept | What it means |
+|---|---|
+| **`DeviceOp` graph** | Lazy composition of GPU work — no execution until driven |
+| **`.graph_on(stream)`** | Capture the entire operation into a replayable `CudaGraph` |
+| **`CudaGraph::scope`** | Imperative graph capture with `&mut` borrows |
+| **`graph.launch()`** | Replay all captured work with a single driver call |
+| **`graph.update(op)`** | Run a DeviceOp on the graph's stream before replay (e.g., memcpy new input) |
+| **Pre-allocated buffers** | Graph writes into fixed memory; vary inputs via `memcpy` |
+| **`.shared()` in graphs** | Each intermediate executes once during capture; clones share the result |
+
+:::{note}
+Weight tensors in `build_forward` are passed as `Arc<Tensor<T>>` because
+they're shared across layers via `.clone()`. In a sync context where weights
+are only read (not shared across spawned tasks), you could pass `&Tensor<T>`
+instead — the borrow checker ensures the weights outlive the graph capture.
+See [Tutorial 7](07-intro-to-async.md#borrowed-inputs-and-spawn-safety) for
+details on borrowed inputs.
+:::
+
+---
+
+### Exercise 1: Add a Second Graph
+
+Capture a second graph that computes the backward pass (or a simplified
+version). How would you sequence the forward and backward graphs?
+
+### Exercise 2: Measure the Speedup
+
+Add timing around `graph.launch()` vs a non-graph path that rebuilds and
+executes the `DeviceOp` each iteration. How does the speedup scale with
+`n_layers`?
+
+### Exercise 3: Dynamic Input Shapes
+
+The current approach bakes in the tensor dimensions at capture time. What
+would need to change to support variable sequence lengths? (Hint: consider
+capturing multiple graphs for common sizes.)
+
+---
+
+## Full Reference Example
+
+The complete working example with benchmarks:
+
+```bash
+cargo run -p cutile-examples --example cuda_graphs
+```

--- a/cutile-compiler/src/kernel_naming.rs
+++ b/cutile-compiler/src/kernel_naming.rs
@@ -53,19 +53,16 @@ impl KernelNaming {
         &self.public_name
     }
 
-    /// Returns the public helper used with `.apply(...)`.
+    /// Returns the `_apply` variant name (legacy, still generated).
     ///
-    /// Example: `zip!(...).apply(my_kernel_apply)`.
+    /// Prefer the unified launcher `<kernel>(...)` which accepts `IntoDeviceOp` args directly.
     pub fn apply_name(&self) -> String {
         format!("{}_apply", self.public_name)
     }
 
-    /// Returns the launcher helper for separate `DeviceOperation` arguments.
+    /// Returns the `_op` variant name (legacy, still generated).
     ///
-    /// In other words:
-    /// - `<kernel>(...)` is the public ergonomic entry point
-    /// - `<kernel>_apply(...)` is the public composition hook
-    /// - `<kernel>_op(...)` is the public helper for separate lazy arguments
+    /// Prefer the unified launcher `<kernel>(...)` which accepts `IntoDeviceOp` args directly.
     pub fn device_op_helper_name(&self) -> String {
         format!("{}_op", self.public_name)
     }

--- a/cutile-examples/examples/add_basic.rs
+++ b/cutile-examples/examples/add_basic.rs
@@ -3,14 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use cuda_async::device_operation::{DeviceOperation, Zippable};
-use cutile::{
-    self, api,
-    tensor::Unpartition,
-    tile_kernel::{
-        zip, IntoDeviceOperationPartition, TensorDeviceOpToHostVec, TileKernel, Unzippable3,
-    },
-};
+use cutile::prelude::*;
 use my_module::add;
 
 #[cutile::module]
@@ -18,9 +11,9 @@ mod my_module {
     use cutile::core::*;
     #[cutile::entry(print_ir = true)]
     fn add<const S: [i32; 1]>(
+        c: &mut Tensor<f32, S>,
         a: &Tensor<f32, { [-1] }>,
         b: &Tensor<f32, { [-1] }>,
-        c: &mut Tensor<f32, S>,
     ) {
         let pid = get_tile_block_id().0;
         let tile_a = a.load_tile(const_shape!(S), [pid]);
@@ -29,16 +22,16 @@ mod my_module {
     }
 }
 
-fn main() -> () {
-    let a = api::ones([32]).arc();
-    let b = api::ones([32]).arc();
-    let c = api::zeros([32]).partition([4]);
-    let c_host_vec = zip!(a, b, c)
-        .apply(|(a, b, c)| add(a, b, c).grid((8, 1, 1)))
-        .unzip()
-        .2
-        .unpartition()
-        .to_host_vec()
-        .sync();
+fn main() {
+    let c_host_vec = add(
+        api::zeros(&[32]).partition([4]),
+        api::ones(&[32]),
+        api::ones(&[32]),
+    )
+    .grid((8, 1, 1))
+    .first()
+    .unpartition()
+    .to_host_vec()
+    .sync();
     println!("{:#?}", c_host_vec);
 }

--- a/cutile-examples/examples/add_ptr.rs
+++ b/cutile-examples/examples/add_ptr.rs
@@ -44,9 +44,9 @@ async fn main() -> Result<(), cutile::error::Error> {
     let tile_size = 4usize;
 
     // Initialize tensors.
-    let z = zeros::<1, f32>([len]).await?;
+    let z = zeros::<f32>(&[len]).await?;
     let x: Tensor<f32> = arange(len).await?;
-    let y: Tensor<f32> = ones([len]).await?;
+    let y: Tensor<f32> = ones(&[len]).await?;
 
     // Extract device pointers.
     let z_ptr = z.device_pointer();

--- a/cutile-examples/examples/add_refs.rs
+++ b/cutile-examples/examples/add_refs.rs
@@ -1,0 +1,58 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Demonstrates the borrow-based kernel API: pass `&Tensor` for inputs and
+//! `Partition<&mut Tensor>` for outputs. No Arc, no return capture, no
+//! unpartition — kernels write in place through the borrows.
+
+use cutile::prelude::*;
+
+#[cutile::module]
+mod my_module {
+    use cutile::core::*;
+
+    #[cutile::entry()]
+    fn add<const S: [i32; 1]>(
+        z: &mut Tensor<f32, S>,
+        x: &Tensor<f32, { [-1] }>,
+        y: &Tensor<f32, { [-1] }>,
+    ) {
+        let tile_x = load_tile_like_1d(x, z);
+        let tile_y = load_tile_like_1d(y, z);
+        z.store(tile_x + tile_y);
+    }
+}
+
+use my_module::add;
+
+fn main() {
+    let ctx = cuda_core::CudaContext::new(0).unwrap();
+    let stream = ctx.new_stream().unwrap();
+
+    let x = api::ones::<f32>(&[32]).sync_on(&stream).unwrap();
+    let y = api::ones::<f32>(&[32]).sync_on(&stream).unwrap();
+    let mut z = api::zeros::<f32>(&[32]).sync_on(&stream).unwrap();
+
+    // Borrow-based launch: &x, &y for inputs, &mut z for output.
+    // No return value needed — z is written in place.
+    let _ = add((&mut z).partition([4]), &x, &y)
+        .sync_on(&stream)
+        .unwrap();
+
+    // z already has the result. Use dup() to read without consuming.
+    let z_host: Vec<f32> = z.dup().to_host_vec().sync_on(&stream).unwrap();
+    assert!(z_host.iter().all(|&v| (v - 2.0).abs() < 1e-5));
+    println!("add_refs: z = {:?}", &z_host[..8]);
+
+    // Run again — reuse the same buffers, no allocation.
+    let _ = add((&mut z).partition([4]), &x, &y)
+        .sync_on(&stream)
+        .unwrap();
+
+    // Final read — can consume z since we're done.
+    let z_host: Vec<f32> = z.to_host_vec().sync_on(&stream).unwrap();
+    assert!(z_host.iter().all(|&v| (v - 2.0).abs() < 1e-5));
+    println!("add_refs: second run, same result — buffers reused");
+}

--- a/cutile-examples/examples/async_add.rs
+++ b/cutile-examples/examples/async_add.rs
@@ -2,13 +2,8 @@
  * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-use cuda_async::device_operation::{DeviceOperation, IntoDeviceOperation, Zippable};
-use cutile;
-use cutile::api::{arange, ones, zeros};
-use cutile::tensor::ToHostVec;
-use cutile::tile_kernel::{zip, IntoDeviceOperationPartition};
-use my_module::add_apply;
-use std::future::IntoFuture;
+use cutile::prelude::*;
+use my_module::add;
 
 #[cutile::module]
 mod my_module {
@@ -29,37 +24,26 @@ mod my_module {
 
 #[tokio::main(flavor = "multi_thread", worker_threads = 16)]
 async fn main() -> Result<(), cuda_async::error::DeviceError> {
-    // Operations in api::default::{*} will use the default global device, which is set to 0.
-    // Create tensors.
     let len = 2usize.pow(5);
-    let z = zeros([len]);
-    let x = arange(len);
-    let y = ones([len]);
-    // Use function calling convention:
-    let add_op_1 = zip!(z.partition([2]), x.arc(), y.arc()).apply(add_apply);
-    // or chain the invocation of the kernel via the DeviceOperation apply method:
-    let add_op_2 = add_op_1.apply(add_apply);
-    // Schedule the operation using the default scheduler.
-    // This converts the DeviceOperation into a DeviceFuture.
-    let fut = add_op_2.into_future();
-    // We can spawn:
-    let (z, x, y) = tokio::spawn(fut)
-        .await
-        .expect("Failed to execute tokio task.")?;
-    // We can convert this back into a device operation.
-    let args = (z, x, y).device_operation();
-    // We can directly await:
-    let (z, x, y) = args.apply(add_apply).await?;
-    // Check output.
-    let x_host = x.to_host_vec().await?;
-    let y_host = y.to_host_vec().await?;
-    let z_host = z.unpartition().to_host_vec().await?;
-    for i in 0..z_host.len() {
-        let x_i: f32 = x_host[i];
-        let y_i: f32 = y_host[i];
-        let answer = x_i + y_i;
-        println!("{} + {} = {}", x_i, y_i, z_host[i]);
-        assert_eq!(answer, z_host[i], "{} != {} ?", answer, z_host[i]);
+
+    // Run add kernel twice, chaining lazily with .then().
+    let z_host: Vec<f32> = add(
+        api::zeros(&[len]).partition([2]),
+        api::arange(len),
+        api::ones(&[len]),
+    )
+    .then(|(z, x, y)| add(z, x, y))
+    .first()
+    .unpartition()
+    .to_host_vec()
+    .await?;
+
+    // Both calls compute z = x + y with the same x, y.
+    // The second overwrites the first, so the result is just x + y.
+    for (i, &v) in z_host.iter().enumerate() {
+        let expected = i as f32 + 1.0;
+        assert_eq!(expected, v, "index {}: {} != {}", i, expected, v);
     }
+    println!("async_add: all values correct");
     Ok(())
 }

--- a/cutile-examples/examples/async_and_then_example.rs
+++ b/cutile-examples/examples/async_and_then_example.rs
@@ -3,12 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 use cuda_async::device_context::global_policy;
-use cuda_async::device_operation::{value, with_context, DeviceOperation};
+use cuda_async::device_operation::{value, with_context, DeviceOp};
 use cuda_async::error::DeviceError;
 use cuda_async::launch::AsyncKernelLaunch;
 use cuda_core::LaunchConfig;
 use cutile;
-use cutile::api::{arange, DeviceOperationReshape};
+use cutile::api::arange;
+use cutile::api::DeviceOpReshape;
 use cutile::tensor::{IntoPartition, ToHostVec};
 use cutile::tile_kernel::{compile_from_context, CompileOptions};
 use my_module::_module_asts;
@@ -20,7 +21,7 @@ mod my_module {
     use cutile::core::*;
 
     #[cutile::entry()]
-    fn saxpy<const S: [i32; 2]>(a: f32, x: &Tensor<f32, { [-1, -1] }>, y: &mut Tensor<f32, S>) {
+    fn saxpy<const S: [i32; 2]>(y: &mut Tensor<f32, S>, a: f32, x: &Tensor<f32, { [-1, -1] }>) {
         let tile_a: Tile<f32, S> = a.broadcast(y.shape());
         let tile_x: Tile<f32, S> = load_tile_like_2d(x, y);
         let tile_y: Tile<f32, S> = y.load();
@@ -37,8 +38,8 @@ async fn main() -> Result<(), DeviceError> {
     let y_partition_strides = strides;
     let function_generics: Vec<String> = y_partition_shape.iter().map(|x| x.to_string()).collect();
     let stride_args: Vec<(String, Vec<i32>)> = vec![
-        ("x".to_string(), strides.to_vec()),
         ("y".to_string(), y_partition_strides.to_vec()),
+        ("x".to_string(), strides.to_vec()),
     ];
 
     // We can start compiling the function while we fetch input.
@@ -57,14 +58,14 @@ async fn main() -> Result<(), DeviceError> {
             );
             value(func)
         })
-        .schedule(policy.as_scheduling_policy().unwrap())?
+        .schedule(&policy)?
         .await
     });
 
     // Spawn allocation of tensor 1 and 2.
     let a: f32 = 2.0;
-    let x: Arc<_> = arange::<f32>(num_elements).reshape([4, 8]).await?.into();
-    let y = arange::<f32>(num_elements).reshape([4, 8]).await?;
+    let x: Arc<_> = arange::<f32>(num_elements).reshape(&[4, 8]).await?.into();
+    let y = arange::<f32>(num_elements).reshape(&[4, 8]).await?;
 
     // We need the function to build the launcher, so we wait on compilation.
     let (function, _) = compilation_task
@@ -75,21 +76,21 @@ async fn main() -> Result<(), DeviceError> {
         let y_part = y.partition(y_partition_shape);
         let mut launcher = AsyncKernelLaunch::new(function.clone());
         launcher
+            .push_arg(&y_part)
             .push_arg(a)
             .push_arg_arc(&x)
-            .push_arg(&y_part)
             .set_launch_config(LaunchConfig {
                 grid_dim: y_part.grid().expect("Invalid grid."),
                 block_dim: (1, 1, 1),
                 shared_mem_bytes: 0,
             });
         launcher
-            .and_then(|_| {
+            .then(|_| {
                 let mut launcher = AsyncKernelLaunch::new(function.clone());
                 launcher
+                    .push_arg(&y_part)
                     .push_arg(a)
                     .push_arg_arc(&x)
-                    .push_arg(&y_part)
                     .set_launch_config(LaunchConfig {
                         grid_dim: y_part.grid().expect("Invalid grid."),
                         block_dim: (1, 1, 1),
@@ -97,12 +98,12 @@ async fn main() -> Result<(), DeviceError> {
                     });
                 launcher
             })
-            .and_then(|_| {
+            .then(|_| {
                 let mut launcher = AsyncKernelLaunch::new(function.clone());
                 launcher
+                    .push_arg(&y_part)
                     .push_arg(a)
                     .push_arg_arc(&x)
-                    .push_arg(&y_part)
                     .set_launch_config(LaunchConfig {
                         grid_dim: y_part.grid().expect("Invalid grid."),
                         block_dim: (1, 1, 1),

--- a/cutile-examples/examples/async_device_op_example.rs
+++ b/cutile-examples/examples/async_device_op_example.rs
@@ -10,7 +10,7 @@ use cutile::tile_kernel::global_policy;
 
 #[tokio::main]
 async fn main() -> Result<(), DeviceError> {
-    // Create a scheduler, which schedules an instance of DeviceOperation on a device stream.
+    // Create a scheduler, which schedules an instance of DeviceOp on a device stream.
     // The schedule operation produces an implementation of Future.
     let _policy = global_policy(0);
 

--- a/cutile-examples/examples/async_gemm.rs
+++ b/cutile-examples/examples/async_gemm.rs
@@ -7,9 +7,9 @@ use cutile;
 use cutile::api;
 use cutile::half::f16;
 use cutile::tensor::{Tensor, ToHostVec, Unpartition};
-use cutile::tile_kernel::{IntoDeviceOperationPartition, TileKernel};
+use cutile::tile_kernel::{PartitionOp, TileKernel};
 use cutile::DType;
-use my_module::gemm_op;
+// Kernel function accessed via my_module::gemm below (not imported to avoid shadowing local fn gemm)
 use std::sync::Arc;
 
 #[cutile::module]
@@ -47,11 +47,11 @@ mod my_module {
 fn gemm<T1: DType, T2: DType>(
     x: Arc<Tensor<T2>>,
     y: Arc<Tensor<T2>>,
-) -> impl DeviceOperation<Output = Tensor<T1>> {
+) -> impl DeviceOp<Output = Tensor<T1>> {
     let (m, n, k) = (
-        x.shape[0] as usize,
-        y.shape[1] as usize,
-        x.shape[1] as usize,
+        x.shape()[0] as usize,
+        y.shape()[1] as usize,
+        x.shape()[1] as usize,
     );
     let (bm, bn, bk) = (16, 16, 8);
     let generics = [
@@ -62,10 +62,8 @@ fn gemm<T1: DType, T2: DType>(
         bk.to_string(),
         k.to_string(),
     ];
-    let z = api::zeros([m, n]).partition([bm, bn]); // impl DeviceOperation
-    let (z, _x, _y) = gemm_op(z, x.device_operation(), y.device_operation())
-        .generics(generics.to_vec())
-        .unzip();
+    let z = api::zeros(&[m, n]).partition([bm, bn]); // impl DeviceOp
+    let (z, _x, _y) = my_module::gemm(z, x, y).generics(generics.to_vec()).unzip();
     z.unpartition()
 }
 
@@ -76,12 +74,12 @@ async fn main() -> Result<(), cuda_async::error::DeviceError> {
     type IN = f16;
     type OUT = f32;
     let (m, n, k) = (64, 64, 16);
-    let x = api::randn_f16(IN::zero(), IN::one(), [m, k], None)
-        .arc()
-        .await?;
-    let y = api::randn_f16(IN::zero(), IN::one(), [k, n], None)
-        .arc()
-        .await?;
+    let x: Arc<Tensor<IN>> = api::randn_f16(IN::zero(), IN::one(), [m, k], None)
+        .await?
+        .into();
+    let y: Arc<Tensor<IN>> = api::randn_f16(IN::zero(), IN::one(), [k, n], None)
+        .await?
+        .into();
     let z = gemm::<OUT, IN>(x.clone(), y.clone()).await?;
     let z_host: Vec<OUT> = z.to_host_vec().await?;
     let x_host: Vec<IN> = x.to_host_vec().await?;

--- a/cutile-examples/examples/async_mlp.rs
+++ b/cutile-examples/examples/async_mlp.rs
@@ -5,10 +5,11 @@
 
 use cuda_async::device_context::global_policy;
 use cuda_async::device_operation::*;
-use cutile::api::copy;
+use cutile::api::dup;
 use cutile::tensor::{Partition, Tensor, ToHostVec, Unpartition};
-use cutile::tile_kernel::{IntoDeviceOperationPartition, TileKernel};
+use cutile::tile_kernel::{PartitionOp, TileKernel};
 use cutile::{api, error::Error};
+use std::sync::Arc;
 use tokio::task::JoinHandle;
 
 #[cutile::module]
@@ -63,13 +64,9 @@ pub mod my_kernels {
     }
 }
 
-use my_kernels::*;
-
 // Simulate loading input data.
-fn load_data<const RANK: usize>(
-    batch_size: [usize; RANK],
-) -> impl DeviceOperation<Output = Tensor<f32>> {
-    api::randn_f32(0.0, 1.0, batch_size, None)
+fn load_data<const RANK: usize>(batch_size: [usize; RANK]) -> impl DeviceOp<Output = Tensor<f32>> {
+    api::randn(0.0, 1.0, batch_size, None)
 }
 
 #[tokio::main(flavor = "multi_thread", worker_threads = 16)]
@@ -98,12 +95,16 @@ async fn main() -> Result<(), Error> {
         block_dim.to_string(),
         dim.to_string(),
     ];
-    let w0 = api::randn_f32(0.0f32, 1.0, [dim, dim], None); // impl DeviceOperation
-    let w1 = api::randn_f32(0.0f32, 1.0, [dim], None); // impl DeviceOperation
-    let w = zip!(w0.arc(), w1.arc()).schedule(&devices[0])?.await?;
+    let w0 = api::randn(0.0f32, 1.0, [dim, dim], None); // impl DeviceOp
+    let w1 = api::randn(0.0f32, 1.0, [dim], None); // impl DeviceOp
+    let w: (Arc<Tensor<f32>>, Arc<Tensor<f32>>) = zip!(w0.map(Into::into), w1.map(Into::into))
+        .schedule(&devices[0])?
+        .await?;
     let mut joins = vec![];
     for i in 1..num_devices {
-        let w_copy = tokio::spawn(zip!(copy(&w.0).arc(), copy(&w.1).arc()).schedule(&devices[i])?);
+        let w_copy = tokio::spawn(
+            zip!(dup(&w.0).map(Into::into), dup(&w.1).map(Into::into)).schedule(&devices[i])?,
+        );
         joins.push(w_copy);
     }
     let mut model_weights = vec![w];
@@ -118,18 +119,18 @@ async fn main() -> Result<(), Error> {
     for i in 0..num_devices {
         let w = &model_weights[i];
         let (w0, w1) = (w.0.clone(), w.1.clone());
-        let data = load_data([dim, dim]).arc();
-        let out0 = api::zeros::<2, f32>([dim, dim]).partition([block_dim, block_dim]);
+        let data = load_data([dim, dim]);
+        let out0 = api::zeros::<f32>(&[dim, dim]).partition([block_dim, block_dim]);
         let fully_connected_layer = fully_connected_layer.to_vec();
-        let (out0, _, _) = gemm_op(out0, data, value(w0))
+        let (out0, _, _) = my_kernels::gemm(out0, data, w0)
             .generics(fully_connected_layer)
             .unzip();
-        let out1 = api::zeros::<1, f32>([dim]).partition([block_dim]);
+        let out1 = api::zeros::<f32>(&[dim]).partition([block_dim]);
         let output_layer = output_layer.to_vec();
-        let (out1, _, _) = matvec_op(out1, out0.unpartition().arc(), value(w1))
+        let (out1, _, _) = my_kernels::matvec(out1, out0.unpartition(), w1)
             .generics(output_layer)
             .unzip();
-        let (out1,) = relu_op(out1).unzip();
+        let (out1,) = my_kernels::relu(out1).unzip();
         futures.push(tokio::spawn(out1.schedule(&devices[i])?));
     }
 

--- a/cutile-examples/examples/async_mlp_fused.rs
+++ b/cutile-examples/examples/async_mlp_fused.rs
@@ -6,10 +6,9 @@ use cuda_async::device_context;
 use cuda_async::device_context::global_policy;
 use cuda_async::device_operation::*;
 use cuda_async::launch::AsyncKernelLaunch;
-use cuda_async::scheduling_policies::WithDeviceId;
 use cuda_core::LaunchConfig;
 use cutile::tensor::{Tensor, ToHostVec};
-use cutile::tile_kernel::IntoDeviceOperationPartition;
+use cutile::tile_kernel::PartitionOp;
 use cutile::{api, error::Error};
 use cutile_compiler::compiler::utils::CompileOptions;
 use cutile_compiler::compiler::{CUDATileFunctionCompiler, CUDATileModules};
@@ -56,10 +55,8 @@ pub mod my_kernels {
 }
 
 // Simulate loading input data.
-fn load_data<const RANK: usize>(
-    batch_size: [usize; RANK],
-) -> impl DeviceOperation<Output = Tensor<f32>> {
-    api::randn_f32(0.0, 1.0, batch_size, None)
+fn load_data<const RANK: usize>(batch_size: [usize; RANK]) -> impl DeviceOp<Output = Tensor<f32>> {
+    api::randn(0.0, 1.0, batch_size, None)
 }
 
 use my_kernels::_module_asts;
@@ -69,10 +66,10 @@ async fn main() -> Result<(), Error> {
     // Data
     let (m, n, k) = (16, 16, 16);
     let (bm, bn, bk) = (4, 4, 4);
-    let data = load_data([m, n]).arc().await?;
-    let w0 = api::randn_f32(0.0f32, 1.0, [n, k], None).arc().await?; // impl DeviceOperation
-    let w1 = api::randn_f32(0.0f32, 1.0, [k], None).arc().await?; // impl DeviceOperation
-    let out = api::zeros::<1, f32>([m]).partition([bm]).await?;
+    let data = load_data([m, n]).await?.into();
+    let w0 = api::randn(0.0f32, 1.0, [n, k], None).await?.into();
+    let w1 = api::randn(0.0f32, 1.0, [k], None).await?.into();
+    let out = api::zeros::<f32>(&[m]).partition([bm]).await?;
 
     // Compilation
     let module_name = "my_kernels";
@@ -108,9 +105,9 @@ async fn main() -> Result<(), Error> {
     )?;
     let module_op: ModuleOperation = compiler.compile()?;
     println!("{}", module_op.as_operation().to_string());
-    let device = global_policy(0)?;
-    let module_filename = compile_module(&module_op, &get_gpu_name(device.get_device_id()));
-    let module = device_context::load_module_from_file(&module_filename, device.get_device_id())?;
+    let _device = global_policy(0)?;
+    let module_filename = compile_module(&module_op, &get_gpu_name(0));
+    let module = device_context::load_module_from_file(&module_filename, 0)?;
     let function = Arc::new(
         module
             .load_function(function_entry)

--- a/cutile-examples/examples/async_saxpy.rs
+++ b/cutile-examples/examples/async_saxpy.rs
@@ -2,13 +2,12 @@
  * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-use cuda_async::device_operation::{DeviceOperation, IntoDeviceOperation, Zippable};
-use cutile;
-use cutile::api::{arange, DeviceOperationReshape};
+use cuda_async::device_operation::value;
+use cutile::api::{arange, DeviceOpReshape};
 use cutile::error::Error;
+use cutile::prelude::*;
 use cutile::tensor::ToHostVec;
-use cutile::tile_kernel::global_policy;
-use cutile::tile_kernel::IntoDeviceOperationPartition;
+use cutile::tile_kernel::ToHostVecOp;
 use cutile::DType;
 use std::fmt::Display;
 use std::ops::{Add, Mul};
@@ -20,9 +19,9 @@ mod my_module {
 
     #[cutile::entry()]
     fn saxpy<const S: [i32; 2], T: ElementType>(
+        y: &mut Tensor<T, S>,
         a: T,
         x: &Tensor<T, { [-1, -1] }>,
-        y: &mut Tensor<T, S>,
     ) {
         let tile_a = a.broadcast(y.shape());
         let tile_x = load_tile_like_2d(x, y);
@@ -31,20 +30,19 @@ mod my_module {
     }
 }
 
-use my_module::*;
+use my_module::saxpy;
 
 async fn execute<T: DType + Display + PartialEq + Mul<Output = T> + Add<Output = T>>(
     size: usize,
 ) -> Result<(), Error> {
-    let a = (<T as DType>::one() + <T as DType>::one()).device_operation();
-    let x = arange(size).reshape([4, 8]);
-    let y = arange(size).reshape([4, 8]);
-    let saxpy_op = (a, x.arc(), y.partition([2, 4])).zip().apply(saxpy_apply);
-    // Convert the saxpy DeviceOperation into a DeviceFuture.
-    let saxpy_future = saxpy_op.schedule(global_policy(0)?.as_scheduling_policy()?)?;
-    // Spawn a tokio task to execute the saxpy future.
-    let (a, _x, y) = saxpy_future.await?;
-    let y_host: Vec<T> = y.unpartition().to_host_vec().await?;
+    let a = <T as DType>::one() + <T as DType>::one();
+    let x = arange(size).reshape(&[4, 8]);
+    let y = arange(size).reshape(&[4, 8]);
+    let y_host: Vec<T> = saxpy(y.partition([2, 4]), value(a), x)
+        .first()
+        .unpartition()
+        .to_host_vec()
+        .await?;
     let input_host: Vec<T> = arange(size).await?.to_host_vec().await?;
     for i in 0..input_host.len() {
         let x_i: T = input_host[i];
@@ -58,7 +56,6 @@ async fn execute<T: DType + Display + PartialEq + Mul<Output = T> + Add<Output =
 
 #[tokio::main(flavor = "multi_thread", worker_threads = 16)]
 async fn main() -> Result<(), Error> {
-    // execute::<i64>(2usize.pow(5)).await;
     execute::<f32>(2usize.pow(5)).await?;
     execute::<f64>(2usize.pow(5)).await?;
     Ok(())

--- a/cutile-examples/examples/async_saxpy_unsafe.rs
+++ b/cutile-examples/examples/async_saxpy_unsafe.rs
@@ -7,17 +7,18 @@
  * Manually use the async API to compile and launch the saxpy kernel using the cutile API.
  */
 
-use cuda_async::device_operation::{value, with_context, DeviceOperation};
+use cuda_async::device_operation::{value, with_context, DeviceOp};
 use cuda_async::launch::AsyncKernelLaunch;
-use cuda_async::scheduling_policies::SchedulingPolicy;
 use cuda_core::LaunchConfig;
 use cutile;
-use cutile::api::{arange, DeviceOperationReshape};
+use cutile::api::arange;
+use cutile::api::DeviceOpReshape;
 use cutile::error::Error;
 use cutile::tensor::{IntoPartition, ToHostVec};
 use cutile::tile_kernel::global_policy;
 use cutile::tile_kernel::{compile_from_context, CompileOptions};
 use my_module::_module_asts;
+use std::sync::Arc;
 
 #[cutile::module]
 mod my_module {
@@ -25,7 +26,7 @@ mod my_module {
     use cutile::core::*;
 
     #[cutile::entry()]
-    fn saxpy<const S: [i32; 2]>(a: f32, x: &Tensor<f32, { [-1, -1] }>, y: &mut Tensor<f32, S>) {
+    fn saxpy<const S: [i32; 2]>(y: &mut Tensor<f32, S>, a: f32, x: &Tensor<f32, { [-1, -1] }>) {
         let tile_a = broadcast_scalar(a, y.shape());
         let tile_x = load_tile_like_2d(x, y);
         let tile_y = y.load();
@@ -42,8 +43,8 @@ async fn main() -> Result<(), Error> {
     let y_partition_strides = strides;
     let function_generics: Vec<String> = y_partition_shape.iter().map(|x| x.to_string()).collect();
     let stride_args: Vec<(String, Vec<i32>)> = vec![
-        ("x".to_string(), strides.to_vec()),
         ("y".to_string(), y_partition_strides.to_vec()),
+        ("x".to_string(), strides.to_vec()),
     ];
 
     // We can start compiling the function while we fetch input.
@@ -62,16 +63,18 @@ async fn main() -> Result<(), Error> {
             );
             value(func)
         })
-        .schedule(global_policy(0)?.as_scheduling_policy()?)?
+        .schedule(&global_policy(0)?)?
         .await
     });
     // Spawn allocation of tensor 1 and 2.
     let a: f32 = 2.0;
-    let x = policy
-        .schedule(arange::<f32>(num_elements).reshape([4, 8]))?
+    let x = arange::<f32>(num_elements)
+        .reshape(&[4, 8])
+        .schedule(&policy)?
         .await?;
-    let y = policy
-        .schedule(arange::<f32>(num_elements).reshape([4, 8]))?
+    let y = arange::<f32>(num_elements)
+        .reshape(&[4, 8])
+        .schedule(&policy)?
         .await?;
     // We need the function to build the launcher, so we wait on compilation.
     let (function, _) = compilation_task
@@ -82,10 +85,11 @@ async fn main() -> Result<(), Error> {
     let cuda_async_op = async move {
         let y_part = y.partition(y_partition_shape);
         let mut launcher = AsyncKernelLaunch::new(function.clone());
+        let x_arc: Arc<_> = x.into();
         launcher
-            .push_arg(a)
-            .push_arg_arc(&x.into())
             .push_arg(&y_part)
+            .push_arg(a)
+            .push_arg_arc(&x_arc)
             .set_launch_config(LaunchConfig {
                 grid_dim: y_part.grid().expect("Invalid grid."),
                 block_dim: (1, 1, 1),

--- a/cutile-examples/examples/batch_matmul.rs
+++ b/cutile-examples/examples/batch_matmul.rs
@@ -2,7 +2,7 @@
  * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-use cuda_async::device_operation::DeviceOperation;
+use cuda_async::device_operation::DeviceOp;
 use cuda_core::CudaContext;
 use cutile;
 use cutile::api::{ones, zeros};
@@ -17,9 +17,9 @@ mod my_module {
 
     #[cutile::entry()]
     fn batch_matmul<E: ElementType, const BM: i32, const BN: i32, const BK: i32, const K: i32>(
+        c: &mut Tensor<E, { [1, BM, BN] }>,
         a: &Tensor<E, { [-1, -1, K] }>,
         b: &Tensor<E, { [-1, K, -1] }>,
-        c: &mut Tensor<E, { [1, BM, BN] }>,
     ) {
         let pid: (i32, i32, i32) = get_tile_block_id(); // (batch_idx, m_idx, n_idx)
         let batch_idx = pid.0;
@@ -52,11 +52,11 @@ fn main() -> Result<(), Error> {
 
     let batch = 4usize;
     let (m, n, k) = (128usize, 256usize, 64usize);
-    let (bm, bn, bk) = (64i32, 64i32, 32i32);
+    let (bm, bn, bk) = (64, 64, 32);
 
-    let a: Arc<Tensor<f32>> = ones([batch, m, k]).sync_on(&stream)?.into();
-    let b: Arc<Tensor<f32>> = ones([batch, k, n]).sync_on(&stream)?.into();
-    let c: Partition<Tensor<f32>> = zeros([batch, m, n])
+    let a: Arc<Tensor<f32>> = ones(&[batch, m, k]).sync_on(&stream)?.into();
+    let b: Arc<Tensor<f32>> = ones(&[batch, k, n]).sync_on(&stream)?.into();
+    let c: Partition<Tensor<f32>> = zeros(&[batch, m, n])
         .sync_on(&stream)?
         .partition([1, bm, bn]);
 
@@ -67,7 +67,7 @@ fn main() -> Result<(), Error> {
         bk.to_string(),
         k.to_string(),
     ];
-    let (_a, _b, c) = batch_matmul(a, b, c).generics(generics).sync_on(&stream)?;
+    let (c, _a, _b) = batch_matmul(c, a, b).generics(generics).sync_on(&stream)?;
     let c_host: Vec<f32> = c.unpartition().to_host_vec().sync_on(&stream)?;
 
     let expected = k as f32;

--- a/cutile-examples/examples/book_examples.rs
+++ b/cutile-examples/examples/book_examples.rs
@@ -1,0 +1,653 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#![allow(unused_variables)]
+
+//! Book Examples - Tests all code examples from the cuTile Rust Book
+//!
+//! This example verifies that all tutorial code from the book compiles and runs correctly.
+//! Run with: cargo run --example book_examples
+
+use cuda_async::device_operation::*;
+use cuda_core::{CudaContext, CudaStream};
+use cutile;
+use cutile::api::{arange, ones, randn, zeros};
+use cutile::error::Error;
+use cutile::tensor::{IntoPartition, Reshape, Tensor, ToHostVec, Unpartition};
+use cutile::tile_kernel::{PartitionOp, TileKernel, ToHostVecOp};
+use std::sync::Arc;
+
+// ============================================================================
+// Tutorial 1: Hello World
+// ============================================================================
+#[cutile::module]
+mod hello_world_module {
+    use cutile::core::*;
+
+    #[cutile::entry()]
+    fn hello_world_kernel() {
+        let pids: (i32, i32, i32) = get_tile_block_id();
+        let npids: (i32, i32, i32) = get_num_tile_blocks();
+        cuda_tile_print!(
+            "Hello from tile <{}, {}, {}> in a grid of <{}, {}, {}> tiles!\n",
+            pids.0,
+            pids.1,
+            pids.2,
+            npids.0,
+            npids.1,
+            npids.2
+        );
+    }
+}
+
+fn test_hello_world(stream: &Arc<CudaStream>) -> Result<(), Error> {
+    println!("\n=== Tutorial 1: Hello World ===");
+    use hello_world_module::hello_world_kernel;
+
+    hello_world_kernel().grid((2, 2, 1)).sync_on(stream)?;
+    println!("Hello World passed\n");
+    Ok(())
+}
+
+// ============================================================================
+// Tutorial 2: Vector Addition
+// ============================================================================
+#[cutile::module]
+mod vector_add_module {
+    use cutile::core::*;
+
+    #[cutile::entry()]
+    fn add<const S: [i32; 2]>(
+        z: &mut Tensor<f32, S>,
+        x: &Tensor<f32, { [-1, -1] }>,
+        y: &Tensor<f32, { [-1, -1] }>,
+    ) {
+        let tile_x = load_tile_like_2d(x, z);
+        let tile_y = load_tile_like_2d(y, z);
+        z.store(tile_x + tile_y);
+    }
+}
+
+fn test_vector_addition(stream: &Arc<CudaStream>) -> Result<(), Error> {
+    println!("=== Tutorial 2: Vector Addition ===");
+    use vector_add_module::add;
+
+    let x: Arc<Tensor<f32>> = ones(&[32, 32]).sync_on(stream)?.into();
+    let y: Arc<Tensor<f32>> = ones(&[32, 32]).sync_on(stream)?.into();
+    let z = zeros(&[32, 32]).sync_on(stream)?.partition([4, 4]);
+
+    let z_host = add(z, x, y)
+        .unzip()
+        .0
+        .unpartition()
+        .to_host_vec()
+        .sync_on(stream)?;
+
+    let all_correct = z_host.iter().all(|&v| (v - 2.0).abs() < 1e-5);
+    assert!(all_correct, "Vector addition failed: expected all 2.0s");
+    println!("z[0] = {} (expected 2.0)", z_host[0]);
+    println!("Vector Addition passed\n");
+    Ok(())
+}
+
+// ============================================================================
+// Tutorial 3: SAXPY (y = a*x + y)
+// ============================================================================
+#[cutile::module]
+mod saxpy_module {
+    use cutile::core::*;
+
+    #[cutile::entry()]
+    fn saxpy<const S: [i32; 2]>(a: f32, x: &Tensor<f32, { [-1, -1] }>, y: &mut Tensor<f32, S>) {
+        let tile_a = a.broadcast(y.shape());
+        let tile_x = load_tile_like_2d(x, y);
+        let tile_y = y.load();
+        y.store(tile_a * tile_x + tile_y);
+    }
+}
+
+fn test_saxpy(stream: &Arc<CudaStream>) -> Result<(), Error> {
+    println!("=== Tutorial 3: SAXPY ===");
+    use saxpy_module::saxpy;
+
+    let a = 2.0f32;
+    let input: Arc<Tensor<f32>> = arange(32usize).sync_on(stream)?.into();
+    let x: Arc<Tensor<f32>> = input
+        .dup()
+        .sync_on(stream)?
+        .reshape(&[4, 8])
+        .unwrap()
+        .into();
+    let y = input
+        .dup()
+        .sync_on(stream)?
+        .reshape(&[4, 8])
+        .unwrap()
+        .partition([2, 2]);
+
+    let (a_out, _x, y) = saxpy(a, x, y).sync_on(stream)?;
+    let y_host: Vec<f32> = y.unpartition().to_host_vec().sync_on(stream)?;
+    let input_host: Vec<f32> = input.to_host_vec().sync_on(stream)?;
+
+    for i in 0..5 {
+        let x_i = input_host[i];
+        let y_original = input_host[i];
+        let expected = a_out * x_i + y_original;
+        println!(
+            "{} * {} + {} = {} (got {})",
+            a_out, x_i, y_original, expected, y_host[i]
+        );
+        assert!(
+            (expected - y_host[i]).abs() < 1e-5,
+            "SAXPY mismatch at index {}",
+            i
+        );
+    }
+    println!("SAXPY passed\n");
+    Ok(())
+}
+
+// ============================================================================
+// Tutorial 4: Matrix Multiplication (GEMM)
+// ============================================================================
+#[cutile::module]
+mod gemm_module {
+    use cutile::core::*;
+
+    #[cutile::entry()]
+    fn gemm<E: ElementType, const BM: i32, const BN: i32, const BK: i32, const K: i32>(
+        z: &mut Tensor<E, { [BM, BN] }>,
+        x: &Tensor<E, { [-1, K] }>,
+        y: &Tensor<E, { [K, -1] }>,
+    ) {
+        let part_x = x.partition(const_shape![BM, BK]);
+        let part_y = y.partition(const_shape![BK, BN]);
+        let pid: (i32, i32, i32) = get_tile_block_id();
+        let mut tile_z = load_tile_mut(z);
+        for i in 0i32..(K / BK) {
+            let tile_x = part_x.load([pid.0, i]);
+            let tile_y = part_y.load([i, pid.1]);
+            tile_z = mma(tile_x, tile_y, tile_z);
+        }
+        z.store(tile_z);
+    }
+}
+
+fn test_gemm(stream: &Arc<CudaStream>) -> Result<(), Error> {
+    println!("=== Tutorial 4: Matrix Multiplication (GEMM) ===");
+    use cutile::api;
+    use cutile::DType;
+    use gemm_module::gemm;
+
+    let (bm, bn, bk) = (16, 16, 8);
+    let (m, n, k) = (64usize, 64usize, 64usize);
+
+    let generics = vec![
+        f32::DTYPE.as_str().to_string(),
+        bm.to_string(),
+        bn.to_string(),
+        bk.to_string(),
+        k.to_string(),
+    ];
+
+    let z = api::zeros(&[m, n]).partition([bm, bn]).sync_on(stream)?;
+    let x: Arc<Tensor<f32>> = api::ones(&[m, k]).sync_on(stream)?.into();
+    let y: Arc<Tensor<f32>> = api::ones(&[k, n]).sync_on(stream)?.into();
+
+    let (z, _x, _y) = gemm(z, x, y).generics(generics).sync_on(stream)?;
+    let z_host: Vec<f32> = z.unpartition().to_host_vec().sync_on(stream)?;
+
+    println!("z[0] = {} (expected {})", z_host[0], k);
+    assert!((z_host[0] - k as f32).abs() < 1e-3, "GEMM result incorrect");
+    println!("GEMM passed\n");
+    Ok(())
+}
+
+// ============================================================================
+// Tutorial 5: Fused Softmax
+// ============================================================================
+#[cutile::module]
+mod softmax_module {
+    use cutile::core::*;
+
+    #[cutile::entry()]
+    fn softmax<const BM: i32, const BN: i32>(
+        x: &Tensor<f32, { [-1, -1] }>,
+        y: &mut Tensor<f32, { [BM, BN] }>,
+    ) {
+        let tile_x: Tile<f32, { [BM, BN] }> = load_tile_like_2d(x, y);
+        let tile_x_max: Tile<f32, { [BM] }> = reduce_max(tile_x, 1i32);
+        let tile_x_max: Tile<f32, { [BM, BN] }> =
+            tile_x_max.reshape(const_shape![BM, 1]).broadcast(y.shape());
+        let num: Tile<f32, { [BM, BN] }> = exp(tile_x - tile_x_max);
+        let denom: Tile<f32, { [BM] }> = reduce_sum(num, 1);
+        let denom = denom.reshape(const_shape![BM, 1]).broadcast(y.shape());
+        y.store(num / denom);
+    }
+}
+
+fn test_softmax(stream: &Arc<CudaStream>) -> Result<(), Error> {
+    println!("=== Tutorial 5: Fused Softmax ===");
+    use softmax_module::softmax;
+
+    let (m, n) = (4usize, 8usize);
+    let (bm, bn) = (2, n);
+
+    let input: Arc<Tensor<f32>> = arange(m * n).sync_on(stream)?.into();
+    let x: Arc<Tensor<f32>> = input
+        .dup()
+        .sync_on(stream)?
+        .reshape(&[m, n])
+        .unwrap()
+        .into();
+    let y = input
+        .dup()
+        .sync_on(stream)?
+        .reshape(&[m, n])
+        .unwrap()
+        .partition([bm, bn]);
+
+    let (_x, y) = softmax(x, y).sync_on(stream)?;
+    let y_host: Vec<f32> = y.unpartition().to_host_vec().sync_on(stream)?;
+
+    for i in (0..y_host.len()).step_by(n) {
+        let row_sum: f32 = y_host[i..i + n].iter().sum();
+        println!("softmax row sum = {} (expected 1.0)", row_sum);
+        assert!(
+            (row_sum - 1.0).abs() < 1e-4,
+            "Softmax row {} doesn't sum to 1.0",
+            i / n
+        );
+    }
+    println!("Softmax passed\n");
+    Ok(())
+}
+
+// ============================================================================
+// Tutorial 6: Fused Multihead Attention
+// ============================================================================
+#[cutile::module]
+mod fmha_module {
+    use cutile::core::*;
+
+    #[cutile::entry(print_ir = false)]
+    fn fmha<
+        const BM: i32, // Q tile size (rows of output we compute)
+        const BN: i32, // K,V tile size (how many K,V we process at once)
+        const D: i32,  // Head dimension
+    >(
+        q: &Tensor<f32, { [-1, -1, -1, -1] }>, // (B, H, M, D)
+        k: &Tensor<f32, { [-1, -1, -1, -1] }>, // (B, H, N, D)
+        v: &Tensor<f32, { [-1, -1, -1, -1] }>, // (B, H, N, D)
+        out: &mut Tensor<f32, { [1, BM, D] }>,
+        qk_scale: f32,
+    ) {
+        let pid: (i32, i32, i32) = get_tile_block_id();
+        let h = get_shape_dim(q.shape(), 1i32);
+        let batch_idx = pid.0 / h;
+        let head_idx = pid.0 % h;
+        let q_m_idx = pid.1;
+
+        // Convert to exp2-friendly scale (exp2 is faster than exp on GPU)
+        let two: Tile<f32, { [] }> = constant(2.0f32, const_shape![]);
+        let log2: f32 = tile_to_scalar(log(two));
+        let qk_scale: f32 = qk_scale / log2;
+        let qk_scale: Tile<f32, { [BM, BN] }> = qk_scale.broadcast(const_shape![BM, BN]);
+
+        // Online softmax state
+        let mut m_i: Tile<f32, { [BM, 1] }> = constant(f32::NEG_INFINITY, const_shape![BM, 1]);
+        let mut l_i: Tile<f32, { [BM, 1] }> = constant(0.0f32, const_shape![BM, 1]);
+        let mut acc: Tile<f32, { [BM, D] }> = constant(0.0f32, const_shape![BM, D]);
+
+        // Load Q tile once and reuse for all K,V tiles
+        let q_part: Partition<f32, { [1, 1, BM, D] }> = q.partition(const_shape![1, 1, BM, D]);
+        let tq: Tile<f32, { [1, 1, BM, D] }> = q_part.load([batch_idx, head_idx, q_m_idx, 0i32]);
+        let tq: Tile<f32, { [BM, D] }> = tq.reshape(const_shape![BM, D]);
+
+        let n: i32 = get_shape_dim(k.shape(), 2i32);
+        let num_tiles: i32 = ceil_div(n, BN);
+
+        let k_part = k.partition(const_shape![1, 1, BN, D]);
+        let v_part = v.partition(const_shape![1, 1, BN, D]);
+        let transpose: Array<{ [1, 0] }> = Array::<{ [1, 0] }> {
+            dims: &[1i32, 0i32],
+        };
+
+        // Stream through K,V tiles
+        for j in 0i32..num_tiles {
+            let k_tile: Tile<f32, { [BN, D] }> = k_part
+                .load([batch_idx, head_idx, j, 0i32])
+                .reshape(const_shape![BN, D]);
+            let k_tile_trans: Tile<f32, { [D, BN] }> = permute(k_tile, transpose);
+            let qk: Tile<f32, { [BM, BN] }> = constant(0.0f32, const_shape![BM, BN]);
+            let qk: Tile<f32, { [BM, BN] }> = mma(tq, k_tile_trans, qk);
+            let qk: Tile<f32, { [BM, BN] }> = qk * qk_scale;
+
+            let qk_max: Tile<f32, { [BM] }> = reduce_max(qk, 1);
+            let qk_max: Tile<f32, { [BM, 1] }> = qk_max.reshape(const_shape![BM, 1]);
+            let m_ij: Tile<f32, { [BM, 1] }> = max_tile(m_i, qk_max);
+            let qk = qk - m_ij.broadcast(const_shape![BM, BN]);
+
+            let p: Tile<f32, { [BM, BN] }> = exp2(qk);
+            let l_ij: Tile<f32, { [BM] }> = reduce_sum(p, 1);
+            let l_ij: Tile<f32, { [BM, 1] }> = l_ij.reshape(const_shape![BM, 1]);
+            let alpha: Tile<f32, { [BM, 1] }> = exp2(m_i - m_ij);
+
+            l_i = l_i * alpha + l_ij;
+            let alpha: Tile<f32, { [BM, D] }> = alpha.broadcast(const_shape![BM, D]);
+            acc = acc * alpha;
+
+            let v_tile: Tile<f32, { [1, 1, BN, D] }> = v_part.load([batch_idx, head_idx, j, 0i32]);
+            let v_tile: Tile<f32, { [BN, D] }> = v_tile.reshape(const_shape![BN, D]);
+            acc = mma(p, v_tile, acc);
+            m_i = m_ij;
+        }
+
+        acc = true_div(acc, l_i.broadcast(const_shape![BM, D]));
+        let acc = acc.reshape(const_shape![1, BM, D]);
+        out.store(acc);
+    }
+}
+
+fn test_flash_attention(stream: &Arc<CudaStream>) -> Result<(), Error> {
+    println!("=== Tutorial 6: Fused Multihead Attention ===");
+    use fmha_module::fmha;
+
+    let (batch, heads, seq_len, head_dim) = (1, 2, 32, 16);
+    let (bm, bn) = (16, 16);
+
+    let seed = 42u64;
+    let q: Arc<Tensor<f32>> = randn(0., 1., [batch, heads, seq_len, head_dim], Some(seed))
+        .sync_on(stream)?
+        .into();
+    let k: Arc<Tensor<f32>> = randn(0., 1., [batch, heads, seq_len, head_dim], Some(seed + 1))
+        .sync_on(stream)?
+        .into();
+    let v: Arc<Tensor<f32>> = randn(0., 1., [batch, heads, seq_len, head_dim], Some(seed + 2))
+        .sync_on(stream)?
+        .into();
+
+    let out = zeros(&[batch * heads, seq_len, head_dim])
+        .sync_on(stream)?
+        .partition([1, bm, head_dim]);
+
+    let qk_scale = 1.0 / f32::sqrt(head_dim as f32);
+    let generics = vec![bm.to_string(), bn.to_string(), head_dim.to_string()];
+
+    let (_, _, _, out, _) = fmha(q, k, v, out, qk_scale)
+        .generics(generics)
+        .sync_on(stream)?;
+
+    let out_host: Vec<f32> = out.unpartition().to_host_vec().sync_on(stream)?;
+
+    // Verify output has correct number of elements.
+    let expected_len = batch * heads * seq_len * head_dim;
+    assert_eq!(
+        out_host.len(),
+        expected_len,
+        "FMHA output length mismatch: got {}, expected {}",
+        out_host.len(),
+        expected_len
+    );
+    // Verify output contains finite values (softmax + matmul should produce finite results).
+    assert!(
+        out_host.iter().all(|v| v.is_finite()),
+        "FMHA output contains non-finite values"
+    );
+    println!(
+        "Output: {} elements, first={:.4}, last={:.4}",
+        out_host.len(),
+        out_host[0],
+        out_host[out_host.len() - 1]
+    );
+    println!("Flash Attention passed\n");
+    Ok(())
+}
+
+// ============================================================================
+// Tutorial 7: Intro to Async (sync equivalent — DeviceOp composition)
+// ============================================================================
+fn test_async_composition(stream: &Arc<CudaStream>) -> Result<(), Error> {
+    println!("=== Tutorial 7: Intro to Async (DeviceOp Composition) ===");
+    use vector_add_module::add;
+
+    // Demonstrate the DeviceOp composition pattern from tutorial 7:
+    // Build a lazy computation graph, then execute it in one shot.
+    let x: Arc<Tensor<f32>> = ones(&[32, 32]).sync_on(stream)?.into();
+    let y: Arc<Tensor<f32>> = ones(&[32, 32]).sync_on(stream)?.into();
+
+    // Compose: partition output, feed inputs, chain kernel, extract result.
+    let z_host: Vec<f32> = add(zeros(&[32, 32]).partition([4, 4]), x, y)
+        .first()
+        .unpartition()
+        .to_host_vec()
+        .sync_on(stream)?;
+
+    let all_correct = z_host.iter().all(|&v| (v - 2.0).abs() < 1e-5);
+    assert!(all_correct, "Async composition failed: expected all 2.0s");
+    println!("z[0] = {} (expected 2.0)", z_host[0]);
+
+    // Demonstrate lazy graph: all inputs are DeviceOps, executed in one shot.
+    let z_host2: Vec<f32> = add(
+        zeros(&[32, 32]).partition([4, 4]),
+        ones(&[32, 32]).map(|t: Tensor<f32>| -> Arc<Tensor<f32>> { Arc::new(t) }),
+        ones(&[32, 32]).map(|t: Tensor<f32>| -> Arc<Tensor<f32>> { Arc::new(t) }),
+    )
+    .first()
+    .unpartition()
+    .to_host_vec()
+    .sync_on(stream)?;
+
+    let all_correct2 = z_host2.iter().all(|&v| (v - 2.0).abs() < 1e-5);
+    assert!(
+        all_correct2,
+        "Lazy graph composition failed: expected all 2.0s"
+    );
+    println!("Lazy graph: z[0] = {} (expected 2.0)", z_host2[0]);
+    println!("Async Composition passed\n");
+    Ok(())
+}
+
+// ============================================================================
+// Tutorial 8: Data Parallel MLP
+// ============================================================================
+#[cutile::module]
+mod mlp_module {
+    use cutile::core::*;
+
+    #[cutile::entry()]
+    fn mlp_gemm<E: ElementType, const BM: i32, const BN: i32, const BK: i32, const K: i32>(
+        z: &mut Tensor<E, { [BM, BN] }>,
+        x: &Tensor<E, { [-1, K] }>,
+        y: &Tensor<E, { [K, -1] }>,
+    ) {
+        let part_x = x.partition(const_shape![BM, BK]);
+        let part_y = y.partition(const_shape![BK, BN]);
+        let pid: (i32, i32, i32) = get_tile_block_id();
+        let mut tile_z = load_tile_mut(z);
+        for i in 0i32..(K / BK) {
+            let tile_x = part_x.load([pid.0, i]);
+            let tile_y = part_y.load([i, pid.1]);
+            tile_z = mma(tile_x, tile_y, tile_z);
+        }
+        z.store(tile_z);
+    }
+
+    #[cutile::entry()]
+    pub fn mlp_matvec<const BM: i32, const BK: i32, const K: i32>(
+        z: &mut Tensor<f32, { [BM] }>,
+        x: &Tensor<f32, { [-1, K] }>,
+        y: &Tensor<f32, { [K] }>,
+    ) {
+        let part_x = x.partition(const_shape![BM, BK]);
+        let part_y = y.partition(const_shape![BK]);
+        let pid: (i32, i32, i32) = get_tile_block_id();
+        let mut tile_z = z.load().reshape(const_shape![BM, 1]);
+        for i in 0i32..(K / BK) {
+            let tile_x = part_x.load([pid.0, i]);
+            let tile_y = part_y.load([i]).reshape(const_shape![BK, 1]);
+            tile_z = mma(tile_x, tile_y, tile_z);
+            continue;
+        }
+        z.store(tile_z.reshape(const_shape![BM]));
+    }
+
+    #[cutile::entry()]
+    fn mlp_relu<const D: i32>(input_output: &mut Tensor<f32, { [D] }>) {
+        let zero_tile: Tile<f32, { [D] }> = constant(0.0f32, const_shape![D]);
+        let input = input_output.load();
+        input_output.store(max_tile(zero_tile, input));
+    }
+}
+
+fn test_data_parallel_mlp(stream: &Arc<CudaStream>) -> Result<(), Error> {
+    println!("=== Tutorial 8: Data Parallel MLP ===");
+    use cutile::api;
+    use cutile::DType;
+    use mlp_module::{mlp_gemm, mlp_matvec, mlp_relu};
+
+    let dim = 16usize;
+    let block_dim = 4usize;
+    let gemm_generics = vec![
+        f32::DTYPE.as_str().to_string(),
+        block_dim.to_string(),
+        block_dim.to_string(),
+        block_dim.to_string(),
+        dim.to_string(),
+    ];
+    let mv_generics = vec![
+        block_dim.to_string(),
+        block_dim.to_string(),
+        dim.to_string(),
+    ];
+
+    // Weights: W0 (dim × dim), W1 (dim,)
+    let w0: Arc<Tensor<f32>> = api::ones(&[dim, dim]).sync_on(stream)?.into();
+    let w1: Arc<Tensor<f32>> = api::ones(&[dim]).sync_on(stream)?.into();
+
+    // Input: ones(dim × dim) — each row is all 1s.
+    let data: Arc<Tensor<f32>> = api::ones(&[dim, dim]).sync_on(stream)?.into();
+
+    // Layer 1: GEMM — data @ W0. ones(16,16) @ ones(16,16) = full(16, 16×16).
+    let out0 = api::zeros(&[dim, dim])
+        .partition([block_dim, block_dim])
+        .sync_on(stream)?;
+    let (out0, _, _) = mlp_gemm(out0, data, w0)
+        .generics(gemm_generics)
+        .sync_on(stream)?;
+    let out0_arc: Arc<Tensor<f32>> = out0.unpartition().into();
+
+    // Layer 2: MatVec — out0[0] @ W1. Sum of row = dim*dim = 256, times 1 = 256.
+    let out1 = api::zeros(&[dim]).partition([block_dim]).sync_on(stream)?;
+    let (out1, _, _) = mlp_matvec(out1, out0_arc, w1)
+        .generics(mv_generics)
+        .sync_on(stream)?;
+
+    // ReLU — all positive, so no change.
+    let (out1,) = mlp_relu(out1).sync_on(stream)?;
+
+    let out_host: Vec<f32> = out1.unpartition().to_host_vec().sync_on(stream)?;
+    let expected = (dim * dim) as f32; // ones @ ones = dim per element, then matvec sums dim elements
+    println!("MLP output[0] = {} (expected {})", out_host[0], expected);
+    assert!(
+        (out_host[0] - expected).abs() < 1e-1,
+        "MLP output incorrect: got {}, expected {}",
+        out_host[0],
+        expected
+    );
+
+    // Verify ReLU: all values should be non-negative.
+    assert!(
+        out_host.iter().all(|&v| v >= 0.0),
+        "ReLU output contains negative values"
+    );
+    println!("Data Parallel MLP passed\n");
+    Ok(())
+}
+
+// ============================================================================
+// Tutorial 9: Pointer Addition
+// ============================================================================
+#[cutile::module]
+mod pointer_add_module {
+    use cutile::core::*;
+
+    unsafe fn get_tensor<T: ElementType>(ptr: *mut T, len: i32) -> Tensor<T, { [-1] }> {
+        let shape: Shape<{ [-1] }> = Shape::<{ [-1] }> { dims: &[len] };
+        let strides: Array<{ [-1] }> = Array::<{ [-1] }> { dims: &[1i32] };
+        let ptr_tile: PointerTile<*mut T, { [] }> = pointer_to_tile(ptr);
+        let tensor = make_tensor_view(ptr_tile, shape, strides, new_token_unordered());
+        tensor
+    }
+
+    #[cutile::entry()]
+    unsafe fn add_ptr<T: ElementType>(z_ptr: *mut T, x_ptr: *mut T, y_ptr: *mut T, len: i32) {
+        let mut z_tensor: Tensor<T, { [-1] }> = get_tensor(z_ptr, len);
+        let x_tensor: Tensor<T, { [-1] }> = get_tensor(x_ptr, len);
+        let y_tensor: Tensor<T, { [-1] }> = get_tensor(y_ptr, len);
+        let pid: (i32, i32, i32) = get_tile_block_id();
+        let tile_shape = const_shape![4i32];
+        let tile_x = x_tensor.partition(tile_shape).load([pid.0]);
+        let tile_y = y_tensor.partition(tile_shape).load([pid.0]);
+        z_tensor
+            .partition_mut(tile_shape)
+            .store(tile_x + tile_y, [pid.0]);
+    }
+}
+
+fn test_pointer_addition(stream: &Arc<CudaStream>) -> Result<(), Error> {
+    println!("=== Tutorial 9: Pointer Addition ===");
+    use pointer_add_module::add_ptr;
+
+    let len = 32usize;
+    let tile_size = 4usize;
+
+    let z: Tensor<f32> = zeros(&[len]).sync_on(stream)?;
+    let x: Tensor<f32> = ones(&[len]).sync_on(stream)?;
+    let y: Tensor<f32> = ones(&[len]).sync_on(stream)?;
+
+    let z_ptr = z.device_pointer();
+    let x_ptr = x.device_pointer();
+    let y_ptr = y.device_pointer();
+
+    let _ = unsafe { add_ptr(z_ptr, x_ptr, y_ptr, len as i32) }
+        .grid(((len / tile_size) as u32, 1, 1))
+        .sync_on(stream)?;
+
+    let z_host: Vec<f32> = z.to_host_vec().sync_on(stream)?;
+
+    for i in 0..5 {
+        println!("1 + 1 = {} (expected 2.0)", z_host[i]);
+        assert!(
+            (z_host[i] - 2.0).abs() < 1e-5,
+            "Pointer addition failed at index {}",
+            i
+        );
+    }
+    println!("Pointer Addition passed\n");
+    Ok(())
+}
+
+// ============================================================================
+// Main
+// ============================================================================
+fn main() -> Result<(), Error> {
+    println!("cuTile Rust Book Examples - Verification Suite\n");
+
+    let ctx = CudaContext::new(0)?;
+    let stream = ctx.new_stream()?;
+
+    test_hello_world(&stream)?;
+    test_vector_addition(&stream)?;
+    test_saxpy(&stream)?;
+    test_gemm(&stream)?;
+    test_softmax(&stream)?;
+    test_flash_attention(&stream)?;
+    test_async_composition(&stream)?;
+    test_data_parallel_mlp(&stream)?;
+    test_pointer_addition(&stream)?;
+
+    println!("\nALL TESTS PASSED");
+    Ok(())
+}

--- a/cutile-examples/examples/cuda_graphs.rs
+++ b/cutile-examples/examples/cuda_graphs.rs
@@ -1,0 +1,363 @@
+/*
+ * CUDA graphs example — scoped capture with borrowed buffers.
+ *
+ * Demonstrates scope(...).graph(stream), which captures a CUDA graph
+ * using an imperative closure. Each s.record(op) records immediately,
+ * releasing borrows — so the same buffer can be written by one kernel
+ * and read by the next.
+ *
+ * No Arc, no try_partition, no take_output, no SharedDeviceOp.
+ *
+ * Usage:
+ *   cargo run -p cutile-examples --example cuda_graphs
+ */
+
+use cuda_core::{CudaContext, CudaStream};
+use cutile::error::Error;
+use cutile::prelude::*;
+use std::time::Instant;
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Kernels
+// ═══════════════════════════════════════════════════════════════════════════════
+
+#[cutile::module]
+mod kernels {
+    use cutile::core::*;
+
+    #[cutile::entry()]
+    pub fn rms_norm<const D: i32, const BS: i32>(
+        out: &mut Tensor<f32, { [1, D] }>,
+        x: &Tensor<f32, { [-1, D] }>,
+        w: &Tensor<f32, { [D] }>,
+        eps: f32,
+    ) {
+        let shape: Shape<{ [1, BS] }> = const_shape![1, BS];
+        let tiles: i32 = D / BS;
+        let pid: (i32, i32, i32) = get_tile_block_id();
+        let row = pid.0;
+        let x_part: Partition<f32, { [1, BS] }> = x.partition(shape);
+        let mut rms: Tile<f32, { [1, BS] }> = constant(0.0, shape);
+        for j in 0i32..tiles {
+            let t: Tile<f32, { [1, BS] }> = x_part.load([row, j]);
+            rms = rms + t * t;
+        }
+        let s: Tile<f32, { [1] }> = reduce_sum(rms, 1i32);
+        let s: f32 = tile_to_scalar(s.reshape(const_shape![]));
+        let n: f32 = convert_scalar(D);
+        let inv: f32 = 1.0f32 / (s / n + eps);
+        let inv_tile: Tile<f32, { [] }> = sqrt(scalar_to_tile(inv), "negative_inf");
+        let inv: f32 = tile_to_scalar(inv_tile);
+        let scale: Tile<f32, { [1, BS] }> = inv.broadcast(shape);
+        let w_part: Partition<f32, { [BS] }> = w.partition(const_shape![BS]);
+        let mut out_part: PartitionMut<f32, { [1, BS] }> = unsafe { out.partition_mut(shape) };
+        for j in 0i32..tiles {
+            let t: Tile<f32, { [1, BS] }> = x_part.load([row, j]);
+            let tw: Tile<f32, { [1, BS] }> = w_part.load([j]).reshape(shape);
+            unsafe { out_part.store(t * scale * tw, [0i32, j]) };
+        }
+    }
+
+    #[cutile::entry()]
+    pub fn matvec<const BN: i32, const BK: i32, const K: i32>(
+        out: &mut Tensor<f32, { [BN] }>,
+        x: &Tensor<f32, { [-1, K] }>,
+        w: &Tensor<f32, { [-1, K] }>,
+    ) {
+        let pid: (i32, i32, i32) = get_tile_block_id();
+        let x_part = x.partition(const_shape![1, BK]);
+        let w_part = w.partition(const_shape![BN, BK]);
+        let mut acc = out.load().reshape(const_shape![BN, 1]);
+        let transpose: Array<{ [1, 0] }> = Array::<{ [1, 0] }> {
+            dims: &[1i32, 0i32],
+        };
+        for k in 0i32..(K / BK) {
+            let tx = x_part.load([0i32, k]).reshape(const_shape![1, BK]);
+            let tw = w_part.load([pid.0, k]);
+            let txt: Tile<f32, { [BK, 1] }> = permute(tx, transpose);
+            acc = mma(tw, txt, acc);
+        }
+        out.store(acc.reshape(const_shape![BN]));
+    }
+
+    #[cutile::entry()]
+    pub fn add<const B: i32>(
+        out: &mut Tensor<f32, { [B] }>,
+        a: &Tensor<f32, { [-1] }>,
+        b: &Tensor<f32, { [-1] }>,
+    ) {
+        let ta: Tile<f32, { [B] }> = load_tile_like_1d(a, out);
+        let tb: Tile<f32, { [B] }> = load_tile_like_1d(b, out);
+        out.store(ta + tb);
+    }
+}
+
+use crate::kernels::{add, matvec, rms_norm};
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Model
+// ═══════════════════════════════════════════════════════════════════════════════
+
+struct Config {
+    d: usize,
+    n_layers: usize,
+    block: usize,
+    bn: usize,
+    bk: usize,
+    eps: f32,
+}
+
+impl Config {
+    fn rms_generics(&self) -> Vec<String> {
+        vec![self.d.to_string(), self.block.to_string()]
+    }
+    fn mv_generics(&self) -> Vec<String> {
+        vec![self.bn.to_string(), self.bk.to_string(), self.d.to_string()]
+    }
+}
+
+struct LayerWeights {
+    norm_w: Tensor<f32>,
+    wq: Tensor<f32>,
+    wo: Tensor<f32>,
+}
+
+/// Pre-allocated per-layer buffers. Plain Tensors — no Arc needed.
+struct LayerBuffers {
+    norm: Tensor<f32>,     // (1, d)
+    q: Tensor<f32>,        // (d,)
+    o: Tensor<f32>,        // (d,)
+    residual: Tensor<f32>, // (d,)
+}
+
+impl LayerBuffers {
+    fn allocate(d: usize, stream: &Arc<CudaStream>) -> Result<Self, Error> {
+        Ok(Self {
+            norm: api::zeros(&[1, d]).sync_on(stream)?,
+            q: api::zeros(&[d]).sync_on(stream)?,
+            o: api::zeros(&[d]).sync_on(stream)?,
+            residual: api::zeros(&[d]).sync_on(stream)?,
+        })
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Graph model — scoped capture
+// ═══════════════════════════════════════════════════════════════════════════════
+
+struct GraphModel {
+    graph: CudaGraph<()>,
+    input: Tensor<f32>, // (d,) — copy new embedding here before launch
+    buffers: Vec<LayerBuffers>,
+}
+
+impl GraphModel {
+    fn new(
+        cfg: &Config,
+        weights: &[LayerWeights],
+        stream: &Arc<CudaStream>,
+    ) -> Result<Self, Error> {
+        let mut input: Tensor<f32> = api::ones::<f32>(&[cfg.d]).sync_on(stream)?;
+        let mut buffers: Vec<_> = (0..cfg.n_layers)
+            .map(|_| LayerBuffers::allocate(cfg.d, stream))
+            .collect::<Result<_, _>>()?;
+        stream.synchronize()?;
+
+        // Capture the forward pass as a CUDA graph. Each s.record()
+        // records a graph node, releasing borrows between kernels.
+        let graph = CudaGraph::scope(stream, |s| {
+            for (w, bufs) in weights.iter().zip(buffers.iter_mut()) {
+                // Create a (1,d) view of input for rms_norm. The view borrows
+                // input — after record consumes the op, the borrow is released.
+                let hidden_2d = input.view(&[1, cfg.d])?;
+
+                // RMSNorm: hidden(1,d) → norm(1,d)
+                s.record(
+                    rms_norm(
+                        (&mut bufs.norm).partition([1, cfg.d]),
+                        &hidden_2d,
+                        &w.norm_w,
+                        cfg.eps,
+                    )
+                    .generics(cfg.rms_generics()),
+                )?;
+                // hidden_2d dropped — input no longer borrowed.
+
+                // Q projection: norm(1,d) @ wq^T → q(d,)
+                s.record(
+                    matvec((&mut bufs.q).partition([cfg.bn]), &bufs.norm, &w.wq)
+                        .generics(cfg.mv_generics()),
+                )?;
+
+                // O projection: q(1,d) @ wo^T → o(d,)
+                let q_2d = bufs.q.view(&[1, cfg.d])?;
+                s.record(
+                    matvec((&mut bufs.o).partition([cfg.bn]), &q_2d, &w.wo)
+                        .generics(cfg.mv_generics()),
+                )?;
+
+                // Residual: hidden(d,) + o(d,) → residual(d,)
+                s.record(add(
+                    (&mut bufs.residual).partition([cfg.block]),
+                    &input,
+                    &bufs.o,
+                ))?;
+
+                // Copy residual into input for the next layer.
+                s.record(api::memcpy(&mut input, &bufs.residual))?;
+            }
+            Ok(())
+        })?;
+
+        Ok(Self {
+            graph,
+            input,
+            buffers,
+        })
+    }
+
+    fn output(&self) -> &Tensor<f32> {
+        &self.buffers.last().unwrap().residual
+    }
+
+    fn forward(&mut self, embedding: &Tensor<f32>) -> Result<(), DeviceError> {
+        self.graph.update(api::memcpy(&mut self.input, embedding))?;
+        self.graph.launch()?;
+        Ok(())
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Eager forward — same kernels, no graph, for validation
+// ═══════════════════════════════════════════════════════════════════════════════
+
+fn eager_forward(
+    cfg: &Config,
+    weights: &[LayerWeights],
+    input: &Tensor<f32>,
+    stream: &Arc<CudaStream>,
+) -> Result<Vec<f32>, Error> {
+    let mut buffers: Vec<_> = (0..cfg.n_layers)
+        .map(|_| LayerBuffers::allocate(cfg.d, stream))
+        .collect::<Result<_, _>>()?;
+
+    let mut input_buf = input.dup().sync_on(stream)?;
+
+    for (w, bufs) in weights.iter().zip(buffers.iter_mut()) {
+        let hidden_2d = input_buf.view(&[1, cfg.d])?;
+        rms_norm(
+            (&mut bufs.norm).partition([1, cfg.d]),
+            &hidden_2d,
+            &w.norm_w,
+            cfg.eps,
+        )
+        .generics(cfg.rms_generics())
+        .sync_on(stream)?;
+
+        matvec((&mut bufs.q).partition([cfg.bn]), &bufs.norm, &w.wq)
+            .generics(cfg.mv_generics())
+            .sync_on(stream)?;
+
+        let q_2d = bufs.q.view(&[1, cfg.d])?;
+        matvec((&mut bufs.o).partition([cfg.bn]), &q_2d, &w.wo)
+            .generics(cfg.mv_generics())
+            .sync_on(stream)?;
+
+        add(
+            (&mut bufs.residual).partition([cfg.block]),
+            &input_buf,
+            &bufs.o,
+        )
+        .sync_on(stream)?;
+
+        api::memcpy(&mut input_buf, &bufs.residual).sync_on(stream)?;
+    }
+
+    let host: Vec<f32> = buffers
+        .last()
+        .unwrap()
+        .residual
+        .dup()
+        .to_host_vec()
+        .sync_on(stream)?;
+    Ok(host)
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Main
+// ═══════════════════════════════════════════════════════════════════════════════
+
+fn main() -> Result<(), Error> {
+    let ctx = CudaContext::new(0)?;
+    let stream = ctx.new_stream()?;
+
+    let cfg = Config {
+        d: 2048,
+        n_layers: 22,
+        block: 128,
+        bn: 16,
+        bk: 16,
+        eps: 1e-5,
+    };
+
+    println!("Allocating model: d={}, layers={}", cfg.d, cfg.n_layers);
+
+    // Deterministic weights for validation.
+    let weights: Vec<LayerWeights> = (0..cfg.n_layers)
+        .map(|_| {
+            Ok(LayerWeights {
+                norm_w: api::ones::<f32>(&[cfg.d]).sync_on(&stream)?,
+                wq: api::ones::<f32>(&[cfg.d, cfg.d]).sync_on(&stream)?,
+                wo: api::ones::<f32>(&[cfg.d, cfg.d]).sync_on(&stream)?,
+            })
+        })
+        .collect::<Result<_, Error>>()?;
+
+    let mut model = GraphModel::new(&cfg, &weights, &stream)?;
+    println!("Graph captured.");
+
+    // ── Validation ──────────────────────────────────────────────────────────
+
+    let test_input = api::ones::<f32>(&[cfg.d]).sync_on(&stream)?;
+
+    // Graph path.
+    model.forward(&test_input)?;
+    let graph_output: Vec<f32> = model
+        .output()
+        .dup()
+        .to_host_vec()
+        .sync_on(model.graph.stream())?;
+
+    // Eager path.
+    let eager_output = eager_forward(&cfg, &weights, &test_input, &stream)?;
+
+    // With deterministic weights (ones), results should be identical.
+    let max_diff = graph_output
+        .iter()
+        .zip(eager_output.iter())
+        .map(|(a, b)| (a - b).abs())
+        .fold(0.0f32, f32::max);
+
+    println!("Validation: max abs diff = {max_diff:.2e}");
+    assert!(
+        max_diff < 1e-2,
+        "Graph output diverged from eager: max_diff={max_diff}"
+    );
+    println!("Validation passed.");
+
+    // ── Timing ──────────────────────────────────────────────────────────────
+
+    let n_tokens = 32;
+    let start = Instant::now();
+    for _ in 0..n_tokens {
+        model.forward(&test_input)?;
+    }
+    let elapsed = start.elapsed();
+    let tps = n_tokens as f64 / elapsed.as_secs_f64();
+    println!(
+        "{n_tokens} tokens in {:.2}s = {tps:.1} tok/s",
+        elapsed.as_secs_f64()
+    );
+
+    Ok(())
+}

--- a/cutile-examples/examples/cuda_graphs_deviceop.rs
+++ b/cutile-examples/examples/cuda_graphs_deviceop.rs
@@ -1,0 +1,438 @@
+/*
+ * CUDA graphs example — safe device-operation combinators.
+ *
+ * Demonstrates how to use the DeviceOp combinator API (zip!, then,
+ * unzip, shared, etc.) to build a multi-kernel forward pass and capture it
+ * into a CUDA graph for efficient replay.
+ *
+ * Usage:
+ *   cargo run -p cutile-examples --example cuda_graphs
+ */
+
+use cuda_core::{CudaContext, CudaStream};
+use cutile::error::Error;
+use cutile::prelude::*;
+use std::time::Instant;
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Kernels — a minimal neural network layer: RMSNorm → MatVec → Add
+// ═══════════════════════════════════════════════════════════════════════════════
+
+#[cutile::module]
+mod kernels {
+    use cutile::core::*;
+
+    /// RMS normalization: out = rms_norm(x) * w
+    #[cutile::entry()]
+    pub fn rms_norm<const D: i32, const BS: i32>(
+        out: &mut Tensor<f32, { [1, D] }>,
+        x: &Tensor<f32, { [-1, D] }>,
+        w: &Tensor<f32, { [D] }>,
+        eps: f32,
+    ) {
+        let shape: Shape<{ [1, BS] }> = const_shape![1, BS];
+        let tiles: i32 = D / BS;
+        let pid: (i32, i32, i32) = get_tile_block_id();
+        let row = pid.0;
+        let x_part: Partition<f32, { [1, BS] }> = x.partition(shape);
+        let mut rms: Tile<f32, { [1, BS] }> = constant(0.0, shape);
+        for j in 0i32..tiles {
+            let t: Tile<f32, { [1, BS] }> = x_part.load([row, j]);
+            rms = rms + t * t;
+        }
+        let s: Tile<f32, { [1] }> = reduce_sum(rms, 1i32);
+        let s: f32 = tile_to_scalar(s.reshape(const_shape![]));
+        let n: f32 = convert_scalar(D);
+        let inv: f32 = 1.0f32 / (s / n + eps);
+        let inv_tile: Tile<f32, { [] }> = sqrt(scalar_to_tile(inv), "negative_inf");
+        let inv: f32 = tile_to_scalar(inv_tile);
+        let scale: Tile<f32, { [1, BS] }> = inv.broadcast(shape);
+        let w_part: Partition<f32, { [BS] }> = w.partition(const_shape![BS]);
+        let mut out_part: PartitionMut<f32, { [1, BS] }> = unsafe { out.partition_mut(shape) };
+        for j in 0i32..tiles {
+            let t: Tile<f32, { [1, BS] }> = x_part.load([row, j]);
+            let tw: Tile<f32, { [1, BS] }> = w_part.load([j]).reshape(shape);
+            unsafe { out_part.store(t * scale * tw, [0i32, j]) };
+        }
+    }
+
+    /// Matrix-vector multiply: out = x @ w^T
+    /// x: (1, K), w: (N, K), out: (N,)
+    #[cutile::entry()]
+    pub fn matvec<const BN: i32, const BK: i32, const K: i32>(
+        out: &mut Tensor<f32, { [BN] }>,
+        x: &Tensor<f32, { [-1, K] }>,
+        w: &Tensor<f32, { [-1, K] }>,
+    ) {
+        let pid: (i32, i32, i32) = get_tile_block_id();
+        let x_part = x.partition(const_shape![1, BK]);
+        let w_part = w.partition(const_shape![BN, BK]);
+        let mut acc = out.load().reshape(const_shape![BN, 1]);
+        let transpose: Array<{ [1, 0] }> = Array::<{ [1, 0] }> {
+            dims: &[1i32, 0i32],
+        };
+        for k in 0i32..(K / BK) {
+            let tx = x_part.load([0i32, k]).reshape(const_shape![1, BK]);
+            let tw = w_part.load([pid.0, k]);
+            let txt: Tile<f32, { [BK, 1] }> = permute(tx, transpose);
+            acc = mma(tw, txt, acc);
+        }
+        out.store(acc.reshape(const_shape![BN]));
+    }
+
+    /// Element-wise add: out = a + b
+    #[cutile::entry()]
+    pub fn add<const B: i32>(
+        out: &mut Tensor<f32, { [B] }>,
+        a: &Tensor<f32, { [-1] }>,
+        b: &Tensor<f32, { [-1] }>,
+    ) {
+        let ta: Tile<f32, { [B] }> = load_tile_like_1d(a, out);
+        let tb: Tile<f32, { [B] }> = load_tile_like_1d(b, out);
+        out.store(ta + tb);
+    }
+}
+
+use crate::kernels::{add, matvec, rms_norm};
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Model definition
+// ═══════════════════════════════════════════════════════════════════════════════
+
+struct Config {
+    d: usize,
+    n_layers: usize,
+    block: usize,
+    bn: usize,
+    bk: usize,
+    eps: f32,
+}
+
+impl Config {
+    fn rms_generics(&self) -> Vec<String> {
+        vec![self.d.to_string(), self.block.to_string()]
+    }
+    fn mv_generics(&self) -> Vec<String> {
+        vec![self.bn.to_string(), self.bk.to_string(), self.d.to_string()]
+    }
+}
+
+struct LayerWeights {
+    norm_w: Arc<Tensor<f32>>, // (D,)
+    wq: Arc<Tensor<f32>>,     // (D, D)
+    wo: Arc<Tensor<f32>>,     // (D, D)
+}
+
+/// Pre-allocated per-layer intermediate buffers (reused every token).
+struct LayerBuffers {
+    norm: Arc<Tensor<f32>>,     // (1, d) — output of rms_norm
+    q: Arc<Tensor<f32>>,        // (d,)   — output of Q matvec
+    o: Arc<Tensor<f32>>,        // (d,)   — output of O matvec
+    residual: Arc<Tensor<f32>>, // (d,)   — output of residual add
+}
+
+impl LayerBuffers {
+    fn allocate(d: usize, stream: &Arc<CudaStream>) -> Result<Self, Error> {
+        Ok(Self {
+            norm: api::zeros(&[1, d]).sync_on(stream)?.into(),
+            q: api::zeros(&[d]).sync_on(stream)?.into(),
+            o: api::zeros(&[d]).sync_on(stream)?.into(),
+            residual: api::zeros(&[d]).sync_on(stream)?.into(),
+        })
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Graph-backed model
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/// A model whose forward pass is captured as a CUDA graph.
+///
+/// Construction builds the lazy operation graph and captures it. After that,
+/// [`forward`] copies a new embedding into the baked-in input buffer and
+/// replays the graph. The output is read directly from the last layer's
+/// residual buffer.
+struct GraphModel {
+    graph: CudaGraph<()>,
+    input: Tensor<f32>,
+    output: Arc<Tensor<f32>>,
+}
+
+impl GraphModel {
+    fn new(
+        cfg: &Config,
+        weights: &[LayerWeights],
+        stream: &Arc<CudaStream>,
+    ) -> Result<Self, Error> {
+        let input: Tensor<f32> = api::rand([cfg.d], None).sync_on(stream)?;
+        let buffers: Vec<_> = (0..cfg.n_layers)
+            .map(|_| LayerBuffers::allocate(cfg.d, stream))
+            .collect::<Result<_, _>>()?;
+        stream.synchronize()?;
+
+        // Create an Arc that shares input's device memory for build_forward.
+        // This requires aliased storage (input + input_arc point to same
+        // memory). The scope-based cuda_graphs.rs example avoids this
+        // entirely with TensorView + safe memcpy.
+        let input_arc: Arc<Tensor<f32>> = unsafe { input.into_shared_alias() };
+
+        // build_forward takes buffers by value — Arc refcounts drop to 1
+        // so try_partition succeeds. Returns a SharedDeviceOp pointing to
+        // the last residual buffer.
+        let (forward_op, output_shared) = Self::build_forward(cfg, weights, &input_arc, buffers);
+        let graph = forward_op.graph_on(stream.clone())?;
+
+        // The graph executed the op once during capture. The SharedDeviceOp
+        // cached the result — sync it to get the output Arc.
+        let output: Arc<Tensor<f32>> = output_shared.sync_on(stream)?;
+
+        Ok(Self {
+            graph,
+            input,
+            output,
+        })
+    }
+
+    /// Returns the output tensor. The graph writes into this device memory
+    /// on each `forward()` call.
+    fn output(&self) -> &Arc<Tensor<f32>> {
+        &self.output
+    }
+
+    /// Returns the stream the graph was captured on.
+    fn stream(&self) -> &Arc<CudaStream> {
+        self.graph.stream()
+    }
+
+    /// Copy a new embedding into the input buffer and replay the graph.
+    fn forward(&mut self, embedding: &Tensor<f32>) -> Result<(), DeviceError> {
+        self.graph.update(api::memcpy(&mut self.input, embedding))?;
+        self.graph.launch()?;
+        Ok(())
+    }
+
+    /// Build the lazy forward pass.
+    ///
+    /// Takes `buffers` by value so each `Arc<Tensor>` has refcount 1,
+    /// allowing `try_partition` to succeed. The graph captures the Arcs
+    /// via `SharedDeviceOp`, keeping the device memory alive for replay.
+    fn build_forward(
+        cfg: &Config,
+        weights: &[LayerWeights],
+        input: &Arc<Tensor<f32>>,
+        buffers: Vec<LayerBuffers>,
+    ) -> (impl DeviceOp<Output = ()>, SharedDeviceOp<Tensor<f32>>) {
+        let mut hidden: SharedDeviceOp<Tensor<f32>> =
+            cuda_async::device_operation::shared(input.clone());
+
+        let mut ops: Vec<BoxedDeviceOp<()>> = Vec::with_capacity(buffers.len());
+
+        for (w, bufs) in weights.iter().zip(buffers) {
+            // RMSNorm: hidden(1,d) × norm_w → norm(1,d)
+            let norm = rms_norm(
+                bufs.norm
+                    .try_partition([1, cfg.d])
+                    .expect("sole buffer owner"),
+                hidden.clone().reshape(&[1, cfg.d]),
+                w.norm_w.clone(),
+                cfg.eps,
+            )
+            .generics(cfg.rms_generics())
+            .first()
+            .unpartition()
+            .shared();
+
+            // Q projection: norm @ wq^T → q
+            let q = matvec(
+                bufs.q.try_partition([cfg.bn]).expect("sole buffer owner"),
+                norm.clone(),
+                w.wq.clone(),
+            )
+            .generics(cfg.mv_generics())
+            .first()
+            .unpartition()
+            .shared();
+
+            // O projection: q @ wo^T → o
+            let o = matvec(
+                bufs.o.try_partition([cfg.bn]).expect("sole buffer owner"),
+                q.clone().reshape(&[1, cfg.d]),
+                w.wo.clone(),
+            )
+            .generics(cfg.mv_generics())
+            .first()
+            .unpartition()
+            .shared();
+
+            // Residual add: hidden + o → residual
+            let residual = add(
+                bufs.residual
+                    .try_partition([cfg.block])
+                    .expect("sole buffer owner"),
+                hidden.clone().reshape(&[cfg.d]),
+                o.clone(),
+            )
+            .first()
+            .unpartition()
+            .shared();
+
+            hidden = residual.clone();
+
+            // Discard the output — buffers are written in place.
+            ops.push(zip!(norm, q, o, residual).map(|_| ()).boxed());
+        }
+
+        (DeviceOpVec::new(ops).map(|_| ()), hidden)
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Warmup — compile all kernels once so JIT cost is excluded from benchmarks
+// ═══════════════════════════════════════════════════════════════════════════════
+
+fn warmup(cfg: &Config, weights: &[LayerWeights], stream: &Arc<CudaStream>) -> Result<(), Error> {
+    println!("Warming up (compiling kernels)...");
+    let h: Arc<Tensor<f32>> = api::rand([cfg.d], None).sync_on(stream)?.into();
+    let h_2d: Arc<Tensor<f32>> = h
+        .dup()
+        .sync_on(stream)?
+        .reshape(&[1, cfg.d])
+        .unwrap()
+        .into();
+    let w = &weights[0];
+
+    let norm_out: Partition<Tensor<f32>> = api::zeros(&[1, cfg.d])
+        .sync_on(stream)?
+        .partition([1, cfg.d]);
+    let _ = rms_norm(norm_out, h_2d.clone(), w.norm_w.clone(), cfg.eps)
+        .generics(cfg.rms_generics())
+        .sync_on(stream)?;
+
+    let q_out: Partition<Tensor<f32>> = api::zeros(&[cfg.d]).sync_on(stream)?.partition([cfg.bn]);
+    let _ = matvec(q_out, h_2d.clone(), w.wq.clone())
+        .generics(cfg.mv_generics())
+        .sync_on(stream)?;
+
+    let add_out: Partition<Tensor<f32>> =
+        api::zeros(&[cfg.d]).sync_on(stream)?.partition([cfg.block]);
+    let _ = add(add_out, h.clone(), h.clone()).sync_on(stream)?;
+
+    println!("Warmup done.");
+    Ok(())
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Eager forward pass — run the same kernels without a graph, for validation
+// ═══════════════════════════════════════════════════════════════════════════════
+
+fn eager_forward(
+    cfg: &Config,
+    weights: &[LayerWeights],
+    input: &Arc<Tensor<f32>>,
+    stream: &Arc<CudaStream>,
+) -> Result<Vec<f32>, Error> {
+    let buffers: Vec<_> = (0..cfg.n_layers)
+        .map(|_| LayerBuffers::allocate(cfg.d, stream))
+        .collect::<Result<_, _>>()?;
+
+    let (forward_op, output_shared) = GraphModel::build_forward(cfg, weights, input, buffers);
+    forward_op.sync_on(stream)?;
+
+    let output: Arc<Tensor<f32>> = output_shared.sync_on(stream)?;
+    let host: Vec<f32> = output.dup().to_host_vec().sync_on(stream)?;
+    Ok(host)
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Main
+// ═══════════════════════════════════════════════════════════════════════════════
+
+fn main() -> Result<(), Error> {
+    let ctx = CudaContext::new(0)?;
+    let stream = ctx.new_stream()?;
+
+    let cfg = Config {
+        d: 2048,
+        n_layers: 22,
+        block: 128,
+        bn: 16,
+        bk: 16,
+        eps: 1e-5,
+    };
+    let n_tokens = 32;
+
+    println!(
+        "Allocating fake model: d={}, layers={}",
+        cfg.d, cfg.n_layers
+    );
+
+    // Deterministic weights for validation — ones produce exact results
+    // so the graph vs eager comparison catches pointer/memory bugs, not
+    // floating-point non-determinism.
+    let weights: Vec<LayerWeights> = (0..cfg.n_layers)
+        .map(|_| {
+            Ok(LayerWeights {
+                norm_w: api::ones::<f32>(&[cfg.d]).sync_on(&stream)?.into(),
+                wq: api::ones::<f32>(&[cfg.d, cfg.d]).sync_on(&stream)?.into(),
+                wo: api::ones::<f32>(&[cfg.d, cfg.d]).sync_on(&stream)?.into(),
+            })
+        })
+        .collect::<Result<_, Error>>()?;
+
+    // Warmup: compile all kernels so JIT cost is excluded.
+    warmup(&cfg, &weights, &stream)?;
+
+    // Build and capture the forward pass as a CUDA graph.
+    let mut model = GraphModel::new(&cfg, &weights, &stream)?;
+    println!("Graph captured.");
+
+    // ── Validation ──────────────────────────────────────────────────────────
+    // Run with a known input, compare graph output against eager execution.
+
+    let test_input: Tensor<f32> = api::ones::<f32>(&[cfg.d]).sync_on(&stream)?;
+
+    // Graph path.
+    model.forward(&test_input)?;
+    let graph_output: Vec<f32> = model.output().dup().to_host_vec().sync_on(model.stream())?;
+
+    // Eager path (same kernels, no graph).
+    let test_input_arc: Arc<Tensor<f32>> = test_input.into();
+    let eager_output = eager_forward(&cfg, &weights, &test_input_arc, &stream)?;
+
+    // With deterministic weights (ones), graph and eager should produce
+    // identical results. Any diff indicates a pointer/memory bug.
+    let max_diff = graph_output
+        .iter()
+        .zip(eager_output.iter())
+        .map(|(a, b)| (a - b).abs())
+        .fold(0.0f32, f32::max);
+
+    println!("Validation: max abs diff between graph and eager = {max_diff:.2e}");
+    assert!(
+        max_diff < 1e-2,
+        "Graph output diverged from eager: max_diff={max_diff}"
+    );
+    println!("Validation passed.");
+
+    // ── Timing ──────────────────────────────────────────────────────────────
+
+    let embeddings: Vec<Tensor<f32>> = (0..n_tokens)
+        .map(|i| -> Result<_, Error> {
+            Ok(api::rand([cfg.d], Some(1000 + i as u64)).sync_on(&stream)?)
+        })
+        .collect::<Result<_, _>>()?;
+
+    let start = Instant::now();
+    for embedding in &embeddings {
+        model.forward(embedding)?;
+    }
+    let elapsed = start.elapsed();
+
+    let tps = n_tokens as f64 / elapsed.as_secs_f64();
+    println!(
+        "{n_tokens} tokens in {:.2}s = {tps:.1} tok/s",
+        elapsed.as_secs_f64()
+    );
+
+    Ok(())
+}

--- a/cutile-examples/examples/dropout.rs
+++ b/cutile-examples/examples/dropout.rs
@@ -2,10 +2,10 @@
  * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-use cuda_async::device_operation::DeviceOperation;
+use cuda_async::device_operation::DeviceOp;
 use cuda_core::CudaContext;
 use cutile;
-use cutile::api::{rand_f32, randn_f32, zeros};
+use cutile::api::{rand, randn, zeros};
 use cutile::error::Error;
 use cutile::tensor::{IntoPartition, Partition, Tensor, ToHostVec};
 use std::sync::Arc;
@@ -43,11 +43,9 @@ fn main() -> Result<(), Error> {
     let bm = 4;
     let p: f32 = 0.4;
     let seed = 123;
-    let x: Arc<Tensor<f32>> = randn_f32(0.0, 1.0, [m], Some(seed))
-        .sync_on(&stream)?
-        .into();
-    let x_keep: Arc<Tensor<f32>> = rand_f32([m], Some(seed)).sync_on(&stream)?.into();
-    let out: Partition<Tensor<f32>> = zeros([m]).sync_on(&stream)?.partition([bm]);
+    let x: Arc<Tensor<f32>> = randn(0.0, 1.0, [m], Some(seed)).sync_on(&stream)?.into();
+    let x_keep: Arc<Tensor<f32>> = rand([m], Some(seed)).sync_on(&stream)?.into();
+    let out: Partition<Tensor<f32>> = zeros(&[m]).sync_on(&stream)?.partition([bm]);
     let (_, _x, _x_keep, out) = dropout(p, x, x_keep, out).sync_on(&stream)?;
     let out_host: Vec<f32> = out.unpartition().to_host_vec().sync_on(&stream)?;
     for i in 0..out_host.len() {

--- a/cutile-examples/examples/flash_attention.rs
+++ b/cutile-examples/examples/flash_attention.rs
@@ -4,13 +4,13 @@
  */
 extern crate core;
 
-use cuda_async::device_operation::DeviceOperation;
+use cuda_async::device_operation::{DeviceOp, Unzippable6};
 use cuda_core::CudaContext;
 use cutile;
-use cutile::api::{randn_f32, zeros};
+use cutile::api::{randn, zeros};
 use cutile::error::Error;
-use cutile::tensor::{IntoPartition, Partition, Tensor, ToHostVec};
-use cutile::tile_kernel::TileKernel;
+use cutile::tensor::{IntoPartition, Partition, Tensor, ToHostVec, Unpartition};
+use cutile::tile_kernel::{TileKernel, ToHostVecOp};
 use std::sync::Arc;
 
 #[cutile::module]
@@ -28,10 +28,10 @@ mod my_module {
         const BN: i32, // KV Sequence length partition size.
         const D: i32,  // Hidden size (weights).
     >(
+        out: &mut Tensor<f32, { [1, BM, D] }>, // (b*h, m, d)
         q: &Tensor<f32, { [-1, -1, -1, -1] }>, // (b, h, m, d)
         k: &Tensor<f32, { [-1, -1, -1, -1] }>, // (b, hkv, n, d) where n == m
         v: &Tensor<f32, { [-1, -1, -1, -1] }>, // (b, hkv, n, d) where n == m
-        out: &mut Tensor<f32, { [1, BM, D] }>, // (b*h, m, d)
         qk_scale: f32,
         query_group_size: i32,
     ) {
@@ -149,9 +149,9 @@ fn fmha(
     hkv: usize, // number of heads (key/value).
     m: usize,   // sequence length.
     d: usize,   // hidden size.
-    bm: i32,    // q seq len part size.
-    bn: i32,    // k, v seq len part size.
-    bbh: i32,   // batch * num_heads part size.
+    bm: usize,  // q seq len part size.
+    bn: usize,  // k, v seq len part size.
+    bbh: usize, // batch * num_heads part size.
 ) -> Result<(), Error> {
     // Create a context. Device 0 is associated with the context.
     let ctx = CudaContext::new(0)?;
@@ -159,42 +159,43 @@ fn fmha(
     let stream = ctx.new_stream()?;
 
     let seed = 123;
-    let q: Arc<Tensor<f32>> = randn_f32(0f32, 1., [b, h, m, d], Some(seed))
+    let q: Arc<Tensor<f32>> = randn(0f32, 1., [b, h, m, d], Some(seed))
         .sync_on(&stream)?
         .into();
-    let k: Arc<Tensor<f32>> = randn_f32(0f32, 1., [b, hkv, m, d], Some(seed))
+    let k: Arc<Tensor<f32>> = randn(0f32, 1., [b, hkv, m, d], Some(seed))
         .sync_on(&stream)?
         .into();
-    let v: Arc<Tensor<f32>> = randn_f32(0f32, 1., [b, hkv, m, d], Some(seed))
+    let v: Arc<Tensor<f32>> = randn(0f32, 1., [b, hkv, m, d], Some(seed))
         .sync_on(&stream)?
         .into();
     // launch grid = (b*h, m/bm, 1)
-    let out: Partition<Tensor<f32>> = zeros([b * h, m, d])
+    let out: Partition<Tensor<f32>> = zeros(&[b * h, m, d])
         .sync_on(&stream)?
-        .partition([bbh, bm, d as i32]);
+        .partition([bbh, bm, d]);
     assert_eq!(out.grid()?, ((b * h) as u32, (m / bm as usize) as u32, 1));
 
-    let qk_scale = 1.0 / f32::sqrt(q.shape[3] as f32);
+    let qk_scale = 1.0 / f32::sqrt(q.shape()[3] as f32);
 
     // This is always 1.
-    let num_heads = q.shape[1];
-    let kv_num_heads = k.shape[1];
+    let num_heads = q.shape()[1];
+    let kv_num_heads = k.shape()[1];
     assert_eq!(num_heads % kv_num_heads, 0);
     let query_group_size = num_heads / kv_num_heads;
 
     let generics = vec![bm.to_string(), bn.to_string(), d.to_string()];
-    let (_, _, _, out, _, _) = fmha_kernel(
+    let out_vec: Vec<f32> = fmha_kernel(
+        out,
         q.clone(),
         k.clone(),
         v.clone(),
-        out,
         qk_scale,
         query_group_size,
     )
     .generics(generics)
+    .first()
+    .unpartition()
+    .to_host_vec()
     .sync_on(&stream)?;
-
-    let out_vec: Vec<f32> = out.unpartition().to_host_vec().sync_on(&stream)?;
     let q_host: Vec<f32> = q.to_host_vec().sync_on(&stream)?;
     let k_host: Vec<f32> = k.to_host_vec().sync_on(&stream)?;
     let v_host: Vec<f32> = v.to_host_vec().sync_on(&stream)?;

--- a/cutile-examples/examples/flash_attention_causal.rs
+++ b/cutile-examples/examples/flash_attention_causal.rs
@@ -4,10 +4,10 @@
  */
 extern crate core;
 
-use cuda_async::device_operation::DeviceOperation;
+use cuda_async::device_operation::DeviceOp;
 use cuda_core::CudaContext;
 use cutile;
-use cutile::api::{randn_f32, zeros};
+use cutile::api::{randn, zeros};
 use cutile::error::Error;
 use cutile::tensor::{IntoPartition, Partition, Tensor, ToHostVec};
 use cutile::tile_kernel::TileKernel;
@@ -31,10 +31,10 @@ mod my_module {
         const CAUSAL: i32,
         const EVEN_K: i32,
     >(
+        out: &mut Tensor<f32, { [1, BM, D] }>, // (b*h, m, d)
         q: &Tensor<f32, { [-1, -1, -1, -1] }>, // (b, h, m, d)
         k: &Tensor<f32, { [-1, -1, -1, -1] }>, // (b, hkv, n, d)
         v: &Tensor<f32, { [-1, -1, -1, -1] }>, // (b, hkv, n, d)
-        out: &mut Tensor<f32, { [1, BM, D] }>, // (b*h, m, d)
         qk_scale: f32,
         input_pos: i32,
         query_group_size: i32,
@@ -217,25 +217,25 @@ fn run_attention_fmha(causal: bool) -> Result<(), Error> {
     let stream = ctx.new_stream()?;
 
     let (batch, heads, heads_kv, seq_len, head_dim) = (2usize, 8usize, 8usize, 64usize, 32usize);
-    let (bm, bn) = (32i32, 32i32);
-    let bbh = 1i32;
+    let (bm, bn) = (32, 32);
+    let bbh = 1usize;
     let input_pos = if causal { 5i32 } else { 0i32 };
     let even_k = seq_len as i32 % bn == 0;
     let qk_scale = 1.0 / f32::sqrt(head_dim as f32);
     let query_group_size = (heads / heads_kv) as i32;
 
-    let q: Arc<Tensor<f32>> = randn_f32(0.0, 1.0, [batch, heads, seq_len, head_dim], Some(7))
+    let q: Arc<Tensor<f32>> = randn(0.0, 1.0, [batch, heads, seq_len, head_dim], Some(7))
         .sync_on(&stream)?
         .into();
-    let k: Arc<Tensor<f32>> = randn_f32(0.0, 1.0, [batch, heads_kv, seq_len, head_dim], Some(11))
+    let k: Arc<Tensor<f32>> = randn(0.0, 1.0, [batch, heads_kv, seq_len, head_dim], Some(11))
         .sync_on(&stream)?
         .into();
-    let v: Arc<Tensor<f32>> = randn_f32(0.0, 1.0, [batch, heads_kv, seq_len, head_dim], Some(13))
+    let v: Arc<Tensor<f32>> = randn(0.0, 1.0, [batch, heads_kv, seq_len, head_dim], Some(13))
         .sync_on(&stream)?
         .into();
-    let out: Partition<Tensor<f32>> = zeros([batch * heads, seq_len, head_dim])
+    let out: Partition<Tensor<f32>> = zeros(&[batch * heads, seq_len, head_dim])
         .sync_on(&stream)?
-        .partition([bbh, bm, head_dim as i32]);
+        .partition([bbh, bm, head_dim]);
 
     let generics = vec![
         bm.to_string(),
@@ -246,11 +246,11 @@ fn run_attention_fmha(causal: bool) -> Result<(), Error> {
         (even_k as i32).to_string(),
     ];
 
-    let (_, _, _, out, _, _, _): (_, _, _, Partition<Tensor<f32>>, _, _, _) = fmha(
+    let (out, _, _, _, _, _, _) = fmha(
+        out,
         q.clone(),
         k.clone(),
         v.clone(),
-        out,
         qk_scale,
         input_pos,
         query_group_size,

--- a/cutile-examples/examples/gemm.rs
+++ b/cutile-examples/examples/gemm.rs
@@ -11,6 +11,7 @@ use cutile::tensor::*;
 use cutile::tile_kernel::*;
 use cutile::DType;
 use my_module::gemm as gemm_kernel;
+use std::sync::Arc;
 
 #[cutile::module]
 mod my_module {
@@ -53,9 +54,9 @@ fn gemm<T: DType + std::fmt::Display>() -> Result<(), Error> {
         bk.to_string(),
         k.to_string(),
     ];
-    let z = api::zeros([m, n]).partition([bm, bn]).sync_on(&stream)?;
-    let x = api::ones([m, k]).arc().sync_on(&stream)?;
-    let y = api::ones([k, n]).arc().sync_on(&stream)?;
+    let z = api::zeros(&[m, n]).partition([bm, bn]).sync_on(&stream)?;
+    let x: Arc<Tensor<T>> = api::ones(&[m, k]).sync_on(&stream)?.into();
+    let y: Arc<Tensor<T>> = api::ones(&[k, n]).sync_on(&stream)?.into();
     let launcher = gemm_kernel(z, x.clone(), y.clone());
     let (z, _x, _y) = launcher.generics(generics.clone()).sync_on(&stream)?;
     let z_host: Vec<T> = z.unpartition().to_host_vec().sync_on(&stream)?;

--- a/cutile-examples/examples/gemm_static.rs
+++ b/cutile-examples/examples/gemm_static.rs
@@ -11,6 +11,7 @@ use cutile::tensor::*;
 use cutile::tile_kernel::*;
 use cutile::DType;
 use my_module::gemm as gemm_kernel;
+use std::sync::Arc;
 
 #[cutile::module]
 mod my_module {
@@ -64,14 +65,14 @@ fn gemm<T: DType + std::fmt::Display>() -> Result<(), Error> {
         n.to_string(),
         k.to_string(),
     ];
-    let z = api::zeros([m, n]).partition([bm, bn]).sync_on(&stream)?;
-    let x = api::ones([m, k]).arc().sync_on(&stream)?;
-    let y = api::ones([k, n]).arc().sync_on(&stream)?;
+    let z = api::zeros(&[m, n]).partition([bm, bn]).sync_on(&stream)?;
+    let x: Arc<Tensor<T>> = api::ones(&[m, k]).sync_on(&stream)?.into();
+    let y: Arc<Tensor<T>> = api::ones(&[k, n]).sync_on(&stream)?.into();
     println!(
         "Everything created. x size(mb)={}, y size(mb)={}, z size(mb)={}",
-        x.num_mb(),
-        y.num_mb(),
-        z.num_mb()
+        x.num_bytes() / 1_000_000,
+        y.num_bytes() / 1_000_000,
+        z.num_bytes() / 1_000_000
     );
     let grid = z.grid()?;
     let (z, _x, _y) = gemm_kernel(z, x, y)

--- a/cutile-examples/examples/hello_world.rs
+++ b/cutile-examples/examples/hello_world.rs
@@ -4,7 +4,7 @@
  */
 #![allow(unused_variables)]
 
-use cuda_async::device_operation::DeviceOperation;
+use cuda_async::device_operation::DeviceOp;
 use cuda_core::CudaContext;
 use cutile;
 use cutile::error::Error;

--- a/cutile-examples/examples/interop.rs
+++ b/cutile-examples/examples/interop.rs
@@ -12,16 +12,15 @@
 //! Shows:
 //!   - Loading a kernel from inline PTX via `load_module_from_ptx`
 //!   - Launching with `AsyncKernelLaunch` (`push_arg` / `push_device_ptr`)
-//!   - Wrapping a custom kernel in a `DeviceOperation` struct for a safe call-site
+//!   - Wrapping a custom kernel in a `DeviceOp` struct for a safe call-site
 //!   - Chaining tile and custom kernels on the same stream with `and_then`
 
 use cuda_async::device_context::{load_module_from_ptx, with_default_device_policy};
 use cuda_async::device_future::DeviceFuture;
-use cuda_async::device_operation::DeviceOperation;
+use cuda_async::device_operation::DeviceOp;
 use cuda_async::device_operation::ExecutionContext;
 use cuda_async::error::DeviceError;
 use cuda_async::launch::AsyncKernelLaunch;
-use cuda_async::scheduling_policies::SchedulingPolicy;
 use cuda_core::{CudaFunction, LaunchConfig};
 use cutile::api::{arange, zeros};
 use cutile::tensor::{IntoPartition, Tensor, ToHostVec};
@@ -101,7 +100,7 @@ $done:
 ";
 
 // ---------------------------------------------------------------------------
-// Safe DeviceOperation wrapper for the custom scale kernel.
+// Safe DeviceOp wrapper for the custom scale kernel.
 //
 // The struct's typed fields enforce the correct argument signature.  `unsafe`
 // is confined to the `execute` implementation where device pointers are
@@ -116,7 +115,7 @@ struct ScaleKernel {
     output: Tensor<f32>,
 }
 
-impl DeviceOperation for ScaleKernel {
+impl DeviceOp for ScaleKernel {
     type Output = (Arc<Tensor<f32>>, Tensor<f32>);
 
     // Safety: execute is unsafe because it enqueues work on a CUDA stream
@@ -126,7 +125,7 @@ impl DeviceOperation for ScaleKernel {
     unsafe fn execute(
         self,
         ctx: &ExecutionContext,
-    ) -> Result<<Self as DeviceOperation>::Output, DeviceError> {
+    ) -> Result<<Self as DeviceOp>::Output, DeviceError> {
         let mut launcher = AsyncKernelLaunch::new(self.function);
         launcher.push_arg(self.n);
         launcher.push_arg(self.scale);
@@ -137,8 +136,8 @@ impl DeviceOperation for ScaleKernel {
         // The kernel accesses elements 0..n, each at byte offset gid * 4, so both allocations are large enough.
         unsafe {
             launcher
-                .push_device_ptr(self.input.cu_deviceptr())
-                .push_device_ptr(self.output.cu_deviceptr());
+                .push_device_ptr(self.input.device_pointer().cu_deviceptr())
+                .push_device_ptr(self.output.device_pointer().cu_deviceptr());
         }
         launcher.set_launch_config(LaunchConfig {
             grid_dim: (self.n.div_ceil(256), 1, 1),
@@ -156,7 +155,10 @@ impl IntoFuture for ScaleKernel {
     type Output = Result<(Arc<Tensor<f32>>, Tensor<f32>), DeviceError>;
     type IntoFuture = DeviceFuture<(Arc<Tensor<f32>>, Tensor<f32>), ScaleKernel>;
     fn into_future(self) -> Self::IntoFuture {
-        match with_default_device_policy(|policy| policy.schedule(self)) {
+        match with_default_device_policy(|policy| {
+            let stream = policy.next_stream()?;
+            Ok(DeviceFuture::scheduled(self, ExecutionContext::new(stream)))
+        }) {
             Ok(Ok(future)) => future,
             Ok(Err(e)) | Err(e) => DeviceFuture::failed(e),
         }
@@ -170,7 +172,7 @@ impl IntoFuture for ScaleKernel {
 #[tokio::main()]
 async fn main() -> Result<(), cutile::error::Error> {
     let num_elements = 2usize.pow(5);
-    let tile_size = 4i32;
+    let tile_size = 4usize;
     let scale = 3.0f32;
     let device_id = 0;
 
@@ -179,16 +181,16 @@ async fn main() -> Result<(), cutile::error::Error> {
     let scale_function = Arc::new(module.load_function("scale_f32")?);
 
     // Step 2: Allocate input tensors.
-    let x: Arc<Tensor<f32>> = arange(num_elements).arc().await?;
-    let y: Arc<Tensor<f32>> = arange(num_elements).arc().await?;
-    let z: Tensor<f32> = zeros::<1, f32>([num_elements]).await?;
+    let x: Arc<Tensor<f32>> = arange(num_elements).await?.into();
+    let y: Arc<Tensor<f32>> = arange(num_elements).await?.into();
+    let z: Tensor<f32> = zeros::<f32>(&[num_elements]).await?;
 
     // Step 3: Run tile add kernel — z = x + y.
     let (z_part, _x, _y) = tile_add::add(z.partition([tile_size]), x.clone(), y.clone()).await?;
     let z: Tensor<f32> = z_part.unpartition();
 
     // Step 4: Run custom scale kernel — w = scale * z.
-    let w: Tensor<f32> = zeros::<1, f32>([num_elements]).await?;
+    let w: Tensor<f32> = zeros::<f32>(&[num_elements]).await?;
     let (_z, w) = ScaleKernel {
         function: scale_function,
         n: num_elements as u32,

--- a/cutile-examples/examples/rms_norm.rs
+++ b/cutile-examples/examples/rms_norm.rs
@@ -2,10 +2,10 @@
  * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-use cuda_async::device_operation::DeviceOperation;
+use cuda_async::device_operation::DeviceOp;
 use cuda_core::CudaContext;
 use cutile;
-use cutile::api::{randn_f32, zeros};
+use cutile::api::{randn, zeros};
 use cutile::error::Error;
 use cutile::tensor::{IntoPartition, Partition, Tensor, ToHostVec};
 use cutile::tile_kernel::TileKernel;
@@ -72,9 +72,9 @@ fn main() -> Result<(), Error> {
     let block_size = 2;
     let generics = vec![n.to_string(), block_size.to_string()];
     let eps: f32 = 1e-8; // A sufficiently small number.
-    let x: Arc<Tensor<f32>> = randn_f32(0.0, 1.0, [m, n], None).sync_on(&stream)?.into();
-    let w: Arc<Tensor<f32>> = randn_f32(0.0, 1.0, [n], None).sync_on(&stream)?.into();
-    let out: Partition<Tensor<f32>> = zeros([m, n]).sync_on(&stream)?.partition([1, n as i32]);
+    let x: Arc<Tensor<f32>> = randn(0.0, 1.0, [m, n], None).sync_on(&stream)?.into();
+    let w: Arc<Tensor<f32>> = randn(0.0, 1.0, [n], None).sync_on(&stream)?.into();
+    let out: Partition<Tensor<f32>> = zeros(&[m, n]).sync_on(&stream)?.partition([1, n]);
     let (_x, _w, out, _eps) = rms_norm(x, w, out, eps)
         .generics(generics)
         .sync_on(&stream)?;

--- a/cutile-examples/examples/saxpy.rs
+++ b/cutile-examples/examples/saxpy.rs
@@ -2,20 +2,14 @@
  * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-use cuda_core::CudaContext;
-use cutile;
-use cutile::api::arange;
-use cutile::error::Error;
-use cutile::tensor::{IntoPartition, Tensor, ToHostVec};
-use cutile::tile_kernel::DeviceOperation;
-use std::sync::Arc;
+use cutile::prelude::*;
 
 #[cutile::module]
 mod my_module {
     use cutile::core::*;
 
     #[cutile::entry()]
-    fn saxpy<const S: [i32; 2]>(a: f32, x: &Tensor<f32, { [-1, -1] }>, y: &mut Tensor<f32, S>) {
+    fn saxpy<const S: [i32; 2]>(y: &mut Tensor<f32, S>, a: f32, x: &Tensor<f32, { [-1, -1] }>) {
         let tile_a = a.broadcast(y.shape());
         let tile_x = load_tile_like_2d(x, y);
         let tile_y = y.load();
@@ -32,11 +26,24 @@ fn main() -> Result<(), Error> {
     // Create a new stream on which we run CUDA operations.
     let stream = ctx.new_stream()?;
     let a = 2.0;
-    let input: Arc<Tensor<f32>> = arange(2usize.pow(5)).sync_on(&stream)?.into();
-    let x = input.copy_sync(&stream)?.reshape([4, 8]).into();
-    let y = input.copy_sync(&stream)?.reshape([4, 8]).partition([2, 2]);
-    let (a, _x, y) = saxpy(a, x, y).sync_on(&stream)?;
-    let y_host: Vec<f32> = y.unpartition().to_host_vec().sync_on(&stream)?;
+    let input: Arc<Tensor<f32>> = api::arange(2usize.pow(5)).sync_on(&stream)?.into();
+    let x: Arc<Tensor<f32>> = input
+        .dup()
+        .sync_on(&stream)?
+        .reshape(&[4, 8])
+        .unwrap()
+        .into();
+    let y = input
+        .dup()
+        .sync_on(&stream)?
+        .reshape(&[4, 8])
+        .unwrap()
+        .partition([2, 2]);
+    let y_host: Vec<f32> = saxpy(y, a, x)
+        .first()
+        .unpartition()
+        .to_host_vec()
+        .sync_on(&stream)?;
     let input_host: Vec<f32> = input.to_host_vec().sync_on(&stream)?;
     for i in 0..input_host.len() {
         let x_i: f32 = input_host[i];

--- a/cutile-examples/examples/scale_ptr.rs
+++ b/cutile-examples/examples/scale_ptr.rs
@@ -72,7 +72,7 @@ async fn main() -> Result<(), cutile::error::Error> {
     let scale = 3.0f32;
 
     let input: Tensor<f32> = arange(len).await?;
-    let output: Tensor<f32> = zeros([len]).await?;
+    let output: Tensor<f32> = zeros(&[len]).await?;
 
     let out_ptr = output.device_pointer();
     let in_ptr = input.device_pointer();

--- a/cutile-examples/examples/softmax.rs
+++ b/cutile-examples/examples/softmax.rs
@@ -2,13 +2,7 @@
  * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-use cuda_async::device_operation::DeviceOperation;
-use cuda_core::CudaContext;
-use cutile;
-use cutile::api::arange;
-use cutile::error::Error;
-use cutile::tensor::{IntoPartition, Tensor, ToHostVec};
-use std::sync::Arc;
+use cutile::prelude::*;
 
 #[cutile::module]
 mod my_module {
@@ -16,8 +10,8 @@ mod my_module {
 
     #[cutile::entry()]
     fn softmax<const BM: i32, const BN: i32>(
-        x: &Tensor<f32, { [-1, -1] }>,
         y: &mut Tensor<f32, { [BM, BN] }>,
+        x: &Tensor<f32, { [-1, -1] }>,
     ) {
         let tile_x: Tile<f32, { [BM, BN] }> = load_tile_like_2d(x, y);
         let tile_x_max: Tile<f32, { [BM] }> = reduce_max(tile_x, 1i32);
@@ -39,15 +33,25 @@ fn main() -> Result<(), Error> {
     // Create a new stream on which we run CUDA operations.
     let stream = ctx.new_stream()?;
     let (m, n) = (4, 8);
-    let (bm, bn) = (2, n as i32);
-    let input: Arc<Tensor<f32>> = arange(m * n).sync_on(&stream)?.into();
-    let x = input.copy_sync(&stream)?.reshape([m, n]).into();
+    let (bm, bn) = (2, n);
+    let input: Arc<Tensor<f32>> = api::arange(m * n).sync_on(&stream)?.into();
+    let x: Arc<Tensor<f32>> = input
+        .dup()
+        .sync_on(&stream)?
+        .reshape(&[m, n])
+        .unwrap()
+        .into();
     let y = input
-        .copy_sync(&stream)?
-        .reshape([m, n])
+        .dup()
+        .sync_on(&stream)?
+        .reshape(&[m, n])
+        .unwrap()
         .partition([bm, bn]);
-    let (_x, y) = softmax(x, y).sync_on(&stream)?;
-    let y_host: Vec<f32> = y.unpartition().to_host_vec().sync_on(&stream)?;
+    let y_host: Vec<f32> = softmax(y, x)
+        .first()
+        .unpartition()
+        .to_host_vec()
+        .sync_on(&stream)?;
     for i in (0..y_host.len()).step_by(8) {
         let x = y_host[i..i + 8].to_vec();
         let sum: f32 = x.iter().sum();

--- a/cutile-examples/examples/tensor_permute.rs
+++ b/cutile-examples/examples/tensor_permute.rs
@@ -4,10 +4,11 @@
  */
 extern crate core;
 
-use cuda_async::device_operation::DeviceOperation;
+use cuda_async::device_operation::DeviceOp;
 use cuda_core::CudaContext;
 use cutile;
-use cutile::api::{arange, zeros, DeviceOperationReshape};
+use cutile::api::DeviceOpReshape;
+use cutile::api::{arange, zeros};
 use cutile::error::Error;
 use cutile::tensor::{IntoPartition, Partition, Tensor, ToHostVec};
 use cutile::tile_kernel::TileKernel;
@@ -84,16 +85,12 @@ fn main() -> Result<(), Error> {
     let dim_map = [0, 1, 3, 2];
 
     let bbh = partition[dim_map[0]] * partition[dim_map[1]];
-    let partition_shape_rank3 = [
-        bbh as i32,
-        partition[dim_map[2]] as i32,
-        partition[dim_map[3]] as i32,
-    ];
+    let partition_shape_rank3 = [bbh, partition[dim_map[2]], partition[dim_map[3]]];
     let src: Arc<Tensor<f32>> = arange(b * h * m * d)
-        .reshape([b, h, m, d])
+        .reshape(&[b, h, m, d])
         .sync_on(&stream)?
         .into();
-    let dst: Partition<Tensor<f32>> = zeros([b * h, d, m])
+    let dst: Partition<Tensor<f32>> = zeros(&[b * h, d, m])
         .sync_on(&stream)?
         .partition(partition_shape_rank3);
 
@@ -104,7 +101,7 @@ fn main() -> Result<(), Error> {
         .collect();
     generics.insert(0, "f32".to_string());
     let grid = dst.grid();
-    println!("in shape = {:?}", src.shape);
+    println!("in shape = {:?}", src.shape());
     println!("in tile = {:?}", partition);
     println!("out shape = {:?}", [b * h, d, m]);
     println!("out tile = {:?}", partition_shape_rank3);

--- a/cutile-macro/src/_module.rs
+++ b/cutile-macro/src/_module.rs
@@ -51,7 +51,7 @@
 //! For each `#[entry]` function, launchers are generated that:
 //! - Compiles the kernel to CUDA
 //! - Manages kernel invocation
-//! - Support direct calls and `.apply(...)` composition
+//! - Support direct calls with `IntoDeviceOp` arguments
 //! - Provides type-safe parameter passing
 
 use convert_case::{Case, Casing};
@@ -171,9 +171,10 @@ pub fn get_asts_ident() -> Ident {
 ///     fn __cutile_user_impl_my_kernel(...) { ... }
 ///
 ///     // Kernel launchers (for #[entry] functions)
-///     pub fn my_kernel(...) -> impl DeviceOperation { ... }
-///     pub fn my_kernel_op(...) -> impl DeviceOperation { ... }
-///     pub fn my_kernel_apply(...) -> impl DeviceOperation { ... }
+///     pub fn my_kernel<_K0: KernelInput<T>, ...>(...) -> MyKernel<T, _K0, DI>
+///         // unified launcher — accepts Tensor<T>, Arc<Tensor<T>>, &Tensor<T>
+///     pub fn my_kernel_apply(...) -> MyKernel<T, Arc<Tensor<T>>, DI>
+///         // internal tuple-input variant (used by api.rs)
 /// }
 /// ```
 // TODO (hme): Prevent reserved names from being used.
@@ -333,6 +334,7 @@ fn module_inner(
                 use #tile_rust_crate_root::error::{*};
                 use #tile_rust_crate_root::DType;
                 use #tile_rust_crate_root::{tensor};
+                use #tile_rust_crate_root::tensor::{KernelInput, KernelInputStored, KernelOutput, KernelOutputStored};
                 use #tile_rust_crate_root::tile_kernel::{*};
                 use #tile_rust_crate_root::cuda_async::error::{*};
                 use #tile_rust_crate_root::cuda_async::scheduling_policies::SchedulingPolicy;
@@ -607,7 +609,7 @@ pub fn function(mut item: ItemFn, tile_rust_crate_root: &Ident) -> Result<TokenS
 
 /// Generates the complete kernel launcher struct and implementations.
 ///
-/// Creates a launcher struct that implements `TileKernel`, `DeviceOperation`, and
+/// Creates a launcher struct that implements `TileKernel`, `DeviceOp`, and
 /// `IntoFuture` for a kernel entry point. This enables the ergonomic launcher API
 /// for launching GPU kernels.
 ///
@@ -621,7 +623,7 @@ pub fn function(mut item: ItemFn, tile_rust_crate_root: &Ident) -> Result<TokenS
 /// Token stream containing:
 /// 1. The launcher struct definition (e.g., `pub struct MyKernel<T, DI> { ... }`)
 /// 2. `TileKernel` impl (provides `.grid()`, `.const_grid()`, `.generics()` methods)
-/// 3. `DeviceOperation` impl (provides `.execute()` for actual kernel launch)
+/// 3. `DeviceOp` impl (provides `.execute()` for actual kernel launch)
 /// 4. `IntoFuture` impl (enables `.await` syntax)
 ///
 /// ## Generated API
@@ -645,53 +647,89 @@ pub fn kernel_launcher(module_ident: &Ident, item: &ItemFn) -> Result<TokenStrea
     let launcher_args_name = format!("{}Args", launcher_name);
     let unsafety = item.sig.unsafety;
 
-    let (required_generics, (launcher_args_type, launcher_type_def), device_op_impl) =
-        generate_kernel_launcher(
-            item,
-            &module_name,
-            &function_name,
-            function_entry_name.as_str(),
-            &launcher_name,
-            &launcher_args_name,
-        )?;
+    let (
+        required_generics,
+        (stored_args_type, returned_args_type),
+        device_op_impl,
+        kernel_input_info,
+    ) = generate_kernel_launcher(
+        item,
+        &module_name,
+        &function_name,
+        function_entry_name.as_str(),
+        &launcher_name,
+        &launcher_args_name,
+    )?;
 
     let launcher_ident = Ident::new(launcher_name.as_str(), Span::call_site());
-    let _launcher_args_ident = Ident::new(launcher_args_name.as_str(), Span::call_site());
 
     let generic_params = required_generics.get_required_generics();
     let generic_args = required_generics.get_generic_args();
 
-    let device_op_param: GenericParam =
-        parse_quote! { DI: DeviceOperation<Output=#launcher_args_type> };
-    let device_op_arg: GenericArgument = parse_quote! { DI };
-
-    // Struct
+    // Build struct generics: kernel params + _K: KernelInput + _P: KernelOutput + DI
     let mut struct_generics = generic_params.clone();
+    for (ki_idx, ki_name) in kernel_input_info.type_param_names.iter().enumerate() {
+        let elem = &kernel_input_info.element_type_names[ki_idx];
+        struct_generics.params.push(
+            syn::parse_str::<GenericParam>(&format!("{ki_name}: KernelInput<{elem}>")).unwrap(),
+        );
+    }
+    for (ko_idx, ko_name) in kernel_input_info.ko_type_param_names.iter().enumerate() {
+        let elem = &kernel_input_info.ko_element_type_names[ko_idx];
+        struct_generics.params.push(
+            syn::parse_str::<GenericParam>(&format!("{ko_name}: KernelOutput<{elem}>")).unwrap(),
+        );
+    }
+    let device_op_param: GenericParam = parse_quote! { DI: DeviceOp<Output=#stored_args_type> };
     struct_generics.params.push(device_op_param.clone());
+
     let mut struct_args = generic_args.clone();
+    for ki_name in &kernel_input_info.type_param_names {
+        struct_args
+            .args
+            .push(syn::parse_str::<GenericArgument>(ki_name).unwrap());
+    }
+    for ko_name in &kernel_input_info.ko_type_param_names {
+        struct_args
+            .args
+            .push(syn::parse_str::<GenericArgument>(ko_name).unwrap());
+    }
+    let device_op_arg: GenericArgument = parse_quote! { DI };
     struct_args.args.push(device_op_arg.clone());
 
     // impl TileKernel
     let tile_kernel_impl_type_params = struct_generics.clone();
     let tile_kernel_type_args: AngleBracketedGenericArguments =
-        parse_quote! { <#launcher_args_type, #device_op_arg> };
-
-    // impl DeviceOperation
-    let _device_operation_impl_type_params = struct_generics.clone();
+        parse_quote! { <#returned_args_type, #device_op_arg, #stored_args_type> };
 
     // impl IntoFuture
     let into_future_impl_type_params = struct_generics.clone();
 
+    // Build PhantomData to consume KernelInput type params and kernel type params.
+    let mut phantom_types: Vec<syn::Type> = vec![];
+    for ki_name in &kernel_input_info.type_param_names {
+        phantom_types.push(syn::parse_str::<syn::Type>(ki_name.as_str()).unwrap());
+    }
+    for ko_name in &kernel_input_info.ko_type_param_names {
+        phantom_types.push(syn::parse_str::<syn::Type>(ko_name.as_str()).unwrap());
+    }
+    // Also include kernel type params (T, SrcType, etc.) that may not appear
+    // directly in the struct fields now that arg types use KernelInput associated types.
+    for param in &generic_params.params {
+        if let syn::GenericParam::Type(tp) = param {
+            phantom_types.push(syn::parse_str::<syn::Type>(&tp.ident.to_string()).unwrap());
+        }
+    }
+    let ki_phantom_types = phantom_types;
+
     let result = quote! {
 
-        #launcher_type_def
-
-        #[derive(Debug)]
         pub struct #launcher_ident #struct_generics {
             _const_grid: bool,
             _grid: (u32, u32, u32),
             input: Option<DI>,
             function_generics: Option<Vec<String>>,
+            _phantom: std::marker::PhantomData<( #(#ki_phantom_types,)* )>,
             _compile_options: CompileOptions,
         }
 
@@ -702,12 +740,12 @@ pub fn kernel_launcher(module_ident: &Ident, item: &ItemFn) -> Result<TokenStrea
                     _grid: (0, 0, 0),
                     input: Some(input),
                     function_generics: None,
+                    _phantom: std::marker::PhantomData,
                     _compile_options: CompileOptions::default(),
                 }
             }
         }
 
-        // TileKernel impl provides things like the compile method.
         impl #tile_kernel_impl_type_params TileKernel #tile_kernel_type_args for #launcher_ident #struct_args {
             fn grid(mut self, grid: (u32, u32, u32)) -> Self {
                 self._grid = grid;
@@ -731,12 +769,11 @@ pub fn kernel_launcher(module_ident: &Ident, item: &ItemFn) -> Result<TokenStrea
                 self
             }
         }
-        // Easily convert into a future.
         impl #into_future_impl_type_params IntoFuture for #launcher_ident #struct_args {
-            type Output = Result<#launcher_args_type, DeviceError>;
-            type IntoFuture = DeviceFuture<#launcher_args_type, #launcher_ident #struct_args>;
+            type Output = Result<#returned_args_type, DeviceError>;
+            type IntoFuture = DeviceFuture<#returned_args_type, #launcher_ident #struct_args>;
             fn into_future(self) -> Self::IntoFuture {
-                match with_default_device_policy(|policy| policy.schedule(self)) {
+                match with_default_device_policy(|policy| { let stream = policy.next_stream()?; Ok(DeviceFuture::scheduled(self, ExecutionContext::new(stream))) }) {
                     Ok(Ok(future)) => future,
                     Ok(Err(e)) => DeviceFuture::failed(e),
                     Err(e) => DeviceFuture::failed(e),
@@ -744,7 +781,7 @@ pub fn kernel_launcher(module_ident: &Ident, item: &ItemFn) -> Result<TokenStrea
             }
         }
 
-        // Implements DeviceOperation, along with the generated launcher functions.
+        // Implements DeviceOp, along with the generated launcher functions.
         #device_op_impl
     };
 

--- a/cutile-macro/src/kernel_launcher_generator.rs
+++ b/cutile-macro/src/kernel_launcher_generator.rs
@@ -5,7 +5,7 @@
 //! Kernel launcher generation.
 //!
 //! This module generates launcher functions for GPU kernel entry points
-//! with support for direct invocation and `.apply(...)`-based composition.
+//! with support for direct invocation via `IntoDeviceOp` arguments.
 //! These launchers provide a type-safe interface for invoking
 //! CUDA Tile kernels from Rust code.
 //!
@@ -14,8 +14,8 @@
 //! For each function marked with `#[cutile::entry]`, this module generates:
 //!
 //! - an unsuffixed launcher for materialized arguments
-//! - an `_apply` helper for `.apply(...)` composition
-//! - an internal helper for `DeviceOperation` arguments
+//! - auto-wraps Tensor→Arc for &Tensor params via IntoDeviceOp
+//! - an internal helper for `DeviceOp` arguments
 //!
 //! Together these helpers:
 //!
@@ -39,20 +39,20 @@
 //! pub fn my_kernel<T: Send + DType>(
 //!     output: Partition<Tensor<T>>,
 //!     input: Arc<Tensor<T>>,
-//! ) -> impl DeviceOperation<Output=(Partition<Tensor<T>>, Arc<Tensor<T>>)> + TileKernel<...> {
+//! ) -> impl DeviceOp<Output=(Partition<Tensor<T>>, Arc<Tensor<T>>)> + TileKernel<...> {
 //!     // Wraps materialized values and delegates to my_kernel_op
 //! }
 //!
 //! pub fn my_kernel_op<T: Send + DType>(
-//!     output: impl DeviceOperation<Output = Partition<Tensor<T>>>,
-//!     input: impl DeviceOperation<Output = Arc<Tensor<T>>>,
-//! ) -> impl DeviceOperation<Output=(Partition<Tensor<T>>, Arc<Tensor<T>>)> + TileKernel<...> {
+//!     output: impl DeviceOp<Output = Partition<Tensor<T>>>,
+//!     input: impl DeviceOp<Output = Arc<Tensor<T>>>,
+//! ) -> impl DeviceOp<Output=(Partition<Tensor<T>>, Arc<Tensor<T>>)> + TileKernel<...> {
 //!     // Launches from separate lazy arguments
 //! }
 //!
-//! pub fn my_kernel_apply<T: Send + DType>(
+//! // (_apply no longer generated)<T: Send + DType>(
 //!     inputs: (Partition<Tensor<T>>, Arc<Tensor<T>>),
-//! ) -> impl DeviceOperation<Output=(Partition<Tensor<T>>, Arc<Tensor<T>>)> + TileKernel<...> {
+//! ) -> impl DeviceOp<Output=(Partition<Tensor<T>>, Arc<Tensor<T>>)> + TileKernel<...> {
 //!     // Launches from one grouped lazy argument tuple
 //! }
 //! ```
@@ -69,9 +69,13 @@
 //!
 //! Kernel parameters are transformed for the launcher:
 //!
-//! - `&mut Tensor<T, S>` → `Partition<Tensor<T>>` (mutable, partitioned)
-//! - `&Tensor<T, S>` → `Arc<Tensor<T>>` (immutable, shared)
+//! - `&mut Tensor<T, S>` → `impl KernelOutput<T>` (accepts `Partition<Tensor<T>>` or `Partition<&mut Tensor<T>>`)
+//! - `&Tensor<T, S>` → `impl KernelInput<T>` (accepts `Tensor<T>`, `Arc<Tensor<T>>`, or `&Tensor<T>`)
+//! - `*mut T` → `DevicePointer<T>` (unsafe only)
 //! - Scalars remain unchanged
+//!
+//! Both `&Tensor` and `&mut Tensor` params return the same type that was passed in
+//! via `KernelInput::recover` / `KernelOutput::recover`.
 //!
 //! ## Grid Inference
 //!
@@ -319,7 +323,7 @@ pub fn zip_cons(inputs: &[String], var_name: &str, wrap_as_val: bool) -> ExprBlo
 /// For inputs `["a", "b", "c"]`, generates code equivalent to:
 /// ```rust,ignore
 /// let result = zip!(a, zip!(b, c));
-/// let result = result.and_then(|(a, (b, c))| value((a, b, c)));
+/// let result = result.then(|(a, (b, c))| value((a, b, c)));
 /// ```
 pub fn zip_and_then_flatten(inputs: &[String], var_name: &str, wrap_as_val: bool) -> ExprBlock {
     let mut zip_block = syn::parse2::<ExprBlock>(quote! {{
@@ -346,7 +350,7 @@ pub fn zip_and_then_flatten(inputs: &[String], var_name: &str, wrap_as_val: bool
     }
     zip_block.block.stmts.push(parse_stmt(format!(
         r#"
-            let {var_name} = {var_name}.and_then(|{}| {{
+            let {var_name} = {var_name}.then(|{}| {{
                 value({})
             }});
         "#,
@@ -444,9 +448,9 @@ pub fn to_tuple_string(args: &[String]) -> String {
 /// This is the main function that transforms a kernel function (marked with `#[entry]`)
 /// into launcher helpers that can be called from Rust code. It generates:
 /// 1. Type aliases for kernel arguments
-/// 2. A launcher struct implementing `DeviceOperation`
+/// 2. A launcher struct implementing `DeviceOp`
 /// 3. A direct launcher for materialized arguments
-/// 4. An `_apply` helper for `.apply(...)` composition
+/// 4. Auto-wraps Tensor→Arc for &Tensor params
 ///
 /// ## Parameters
 ///
@@ -472,7 +476,7 @@ pub fn to_tuple_string(args: &[String]) -> String {
 /// pub struct MyKernel<T> {
 ///     args: MyKernelArgs<T>,
 /// }
-/// impl<T: DType> DeviceOperation for MyKernel<T> {
+/// impl<T: DType> DeviceOp for MyKernel<T> {
 ///     type Output = ();
 ///     unsafe fn execute(mut self, ctx: &ExecutionContext) -> Self::Output {
 ///         // Kernel launch logic here
@@ -485,13 +489,21 @@ pub fn generate_kernel_launcher(
     function_name: &str,
     function_entry_name: &str,
     launcher_name: &str,
-    launcher_args_name: &str,
-) -> Result<(RequiredGenerics, (Type, TokenStream2), TokenStream2), Error> {
+    _launcher_args_name: &str,
+) -> Result<
+    (
+        RequiredGenerics,
+        (Type, Type),
+        TokenStream2,
+        KernelInputInfo,
+    ),
+    Error,
+> {
     let unsafety = item.sig.unsafety;
     let is_unsafe = unsafety.is_some();
     let launcher_ident = Ident::new(launcher_name, Span::call_site());
     let mut launcher_method = syn::parse2::<ImplItemFn>(quote! {
-        unsafe fn execute(mut self, ctx: &ExecutionContext) -> Result<<Self as DeviceOperation>::Output, DeviceError> {}
+        unsafe fn execute(mut self, ctx: &ExecutionContext) -> Result<<Self as DeviceOp>::Output, DeviceError> {}
     })
     .unwrap();
 
@@ -504,18 +516,17 @@ pub fn generate_kernel_launcher(
     let mut launch_grid_expr_strs = vec![];
     let mut validator_statements = vec![];
     let mut arg_types: Vec<Type> = vec![];
+    // Track element type per param (Some for &Tensor params, None for others).
+    let mut param_element_types: Vec<Option<String>> = vec![];
 
     let mut required_generics: RequiredGenerics = RequiredGenerics::new(&item.sig.generics);
-    // println!("required_generics: {}", required_generics.get_required_generics().to_token_stream().to_string());
     for (i, ty) in input_types.iter().enumerate() {
         let var_name = &param_names[i];
-        // Currently only supporting scalars, &Tensor, and &mut Tensor.
-        // This should be enough to do everything safely.
-        // Added support for * mut T to allow for unsafe kernels.
         match ty {
             Type::Reference(ref_ty) => {
                 let res = get_tensor_code(i, var_name, ref_ty, &mut required_generics)?;
                 arg_types.push(res.fn_arg.ty.as_ref().clone());
+                param_element_types.push(res.element_type_name);
                 stride_args.push(res.stride_expr_str);
                 builder_statements.extend(res.builder_statements);
                 launch_grid_expr_strs.extend(res.launch_grid_expr_strs);
@@ -536,6 +547,7 @@ pub fn generate_kernel_launcher(
                     );
                 }
                 builder_statements.push(parse_stmt(format!("kernel_launch.push_arg({var_name});")));
+                param_element_types.push(None);
             }
             Type::Ptr(ptr_type) => {
                 // Let's require this to be unsafe, even though all unsafe operations on pointers
@@ -568,6 +580,7 @@ pub fn generate_kernel_launcher(
                 builder_statements.push(parse_stmt(format!(
                     "unsafe {{ kernel_launch.push_device_ptr({var_name}.cu_deviceptr()); }}"
                 )));
+                param_element_types.push(None);
             }
             _ => {
                 return ty.err("Unable to generate launcher: unsupported parameter type.");
@@ -575,23 +588,197 @@ pub fn generate_kernel_launcher(
         }
     }
 
+    // Build KernelInput metadata: which params are &Tensor (Arc) and need
+    // KernelInput type params on the launcher struct.
+    let mut ki_type_param_names: Vec<String> = vec![];
+    let mut ki_element_type_names: Vec<String> = vec![];
+    let mut ki_param_idx: Vec<Option<usize>> = vec![];
+    // Build KernelOutput metadata: which params are &mut Tensor (Partition).
+    let mut ko_type_param_names: Vec<String> = vec![];
+    let mut ko_element_type_names: Vec<String> = vec![];
+    let mut ko_param_idx: Vec<Option<usize>> = vec![];
+    for (i, ty) in arg_types.iter().enumerate() {
+        let ty_str = ty.to_token_stream().to_string();
+        if ty_str.starts_with("Arc <") {
+            let idx = ki_type_param_names.len();
+            ki_type_param_names.push(format!("_K{}", idx));
+            ki_element_type_names.push(
+                param_element_types[i]
+                    .clone()
+                    .expect("&Tensor param must have element type"),
+            );
+            ki_param_idx.push(Some(idx));
+            ko_param_idx.push(None);
+        } else if ty_str.contains("Partition") {
+            let idx = ko_type_param_names.len();
+            ko_type_param_names.push(format!("_P{}", idx));
+            // Extract element type from "tensor :: Partition < tensor :: Tensor < T > >"
+            let elem = ty_str
+                .split("Tensor <")
+                .nth(1)
+                .and_then(|s| s.split('>').next())
+                .map(|s| s.trim().to_string())
+                .expect("Partition param must have element type");
+            ko_element_type_names.push(elem);
+            ko_param_idx.push(Some(idx));
+            ki_param_idx.push(None);
+        } else {
+            ki_param_idx.push(None);
+            ko_param_idx.push(None);
+        }
+    }
+    // Build the recovered return tuple expression:
+    // KernelInput params call recover, KernelOutput params call recover, others pass through.
+    let recovered_fields: Vec<String> = param_names
+        .iter()
+        .enumerate()
+        .map(|(i, name)| {
+            if let Some(ki_idx) = ki_param_idx[i] {
+                let ki_name = &ki_type_param_names[ki_idx];
+                let elem = &ki_element_type_names[ki_idx];
+                format!("<{ki_name} as KernelInput<{elem}>>::recover({name})")
+            } else if let Some(ko_idx) = ko_param_idx[i] {
+                let ko_name = &ko_type_param_names[ko_idx];
+                let elem = &ko_element_type_names[ko_idx];
+                format!("<{ko_name} as KernelOutput<{elem}>>::recover({name})")
+            } else {
+                name.clone()
+            }
+        })
+        .collect();
+    let recovered_tuple_str = to_tuple_string(&recovered_fields);
+    let kernel_input_info = KernelInputInfo {
+        type_param_names: ki_type_param_names,
+        element_type_names: ki_element_type_names,
+        param_kernel_input_idx: ki_param_idx.clone(),
+        ko_type_param_names: ko_type_param_names.clone(),
+        ko_element_type_names: ko_element_type_names.clone(),
+        param_kernel_output_idx: ko_param_idx.clone(),
+        recovered_tuple_str: recovered_tuple_str.clone(),
+    };
+
+    // Build stored and returned arg type lists for KernelInput parameterization.
+    // Stored types are what DI produces and execute() receives.
+    // Returned types are what execute() returns after calling recover.
+    let ki_info = &kernel_input_info;
+    let stored_arg_types: Vec<Type> = arg_types
+        .iter()
+        .enumerate()
+        .map(|(i, ty)| {
+            if let Some(ki_idx) = ki_info.param_kernel_input_idx[i] {
+                let ki_name = &ki_info.type_param_names[ki_idx];
+                let elem = &ki_info.element_type_names[ki_idx];
+                syn::parse_str::<Type>(&format!("<{ki_name} as KernelInput<{elem}>>::Stored"))
+                    .unwrap()
+            } else if let Some(ko_idx) = ki_info.param_kernel_output_idx[i] {
+                let ko_name = &ki_info.ko_type_param_names[ko_idx];
+                let elem = &ki_info.ko_element_type_names[ko_idx];
+                syn::parse_str::<Type>(&format!("<{ko_name} as KernelOutput<{elem}>>::Stored"))
+                    .unwrap()
+            } else {
+                ty.clone()
+            }
+        })
+        .collect();
+    let returned_arg_types: Vec<Type> = arg_types
+        .iter()
+        .enumerate()
+        .map(|(i, ty)| {
+            if let Some(ki_idx) = ki_info.param_kernel_input_idx[i] {
+                let ki_name = &ki_info.type_param_names[ki_idx];
+                let elem = &ki_info.element_type_names[ki_idx];
+                syn::parse_str::<Type>(&format!("<{ki_name} as KernelInput<{elem}>>::Returned"))
+                    .unwrap()
+            } else if let Some(ko_idx) = ki_info.param_kernel_output_idx[i] {
+                let ko_name = &ki_info.ko_type_param_names[ko_idx];
+                let elem = &ki_info.ko_element_type_names[ko_idx];
+                syn::parse_str::<Type>(&format!("<{ko_name} as KernelOutput<{elem}>>::Returned"))
+                    .unwrap()
+            } else {
+                ty.clone()
+            }
+        })
+        .collect();
+
+    // Build inline tuple types (no type alias — simpler with associated types).
+    let stored_args_type: Type = parse_quote! { ( #(#stored_arg_types,)* ) };
+    let returned_args_type: Type = parse_quote! { ( #(#returned_arg_types,)* ) };
+    let stored_args_type_str = stored_args_type.to_token_stream().to_string();
+
     // Prepare generics.
     let generic_params = required_generics.get_required_generics();
     let generic_args = required_generics.get_generic_args();
-    let (launcher_args_type, launcher_arg_type_def) =
-        generate_launcher_arg_types(&generic_args, &arg_types, launcher_name, launcher_args_name);
-    let launcher_args_type_str = launcher_args_type.to_token_stream().to_string();
-    let device_op_param: GenericParam =
-        parse_quote! { DI: DeviceOperation<Output=#launcher_args_type> };
-    let device_op_arg: GenericArgument = parse_quote! { DI };
+
+    // Add KernelInput (_K) and KernelOutput (_P) type params to struct generics.
     let mut struct_generics = generic_params.clone();
+    for (ki_idx, ki_name) in ki_info.type_param_names.iter().enumerate() {
+        let elem = &ki_info.element_type_names[ki_idx];
+        struct_generics.params.push(
+            syn::parse_str::<GenericParam>(&format!("{ki_name}: KernelInput<{elem}>")).unwrap(),
+        );
+    }
+    for (ko_idx, ko_name) in ki_info.ko_type_param_names.iter().enumerate() {
+        let elem = &ki_info.ko_element_type_names[ko_idx];
+        struct_generics.params.push(
+            syn::parse_str::<GenericParam>(&format!("{ko_name}: KernelOutput<{elem}>")).unwrap(),
+        );
+    }
+    let device_op_param: GenericParam = parse_quote! { DI: DeviceOp<Output=#stored_args_type> };
     struct_generics.params.push(device_op_param.clone());
+
     let mut struct_args = generic_args.clone();
+    for ki_name in &ki_info.type_param_names {
+        struct_args
+            .args
+            .push(syn::parse_str::<GenericArgument>(ki_name).unwrap());
+    }
+    for ko_name in &ki_info.ko_type_param_names {
+        struct_args
+            .args
+            .push(syn::parse_str::<GenericArgument>(ko_name).unwrap());
+    }
+    let device_op_arg: GenericArgument = parse_quote! { DI };
     struct_args.args.push(device_op_arg.clone());
+
+    // Build stored_args_type using _S/_Q names for the unified launcher's context.
+    let launcher_stored_arg_types: Vec<Type> = arg_types
+        .iter()
+        .enumerate()
+        .map(|(i, ty)| {
+            if let Some(ki_idx) = ki_info.param_kernel_input_idx[i] {
+                let elem = &ki_info.element_type_names[ki_idx];
+                syn::parse_str::<Type>(&format!("<_S{i} as KernelInput<{elem}>>::Stored")).unwrap()
+            } else if let Some(ko_idx) = ki_info.param_kernel_output_idx[i] {
+                let elem = &ki_info.ko_element_type_names[ko_idx];
+                syn::parse_str::<Type>(&format!("<_Q{i} as KernelOutput<{elem}>>::Stored")).unwrap()
+            } else {
+                ty.clone()
+            }
+        })
+        .collect();
+    let launcher_stored_args_type: Type = parse_quote! { ( #(#launcher_stored_arg_types,)* ) };
+
+    // launch_output_type is used for the unified launcher's return type.
     let mut launch_output_type = generic_args.clone();
+    for (i, is_arc) in ki_param_idx.iter().enumerate() {
+        if is_arc.is_some() {
+            launch_output_type
+                .args
+                .push(syn::parse_str::<GenericArgument>(&format!("_S{}", i)).unwrap());
+        }
+    }
+    for (i, is_part) in ko_param_idx.iter().enumerate() {
+        if is_part.is_some() {
+            launch_output_type
+                .args
+                .push(syn::parse_str::<GenericArgument>(&format!("_Q{}", i)).unwrap());
+        }
+    }
     let impl_device_op: GenericArgument =
-        parse_quote! { impl DeviceOperation<Output=#launcher_args_type> };
+        parse_quote! { impl DeviceOp<Output=#launcher_stored_args_type> };
     launch_output_type.args.push(impl_device_op);
+
+    // ── execute() method body ───────────────────────────────────────────────
 
     let init_stmts = syn::parse2::<ExprBlock>(quote! {{
         let module_name = #module_name;
@@ -604,7 +791,7 @@ pub fn generate_kernel_launcher(
     .stmts;
     launcher_method.block.stmts.extend(init_stmts);
     launcher_method.block.stmts.push(parse_stmt(format!(
-        r#"let {param_names_tuple_str}: {launcher_args_type_str} = input.execute(ctx)?;"#
+        r#"let {param_names_tuple_str}: {stored_args_type_str} = input.execute(ctx)?;"#
     )));
 
     if !required_generics.names.is_empty() {
@@ -638,7 +825,6 @@ pub fn generate_kernel_launcher(
             function_generics, stride_args, const_grid,
             compile_options
         )?;
-        // Do validation here.
     }})
     .unwrap()
     .block
@@ -646,20 +832,17 @@ pub fn generate_kernel_launcher(
     launcher_method.block.stmts.extend(compile_stmts);
     launcher_method.block.stmts.extend(validator_statements);
 
-    // Add launcher arguments.
     launcher_method.block.stmts.push(parse_stmt(
         "let mut kernel_launch = AsyncKernelLaunch::new(function.clone());".to_string(),
     ));
     launcher_method.block.stmts.extend(builder_statements);
 
-    // Infer launch grid.
     launcher_method.block.stmts.push(parse_stmt(format!(
         "let launch_grid: (u32, u32, u32) = self.infer_launch_grid(&[{}])?;",
         launch_grid_expr_strs.join(",")
     )));
 
     let launch_stmts = syn::parse2::<ExprBlock>(quote! {{
-        // Launch the kernel. This is the same for all functions.
         kernel_launch
             .set_launch_config(LaunchConfig {
                 grid_dim: launch_grid,
@@ -672,116 +855,221 @@ pub fn generate_kernel_launcher(
     .block
     .stmts;
     launcher_method.block.stmts.extend(launch_stmts);
-    launcher_method.block.stmts.push(parse_stmt(format!(
-        r#"return Ok({param_names_tuple_str});"#
-    )));
+    // Return with KernelInput::recover applied to each &Tensor param.
+    launcher_method
+        .block
+        .stmts
+        .push(parse_stmt(format!(r#"return Ok({recovered_tuple_str});"#)));
 
-    // Generate launcher apply function. This is the simplest case.
-    let kernel_return_type = quote! {
-        #launcher_ident #launch_output_type
-    };
+    // ── _apply launcher (used internally by api.rs) ───────────────────────
+    // Takes a concrete tuple with Arc<Tensor<T>> for &Tensor params.
+    // Specialized: _K = Arc<Tensor<T>> for all KernelInput params.
+
     let kernel_naming = KernelNaming::new(function_name);
+    let concrete_args_type: Type = parse_quote! { ( #(#arg_types,)* ) };
+
+    // Build launch_output_type specialized with Arc for _apply.
+    let mut apply_launch_output_type = generic_args.clone();
+    for ki_name in &ki_info.type_param_names {
+        // Find the corresponding Arc<Tensor<T>> type for this _K param.
+        let ki_idx_in_types = ki_info
+            .param_kernel_input_idx
+            .iter()
+            .enumerate()
+            .find(|(_, idx)| {
+                idx.map(|k| ki_info.type_param_names[k] == *ki_name)
+                    .unwrap_or(false)
+            })
+            .map(|(i, _)| i)
+            .unwrap();
+        let arc_type = &arg_types[ki_idx_in_types];
+        apply_launch_output_type.args.push(
+            syn::parse_str::<GenericArgument>(&arc_type.to_token_stream().to_string()).unwrap(),
+        );
+    }
+    // Also specialize _P = Partition<Tensor<T>> for _apply.
+    for ko_name in &ki_info.ko_type_param_names {
+        let ko_idx_in_types = ki_info
+            .param_kernel_output_idx
+            .iter()
+            .enumerate()
+            .find(|(_, idx)| {
+                idx.map(|k| ki_info.ko_type_param_names[k] == *ko_name)
+                    .unwrap_or(false)
+            })
+            .map(|(i, _)| i)
+            .unwrap();
+        let part_type = &arg_types[ko_idx_in_types];
+        apply_launch_output_type.args.push(
+            syn::parse_str::<GenericArgument>(&part_type.to_token_stream().to_string()).unwrap(),
+        );
+    }
+    let apply_impl_device_op: GenericArgument =
+        parse_quote! { impl DeviceOp<Output=#concrete_args_type> };
+    apply_launch_output_type.args.push(apply_impl_device_op);
+
+    let apply_return_type = quote! { #launcher_ident #apply_launch_output_type };
     let apply_name = kernel_naming.apply_name();
     let launcher_apply_ident = Ident::new(apply_name.as_str(), Span::call_site());
     let launcher_apply = syn::parse2::<ItemFn>(quote! {
-        pub #unsafety fn #launcher_apply_ident #generic_params (input: #launcher_args_type) -> #kernel_return_type {
+        pub #unsafety fn #launcher_apply_ident #generic_params (input: #concrete_args_type) -> #apply_return_type {
             return #launcher_ident::launch(value(input));
         }
     })
     .unwrap();
 
-    // These are the type aliases generated for the argument types for this kernel function.
+    // ── Unified launcher (the primary public entry point) ───────────────────
+
+    let kernel_return_type = quote! { #launcher_ident #launch_output_type };
+
     let arg_aliases = arg_types
         .iter()
         .map(|i| i.to_token_stream().to_string())
         .collect::<Vec<_>>();
 
-    // Generate internal op-based launcher. Uses the apply function and operates on
-    // a flat tuple of `DeviceOperation` arguments.
-    let op_name = kernel_naming.device_op_helper_name();
-    let launcher_op_ident = Ident::new(op_name.as_str(), Span::call_site());
-    let mut launcher_op = syn::parse2::<ItemFn>(quote! {
-        pub #unsafety fn #launcher_op_ident #generic_params() -> #kernel_return_type {}
-    })
-    .unwrap();
-    let mut function_params = vec![];
-    launcher_op.sig.generics.make_where_clause();
-    for (i, _arg_ty) in arg_types.iter().enumerate() {
-        let function_param = format!("arg{}", i);
-        let type_param = format!("DI{}", i);
-        let type_bound = format!("DeviceOperation<Output={}>", arg_aliases[i]);
-        launcher_op.sig.inputs.push(FnArg::Typed(
-            syn::parse2::<PatType>(
-                format!("{}: {}", function_param, type_param)
-                    .parse()
-                    .unwrap(),
-            )
-            .unwrap(),
-        ));
-        launcher_op.sig.generics.params.push(GenericParam::Type(
-            syn::parse2::<TypeParam>(type_param.parse().unwrap()).unwrap(),
-        ));
-        let where_clause = launcher_op
-            .sig
-            .generics
-            .where_clause
-            .as_mut()
-            .expect("Impossible.");
-        where_clause.predicates.push(
-            syn::parse2::<WherePredicate>(
-                format!("{}: {}", type_param, type_bound).parse().unwrap(),
-            )
-            .unwrap(),
-        );
-        function_params.push(function_param);
-    }
-    let input_zips = zip_and_then_flatten(&function_params, "input", false);
-    launcher_op.block.stmts.extend(input_zips.block.stmts);
-    launcher_op.block.stmts.push(parse_stmt(format!(
-        "return {}::launch(input);",
-        launcher_ident
-    )));
-
-    // Generate the public launcher that accepts materialized arguments.
     let launcher_direct_ident = Ident::new(kernel_naming.public_name(), Span::call_site());
     let mut launcher_direct = syn::parse2::<ItemFn>(quote! {
         pub #unsafety fn #launcher_direct_ident #generic_params() -> #kernel_return_type {}
     })
     .unwrap();
+    launcher_direct.sig.generics.make_where_clause();
+    let mut function_params = vec![];
+    let mut is_arc_param = vec![];
     for (i, _arg_ty) in arg_types.iter().enumerate() {
-        let function_param = &function_params[i];
-        let type_param = &arg_aliases[i];
+        let function_param = format!("arg{}", i);
+        let type_param_name = format!("_A{}", i);
+        let arg_type_str = &arg_aliases[i];
+        let is_arc = arg_type_str.starts_with("Arc <");
+        is_arc_param.push(is_arc);
+
         launcher_direct.sig.inputs.push(FnArg::Typed(
             syn::parse2::<PatType>(
-                format!("{}: {}", function_param, type_param)
+                format!("{}: {}", function_param, type_param_name)
                     .parse()
                     .unwrap(),
             )
             .unwrap(),
         ));
-    }
-    let return_op = format!(
-        "return {op_name}({});",
-        function_params
-            .iter()
-            .map(|var| zippable(var, true))
-            .collect::<Vec<String>>()
-            .join(", ")
-    );
 
-    launcher_direct.block.stmts.push(parse_stmt(return_op));
+        let where_clause = launcher_direct
+            .sig
+            .generics
+            .where_clause
+            .as_mut()
+            .expect("Impossible.");
+
+        if is_arc {
+            // KernelInput bound: accepts Tensor<T>, Arc<Tensor<T>>, or &Tensor<T>.
+            let intermediate_type = format!("_S{}", i);
+            launcher_direct.sig.generics.params.push(GenericParam::Type(
+                syn::parse2::<TypeParam>(type_param_name.parse().unwrap()).unwrap(),
+            ));
+            launcher_direct.sig.generics.params.push(GenericParam::Type(
+                syn::parse2::<TypeParam>(intermediate_type.parse().unwrap()).unwrap(),
+            ));
+            where_clause.predicates.push(
+                syn::parse2::<WherePredicate>(
+                    format!("{}: IntoDeviceOp<{}>", type_param_name, intermediate_type)
+                        .parse()
+                        .unwrap(),
+                )
+                .unwrap(),
+            );
+            let ki_idx = ki_param_idx[i].unwrap();
+            let elem = &ki_info.element_type_names[ki_idx];
+            where_clause.predicates.push(
+                syn::parse2::<WherePredicate>(
+                    format!("{}: KernelInput<{}>", intermediate_type, elem)
+                        .parse()
+                        .unwrap(),
+                )
+                .unwrap(),
+            );
+        } else if ko_param_idx[i].is_some() {
+            // KernelOutput bound: accepts Partition<Tensor<T>> or Partition<&mut Tensor<T>>.
+            let intermediate_type = format!("_Q{}", i);
+            launcher_direct.sig.generics.params.push(GenericParam::Type(
+                syn::parse2::<TypeParam>(type_param_name.parse().unwrap()).unwrap(),
+            ));
+            launcher_direct.sig.generics.params.push(GenericParam::Type(
+                syn::parse2::<TypeParam>(intermediate_type.parse().unwrap()).unwrap(),
+            ));
+            where_clause.predicates.push(
+                syn::parse2::<WherePredicate>(
+                    format!("{}: IntoDeviceOp<{}>", type_param_name, intermediate_type)
+                        .parse()
+                        .unwrap(),
+                )
+                .unwrap(),
+            );
+            let ko_idx = ko_param_idx[i].unwrap();
+            let elem = &ki_info.ko_element_type_names[ko_idx];
+            where_clause.predicates.push(
+                syn::parse2::<WherePredicate>(
+                    format!("{}: KernelOutput<{}>", intermediate_type, elem)
+                        .parse()
+                        .unwrap(),
+                )
+                .unwrap(),
+            );
+        } else {
+            // Scalars: direct IntoDeviceOp bound.
+            launcher_direct.sig.generics.params.push(GenericParam::Type(
+                syn::parse2::<TypeParam>(type_param_name.parse().unwrap()).unwrap(),
+            ));
+            where_clause.predicates.push(
+                syn::parse2::<WherePredicate>(
+                    format!("{}: IntoDeviceOp<{}>", type_param_name, arg_type_str)
+                        .parse()
+                        .unwrap(),
+                )
+                .unwrap(),
+            );
+        }
+        function_params.push(function_param);
+    }
+    // Convert each arg into a DeviceOp, applying KernelInput::prepare for
+    // &Tensor params and KernelOutput::prepare for &mut Tensor params.
+    let mut di_var_names: Vec<String> = vec![];
+    for (i, var) in function_params.iter().enumerate() {
+        let di_var = format!("_di{}", i);
+        if is_arc_param[i] {
+            launcher_direct.block.stmts.push(parse_stmt(format!(
+                "let {di_var} = {var}.into_op().map(KernelInput::prepare);"
+            )));
+        } else if ko_param_idx[i].is_some() {
+            launcher_direct.block.stmts.push(parse_stmt(format!(
+                "let {di_var} = {var}.into_op().map(KernelOutput::prepare);"
+            )));
+        } else {
+            launcher_direct
+                .block
+                .stmts
+                .push(parse_stmt(format!("let {di_var} = {var}.into_op();")));
+        }
+        di_var_names.push(di_var);
+    }
+    let input_zips = zip_and_then_flatten(&di_var_names, "input", false);
+    launcher_direct.block.stmts.extend(input_zips.block.stmts);
+    launcher_direct.block.stmts.push(parse_stmt(format!(
+        "return {}::launch(input);",
+        launcher_ident
+    )));
+
+    let returned_args_type_2 = returned_args_type.clone();
     Ok((
         required_generics,
-        (launcher_args_type.clone(), launcher_arg_type_def),
+        (stored_args_type, returned_args_type),
         quote! {
-            impl #struct_generics DeviceOperation for #launcher_ident #struct_args {
-                type Output = #launcher_args_type;
+            impl #struct_generics DeviceOp for #launcher_ident #struct_args {
+                type Output = #returned_args_type_2;
                 #launcher_method
             }
+            impl #struct_generics GraphNode for #launcher_ident #struct_args {}
             #launcher_apply
-            #launcher_op
             #launcher_direct
         },
+        kernel_input_info,
     ))
 }
 
@@ -822,6 +1110,25 @@ fn parse_expr(s: String) -> Expr {
     syn::parse::<Expr>(s.parse().unwrap()).unwrap()
 }
 
+/// Metadata about KernelInput params for the struct definition in _module.rs.
+pub struct KernelInputInfo {
+    /// Names of the KernelInput type params, e.g., ["_K0", "_K1"].
+    pub type_param_names: Vec<String>,
+    /// Element type name for each KernelInput param, e.g., ["T", "SrcType"].
+    pub element_type_names: Vec<String>,
+    /// For each param in the args tuple, the index into type_param_names (if it's
+    /// a KernelInput param), or None (if it's a partition/scalar).
+    pub param_kernel_input_idx: Vec<Option<usize>>,
+    /// Names of the KernelOutput type params, e.g., ["_P0", "_P1"].
+    pub ko_type_param_names: Vec<String>,
+    /// Element type name for each KernelOutput param.
+    pub ko_element_type_names: Vec<String>,
+    /// For each param, the index into ko_type_param_names (if partition).
+    pub param_kernel_output_idx: Vec<Option<usize>>,
+    /// The "recovered" return expression with both KernelInput and KernelOutput recover calls.
+    pub recovered_tuple_str: String,
+}
+
 /// Code generation result for a tensor kernel parameter.
 ///
 /// Contains all the generated code components needed for a single tensor
@@ -839,6 +1146,8 @@ struct TensorLaunchCode {
     builder_statements: Vec<Stmt>,
     launch_grid_expr_strs: Vec<String>,
     validator_statements: ExprBlock,
+    /// Element type name (e.g., "T", "SrcType", "f32") for &Tensor params.
+    element_type_name: Option<String>,
 }
 
 /// Generates launcher code for a tensor kernel parameter.
@@ -902,27 +1211,20 @@ fn get_tensor_code(
         syn::parse::<PatType>(format!("{var_name}: {tensor_type}").parse().unwrap()).unwrap();
     // Stride expr.
     let stride_expr_str = if ty.mutability.is_some() {
-        // TODO (hme): Re-enable this for const stride?
-        // format!(r#"("{var_name}".to_string(), {var_name}.partition_strides.to_vec())"#)
         format!(
             r#"(
             "{var_name}".to_string(),
-            {{
-                let len = {var_name}.partition_strides.len();
-                let mut res = vec![-1; len];
-                res[len-1] = 1;
-                res
-            }}
+            KernelOutputStored::strides_hint(&{var_name})
         )"#
         )
     } else {
         // TODO (hme): Re-enable this for const stride?
-        // format!(r#"("{var_name}".to_string(), {var_name}.strides.to_vec())"#)
+        // format!(r#"("{var_name}".to_string(), {var_name}.strides().to_vec())"#)
         format!(
             r#"(
         "{var_name}".to_string(),
         {{
-            let len = {var_name}.strides.len();
+            let len = {var_name}.strides().len();
             let mut res = vec![-1; len];
             res[len-1] = 1;
             res
@@ -936,26 +1238,27 @@ fn get_tensor_code(
     let mut builder_statements = vec![];
     let mut launch_grid_expr_strs = vec![];
     let validator_statements = if ty.mutability.is_some() {
-        builder_statements.push(parse_stmt(format!("kernel_launch.push_arg(&{var_name});")));
-        launch_grid_expr_strs.push(format!("{var_name}.grid()?"));
+        builder_statements.push(parse_stmt(format!(
+            "KernelOutputStored::push_kernel_args(&{var_name}, &mut kernel_launch);"
+        )));
+        launch_grid_expr_strs.push(format!("KernelOutputStored::grid(&{var_name})?"));
         syn::parse2::<ExprBlock>(quote! {{
             {
                 let ValidParamType::Tensor(tensor_validator) = &validator.params[#var_idx] else {
                     panic!("Unexpected validator type {:#?}", &validator.params[#var_idx]);
                 };
                 let valid_shape = &tensor_validator.shape;
-                let given_shape = &#var_ident.partition_shape;
+                let given_shape: Vec<i32> = KernelOutputStored::partition_shape_as_i32(&#var_ident);
                 kernel_launch_assert(valid_shape.len() == given_shape.len(),
                     format!("{} rank mismatch: Expected {}, got {}", #var_name, valid_shape.len(), given_shape.len()).as_str())?;
-                kernel_launch_assert(valid_shape == given_shape,
+                kernel_launch_assert(valid_shape == &given_shape,
                     format!("{} partition shape mismatch. Expected {:?}, got {:?}", #var_name, valid_shape, given_shape).as_str())?;
-                // TODO (hme): add validation for strides here too.
             }
         }})
         .unwrap()
     } else {
         builder_statements.push(parse_stmt(format!(
-            "kernel_launch.push_arg_arc(&{var_name});"
+            "KernelInputStored::push_kernel_args(&{var_name}, &mut kernel_launch);"
         )));
 
         syn::parse2::<ExprBlock>(quote! {{
@@ -964,7 +1267,7 @@ fn get_tensor_code(
                     panic!("Unexpected validator type {:#?}", &validator.params[#var_idx]);
                 };
                 let valid_shape = &tensor_validator.shape;
-                let given_shape = &#var_ident.shape;
+                let given_shape = #var_ident.shape();
                 kernel_launch_assert(valid_shape.len() == given_shape.len(),
                     format!("{} rank mismatch: Expected {}, got {}", #var_name, valid_shape.len(), given_shape.len()).as_str())?;
                 let valid_shape_mixed = zip(valid_shape, given_shape).map(|(&expected, &given)|{
@@ -981,12 +1284,18 @@ fn get_tensor_code(
         .unwrap()
     };
 
+    let element_type_name = if ty.mutability.is_none() {
+        Some(dtype.clone())
+    } else {
+        None
+    };
     Ok(TensorLaunchCode {
         fn_arg,
         stride_expr_str,
         builder_statements,
         launch_grid_expr_strs,
         validator_statements,
+        element_type_name,
     })
 }
 
@@ -1037,16 +1346,16 @@ pub fn infer_shape_params_from_tensor_type(
                             .push(last_ident.clone());
                         required_generics.expressions.insert(
                             last_ident.clone(),
-                            Some(format!("vec![{var_name}.dtype().as_str().to_string()]")),
+                            Some(format!("vec![{var_name}.dtype_str().to_string()]")),
                         );
                     }
                     SupportedGenericType::ConstArray => {
                         // This is a CGA type.
                         if is_mutable {
-                            required_generics.expressions.insert(last_ident.clone(), Some(format!("{var_name}.partition_shape.iter().map(|x| x.to_string()).collect::<Vec<String>>()")));
+                            required_generics.expressions.insert(last_ident.clone(), Some(format!("KernelOutputStored::partition_shape_as_i32(&{var_name}).iter().map(|x| x.to_string()).collect::<Vec<String>>()")));
                         } else {
                             // This might make sense for a small tensor.
-                            required_generics.expressions.insert(last_ident.clone(), Some(format!("{var_name}.shape.iter().map(|x| x.to_string()).collect::<Vec<String>>()")));
+                            required_generics.expressions.insert(last_ident.clone(), Some(format!("{var_name}.shape().iter().map(|x| x.to_string()).collect::<Vec<String>>()")));
                         }
                     }
                     SupportedGenericType::ConstScalar => {
@@ -1098,12 +1407,12 @@ pub fn infer_shape_params_from_tensor_type(
                                         }
                                         SupportedGenericType::ConstScalar => {
                                             if is_mutable {
-                                                required_generics.expressions.insert(ident.clone(), Some(format!("vec![{var_name}.partition_shape[{i}].to_string()]")));
+                                                required_generics.expressions.insert(ident.clone(), Some(format!("vec![KernelOutputStored::partition_shape_as_i32(&{var_name})[{i}].to_string()]")));
                                             } else {
                                                 required_generics.expressions.insert(
                                                     ident.clone(),
                                                     Some(format!(
-                                                        "vec![{var_name}.shape[{i}].to_string()]"
+                                                        "vec![{var_name}.shape()[{i}].to_string()]"
                                                     )),
                                                 );
                                             }

--- a/cutile-macro/src/lib.rs
+++ b/cutile-macro/src/lib.rs
@@ -72,7 +72,7 @@
 //! The macro transforms this into:
 //! - An AST builder function for MLIR compilation
 //! - A direct launcher function (`vector_add`)
-//! - An `.apply(...)` helper (`vector_add_apply`)
+//! - A unified launcher that accepts both values and DeviceOps
 //! - Type metadata for shape inference
 //! - Proper handling of generic parameters
 //!
@@ -142,7 +142,7 @@ mod validate_dsl_syntax;
 ///
 /// - MLIR AST builder functions for compilation to CUDA
 /// - Direct launcher functions for host-side execution
-/// - `.apply(...)` helpers for composing existing `DeviceOperation`s
+/// - `Unified launchers accepting `IntoDeviceOp` for each parameter
 /// - Type metadata for shape inference and validation
 ///
 /// ## Basic Usage
@@ -159,9 +159,7 @@ mod validate_dsl_syntax;
 ///     }
 /// }
 ///
-/// // Generated: kernels::my_kernel() direct launcher
-/// // Generated: kernels::my_kernel_op() helper for separate DeviceOperations
-/// // Generated: kernels::my_kernel_apply() composition helper
+/// // Generated: kernels::my_kernel() unified launcher (accepts IntoDeviceOp args)
 /// ```
 ///
 /// ## Attributes
@@ -175,7 +173,6 @@ mod validate_dsl_syntax;
 ///
 /// 1. **AST Builder** - `<function>_ast()` - Builds MLIR representation
 /// 2. **Direct Launcher** - `<function>()` - Wraps materialized values as device operations
-/// 3. **Apply Helper** - `<function>_apply()` - Composition entry point for `.apply(...)`
 /// 4. **Metadata** - Type information for shape inference
 ///
 /// ## See Also

--- a/cutile-macro/src/validate_dsl_syntax.rs
+++ b/cutile-macro/src/validate_dsl_syntax.rs
@@ -124,7 +124,7 @@ pub fn validate_entry_point_parameters(item: &ItemFn) -> Result<(), Error> {
                 if type_name == "Tensor" {
                     ty.err("Tensors cannot be moved into kernel functions. \
                                   &mut Tensor corresponds to a partitioned tensor argument (e.g. x.partition([...])), \
-                                  and &Tensor corresponds to tensor reference argument (e.g. x.arc()).")?;
+                                  and &Tensor corresponds to a tensor reference argument (e.g. Arc::new(x) or x.into()).")?;
                 }
             }
             Type::Ptr(ptr_type) => {

--- a/cutile/src/api.rs
+++ b/cutile/src/api.rs
@@ -5,7 +5,7 @@
 //! High-level API for tensor creation and manipulation.
 //!
 //! This module provides NumPy-like functions for creating and manipulating GPU tensors.
-//! All operations are asynchronous and return [`DeviceOperation`]s that can be `.await`ed.
+//! All operations are asynchronous and return [`DeviceOp`]s that can be `.await`ed.
 //!
 //! ## Overview
 //!
@@ -33,8 +33,6 @@
 //! ### Memory Operations
 //!
 //! - [`copy`] - Copy a tensor to new GPU memory
-//! - [`copy_to_device`] - Copy CPU tensor to GPU
-//! - [`copy_to_host`] - Copy GPU tensor to CPU
 //! - [`copy_device_to_host_vec`] - Copy GPU tensor to CPU Vec
 //!
 //! ## Examples
@@ -47,10 +45,10 @@
 //! #[tokio::main]
 //! async fn main() {
 //!     // Create different types of tensors
-//!     let zeros = api::zeros::<f32>([1024]).await;
-//!     let ones = api::ones::<f32>([512, 512]).await;
+//!     let zeros = api::zeros::<f32>(&[1024]).await;
+//!     let ones = api::ones::<f32>(&[512, 512]).await;
 //!     let range = api::arange::<i32>(100).await;
-//!     let random = api::randn(0.0, 1.0, [256, 256]).await;
+//!     let random = api::randn(0.0, 1.0, [256, 256], None).await;
 //! }
 //! ```
 //!
@@ -60,14 +58,14 @@
 //! use cutile::api;
 //! use std::sync::Arc;
 //!
-//! // Create tensor and wrap in Arc for shared ownership
-//! let x = Arc::new(api::zeros::<f32>([1024]).await);
+//! // Create a tensor
+//! let x: Tensor<f32> = api::zeros(&[1024]).await;
 //!
-//! // Copy to new memory
-//! let y = api::copy(&x).await;
+//! // Duplicate to new memory
+//! let y = api::dup(&x).await;
 //!
 //! // Copy to CPU for inspection
-//! let cpu_data = api::copy_to_host(&x).await;
+//! let cpu_data: Vec<f32> = x.to_host_vec().await;
 //! ```
 //!
 //! ### Composing Operations
@@ -76,9 +74,8 @@
 //! use cutile::api;
 //!
 //! // Operations compose naturally with async/await
-//! let x = api::randn(0.0, 1.0, [1024]).await;
-//! let x_arc = Arc::new(x);
-//! let y = api::copy(&x_arc).await;
+//! let x: Tensor<f32> = api::randn(0.0, 1.0, [1024], None).await;
+//! let y = api::dup(&x).await;
 //! let z = y.partition([128]); // Prepare for kernel
 //! ```
 //!
@@ -86,11 +83,11 @@
 //!
 //! ### Lazy Execution
 //!
-//! All functions return [`DeviceOperation`]s that don't execute immediately:
+//! All functions return [`DeviceOp`]s that don't execute immediately:
 //!
 //! ```rust,ignore
-//! let x = api::zeros([1024]);  // No GPU work yet!
-//! let y = api::ones([1024]);   // Still no GPU work!
+//! let x = api::zeros(&[1024]);  // No GPU work yet!
+//! let y = api::ones(&[1024]);   // Still no GPU work!
 //!
 //! let x = x.await;  // NOW x allocates and fills
 //! let y = y.await;  // NOW y allocates and fills
@@ -106,7 +103,7 @@
 //! Tensor shapes are tracked at compile time where possible:
 //!
 //! ```rust,ignore
-//! let x = api::zeros([256]);           // Shape known at compile time
+//! let x = api::zeros(&[256]);           // Shape known at compile time
 //! let partitioned = x.partition([64]); // Compiler checks 256 % 64 == 0
 //! ```
 //!
@@ -138,14 +135,13 @@
 use crate::kernels::conversion::convert_apply;
 use crate::kernels::creation::{arange_apply, full_apply};
 use crate::tensor::{IntoPartition, Tensor, Unpartition};
+use cuda_async::device_buffer::DeviceBuffer;
 use cuda_async::device_context::with_default_device_policy;
 use cuda_async::device_future::DeviceFuture;
-use cuda_async::device_operation::{
-    value, DeviceOperation, ExecutionContext, Unzippable1, Unzippable2,
-};
+use cuda_async::device_operation::{value, DeviceOp, ExecutionContext, Unzippable1, Unzippable2};
 use cuda_async::error::DeviceError;
-use cuda_async::scheduling_policies::SchedulingPolicy;
-use cuda_core::curand::RNG;
+use cuda_core::curand::{RandNormal, RandUniform, RNG};
+use cuda_core::sys::CUdeviceptr;
 use cuda_core::DType;
 use cuda_core::{malloc_async, memcpy_dtod_async, memcpy_dtoh_async, memcpy_htod_async};
 use half::f16;
@@ -159,35 +155,30 @@ use std::sync::Arc;
 /// This internal type implements the async copy operation that allocates new
 /// GPU memory and copies tensor data device-to-device.
 pub struct CopyDeviceToDevice<T: DType> {
-    tensor: Arc<Tensor<T>>,
+    _storage: Arc<DeviceBuffer>, // keeps source GPU memory alive
+    src_ptr: CUdeviceptr,
+    shape: Vec<i32>,
+    strides: Vec<i32>,
+    num_elements: usize,
+    _dtype: std::marker::PhantomData<T>,
 }
 
-/// Implements the device-to-device copy operation.
-///
-/// Allocates new GPU memory asynchronously and uses `memcpy_dtod_async` for
-/// efficient GPU-to-GPU data transfer.
-impl<T: DType> DeviceOperation for CopyDeviceToDevice<T> {
+impl<T: DType> DeviceOp for CopyDeviceToDevice<T> {
     type Output = Tensor<T>;
 
     unsafe fn execute(
         self,
         ctx: &ExecutionContext,
-    ) -> Result<<Self as DeviceOperation>::Output, DeviceError> {
-        let tensor = self.tensor;
-        let shape = tensor.shape.clone();
-        let strides = tensor.strides.clone();
-        let element_size = std::mem::size_of::<T>();
-        let num_elements = tensor.size();
-        let num_bytes = element_size * num_elements;
-        let src = tensor.cu_deviceptr();
+    ) -> Result<<Self as DeviceOp>::Output, DeviceError> {
+        let num_bytes = self.num_elements * std::mem::size_of::<T>();
         let dst = malloc_async(num_bytes, ctx.get_cuda_stream());
-        memcpy_dtod_async::<T>(dst, src, num_elements, ctx.get_cuda_stream());
+        memcpy_dtod_async::<T>(dst, self.src_ptr, self.num_elements, ctx.get_cuda_stream());
         Ok(Tensor::from_raw_parts(
             dst,
             num_bytes,
             ctx.get_device_id(),
-            shape.clone(),
-            strides.clone(),
+            self.shape,
+            self.strides,
         ))
     }
 }
@@ -196,7 +187,10 @@ impl<T: DType> IntoFuture for CopyDeviceToDevice<T> {
     type Output = Result<Tensor<T>, DeviceError>;
     type IntoFuture = DeviceFuture<Tensor<T>, CopyDeviceToDevice<T>>;
     fn into_future(self) -> Self::IntoFuture {
-        match with_default_device_policy(|policy| policy.schedule(self)) {
+        match with_default_device_policy(|policy| {
+            let stream = policy.next_stream()?;
+            Ok(DeviceFuture::scheduled(self, ExecutionContext::new(stream)))
+        }) {
             Ok(Ok(future)) => future,
             Ok(Err(e)) => DeviceFuture::failed(e),
             Err(e) => DeviceFuture::failed(e),
@@ -215,13 +209,107 @@ impl<T: DType> IntoFuture for CopyDeviceToDevice<T> {
 /// use cutile::api;
 /// use std::sync::Arc;
 ///
-/// let x = Arc::new(api::zeros::<f32>([1024]).await);
-/// let y = api::copy(&x).await;
+/// let x: Tensor<f32> = api::zeros(&[1024]).await;
+/// let y = api::dup(&x).await;
 /// // y is now an independent copy of x
 /// ```
-pub fn copy<T: DType>(tensor: &Arc<Tensor<T>>) -> impl DeviceOperation<Output = Tensor<T>> {
+pub fn dup<T: DType>(tensor: &Tensor<T>) -> impl DeviceOp<Output = Tensor<T>> {
     CopyDeviceToDevice {
-        tensor: tensor.clone(),
+        _storage: tensor.storage.clone(),
+        src_ptr: tensor.cu_deviceptr(),
+        shape: tensor.shape.clone(),
+        strides: tensor.strides.clone(),
+        num_elements: tensor.size(),
+        _dtype: std::marker::PhantomData,
+    }
+}
+
+/// Copy data from `src` into `dst` without transferring ownership of either.
+///
+/// Device-to-device copy into an existing buffer.
+///
+/// Copies the contents of `src` into `dst`. Both must have the same number
+/// of elements. No new GPU memory is allocated.
+///
+/// Accepts any types that deref to `Tensor<T>`: `&Tensor<T>`, `&Arc<Tensor<T>>`,
+/// `Arc<Tensor<T>>`, etc.
+///
+/// # Safety
+///
+/// This function writes to `dst` through its device pointer. The caller
+/// must ensure:
+/// - No other operation reads from `dst` concurrently on a different stream.
+/// - The copy completes (via stream ordering or synchronization) before
+///   `dst` is read.
+///
+/// This is safe when used with [`CudaGraph::update`] (stream ordering
+/// ensures the copy completes before graph launch) and inside
+/// [`CudaGraph::scope`](cuda_async::cuda_graph::CudaGraph::scope)
+/// (capture mode records the copy as a graph node).
+///
+/// ## Panics
+///
+/// Panics if `src` and `dst` have different element counts.
+///
+/// ## Examples
+///
+/// ```rust,ignore
+/// // CUDA graph update pattern:
+/// graph.update(api::memcpy(&mut self.input, &embedding))?;
+///
+/// // Scope capture pattern:
+/// s.record(api::memcpy(&mut input, &bufs.residual))?;
+/// ```
+pub fn memcpy<T: DType>(dst: &mut Tensor<T>, src: &Tensor<T>) -> Memcpy {
+    assert_eq!(
+        src.size(),
+        dst.size(),
+        "memcpy: src length ({}) != dst length ({})",
+        src.size(),
+        dst.size(),
+    );
+    Memcpy {
+        src_ptr: src.cu_deviceptr(),
+        dst_ptr: dst.cu_deviceptr(),
+        len: dst.num_bytes(),
+    }
+}
+
+/// Unsafe variant of [`memcpy`] that accepts `&Tensor` for the destination.
+///
+/// Use this in CUDA graph capture scopes and graph `update()` calls where
+/// the destination is borrowed immutably but written to through the device
+/// pointer during graph replay.
+///
+
+pub struct Memcpy {
+    src_ptr: cuda_core::sys::CUdeviceptr,
+    dst_ptr: cuda_core::sys::CUdeviceptr,
+    len: usize,
+}
+
+impl DeviceOp for Memcpy {
+    type Output = ();
+    unsafe fn execute(self, ctx: &ExecutionContext) -> Result<(), DeviceError> {
+        memcpy_dtod_async::<u8>(self.dst_ptr, self.src_ptr, self.len, ctx.get_cuda_stream());
+        Ok(())
+    }
+}
+
+impl cuda_async::device_operation::GraphNode for Memcpy {}
+
+impl IntoFuture for Memcpy {
+    type Output = Result<(), DeviceError>;
+    type IntoFuture = DeviceFuture<(), Memcpy>;
+    fn into_future(self) -> Self::IntoFuture {
+        match with_default_device_policy(|policy| {
+            let stream = policy.next_stream()?;
+            Ok(DeviceFuture::scheduled(self, ExecutionContext::new(stream)))
+        }) {
+            Ok(Ok(future)) => future,
+            Ok(Err(e)) => DeviceFuture::failed(e),
+            Err(e) => DeviceFuture::failed(e),
+        }
     }
 }
 
@@ -237,13 +325,13 @@ struct CopyDeviceToHostVec<T: DType> {
 ///
 /// Allocates CPU memory and uses `memcpy_dtoh_async` to transfer data,
 /// returning the result as a `Vec<T>` for direct access.
-impl<T: DType> DeviceOperation for CopyDeviceToHostVec<T> {
+impl<T: DType> DeviceOp for CopyDeviceToHostVec<T> {
     type Output = Vec<T>;
 
     unsafe fn execute(
         self,
         ctx: &ExecutionContext,
-    ) -> Result<<Self as DeviceOperation>::Output, DeviceError> {
+    ) -> Result<<Self as DeviceOp>::Output, DeviceError> {
         let cu_deviceptr = self.tensor.cu_deviceptr();
         let size = self.tensor.size();
         let layout = Layout::array::<T>(size).expect("overflow cannot happen");
@@ -257,7 +345,10 @@ impl<T: DType> IntoFuture for CopyDeviceToHostVec<T> {
     type Output = Result<Vec<T>, DeviceError>;
     type IntoFuture = DeviceFuture<Vec<T>, CopyDeviceToHostVec<T>>;
     fn into_future(self) -> Self::IntoFuture {
-        match with_default_device_policy(|policy| policy.schedule(self)) {
+        match with_default_device_policy(|policy| {
+            let stream = policy.next_stream()?;
+            Ok(DeviceFuture::scheduled(self, ExecutionContext::new(stream)))
+        }) {
             Ok(Ok(future)) => future,
             Ok(Err(e)) => DeviceFuture::failed(e),
             Err(e) => DeviceFuture::failed(e),
@@ -280,7 +371,7 @@ impl<T: DType> IntoFuture for CopyDeviceToHostVec<T> {
 /// ```
 pub fn copy_device_to_host_vec<T: DType>(
     tensor: &Arc<Tensor<T>>,
-) -> impl DeviceOperation<Output = Vec<T>> {
+) -> impl DeviceOp<Output = Vec<T>> {
     CopyDeviceToHostVec {
         tensor: tensor.clone(),
     }
@@ -290,13 +381,13 @@ struct CopyHostVecToDevice<T: DType> {
     vec: Arc<Vec<T>>,
 }
 
-impl<T: DType> DeviceOperation for CopyHostVecToDevice<T> {
+impl<T: DType> DeviceOp for CopyHostVecToDevice<T> {
     type Output = Tensor<T>;
 
     unsafe fn execute(
         self,
         ctx: &ExecutionContext,
-    ) -> Result<<Self as DeviceOperation>::Output, DeviceError> {
+    ) -> Result<<Self as DeviceOp>::Output, DeviceError> {
         let vec = self.vec;
         let element_size = std::mem::size_of::<T>();
         let num_elements = vec.len();
@@ -318,7 +409,10 @@ impl<T: DType> IntoFuture for CopyHostVecToDevice<T> {
     type Output = Result<Tensor<T>, DeviceError>;
     type IntoFuture = DeviceFuture<Tensor<T>, CopyHostVecToDevice<T>>;
     fn into_future(self) -> Self::IntoFuture {
-        match with_default_device_policy(|policy| policy.schedule(self)) {
+        match with_default_device_policy(|policy| {
+            let stream = policy.next_stream()?;
+            Ok(DeviceFuture::scheduled(self, ExecutionContext::new(stream)))
+        }) {
             Ok(Ok(future)) => future,
             Ok(Err(e)) => DeviceFuture::failed(e),
             Err(e) => DeviceFuture::failed(e),
@@ -326,9 +420,7 @@ impl<T: DType> IntoFuture for CopyHostVecToDevice<T> {
     }
 }
 
-pub fn copy_host_vec_to_device<T: DType>(
-    vec: &Arc<Vec<T>>,
-) -> impl DeviceOperation<Output = Tensor<T>> {
+pub fn copy_host_vec_to_device<T: DType>(vec: &Arc<Vec<T>>) -> impl DeviceOp<Output = Tensor<T>> {
     CopyHostVecToDevice { vec: vec.clone() }
 }
 
@@ -343,17 +435,15 @@ pub fn copy_host_vec_to_device<T: DType>(
 /// use cutile::api;
 ///
 /// // 1D tensor
-/// let x = api::zeros::<f32>([1024]).await;
+/// let x = api::zeros::<f32>(&[1024]).await;
 ///
 /// // 2D tensor
-/// let matrix = api::zeros::<f32>([512, 512]).await;
+/// let matrix = api::zeros::<f32>(&[512, 512]).await;
 ///
 /// // 3D tensor
-/// let volume = api::zeros::<i32>([64, 64, 64]).await;
+/// let volume = api::zeros::<i32>(&[64, 64, 64]).await;
 /// ```
-pub fn zeros<const RANK: usize, T: DType>(
-    shape: [usize; RANK],
-) -> impl DeviceOperation<Output = Tensor<T>> {
+pub fn zeros<T: DType>(shape: &[usize]) -> impl DeviceOp<Output = Tensor<T>> {
     full(T::zero(), shape)
 }
 
@@ -367,12 +457,10 @@ pub fn zeros<const RANK: usize, T: DType>(
 /// ```rust,ignore
 /// use cutile::api;
 ///
-/// let x = api::ones::<f32>([1024]).await;
-/// let matrix = api::ones::<f16>([256, 256]).await;
+/// let x = api::ones::<f32>(&[1024]).await;
+/// let matrix = api::ones::<f16>(&[256, 256]).await;
 /// ```
-pub fn ones<const RANK: usize, T: DType>(
-    shape: [usize; RANK],
-) -> impl DeviceOperation<Output = Tensor<T>> {
+pub fn ones<T: DType>(shape: &[usize]) -> impl DeviceOp<Output = Tensor<T>> {
     full(T::one(), shape)
 }
 
@@ -387,29 +475,27 @@ pub fn ones<const RANK: usize, T: DType>(
 /// use cutile::api;
 ///
 /// // Fill with a specific value
-/// let x = api::full(3.14f32, [1024]).await;
-/// let matrix = api::full(-1, [128, 128]).await;
+/// let x = api::full(3.14f32, &[1024]).await;
+/// let matrix = api::full(-1, &[128, 128]).await;
 /// ```
-pub fn full<const RANK: usize, T: DType>(
-    val: T,
-    shape: [usize; RANK],
-) -> impl DeviceOperation<Output = Tensor<T>> {
+pub fn full<T: DType>(val: T, shape: &[usize]) -> impl DeviceOp<Output = Tensor<T>> {
+    let shape = shape.to_vec();
     let len = shape.iter().product::<usize>();
-    Tensor::<T>::uninitialized(len).and_then(move |t| {
+    Tensor::<T>::uninitialized(len).then(move |t| {
         // TODO (hme): It's awkward to assume_init this before actually initializing it.
         let partition_size = min(len, 128);
-        let result = unsafe { t.assume_init() }.partition([partition_size as i32]);
-        let (_, res) = value((val, result)).apply(full_apply).unzip();
-        res.unpartition().reshape::<RANK>(shape)
+        let result = unsafe { t.assume_init() }.partition([partition_size]);
+        let (_, res) = value((val, result)).then(full_apply).unzip();
+        res.unpartition().reshape(&shape)
     })
 }
 
-pub fn fill<T: DType>(tensor: Tensor<T>, val: T) -> impl DeviceOperation<Output = Tensor<T>> {
-    value(tensor).and_then(move |t| {
+pub fn fill<T: DType>(tensor: Tensor<T>, val: T) -> impl DeviceOp<Output = Tensor<T>> {
+    value(tensor).then(move |t| {
         let len = t.shape.iter().product::<i32>() as usize;
         let partition_size = min(len, 128);
-        let result = t.partition([partition_size as i32]);
-        let (_, res) = value((val, result)).apply(full_apply).unzip();
+        let result = t.partition([partition_size]);
+        let (_, res) = value((val, result)).then(full_apply).unzip();
         res.unpartition()
     })
 }
@@ -427,11 +513,11 @@ pub fn fill<T: DType>(tensor: Tensor<T>, val: T) -> impl DeviceOperation<Output 
 /// let indices = api::arange::<i32>(100).await; // [0, 1, 2, ..., 99]
 /// let floats = api::arange::<f32>(1000).await;
 /// ```
-pub fn arange<T: DType>(len: usize) -> impl DeviceOperation<Output = Tensor<T>> {
-    Tensor::<T>::uninitialized(len).and_then(move |t| {
+pub fn arange<T: DType>(len: usize) -> impl DeviceOp<Output = Tensor<T>> {
+    Tensor::<T>::uninitialized(len).then(move |t| {
         let partition_size = min(len, 128);
-        let result = unsafe { t.assume_init() }.partition([partition_size as i32]);
-        let res = value((result,)).apply(arange_apply).unzip();
+        let result = unsafe { t.assume_init() }.partition([partition_size]);
+        let res = value((result,)).then(arange_apply).unzip();
         res.0.unpartition()
     })
 }
@@ -450,15 +536,15 @@ pub fn arange<T: DType>(len: usize) -> impl DeviceOperation<Output = Tensor<T>> 
 /// ```
 pub fn convert<FromType: DType, ToType: DType>(
     src: Arc<Tensor<FromType>>,
-) -> impl DeviceOperation<Output = Tensor<ToType>> {
+) -> impl DeviceOp<Output = Tensor<ToType>> {
     let len = src.shape.clone().iter().product::<i32>() as usize;
-    Tensor::<ToType>::uninitialized(len).and_then(move |t| {
+    Tensor::<ToType>::uninitialized(len).then(move |t| {
         let partition_size = min(len, 128);
-        let dst = unsafe { t.assume_init() }.partition([partition_size as i32]);
-        let res = value((src.clone(), dst)).apply(convert_apply).unzip();
+        let dst = unsafe { t.assume_init() }.partition([partition_size]);
+        let res = value((src.clone(), dst)).then(convert_apply).unzip();
         res.1
             .unpartition()
-            .reshape_dyn(src.shape.iter().map(|x| *x as usize).collect::<Vec<_>>())
+            .reshape(&src.shape.iter().map(|x| *x as usize).collect::<Vec<_>>())
     })
 }
 
@@ -473,235 +559,91 @@ pub fn convert<FromType: DType, ToType: DType>(
 /// - `std`: Standard deviation
 /// - `shape`: Tensor shape
 /// - `seed`: Optional random seed for reproducibility
+/// Generates a tensor with values from a normal distribution.
+///
+/// Supports `f32` and `f64` natively via cuRAND. For `f16`, generates `f32`
+/// and converts — use `randn_f16` for that case.
+pub fn randn<T: DType + RandNormal, const RANK: usize>(
+    mean: T,
+    std: T,
+    shape: [usize; RANK],
+    seed: Option<u64>,
+) -> impl DeviceOp<Output = Tensor<T>> {
+    let len = shape.iter().product::<usize>();
+    Tensor::<T>::uninitialized(len).then(move |t| unsafe {
+        let t = t.assume_init();
+        let rng = RNG::new(seed);
+        T::generate_normal(&rng, t.cu_deviceptr(), len, mean, std);
+        value(t.reshape_unchecked(&shape))
+    })
+}
+
+/// Generates a tensor with normally distributed f16 values.
+///
+/// cuRAND doesn't support f16 natively, so this generates f32 and converts.
 pub fn randn_f16<const RANK: usize>(
     mean: f16,
     std: f16,
     shape: [usize; RANK],
     seed: Option<u64>,
-) -> impl DeviceOperation<Output = Tensor<f16>> {
+) -> impl DeviceOp<Output = Tensor<f16>> {
     let len = shape.clone().iter().product::<usize>();
-    randn_f32(mean.to_f32(), std.to_f32(), [len], seed).and_then(move |src_tensor| {
+    randn(mean.to_f32(), std.to_f32(), [len], seed).then(move |src_tensor| {
         let dst = Tensor::<f16>::uninitialized(len);
-        dst.and_then(move |dst_tensor| {
+        dst.then(move |dst_tensor| {
             let partition_size = min(len, 128);
-            let dst = unsafe { dst_tensor.assume_init() }.partition([partition_size as i32]);
+            let dst = unsafe { dst_tensor.assume_init() }.partition([partition_size]);
             let res = value((Arc::new(src_tensor), dst))
-                .apply(convert_apply)
+                .then(convert_apply)
                 .unzip();
-            res.1.unpartition().reshape_dyn(shape.to_vec())
+            res.1.unpartition().reshape(&shape.to_vec())
         })
     })
 }
 
-/// Generates a tensor with values from a normal distribution (f32 version).
+/// Generates a tensor with uniformly distributed random values in [0, 1).
 ///
-/// Uses cuRAND to generate random values directly on the GPU with the specified
-/// mean and standard deviation.
-///
-/// ## Parameters
-///
-/// - `mean`: Mean of the normal distribution
-/// - `std`: Standard deviation
-/// - `shape`: Tensor shape
-/// - `seed`: Optional random seed for reproducibility
-pub fn randn_f32<const RANK: usize>(
-    mean: f32,
-    std: f32,
+/// Supports `f32` and `f64` via cuRAND.
+pub fn rand<T: DType + RandUniform, const RANK: usize>(
     shape: [usize; RANK],
     seed: Option<u64>,
-) -> impl DeviceOperation<Output = Tensor<f32>> {
+) -> impl DeviceOp<Output = Tensor<T>> {
     let len = shape.iter().product::<usize>();
-    Tensor::<f32>::uninitialized(len).and_then(move |t| unsafe {
+    Tensor::<T>::uninitialized(len).then(move |t| unsafe {
         let t = t.assume_init();
         let rng = RNG::new(seed);
-        rng.generate_normal_f32(t.cu_deviceptr(), len, mean, std);
-        value(t.reshape::<RANK>(shape))
-    })
-}
-
-/// Generates a tensor with values from a normal distribution (f64 version).
-///
-/// Uses cuRAND to generate random double-precision values on the GPU.
-///
-/// ## Parameters
-///
-/// - `mean`: Mean of the normal distribution
-/// - `std`: Standard deviation
-/// - `shape`: Tensor shape
-/// - `seed`: Optional random seed for reproducibility
-pub fn randn_f64<const RANK: usize>(
-    mean: f64,
-    std: f64,
-    shape: [usize; RANK],
-    seed: Option<u64>,
-) -> impl DeviceOperation<Output = Tensor<f64>> {
-    let len = shape.iter().product::<usize>();
-    Tensor::<f64>::uninitialized(len).and_then(move |t| unsafe {
-        let t = t.assume_init();
-        let rng = RNG::new(seed);
-        rng.generate_normal_f64(t.cu_deviceptr(), len, mean, std);
-        value(t.reshape::<RANK>(shape))
-    })
-}
-
-/// Generates a tensor with uniformly distributed random values in [0, 1) (f32).
-///
-/// Uses cuRAND to generate uniform random values on the GPU.
-///
-/// ## Parameters
-///
-/// - `shape`: Tensor shape
-/// - `seed`: Optional random seed for reproducibility
-pub fn rand_f32<const RANK: usize>(
-    shape: [usize; RANK],
-    seed: Option<u64>,
-) -> impl DeviceOperation<Output = Tensor<f32>> {
-    let len = shape.iter().product::<usize>();
-    Tensor::<f32>::uninitialized(len).and_then(move |t| unsafe {
-        let t = t.assume_init();
-        let rng = RNG::new(seed);
-        rng.generate_uniform_f32(t.cu_deviceptr(), len);
-        value(t.reshape::<RANK>(shape))
-    })
-}
-
-/// Generates a tensor with uniformly distributed random values in [0, 1) (f64).
-///
-/// Uses cuRAND to generate uniform random double-precision values on the GPU.
-///
-/// ## Parameters
-///
-/// - `shape`: Tensor shape
-/// - `seed`: Optional random seed for reproducibility
-pub fn rand_f64<const RANK: usize>(
-    shape: [usize; RANK],
-    seed: Option<u64>,
-) -> impl DeviceOperation<Output = Tensor<f64>> {
-    let len = shape.iter().product::<usize>();
-    Tensor::<f64>::uninitialized(len).and_then(move |t| unsafe {
-        let t = t.assume_init();
-        let rng = RNG::new(seed);
-        rng.generate_uniform_f64(t.cu_deviceptr(), len);
-        value(t.reshape::<RANK>(shape))
+        T::generate_uniform(&rng, t.cu_deviceptr(), len);
+        value(t.reshape_unchecked(&shape))
     })
 }
 
 // Reshape operations
 
 /// Device operation that reshapes a tensor to a new static shape.
-///
-/// This wraps another device operation and reshapes its tensor output.
-/// The reshape is performed after the input operation executes.
-pub struct Reshape<const RANK: usize, T: DType, DI: DeviceOperation<Output = Tensor<T>>> {
-    shape: [usize; RANK],
-    input: DI,
-}
-
-/// Implements reshape as a device operation.
-///
-/// Executes the input operation and then reshapes the resulting tensor.
-impl<const RANK: usize, T: DType, DI: DeviceOperation<Output = Tensor<T>>> DeviceOperation
-    for Reshape<RANK, T, DI>
-{
-    type Output = Tensor<T>;
-
-    unsafe fn execute(
-        self,
-        context: &ExecutionContext,
-    ) -> Result<<Self as DeviceOperation>::Output, DeviceError> {
-        let tensor = self.input.execute(context)?;
-        Ok(tensor.reshape(self.shape))
-    }
-}
-
-impl<const RANK: usize, T: DType, DI: DeviceOperation<Output = Tensor<T>>> IntoFuture
-    for Reshape<RANK, T, DI>
-{
-    type Output = Result<Tensor<T>, DeviceError>;
-    type IntoFuture = DeviceFuture<Tensor<T>, Reshape<RANK, T, DI>>;
-    fn into_future(self) -> Self::IntoFuture {
-        match with_default_device_policy(|policy| policy.schedule(self)) {
-            Ok(Ok(future)) => future,
-            Ok(Err(e)) => DeviceFuture::failed(e),
-            Err(e) => DeviceFuture::failed(e),
-        }
-    }
-}
-
-/// Extension trait for reshaping tensor operations.
-///
-/// This trait allows device operations that produce tensors to be reshaped without
-/// materializing the intermediate tensor. The reshape happens as part of the operation chain.
-///
-/// ## Examples
-///
-/// ```rust,ignore
-/// use cutile::api;
-///
-/// // Reshape after creation
-/// let x = api::arange::<f32>(1024).reshape([32, 32]).await;
-///
-/// // Chain with other operations
-/// let y = api::zeros([256])
-///     .reshape([16, 16])
-///     .await;
-/// ```
-pub trait DeviceOperationReshape<T, DI>
-where
-    T: DType,
-    DI: DeviceOperation<Output = Tensor<T>>,
-{
-    /// Reshapes the output tensor of this operation to the specified shape.
-    ///
-    /// The new shape must have the same total number of elements as the original.
-    fn reshape<const RANK: usize>(self, shape: [usize; RANK]) -> Reshape<RANK, T, DI>;
-}
-
-impl<T, DI> DeviceOperationReshape<T, DI> for DI
-where
-    T: DType,
-    DI: DeviceOperation<Output = Tensor<T>>,
-{
-    fn reshape<const RANK: usize>(self, shape: [usize; RANK]) -> Reshape<RANK, T, DI>
-    where
-        Self: Sized,
-    {
-        Reshape::<RANK, T, DI> { shape, input: self }
-    }
-}
-
-// DynamicReshape.
-
-/// Device operation that reshapes a tensor to a new dynamic shape.
-///
-/// Similar to [`Reshape`] but uses a runtime-determined shape (`Vec<usize>`)
-/// instead of a compile-time constant array.
-pub struct DynamicReshape<T: DType, DI: DeviceOperation<Output = Tensor<T>>> {
+/// Device operation that reshapes a tensor output. Works for both owned
+/// `Tensor<T>` (reshapes in place) and `Arc<Tensor<T>>` (zero-copy view).
+pub struct ReshapeOp<O: Send, DI: DeviceOp<Output = O>> {
     shape: Vec<usize>,
     input: DI,
 }
 
-/// Implements dynamic reshape as a device operation.
-///
-/// Executes the input operation and then reshapes the resulting tensor
-/// using the runtime-specified shape.
-impl<T: DType, DI: DeviceOperation<Output = Tensor<T>>> DeviceOperation for DynamicReshape<T, DI> {
+impl<T: DType, DI: DeviceOp<Output = Tensor<T>>> DeviceOp for ReshapeOp<Tensor<T>, DI> {
     type Output = Tensor<T>;
 
-    unsafe fn execute(
-        self,
-        context: &ExecutionContext,
-    ) -> Result<<Self as DeviceOperation>::Output, DeviceError> {
+    unsafe fn execute(self, context: &ExecutionContext) -> Result<Tensor<T>, DeviceError> {
         let tensor = self.input.execute(context)?;
-        Ok(tensor.reshape_dyn(&self.shape))
+        Ok(tensor.reshape_unchecked(&self.shape))
     }
 }
 
-impl<T: DType, DI: DeviceOperation<Output = Tensor<T>>> IntoFuture for DynamicReshape<T, DI> {
+impl<T: DType, DI: DeviceOp<Output = Tensor<T>>> IntoFuture for ReshapeOp<Tensor<T>, DI> {
     type Output = Result<Tensor<T>, DeviceError>;
-    type IntoFuture = DeviceFuture<Tensor<T>, DynamicReshape<T, DI>>;
+    type IntoFuture = DeviceFuture<Tensor<T>, Self>;
     fn into_future(self) -> Self::IntoFuture {
-        match with_default_device_policy(|policy| policy.schedule(self)) {
+        match with_default_device_policy(|policy| {
+            let stream = policy.next_stream()?;
+            Ok(DeviceFuture::scheduled(self, ExecutionContext::new(stream)))
+        }) {
             Ok(Ok(future)) => future,
             Ok(Err(e)) => DeviceFuture::failed(e),
             Err(e) => DeviceFuture::failed(e),
@@ -709,41 +651,58 @@ impl<T: DType, DI: DeviceOperation<Output = Tensor<T>>> IntoFuture for DynamicRe
     }
 }
 
-/// Extension trait for dynamically reshaping device operation outputs.
-///
-/// This trait enables chaining a reshape operation with a runtime-determined shape
-/// onto any device operation that produces a tensor.
-///
-/// ## Examples
-///
-/// ```rust,ignore
-/// use cutile::api::{self, DeviceOperationDynamicReshape};
-///
-/// let shape_vec = vec![32, 32];  // Runtime-determined shape
-/// let tensor = api::arange::<f32>(1024)
-///     .reshape_dyn(shape_vec)
-///     .await;
-/// ```
-pub trait DeviceOperationDynamicReshape<T, DI>
-where
-    T: DType,
-    DI: DeviceOperation<Output = Tensor<T>>,
+impl<T: DType + Send, DI: DeviceOp<Output = Arc<Tensor<T>>>> DeviceOp
+    for ReshapeOp<Arc<Tensor<T>>, DI>
 {
-    /// Reshapes the output tensor using a runtime-specified shape.
-    ///
-    /// The new shape must have the same total number of elements as the original.
-    fn reshape_dyn(self, shape: Vec<usize>) -> DynamicReshape<T, DI>;
-}
+    type Output = Arc<Tensor<T>>;
 
-impl<T, DI> DeviceOperationDynamicReshape<T, DI> for DI
-where
-    T: DType,
-    DI: DeviceOperation<Output = Tensor<T>>,
-{
-    fn reshape_dyn(self, shape: Vec<usize>) -> DynamicReshape<T, DI>
-    where
-        Self: Sized,
-    {
-        DynamicReshape::<T, DI> { shape, input: self }
+    unsafe fn execute(self, context: &ExecutionContext) -> Result<Arc<Tensor<T>>, DeviceError> {
+        let arc_tensor = self.input.execute(context)?;
+        arc_tensor
+            .reshape_shared(&self.shape)
+            .map_err(|e| DeviceError::Internal(e.to_string()))
     }
 }
+
+impl<T: DType + Send, DI: DeviceOp<Output = Arc<Tensor<T>>>> IntoFuture
+    for ReshapeOp<Arc<Tensor<T>>, DI>
+{
+    type Output = Result<Arc<Tensor<T>>, DeviceError>;
+    type IntoFuture = DeviceFuture<Arc<Tensor<T>>, Self>;
+    fn into_future(self) -> Self::IntoFuture {
+        match with_default_device_policy(|policy| {
+            let stream = policy.next_stream()?;
+            Ok(DeviceFuture::scheduled(self, ExecutionContext::new(stream)))
+        }) {
+            Ok(Ok(future)) => future,
+            Ok(Err(e)) => DeviceFuture::failed(e),
+            Err(e) => DeviceFuture::failed(e),
+        }
+    }
+}
+
+/// Extension trait: `.reshape(&[usize])` on any `DeviceOp` producing `Tensor<T>`.
+pub trait DeviceOpReshape<T: DType>: DeviceOp<Output = Tensor<T>> + Sized {
+    fn reshape(self, shape: &[usize]) -> ReshapeOp<Tensor<T>, Self> {
+        ReshapeOp {
+            shape: shape.to_vec(),
+            input: self,
+        }
+    }
+}
+
+impl<T: DType, DI: DeviceOp<Output = Tensor<T>>> DeviceOpReshape<T> for DI {}
+
+/// Extension trait: `.reshape(&[usize])` on any `DeviceOp` producing `Arc<Tensor<T>>`.
+pub trait DeviceOpReshapeShared<T: DType + Send>:
+    DeviceOp<Output = Arc<Tensor<T>>> + Sized
+{
+    fn reshape(self, shape: &[usize]) -> ReshapeOp<Arc<Tensor<T>>, Self> {
+        ReshapeOp {
+            shape: shape.to_vec(),
+            input: self,
+        }
+    }
+}
+
+impl<T: DType + Send, DI: DeviceOp<Output = Arc<Tensor<T>>>> DeviceOpReshapeShared<T> for DI {}

--- a/cutile/src/kernels/_conversion.rs
+++ b/cutile/src/kernels/_conversion.rs
@@ -16,16 +16,13 @@
 ///
 /// ```rust,ignore
 /// use cutile::api;
-/// use cutile::kernels::conversion::convert_apply;
+/// use cutile::kernels::conversion::convert;
 ///
 /// // Convert f32 tensor to f16
-/// let src = Arc::new(api::randn(0.0, 1.0, [1024]).await);
-/// let dst = api::zeros::<f16>([1024]).partition([128]);
+/// let src: Arc<Tensor<f32>> = api::randn(0.0, 1.0, [1024], None).await?.into();
+/// let dst = api::zeros::<f16>(&[1024]).partition([128]);
 ///
-/// let result = zip!(src, dst)
-///     .apply(convert_apply)
-///     .unpartition()
-///     .await;
+/// let (src, dst) = convert(src, dst).await?;
 /// ```
 
 #[crate::module(tile_rust_crate = true)]
@@ -52,21 +49,17 @@ pub mod conversion {
     /// ## Examples
     ///
     /// ```rust,ignore
-    /// use cutile::kernels::conversion::convert_apply;
+    /// use cutile::kernels::conversion::convert;
     ///
-    /// // Convert f32 to f16
-    /// let src_f32 = Arc::new(api::arange::<f32>(1024).await);
-    /// let dst_f16 = api::zeros::<f16>([1024]).partition([128]);
-    /// let result = zip!(src_f32, dst_f16)
-    ///     .apply(convert_apply)
-    ///     .unzip();
+    /// // Convert f32 to f16 — unified launcher, no zip! needed.
+    /// let src_f32: Arc<Tensor<f32>> = api::arange(1024).await?.into();
+    /// let dst_f16 = api::zeros::<f16>(&[1024]).partition([128]);
+    /// let (src, dst) = convert(src_f32, dst_f16).await?;
     ///
     /// // Convert i32 to f32
-    /// let src_i32 = Arc::new(api::arange::<i32>(1024).await);
-    /// let dst_f32 = api::zeros::<f32>([1024]).partition([128]);
-    /// let result = zip!(src_i32, dst_f32)
-    ///     .apply(convert_apply)
-    ///     .unzip();
+    /// let src_i32: Arc<Tensor<i32>> = api::arange(1024).await?.into();
+    /// let dst_f32 = api::zeros::<f32>(&[1024]).partition([128]);
+    /// let (src, dst) = convert(src_i32, dst_f32).await?;
     /// ```
     ///
     /// ## Supported Conversions

--- a/cutile/src/kernels/_creation.rs
+++ b/cutile/src/kernels/_creation.rs
@@ -32,12 +32,12 @@ pub mod creation {
     /// This kernel is used by `api::full()`, `api::zeros()`, and `api::ones()`.
     ///
     /// ```rust,ignore
-    /// use cutile::kernels::creation::full_apply;
+    /// use cutile::kernels::creation::full;
     ///
     /// let val = 42.0f32;
-    /// let tensor = api::zeros([1024]).partition([128]);
+    /// let tensor = api::zeros(&[1024]).partition([128]);
     /// let result = value((val, tensor))
-    ///     .apply(full_apply)
+    ///     .then(full)
     ///     .unzip();
     /// ```
     #[crate::entry()]
@@ -65,13 +65,13 @@ pub mod creation {
     /// This kernel is used by `api::arange()`.
     ///
     /// ```rust,ignore
-    /// use cutile::kernels::creation::arange_apply;
+    /// use cutile::kernels::creation::arange;
     ///
     /// let tensor = Tensor::<i32>::uninitialized(256)
     ///     .await
     ///     .partition([64]);
     /// let result = value((tensor,))
-    ///     .apply(arange_apply)
+    ///     .then(arange)
     ///     .unzip();
     /// // Result contains [0, 1, 2, ..., 255]
     /// ```

--- a/cutile/src/lib.rs
+++ b/cutile/src/lib.rs
@@ -26,8 +26,8 @@
 //! use cutile::api;
 //!
 //! // Create tensors on GPU
-//! let x = api::ones::<f32>([1024]).await;
-//! let y = api::zeros::<f32>([1024]).await;
+//! let x = api::ones::<f32>(&[1024]).await;
+//! let y = api::zeros::<f32>(&[1024]).await;
 //! let z = api::arange::<f32>(256).await;
 //!
 //! // All operations are async and execute on GPU
@@ -54,15 +54,16 @@
 //!     }
 //! }
 //!
-//! // Use the kernel with partitioned tensors
-//! let x = api::ones([256]).partition([64]);
-//! let y = api::ones([256]).partition([64]);
-//! let z = api::zeros([256]).partition([64]);
-//!
-//! let result = zip!(z, x, y)
-//!     .apply(kernels::vector_add_apply)
-//!     .generics(vec!["f32".to_string(), "64".to_string()])
-//!     .await; // Automatically launches with grid (4, 1, 1)
+//! // Output-first: &mut param is first. Pass DeviceOps directly.
+//! let result = kernels::vector_add(
+//!     api::zeros(&[256]).partition([64]),
+//!     api::ones(&[256]),
+//!     api::ones(&[256]),
+//! )
+//! .first()
+//! .unpartition()
+//! .to_host_vec()
+//! .await?;
 //! ```
 //!
 //! ### Async GPU pipelines
@@ -70,25 +71,18 @@
 //! ```rust,ignore
 //! use cutile::api;
 //!
-//! async fn compute_pipeline() -> Tensor<f32> {
-//!     // All operations execute asynchronously on GPU
-//!     let x = api::randn(0.0, 1.0, [1024, 1024]).await;
-//!     let y = api::randn(0.0, 1.0, [1024, 1024]).await;
-//!     
-//!     // Use built-in kernels
-//!     use cutile::kernels::linalg::gemm_apply;
-//!     
-//!     let x_part = x.partition([128, 128]);
-//!     let y_part = y.partition([128, 128]);
-//!     let z = api::zeros([1024, 1024]).partition([128, 128]);
-//!     
-//!     zip!(z, x_part, y_part)
-//!         .apply(gemm_apply)
-//!         .generics(vec!["128".to_string(), "128".to_string(),
-//!                        "32".to_string(), "1024".to_string()])
-//!         .unpartition()
-//!         .await
-//! }
+//! // All operations are lazy — no GPU work until .await
+//! let x = api::randn(0.0, 1.0, &[1024, 1024]).await?;
+//! let y = api::randn(0.0, 1.0, &[1024, 1024]).await?;
+//!
+//! let z = gemm(
+//!     api::zeros(&[1024, 1024]).partition([128, 128]),
+//!     x, y,
+//! )
+//! .generics(vec!["128".into(), "128".into(), "32".into(), "1024".into()])
+//! .first()
+//! .unpartition()
+//! .await?;
 //! ```
 //!
 //! ## Module Organization
@@ -108,7 +102,7 @@
 //!
 //! ```rust,ignore
 //! // Create a tensor and partition it into 64-element tiles
-//! let x = api::ones([256]).partition([64]); // Creates 4 partitions
+//! let x = api::ones(&[256]).partition([64]); // Creates 4 partitions
 //! ```
 //!
 //! ### Tiles
@@ -129,7 +123,7 @@
 //!
 //! ```rust,ignore
 //! // Operations compose naturally with async/await
-//! let x = api::zeros([1024]).await;
+//! let x = api::zeros(&[1024]).await;
 //! let y = my_kernel(x).await;
 //! let z = another_kernel(y).await;
 //! ```
@@ -170,6 +164,7 @@ pub mod error;
 pub use _core::core;
 pub mod api;
 pub mod kernels;
+pub mod prelude;
 pub mod tensor;
 pub mod tile_kernel;
 pub mod utils;

--- a/cutile/src/prelude.rs
+++ b/cutile/src/prelude.rs
@@ -1,0 +1,34 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Convenience re-exports for common `cutile` types and traits.
+//!
+//! ```rust,ignore
+//! use cutile::prelude::*;
+//! ```
+
+// Re-export the cuda-async prelude
+pub use cuda_async::prelude::*;
+
+// API functions and extension traits
+pub use crate::api::{self, DeviceOpReshape, DeviceOpReshapeShared};
+
+// Error type
+pub use crate::error::Error;
+
+// Tensor types and traits
+pub use crate::tensor::{
+    IntoPartition, KernelInput, KernelInputStored, KernelOutput, KernelOutputStored, Partition,
+    PartitionMut, Reshape, Tensor, TensorView, ToHostVec, TryPartition, Unpartition,
+};
+
+// Tile kernel traits
+pub use crate::tile_kernel::{PartitionOp, TileKernel, ToHostVecOp};
+
+// Common types from cuda-core
+pub use cuda_core::{CudaContext, DType};
+
+// Common dependencies
+pub use std::sync::Arc;

--- a/cutile/src/tensor.rs
+++ b/cutile/src/tensor.rs
@@ -46,7 +46,7 @@
 //! use cutile::api;
 //! use cutile::tensor::IntoPartition;
 //!
-//! let tensor = api::zeros([256]).await;
+//! let tensor = api::zeros(&[256]).await;
 //! let partitioned = tensor.partition([64]);  // 4 tiles
 //! assert_eq!(partitioned.grid(), (4, 1, 1));
 //! ```
@@ -66,7 +66,7 @@
 //! ```rust,ignore
 //! use cutile::tensor::ToHostVec;
 //!
-//! let tensor = api::ones([1024]).await;
+//! let tensor = api::ones(&[1024]).await;
 //! let host_vec: Vec<f32> = tensor.to_host_vec().await;
 //! ```
 //!
@@ -121,10 +121,10 @@
 //! use cutile::api;
 //!
 //! // Create tensor
-//! let tensor = api::zeros::<f32>([1024]).await;
+//! let tensor = api::zeros::<f32>(&[1024]).await;
 //!
 //! // Access properties
-//! println!("Shape: {:?}", tensor.shape);
+//! println!("Shape: {:?}", tensor.shape());
 //! println!("Size: {}", tensor.size());
 //! println!("Bytes: {}", tensor.num_bytes());
 //! ```
@@ -135,7 +135,7 @@
 //! use cutile::api;
 //! use cutile::tensor::IntoPartition;
 //!
-//! let tensor = api::zeros([256]).await;
+//! let tensor = api::zeros(&[256]).await;
 //! let partitioned = tensor.partition([64]);
 //!
 //! // Use in kernel launch
@@ -148,7 +148,7 @@
 //! use cutile::api;
 //! use cutile::tensor::ToHostVec;
 //!
-//! let gpu_tensor = api::ones([1024]).await;
+//! let gpu_tensor = api::ones(&[1024]).await;
 //! let cpu_vec: Vec<f32> = gpu_tensor.to_host_vec().await;
 //! assert_eq!(cpu_vec.len(), 1024);
 //! ```
@@ -160,7 +160,7 @@
 //! use cutile::tensor::IntoPartitionArc;
 //! use std::sync::Arc;
 //!
-//! let tensor = Arc::new(api::zeros([256]).await);
+//! let tensor = Arc::new(api::zeros(&[256]).await);
 //!
 //! // Can partition Arc<Tensor> directly
 //! let partitioned = tensor.partition_arc([64]);
@@ -180,7 +180,7 @@
 //!
 //! ```rust,ignore
 //! // Safe: Each block writes to non-overlapping tiles
-//! let z = api::zeros([256]).partition([64]);
+//! let z = api::zeros(&[256]).partition([64]);
 //! // Block 0: writes to [0:64)
 //! // Block 1: writes to [64:128)
 //! // Block 2: writes to [128:192)
@@ -200,16 +200,15 @@
 //! - [`tile_async`](crate::tile_async) - Async execution infrastructure
 //! - [`core`](crate::core) - GPU kernel DSL types
 
-use crate::api::{copy, copy_device_to_host_vec, copy_host_vec_to_device};
+use crate::api::{copy_device_to_host_vec, copy_host_vec_to_device};
 use crate::error::{tensor_error_result, Error};
 use crate::tile_kernel::UnwrapPartition;
 use anyhow::Result;
 use cuda_async::device_buffer::{DeviceBuffer, DevicePointer};
 use cuda_async::device_operation;
-use cuda_async::device_operation::{value, DeviceOperation};
-use cuda_async::error::DeviceError;
+use cuda_async::device_operation::{value, DeviceOp, IntoDeviceOp, Value};
+use cuda_core::malloc_async;
 use cuda_core::sys::CUdeviceptr;
-use cuda_core::{malloc_async, CudaStream};
 use cuda_core::{DType, DTypeId};
 use std::fmt::Debug;
 use std::marker::PhantomData;
@@ -235,7 +234,7 @@ use std::sync::Arc;
 /// use cutile::api;
 ///
 /// // Create a tensor and partition it into 64-element tiles
-/// let tensor = api::ones([256]).await;
+/// let tensor = api::ones(&[256]).await;
 /// let partitioned = tensor.partition([64]);
 ///
 /// // The partition has 4 tiles: (256 / 64 = 4)
@@ -248,13 +247,13 @@ use std::sync::Arc;
 /// Partitions automatically calculate the launch grid for kernels:
 ///
 /// ```rust,ignore
-/// let x = api::zeros([128, 128]).partition([32, 32]);
+/// let x = api::zeros(&[128, 128]).partition([32, 32]);
 /// assert_eq!(x.grid(), (4, 4, 1)); // 128/32 = 4 in each dimension
 /// ```
 pub struct Partition<T> {
     pub(crate) object: T,
-    pub partition_shape: Vec<i32>,
-    pub partition_strides: Vec<i32>,
+    pub partition_shape: Vec<usize>,
+    pub partition_strides: Vec<usize>,
 }
 
 impl<T> Partition<T> {
@@ -287,6 +286,11 @@ impl<T: DType> Partition<Tensor<T>> {
         T::DTYPE
     }
 
+    /// Returns the data type name as a string.
+    pub fn dtype_str(&self) -> &'static str {
+        T::DTYPE.as_str()
+    }
+
     /// Calculates the CUDA launch grid dimensions based on the partition.
     ///
     /// The grid is computed as `tensor_shape / partition_shape` for each dimension.
@@ -295,10 +299,10 @@ impl<T: DType> Partition<Tensor<T>> {
     /// ## Examples
     ///
     /// ```rust,ignore
-    /// let x = api::zeros([256]).partition([64]);
+    /// let x = api::zeros(&[256]).partition([64]);
     /// assert_eq!(x.grid(), (4, 1, 1));
     ///
-    /// let y = api::zeros([128, 256]).partition([32, 64]);
+    /// let y = api::zeros(&[128, 256]).partition([32, 64]);
     /// assert_eq!(y.grid(), (4, 4, 1));
     /// ```
     ///
@@ -306,19 +310,11 @@ impl<T: DType> Partition<Tensor<T>> {
     ///
     /// Panics if the tensor rank is greater than 3.
     pub fn grid(&self) -> Result<(u32, u32, u32), Error> {
-        let check_i32 = |x: &i32| *x > 0;
-        if !self.object.shape.iter().all(check_i32) {
-            // TODO (hme): This check may be relaxed or unnecessary if we let shapes be u32.
-            //  Doing so can't break future features around dynamic shape dims in tile kernels.
+        if !self.object.shape.iter().all(|&x| x > 0) {
             return tensor_error_result("Shape dimensions must be positive.");
         }
-        let to_u32 = |x: &i32| *x as u32;
-        let shape = self.object.shape.iter().map(to_u32).collect::<Vec<u32>>();
-        let partition_shape = self
-            .partition_shape
-            .iter()
-            .map(to_u32)
-            .collect::<Vec<u32>>();
+        let shape: Vec<u32> = self.object.shape.iter().map(|&x| x as u32).collect();
+        let partition_shape: Vec<u32> = self.partition_shape.iter().map(|&x| x as u32).collect();
         let rank = shape.len();
         match rank {
             1 => Ok((u32::div_ceil(shape[0], partition_shape[0]), 1, 1)),
@@ -353,10 +349,10 @@ pub trait IntoPartition {
     /// ## Examples
     ///
     /// ```rust,ignore
-    /// let tensor = api::zeros([1024]).await;
+    /// let tensor = api::zeros(&[1024]).await;
     /// let partitioned = tensor.partition([128]); // 8 partitions
     /// ```
-    fn partition<const RANK: usize>(self, partition_shape: [i32; RANK]) -> Partition<Self>
+    fn partition<const RANK: usize>(self, partition_shape: [usize; RANK]) -> Partition<Self>
     where
         Self: Sized;
 }
@@ -371,12 +367,12 @@ pub trait IntoPartitionArc {
     /// ## Examples
     ///
     /// ```rust,ignore
-    /// let tensor = Arc::new(api::zeros([1024]).await);
+    /// let tensor = Arc::new(api::zeros(&[1024]).await);
     /// let partitioned = tensor.partition([128]);
     /// ```
     fn partition<const RANK: usize>(
         self: Arc<Self>,
-        partition_shape: [i32; RANK],
+        partition_shape: [usize; RANK],
     ) -> Partition<Self>
     where
         Self: Sized;
@@ -402,22 +398,21 @@ pub trait IntoPartitionArc {
 /// use cutile::api;
 ///
 /// // Create tensors using the API
-/// let x = api::zeros::<f32>([1024]).await;
-/// let y = api::ones::<f32>([512, 512]).await;
+/// let x = api::zeros::<f32>(&[1024]).await;
+/// let y = api::ones::<f32>(&[512, 512]).await;
 /// let z = api::arange::<i32>(256).await;
 /// ```
 ///
 /// ### Copying and reshaping
 ///
 /// ```rust,ignore
-/// let x = api::zeros([1024]).await;
-/// let x_arc = Arc::new(x);
+/// let x: Tensor<f32> = api::zeros(&[1024]).await;
 ///
-/// // Copy to create a new tensor
-/// let y = x_arc.copy().await;
+/// // Duplicate to create a new tensor with the same data
+/// let y: Tensor<f32> = x.dup().await;
 ///
 /// // Reshape (must preserve total size)
-/// let reshaped = y.reshape([32, 32]); // 1024 = 32 * 32
+/// let reshaped = y.reshape(&[32, 32]); // 1024 = 32 * 32
 /// ```
 ///
 /// ### Transferring to host
@@ -431,8 +426,8 @@ pub trait IntoPartitionArc {
 #[derive(Debug)]
 pub struct Tensor<T: DType> {
     pub(crate) storage: Arc<DeviceBuffer>,
-    pub shape: Vec<i32>,
-    pub strides: Vec<i32>,
+    pub(crate) shape: Vec<i32>,
+    pub(crate) strides: Vec<i32>,
     _dtype: PhantomData<T>,
 }
 
@@ -607,7 +602,7 @@ impl<T: DType> Tensor<T> {
     /// // Must initialize before use
     /// let tensor = unsafe { uninit.assume_init() };
     /// ```
-    pub fn uninitialized(len: usize) -> impl DeviceOperation<Output = MaybeUninit<Self>> {
+    pub fn uninitialized(len: usize) -> impl DeviceOp<Output = MaybeUninit<Self>> {
         assert!(len > 0, "Non-zero length required.");
         device_operation::with_context(move |ctx| {
             let num_bytes = len * size_of::<T>();
@@ -627,7 +622,7 @@ impl<T: DType> Tensor<T> {
         T::DTYPE
     }
 
-    pub fn cu_deviceptr(&self) -> CUdeviceptr {
+    pub(crate) fn cu_deviceptr(&self) -> CUdeviceptr {
         self.storage.cu_deviceptr()
     }
 
@@ -640,40 +635,33 @@ impl<T: DType> Tensor<T> {
         unsafe { DevicePointer::from_cu_deviceptr(self.cu_deviceptr()) }
     }
 
+    /// Returns the tensor's shape.
+    pub fn shape(&self) -> &[i32] {
+        &self.shape
+    }
+
+    /// Returns the tensor's strides.
+    pub fn strides(&self) -> &[i32] {
+        &self.strides
+    }
+
     /// Returns the total number of elements in the tensor.
     pub fn size(&self) -> usize {
         debug_assert_eq!(self.typed_num_bytes(), self.storage_num_bytes());
         self.num_elements()
     }
 
-    /// Creates a copy of this tensor on the GPU.
+    /// Creates an independent copy of this tensor's GPU data.
     ///
     /// Returns a device operation that, when executed, will allocate new GPU memory
     /// and copy the tensor's data.
-    pub fn copy(self: &Arc<Self>) -> impl DeviceOperation<Output = Self> {
-        copy(self)
-    }
-
-    /// Synchronously copies this tensor on the GPU using the specified stream.
-    pub fn copy_sync(self: &Arc<Self>, stream: &Arc<CudaStream>) -> Result<Self, DeviceError> {
-        copy(self).sync_on(stream)
+    pub fn dup(&self) -> impl DeviceOp<Output = Self> {
+        crate::api::dup(self)
     }
 
     /// Returns the total size of the tensor in bytes.
-    pub fn num_bytes(self: &Arc<Self>) -> usize {
-        let n = self.typed_num_bytes();
-        debug_assert_eq!(n, self.storage_num_bytes());
-        n
-    }
-
-    /// Returns the size of the tensor in megabytes (base 10).
-    pub fn num_mb(self: &Arc<Self>) -> usize {
-        self.num_bytes() / 10usize.pow(6)
-    }
-
-    /// Returns the size of the tensor in gigabytes (base 10).
-    pub fn num_gb(self: &Arc<Self>) -> usize {
-        self.num_bytes() / 10usize.pow(9)
+    pub fn num_bytes(&self) -> usize {
+        self.typed_num_bytes()
     }
 
     /// Returns `true` if the tensor metadata describes a contiguous row-major layout.
@@ -681,182 +669,60 @@ impl<T: DType> Tensor<T> {
         self.strides == contiguous_strides(&self.shape)
     }
 
-    /// Reshapes the tensor to a new shape without copying data.
+    /// Create an `Arc<Tensor<T>>` that shares this tensor's device memory.
     ///
-    /// The new shape must have the same total number of elements as the original.
-    /// This operation updates the shape and stride information but does not move data.
+    /// # Safety
     ///
-    /// ## Examples
-    ///
-    /// ```rust,ignore
-    /// let x = api::arange::<f32>(1024).await;
-    /// let reshaped = x.reshape([32, 32]); // 1024 = 32 * 32
-    /// ```
-    ///
-    /// ## Panics
-    ///
-    /// Panics if:
-    /// - The new shape has a different total number of elements
-    pub fn reshape<const RANK: usize>(mut self, shape: [usize; RANK]) -> Self {
-        // Make sure it's a valid shape for this tensor.
-        let shape = shape.iter().map(|x| *x as i32).collect::<Vec<_>>();
-        assert_eq!(
-            shape.iter().product::<i32>(),
-            self.shape.iter().product::<i32>()
-        );
-        self.shape = shape.to_vec();
+    /// Two tensors sharing storage can cause mutable aliasing if both are
+    /// passed to kernels. The caller must ensure only one is written at a
+    /// time. Prefer `tensor.view()` (returns `TensorView`) for safe
+    /// borrow-based sharing.
+    pub unsafe fn into_shared_alias(&self) -> Arc<Self> {
+        Arc::new(Self {
+            storage: self.storage.clone(),
+            shape: self.shape.clone(),
+            strides: self.strides.clone(),
+            _dtype: PhantomData,
+        })
+    }
+
+    // Internal: reshape without validation. Caller must ensure element count matches.
+    pub(crate) fn reshape_unchecked(mut self, shape: &[usize]) -> Self {
+        let shape: Vec<i32> = shape.iter().map(|&x| x as i32).collect();
         self.strides = contiguous_strides(&shape);
+        self.shape = shape;
         self
     }
 
-    pub fn reshape_dyn(mut self, shape: &[usize]) -> Self {
-        let shape = shape.iter().map(|x| *x as i32).collect::<Vec<_>>();
-        assert_eq!(
-            shape.iter().product::<i32>(),
-            self.shape.iter().product::<i32>()
-        );
-        self.shape = shape.to_vec();
-        self.strides = contiguous_strides(&shape);
-        self
-    }
-
-    /// Flattens an owned tensor into a rank-1 tensor without copying data.
-    pub fn flatten(self) -> Self {
-        let size = self.size();
-        self.reshape([size])
-    }
-
-    /// Creates a zero-copy Arc-backed view with a new static shape.
-    pub fn try_view<const RANK: usize>(
-        self: &Arc<Self>,
-        shape: [usize; RANK],
-    ) -> Result<Arc<Self>, Error> {
-        self.try_view_dyn(&shape)
-    }
-
-    /// Creates a zero-copy Arc-backed view with a new runtime shape.
-    pub fn try_view_dyn(self: &Arc<Self>, shape: &[usize]) -> Result<Arc<Self>, Error> {
+    // Internal: create a new Arc sharing storage with different shape.
+    // Used by ReshapeOp and the Reshape trait impl for &Arc<Tensor<T>>.
+    pub(crate) fn reshape_shared(self: &Arc<Self>, shape: &[usize]) -> Result<Arc<Self>, Error> {
         self.validate_view_shape(shape)?;
-        let shape = shape.iter().map(|x| *x as i32).collect::<Vec<_>>();
+        let new_shape: Vec<i32> = shape.iter().map(|x| *x as i32).collect();
         Ok(Arc::new(Self {
             storage: self.storage.clone(),
-            strides: contiguous_strides(&shape),
-            shape,
+            strides: contiguous_strides(&new_shape),
+            shape: new_shape,
             _dtype: PhantomData,
         }))
     }
 
-    /// Flattens an Arc-backed tensor into a rank-1 view without copying data.
-    pub fn try_flatten_view(self: &Arc<Self>) -> Result<Arc<Self>, Error> {
-        self.try_view([self.size()])
-    }
-
-    /// Creates a zero-copy Arc-backed view with a new static shape.
+    /// Reinterprets the tensor's bytes as a different type with a new shape.
     ///
-    /// ## Examples
-    ///
-    /// ```rust,ignore
-    ///
-    /// let x = Arc::new(api::arange::<f32>(8).await);
-    /// let y = x.view([2, 4]);
-    /// ```
-    ///
-    /// ## Errors
-    ///
-    /// This convenience API panics on failure instead of returning an error.
-    /// Use [`Tensor::try_view`] to handle failures as `Result`.
-    ///
-    /// ## Panics
-    ///
-    /// Panics if the tensor is not contiguous or if the target shape does not preserve
-    /// the logical element count.
-    pub fn view<const RANK: usize>(self: &Arc<Self>, shape: [usize; RANK]) -> Arc<Self> {
-        self.try_view(shape)
-            .expect("Failed to create zero-copy tensor view.")
-    }
-
-    /// Creates a zero-copy Arc-backed view with a new runtime shape.
-    pub fn view_dyn(self: &Arc<Self>, shape: &[usize]) -> Arc<Self> {
-        self.try_view_dyn(shape)
-            .expect("Failed to create zero-copy tensor view.")
-    }
-
-    /// Flattens an Arc-backed tensor into a rank-1 view without copying data.
-    ///
-    /// ## Examples
-    ///
-    /// ```rust,ignore
-    /// let x = Arc::new(api::arange::<f32>(8).await).view([2, 4]);
-    /// let y = x.flatten_view();
-    /// ```
-    ///
-    /// ## Errors
-    ///
-    /// This convenience API panics on failure instead of returning an error.
-    /// Use [`Tensor::try_flatten_view`] to handle failures as `Result`.
-    ///
-    /// ## Panics
-    ///
-    /// Panics if the tensor is not contiguous.
-    pub fn flatten_view(self: &Arc<Self>) -> Arc<Self> {
-        self.try_flatten_view()
-            .expect("Failed to create zero-copy tensor view.")
-    }
-
-    /// Creates a zero-copy reinterpret view with a new static shape.
-    pub fn try_reinterpret<U: DType, const RANK: usize>(
-        self: &Arc<Self>,
-        shape: [usize; RANK],
-    ) -> Result<Arc<Tensor<U>>, Error> {
-        self.try_reinterpret_dyn(&shape)
-    }
-
-    /// Creates a zero-copy reinterpret view with a new runtime shape.
-    pub fn try_reinterpret_dyn<U: DType>(
+    /// Zero-copy. Returns `Err` if the tensor is not contiguous, the total
+    /// byte size doesn't match, or the pointer alignment is incompatible.
+    pub fn reinterpret<U: DType>(
         self: &Arc<Self>,
         shape: &[usize],
     ) -> Result<Arc<Tensor<U>>, Error> {
         self.validate_reinterpret_shape::<U>(shape)?;
-        let shape = shape.iter().map(|x| *x as i32).collect::<Vec<_>>();
+        let new_shape: Vec<i32> = shape.iter().map(|x| *x as i32).collect();
         Ok(Arc::new(Tensor::<U> {
             storage: self.storage.clone(),
-            strides: contiguous_strides(&shape),
-            shape,
+            strides: contiguous_strides(&new_shape),
+            shape: new_shape,
             _dtype: PhantomData,
         }))
-    }
-
-    /// Creates a zero-copy reinterpret view with a new static shape.
-    ///
-    /// ## Examples
-    ///
-    /// ```rust,ignore
-    /// let bits: Arc<Vec<u32>> = Arc::new(vec![0x3f800000, 0x40000000]);
-    /// let base = Arc::new(bits.copy_to_device_tensor().await);
-    /// let floats = base.reinterpret::<f32, 1>([2]);
-    /// ```
-    ///
-    /// ## Errors
-    ///
-    /// This convenience API panics on failure instead of returning an error.
-    /// Use [`Tensor::try_reinterpret`] to handle failures as `Result`.
-    ///
-    /// ## Panics
-    ///
-    /// Panics if the tensor is not contiguous, if the target shape does not preserve
-    /// total byte size, or if pointer alignment is incompatible with the target type.
-    pub fn reinterpret<U: DType, const RANK: usize>(
-        self: &Arc<Self>,
-        shape: [usize; RANK],
-    ) -> Arc<Tensor<U>> {
-        self.try_reinterpret(shape)
-            .expect("Failed to reinterpret tensor storage.")
-    }
-
-    /// Creates a zero-copy reinterpret view with a new runtime shape.
-    pub fn reinterpret_dyn<U: DType>(self: &Arc<Self>, shape: &[usize]) -> Arc<Tensor<U>> {
-        self.try_reinterpret_dyn(shape)
-            .expect("Failed to reinterpret tensor storage.")
     }
 }
 
@@ -876,35 +742,133 @@ impl<T: DType> Tensor<T> {
 /// ```
 pub trait ToHostVec<T: Send> {
     /// Copies the tensor data from GPU to host memory, returning a `Vec<T>`.
-    fn to_host_vec(self) -> impl DeviceOperation<Output = Vec<T>>;
+    fn to_host_vec(self) -> impl DeviceOp<Output = Vec<T>>;
 }
 
 impl<T: DType> ToHostVec<T> for Tensor<T> {
-    fn to_host_vec(self) -> impl DeviceOperation<Output = Vec<T>> {
+    fn to_host_vec(self) -> impl DeviceOp<Output = Vec<T>> {
         let arc_self = Arc::new(self);
         copy_device_to_host_vec(&arc_self)
     }
 }
 
 impl<T: DType> ToHostVec<T> for Arc<Tensor<T>> {
-    fn to_host_vec(self) -> impl DeviceOperation<Output = Vec<T>> {
+    fn to_host_vec(self) -> impl DeviceOp<Output = Vec<T>> {
         copy_device_to_host_vec(&self)
     }
 }
 
 impl<T: DType> ToHostVec<T> for &Arc<Tensor<T>> {
-    fn to_host_vec(self) -> impl DeviceOperation<Output = Vec<T>> {
+    fn to_host_vec(self) -> impl DeviceOp<Output = Vec<T>> {
         copy_device_to_host_vec(self)
+    }
+}
+
+// ── Reshape trait ────────────────────────────────────────────────────────────
+
+/// Reshape a tensor or Arc<Tensor> to a new shape.
+///
+/// - On `Tensor<T>`: consumes and returns a reshaped `Tensor<T>`.
+/// - On `&Arc<Tensor<T>>`: creates a new `Arc` sharing device memory.
+pub trait Reshape {
+    type Output;
+    fn reshape(self, shape: &[usize]) -> Result<Self::Output, Error>;
+}
+
+impl<T: DType> Reshape for Tensor<T> {
+    type Output = Tensor<T>;
+    fn reshape(self, shape: &[usize]) -> Result<Tensor<T>, Error> {
+        let current_elems: i32 = self.shape.iter().product();
+        let new_elems: i32 = shape.iter().map(|&x| x as i32).product();
+        if new_elems != current_elems {
+            return tensor_error_result("reshape: new shape must preserve element count.");
+        }
+        Ok(self.reshape_unchecked(shape))
+    }
+}
+
+impl<'a, T: DType> Reshape for &'a Arc<Tensor<T>> {
+    type Output = Arc<Tensor<T>>;
+    fn reshape(self, shape: &[usize]) -> Result<Arc<Tensor<T>>, Error> {
+        self.reshape_shared(shape)
+    }
+}
+
+// ── TensorView ──────────────────────────────────────────────────────────────
+
+/// A borrowed, reshaped view of a tensor.
+///
+/// Created by [`Tensor::view`]. The view borrows the base tensor's device
+/// memory with different shape/strides metadata. The borrow checker ensures
+/// the base tensor can't be mutated while the view exists.
+///
+/// Kernel `&Tensor` params accept `&TensorView<T>` via `KernelInput`.
+///
+/// ```rust,ignore
+/// let tensor = api::ones::<f32>(&[1024]).sync()?;
+/// let view = tensor.view(&[32, 32])?;    // borrows tensor
+/// kernel(out, &view).sync()?;             // view accepted as &Tensor param
+/// // view dropped — tensor can be mutated again
+/// ```
+pub struct TensorView<'a, T: DType> {
+    base: &'a Tensor<T>,
+    shape: Vec<i32>,
+    strides: Vec<i32>,
+}
+
+impl<'a, T: DType> TensorView<'a, T> {
+    pub fn shape(&self) -> &[i32] {
+        &self.shape
+    }
+    pub fn strides(&self) -> &[i32] {
+        &self.strides
+    }
+    pub fn size(&self) -> usize {
+        self.shape.iter().map(|&x| x as usize).product()
+    }
+    /// Re-view with a different shape.
+    pub fn view(&self, shape: &[usize]) -> Result<TensorView<'_, T>, Error> {
+        let current_elems: i32 = self.shape.iter().product();
+        let new_elems: i32 = shape.iter().map(|&x| x as i32).product();
+        if new_elems != current_elems {
+            return tensor_error_result("view: new shape must preserve element count.");
+        }
+        let new_shape: Vec<i32> = shape.iter().map(|&x| x as i32).collect();
+        Ok(TensorView {
+            base: self.base,
+            shape: new_shape.clone(),
+            strides: contiguous_strides(&new_shape),
+        })
+    }
+}
+
+impl<T: DType> Tensor<T> {
+    /// Create a borrowed view with a different shape.
+    ///
+    /// The view borrows `self` — the tensor can't be mutated while the
+    /// view exists. No allocation or copy.
+    pub fn view(&self, shape: &[usize]) -> Result<TensorView<'_, T>, Error> {
+        let current_elems: i32 = self.shape.iter().product();
+        let new_elems: i32 = shape.iter().map(|&x| x as i32).product();
+        if new_elems != current_elems {
+            return tensor_error_result("view: new shape must preserve element count.");
+        }
+        let new_shape: Vec<i32> = shape.iter().map(|&x| x as i32).collect();
+        Ok(TensorView {
+            base: self,
+            shape: new_shape.clone(),
+            strides: contiguous_strides(&new_shape),
+        })
     }
 }
 
 impl<T: DType> IntoPartitionArc for Tensor<T> {
     fn partition<const RANK: usize>(
         self: Arc<Tensor<T>>,
-        partition_shape: [i32; RANK],
+        partition_shape: [usize; RANK],
     ) -> Partition<Tensor<T>> {
         let partition_shape = partition_shape.to_vec();
-        let partition_strides = self.strides.clone();
+        let partition_strides: Vec<usize> = self.strides.iter().map(|&s| s as usize).collect();
         let tensor = Arc::try_unwrap(self).expect("Failed to convert Arc to Partition.");
         tensor.assert_unique_storage();
         Partition::<Tensor<T>> {
@@ -916,9 +880,9 @@ impl<T: DType> IntoPartitionArc for Tensor<T> {
 }
 
 impl<T: DType> IntoPartition for Tensor<T> {
-    fn partition<const RANK: usize>(self, partition_shape: [i32; RANK]) -> Partition<Tensor<T>> {
+    fn partition<const RANK: usize>(self, partition_shape: [usize; RANK]) -> Partition<Tensor<T>> {
         let partition_shape = partition_shape.to_vec();
-        let partition_strides = self.strides.clone();
+        let partition_strides: Vec<usize> = self.strides.iter().map(|&s| s as usize).collect();
         self.assert_unique_storage();
         Partition::<Tensor<T>> {
             object: self,
@@ -928,13 +892,101 @@ impl<T: DType> IntoPartition for Tensor<T> {
     }
 }
 
-pub trait Unpartition<T: DType> {
-    /// Unwraps the partition to produce the underlying value.
-    fn unpartition(self) -> impl DeviceOperation<Output = Tensor<T>>;
+// ── Partition<&'a mut Tensor<T>> ─────────────────────────────────────────────
+
+/// Partition a mutably borrowed tensor. The partition borrows the tensor,
+/// so no `unpartition()` is needed — the tensor already has the kernel's output.
+pub trait PartitionMut<'a, T: DType> {
+    fn partition<const RANK: usize>(
+        self,
+        partition_shape: [usize; RANK],
+    ) -> Partition<&'a mut Tensor<T>>;
 }
 
-impl<T: DType, DI: DeviceOperation<Output = Partition<Tensor<T>>>> Unpartition<T> for DI {
-    fn unpartition(self) -> impl DeviceOperation<Output = Tensor<T>> {
+impl<'a, T: DType> PartitionMut<'a, T> for &'a mut Tensor<T> {
+    fn partition<const RANK: usize>(
+        self,
+        partition_shape: [usize; RANK],
+    ) -> Partition<&'a mut Tensor<T>> {
+        let partition_shape = partition_shape.to_vec();
+        let partition_strides: Vec<usize> = self.strides.iter().map(|&s| s as usize).collect();
+        Partition {
+            object: self,
+            partition_shape,
+            partition_strides,
+        }
+    }
+}
+
+impl<'a, T: DType> Partition<&'a mut Tensor<T>> {
+    pub fn dtype_str(&self) -> &'static str {
+        T::DTYPE.as_str()
+    }
+
+    pub fn grid(&self) -> Result<(u32, u32, u32), Error> {
+        if !self.object.shape.iter().all(|&x| x > 0) {
+            return tensor_error_result("Shape dimensions must be positive.");
+        }
+        let shape: Vec<u32> = self.object.shape.iter().map(|&x| x as u32).collect();
+        let partition_shape: Vec<u32> = self.partition_shape.iter().map(|&x| x as u32).collect();
+        let rank = shape.len();
+        match rank {
+            1 => Ok((u32::div_ceil(shape[0], partition_shape[0]), 1, 1)),
+            2 => Ok((
+                u32::div_ceil(shape[0], partition_shape[0]),
+                u32::div_ceil(shape[1], partition_shape[1]),
+                1,
+            )),
+            3 => Ok((
+                u32::div_ceil(shape[0], partition_shape[0]),
+                u32::div_ceil(shape[1], partition_shape[1]),
+                u32::div_ceil(shape[2], partition_shape[2]),
+            )),
+            _ => tensor_error_result("Mutable tensor must be at most rank 3."),
+        }
+    }
+}
+
+impl<'a, T: DType + Sync> IntoDeviceOp<Partition<&'a mut Tensor<T>>>
+    for Partition<&'a mut Tensor<T>>
+{
+    type Op = Value<Partition<&'a mut Tensor<T>>>;
+    fn into_op(self) -> Value<Partition<&'a mut Tensor<T>>> {
+        value(self)
+    }
+}
+
+/// Extension trait for partitioning an `Arc<Tensor<T>>` by consuming sole ownership.
+pub trait TryPartition<T: DType> {
+    /// Consumes the Arc and partitions the tensor.
+    ///
+    /// Returns `Err` if the Arc has other owners (refcount > 1) or the
+    /// underlying storage is shared with views.
+    fn try_partition<const RANK: usize>(
+        self,
+        partition_shape: [usize; RANK],
+    ) -> Result<Partition<Tensor<T>>, Error>;
+}
+
+impl<T: DType> TryPartition<T> for Arc<Tensor<T>> {
+    fn try_partition<const RANK: usize>(
+        self,
+        partition_shape: [usize; RANK],
+    ) -> Result<Partition<Tensor<T>>, Error> {
+        let tensor = Arc::try_unwrap(self).map_err(|_| {
+            crate::error::tensor_error("try_partition: Arc<Tensor> has multiple owners")
+        })?;
+        Ok(tensor.partition(partition_shape))
+    }
+}
+
+pub trait Unpartition<T: DType> {
+    /// Unwraps the partition to produce the underlying value.
+    fn unpartition(self) -> impl DeviceOp<Output = Tensor<T>>;
+}
+
+impl<T: DType, DI: DeviceOp<Output = Partition<Tensor<T>>>> Unpartition<T> for DI {
+    fn unpartition(self) -> impl DeviceOp<Output = Tensor<T>> {
         UnwrapPartition { op: self }
     }
 }
@@ -957,7 +1009,7 @@ impl<T: DType> DeviceVec<Tensor<T>> {
         let device_vec: Arc<Tensor<i64>> = copy_host_vec_to_device(&i64vec)
             .sync()
             .expect("Failed to execute device operation.")
-            .reshape([v.len()])
+            .reshape_unchecked(&[v.len()])
             .into();
         let host_vec: Vec<Arc<Tensor<T>>> = v.into_iter().map(Arc::new).collect::<Vec<_>>();
         DeviceVec {
@@ -1009,5 +1061,353 @@ impl<T: DType> IntoIterator for DeviceVec<Tensor<T>> {
     type IntoIter = DeviceVecIntoIter<Tensor<T>>;
     fn into_iter(self) -> Self::IntoIter {
         DeviceVecIntoIter { items: self }
+    }
+}
+
+// IntoDeviceOp impls for Tensor types
+
+impl<T: DType> IntoDeviceOp<Partition<Tensor<T>>> for Partition<Tensor<T>> {
+    type Op = Value<Partition<Tensor<T>>>;
+    fn into_op(self) -> Value<Partition<Tensor<T>>> {
+        value(self)
+    }
+}
+
+impl<T: DType> IntoDeviceOp<Tensor<T>> for Tensor<T> {
+    type Op = Value<Tensor<T>>;
+    fn into_op(self) -> Value<Tensor<T>> {
+        value(self)
+    }
+}
+
+impl<'a, T: DType + Sync> IntoDeviceOp<&'a Tensor<T>> for &'a Tensor<T> {
+    type Op = Value<&'a Tensor<T>>;
+    fn into_op(self) -> Value<&'a Tensor<T>> {
+        value(self)
+    }
+}
+
+// KernelInput impls — how &Tensor kernel params are held and recovered.
+
+use cuda_async::launch::AsyncKernelLaunch;
+
+// ── KernelOutput trait ──────────────────────────────────────────────────────
+//
+// Abstracts over Partition<Tensor<T>> and Partition<&mut Tensor<T>> so the
+// macro-generated launcher accepts both for &mut Tensor params.
+
+/// How a `&mut Tensor` kernel param is stored during execution and recovered.
+///
+/// | Input | Stored | Returned |
+/// |---|---|---|
+/// | `Partition<Tensor<T>>` | `Partition<Tensor<T>>` | `Partition<Tensor<T>>` |
+/// | `Partition<&'a mut Tensor<T>>` | `Partition<&'a mut Tensor<T>>` | `Partition<&'a mut Tensor<T>>` |
+pub trait KernelOutputStored<T: DType>: Send {
+    fn push_kernel_args(&self, launcher: &mut AsyncKernelLaunch);
+    fn grid(&self) -> Result<(u32, u32, u32), Error>;
+    fn dtype_str(&self) -> &'static str;
+    fn partition_shape_as_i32(&self) -> Vec<i32>;
+    fn strides_hint(&self) -> Vec<i32>;
+    fn shape_as_i32(&self) -> Vec<i32>;
+}
+
+pub trait KernelOutput<T: DType>: Send + Sized {
+    type Stored: KernelOutputStored<T>;
+    type Returned: Send;
+    fn prepare(self) -> Self::Stored;
+    fn recover(stored: Self::Stored) -> Self::Returned;
+}
+
+impl<T: DType> KernelOutputStored<T> for Partition<Tensor<T>> {
+    fn push_kernel_args(&self, launcher: &mut AsyncKernelLaunch) {
+        unsafe {
+            launcher.push_device_ptr(self.object.cu_deviceptr());
+        }
+        for dim in self.object.shape.iter() {
+            launcher.push_arg(*dim);
+        }
+        for stride in self.object.strides.iter() {
+            launcher.push_arg(*stride);
+        }
+        for dim in self.partition_shape.iter() {
+            launcher.push_arg(*dim as i32);
+        }
+        for stride in self.partition_strides.iter() {
+            launcher.push_arg(*stride as i32);
+        }
+    }
+    fn grid(&self) -> Result<(u32, u32, u32), Error> {
+        let shape: Vec<u32> = self.shape_as_i32().iter().map(|&x| x as u32).collect();
+        let pshape: Vec<u32> = self
+            .partition_shape_as_i32()
+            .iter()
+            .map(|&x| x as u32)
+            .collect();
+        match shape.len() {
+            1 => Ok((u32::div_ceil(shape[0], pshape[0]), 1, 1)),
+            2 => Ok((
+                u32::div_ceil(shape[0], pshape[0]),
+                u32::div_ceil(shape[1], pshape[1]),
+                1,
+            )),
+            3 => Ok((
+                u32::div_ceil(shape[0], pshape[0]),
+                u32::div_ceil(shape[1], pshape[1]),
+                u32::div_ceil(shape[2], pshape[2]),
+            )),
+            _ => tensor_error_result("Mutable tensor must be at most rank 3."),
+        }
+    }
+    fn dtype_str(&self) -> &'static str {
+        T::DTYPE.as_str()
+    }
+    fn partition_shape_as_i32(&self) -> Vec<i32> {
+        self.partition_shape.iter().map(|&x| x as i32).collect()
+    }
+    fn strides_hint(&self) -> Vec<i32> {
+        let len = self.partition_strides.len();
+        let mut res = vec![-1; len];
+        res[len - 1] = 1;
+        res
+    }
+    fn shape_as_i32(&self) -> Vec<i32> {
+        self.object.shape.clone()
+    }
+}
+
+impl<'a, T: DType> KernelOutputStored<T> for Partition<&'a mut Tensor<T>> {
+    fn push_kernel_args(&self, launcher: &mut AsyncKernelLaunch) {
+        unsafe {
+            launcher.push_device_ptr(self.object.cu_deviceptr());
+        }
+        for dim in self.object.shape.iter() {
+            launcher.push_arg(*dim);
+        }
+        for stride in self.object.strides.iter() {
+            launcher.push_arg(*stride);
+        }
+        for dim in self.partition_shape.iter() {
+            launcher.push_arg(*dim as i32);
+        }
+        for stride in self.partition_strides.iter() {
+            launcher.push_arg(*stride as i32);
+        }
+    }
+    fn grid(&self) -> Result<(u32, u32, u32), Error> {
+        let shape: Vec<u32> = self.shape_as_i32().iter().map(|&x| x as u32).collect();
+        let pshape: Vec<u32> = self
+            .partition_shape_as_i32()
+            .iter()
+            .map(|&x| x as u32)
+            .collect();
+        match shape.len() {
+            1 => Ok((u32::div_ceil(shape[0], pshape[0]), 1, 1)),
+            2 => Ok((
+                u32::div_ceil(shape[0], pshape[0]),
+                u32::div_ceil(shape[1], pshape[1]),
+                1,
+            )),
+            3 => Ok((
+                u32::div_ceil(shape[0], pshape[0]),
+                u32::div_ceil(shape[1], pshape[1]),
+                u32::div_ceil(shape[2], pshape[2]),
+            )),
+            _ => tensor_error_result("Mutable tensor must be at most rank 3."),
+        }
+    }
+    fn dtype_str(&self) -> &'static str {
+        T::DTYPE.as_str()
+    }
+    fn partition_shape_as_i32(&self) -> Vec<i32> {
+        self.partition_shape.iter().map(|&x| x as i32).collect()
+    }
+    fn strides_hint(&self) -> Vec<i32> {
+        let len = self.partition_strides.len();
+        let mut res = vec![-1; len];
+        res[len - 1] = 1;
+        res
+    }
+    fn shape_as_i32(&self) -> Vec<i32> {
+        self.object.shape.clone()
+    }
+}
+
+impl<T: DType> KernelOutput<T> for Partition<Tensor<T>> {
+    type Stored = Partition<Tensor<T>>;
+    type Returned = Partition<Tensor<T>>;
+    fn prepare(self) -> Self::Stored {
+        self
+    }
+    fn recover(stored: Self::Stored) -> Self::Returned {
+        stored
+    }
+}
+
+impl<'a, T: DType> KernelOutput<T> for Partition<&'a mut Tensor<T>> {
+    type Stored = Partition<&'a mut Tensor<T>>;
+    type Returned = Partition<&'a mut Tensor<T>>;
+    fn prepare(self) -> Self::Stored {
+        self
+    }
+    fn recover(stored: Self::Stored) -> Self::Returned {
+        stored
+    }
+}
+
+// ── KernelInput traits ──────────────────────────────────────────────────────
+//
+// Defined here (not in cuda-async) so that impls on Arc<Tensor<T>> satisfy
+// the orphan rule — both trait and Tensor<T> are in the same crate.
+
+/// How a stored kernel input pushes its arguments to the launcher.
+///
+/// Implemented for `Arc<Tensor<T>>` and `&Tensor<T>`. Both push the same
+/// data: device pointer, shape, and strides.
+pub trait KernelInputStored: Send {
+    fn push_kernel_args(&self, launcher: &mut AsyncKernelLaunch);
+    fn shape(&self) -> &[i32];
+    fn strides(&self) -> &[i32];
+    fn dtype_str(&self) -> &'static str;
+}
+
+/// Converts a user-provided kernel input into a stored form for execution,
+/// and recovers the caller's original type afterward.
+///
+/// | Input | Stored | Returned | `'static`? |
+/// |---|---|---|---|
+/// | `Tensor<T>` | `Arc<Tensor<T>>` | `Tensor<T>` | Yes |
+/// | `Arc<Tensor<T>>` | `Arc<Tensor<T>>` | `Arc<Tensor<T>>` | Yes |
+/// | `&'a Tensor<T>` | `&'a Tensor<T>` | `&'a Tensor<T>` | No |
+pub trait KernelInput<T: DType>: Send + Sized {
+    type Stored: KernelInputStored;
+    type Returned: Send;
+    fn prepare(self) -> Self::Stored;
+    fn recover(stored: Self::Stored) -> Self::Returned;
+}
+
+// ── KernelInputStored impls ─────────────────────────────────────────────────
+
+impl<T: DType> KernelInputStored for Arc<Tensor<T>> {
+    fn push_kernel_args(&self, launcher: &mut AsyncKernelLaunch) {
+        unsafe {
+            launcher.push_device_ptr(self.cu_deviceptr());
+        }
+        for dim in self.shape.iter() {
+            launcher.push_arg(*dim);
+        }
+        for stride in self.strides.iter() {
+            launcher.push_arg(*stride);
+        }
+    }
+    fn shape(&self) -> &[i32] {
+        Tensor::shape(self)
+    }
+    fn strides(&self) -> &[i32] {
+        Tensor::strides(self)
+    }
+    fn dtype_str(&self) -> &'static str {
+        T::DTYPE.as_str()
+    }
+}
+
+impl<'a, T: DType + Sync> KernelInputStored for &'a Tensor<T> {
+    fn push_kernel_args(&self, launcher: &mut AsyncKernelLaunch) {
+        unsafe {
+            launcher.push_device_ptr(self.cu_deviceptr());
+        }
+        for dim in self.shape.iter() {
+            launcher.push_arg(*dim);
+        }
+        for stride in self.strides.iter() {
+            launcher.push_arg(*stride);
+        }
+    }
+    fn shape(&self) -> &[i32] {
+        Tensor::shape(self)
+    }
+    fn strides(&self) -> &[i32] {
+        Tensor::strides(self)
+    }
+    fn dtype_str(&self) -> &'static str {
+        T::DTYPE.as_str()
+    }
+}
+
+// ── KernelInput impls ───────────────────────────────────────────────────────
+
+impl<T: DType> KernelInput<T> for Tensor<T> {
+    type Stored = Arc<Tensor<T>>;
+    type Returned = Tensor<T>;
+    fn prepare(self) -> Arc<Tensor<T>> {
+        Arc::new(self)
+    }
+    fn recover(stored: Arc<Tensor<T>>) -> Tensor<T> {
+        Arc::try_unwrap(stored).expect("KernelInput::recover: Arc has multiple owners")
+    }
+}
+
+impl<T: DType> KernelInput<T> for Arc<Tensor<T>> {
+    type Stored = Arc<Tensor<T>>;
+    type Returned = Arc<Tensor<T>>;
+    fn prepare(self) -> Arc<Tensor<T>> {
+        self
+    }
+    fn recover(stored: Arc<Tensor<T>>) -> Arc<Tensor<T>> {
+        stored
+    }
+}
+
+impl<'a, T: DType + Sync> KernelInput<T> for &'a Tensor<T> {
+    type Stored = &'a Tensor<T>;
+    type Returned = &'a Tensor<T>;
+    fn prepare(self) -> &'a Tensor<T> {
+        self
+    }
+    fn recover(stored: &'a Tensor<T>) -> &'a Tensor<T> {
+        stored
+    }
+}
+
+// ── TensorView KernelInput impls ────────────────────────────────────────────
+
+impl<'a, T: DType + Sync> KernelInputStored for &'a TensorView<'a, T> {
+    fn push_kernel_args(&self, launcher: &mut AsyncKernelLaunch) {
+        // Push the base tensor's device pointer with the VIEW's shape/strides.
+        unsafe {
+            launcher.push_device_ptr(self.base.cu_deviceptr());
+        }
+        for dim in self.shape.iter() {
+            launcher.push_arg(*dim);
+        }
+        for stride in self.strides.iter() {
+            launcher.push_arg(*stride);
+        }
+    }
+    fn shape(&self) -> &[i32] {
+        &self.shape
+    }
+    fn strides(&self) -> &[i32] {
+        &self.strides
+    }
+    fn dtype_str(&self) -> &'static str {
+        T::DTYPE.as_str()
+    }
+}
+
+impl<'a, T: DType + Sync> KernelInput<T> for &'a TensorView<'a, T> {
+    type Stored = &'a TensorView<'a, T>;
+    type Returned = &'a TensorView<'a, T>;
+    fn prepare(self) -> Self::Stored {
+        self
+    }
+    fn recover(stored: Self::Stored) -> Self::Returned {
+        stored
+    }
+}
+
+impl<'a, T: DType + Sync> IntoDeviceOp<&'a TensorView<'a, T>> for &'a TensorView<'a, T> {
+    type Op = Value<&'a TensorView<'a, T>>;
+    fn into_op(self) -> Value<&'a TensorView<'a, T>> {
+        value(self)
     }
 }

--- a/cutile/src/tile_kernel.rs
+++ b/cutile/src/tile_kernel.rs
@@ -341,7 +341,7 @@ pub fn infer_launch_grid(
 
 /// A compiled CUDA kernel generated from Rust code that can be launched on the GPU.
 ///
-/// `TileKernel` extends `DeviceOperation` with kernel-specific functionality. Kernels are
+/// `TileKernel` extends [`DeviceOp`] with kernel-specific functionality. Kernels are
 /// automatically generated from Rust functions marked with `#[cutile::entry]` and compiled
 /// to MLIR, then to CUDA PTX at runtime.
 ///
@@ -354,13 +354,10 @@ pub fn infer_launch_grid(
 /// ### Basic kernel launch
 ///
 /// ```rust,ignore
-/// use cutile::tile_async::TileKernel;
-/// use cuda_async::device_operation::DeviceOperation;
-///
 /// #[cutile::module]
 /// mod my_module {
 ///     use cutile::core::*;
-///     
+///
 ///     #[cutile::entry]
 ///     fn hello_world() {
 ///         let pid = get_tile_block_id();
@@ -371,59 +368,30 @@ pub fn infer_launch_grid(
 /// // Launch with explicit grid
 /// my_module::hello_world()
 ///     .grid((4, 1, 1))
-///     .sync_on(&stream);
+///     .sync_on(&stream)?;
 /// ```
 ///
 /// ### Kernel with arguments and grid inference
 ///
 /// ```rust,ignore
-/// #[cutile::module]
-/// mod kernels {
-///     use cutile::core::*;
-///     
-///     #[cutile::entry]
-///     fn add<T: ElementType, const N: i32>(
-///         z: &mut Tensor<T, {[N]}>,
-///         x: &Tensor<T, {[N]}>,
-///         y: &Tensor<T, {[N]}>,
-///     ) {
-///         let tile_x = load_tile_mut(x);
-///         let tile_y = load_tile_mut(y);
-///         z.store(tile_x + tile_y);
-///     }
-/// }
-///
-/// use kernels::add_apply;
-///
-/// // Grid is inferred from partitioned tensors
-/// let x = api::ones([256]).partition([64]);
-/// let y = api::ones([256]).partition([64]);
-/// let z = api::zeros([256]).partition([64]);
-///
-/// let result = zip!(z, x, y)
-///     .apply(add_apply)
-///     .generics(vec!["f32".to_string(), "256".to_string()])
-///     .await; // Automatically launches with grid (4, 1, 1)
-/// ```
-///
-/// When your inputs are already `DeviceOperation`s, prefer `.apply(...)`
-/// rather than a separate op-taking kernel wrapper:
-///
-/// ```rust,ignore
-/// let x = api::randn(0.0, 1.0, [256]);
-/// let y = api::randn(0.0, 1.0, [256]);
-/// let z = api::zeros([256]);
-///
-/// let result = zip!(z, x, y)
-///     .apply(add_apply)
-///     .generics(vec!["f32".to_string(), "256".to_string()])
-///     .await;
+/// // Output-first convention: &mut param is the first argument.
+/// // Grid is inferred from partitioned tensors.
+/// // The unified launcher accepts both plain values and DeviceOps.
+/// let result = add(
+///     api::zeros(&[256]).partition([64]),
+///     api::ones(&[256]),
+///     api::ones(&[256]),
+/// )
+/// .first()        // extract the &mut output
+/// .unpartition()  // recover Tensor from Partition
+/// .to_host_vec()
+/// .sync()?;
 /// ```
 ///
 /// ### Using with async composition
 ///
 /// ```rust,ignore
-/// async fn pipeline() -> impl DeviceOperation<Output=Tensor<f32>> {
+/// async fn pipeline() -> impl DeviceOp<Output=Tensor<f32>> {
 ///     let x = api::randn(0.0, 1.0, [128, 128]).await;
 ///     
 ///     // Chain kernel operations
@@ -438,9 +406,9 @@ pub fn infer_launch_grid(
 ///     z
 /// }
 /// ```
-pub trait TileKernel<ARGS: Send, DI>: DeviceOperation<Output = ARGS>
+pub trait TileKernel<ARGS: Send, DI, STORED: Send = ARGS>: DeviceOp<Output = ARGS>
 where
-    DI: DeviceOperation<Output = ARGS>,
+    DI: DeviceOp<Output = STORED>,
 {
     /// Compiles the kernel from module ASTs, returning the CUDA function and validator.
     fn compile<F: Fn() -> Vec<Module>>(
@@ -573,10 +541,31 @@ impl<T: DType> KernelArgument for &Partition<Tensor<T>> {
             launcher.push_arg(*stride);
         }
         for dim in self.partition_shape.iter() {
-            launcher.push_arg(*dim);
+            launcher.push_arg(*dim as i32);
         }
         for stride in self.partition_strides.iter() {
+            launcher.push_arg(*stride as i32);
+        }
+    }
+}
+
+/// Same as above but for borrowed mutable tensor partitions.
+impl<'a, T: DType> KernelArgument for &Partition<&'a mut Tensor<T>> {
+    fn push_arg(self, launcher: &mut AsyncKernelLaunch) {
+        unsafe {
+            launcher.push_device_ptr(self.object.cu_deviceptr());
+        }
+        for dim in self.object.shape.iter() {
+            launcher.push_arg(*dim);
+        }
+        for stride in self.object.strides.iter() {
             launcher.push_arg(*stride);
+        }
+        for dim in self.partition_shape.iter() {
+            launcher.push_arg(*dim as i32);
+        }
+        for stride in self.partition_strides.iter() {
+            launcher.push_arg(*stride as i32);
         }
     }
 }
@@ -592,37 +581,37 @@ impl<T: DType> KernelArgument for &Partition<Tensor<T>> {
 /// ## Examples
 ///
 /// ```rust,ignore
-/// use cutile::tile_async::IntoDeviceOperationPartition;
+/// use cutile::tile_async::PartitionOp;
 ///
 /// // Partition a tensor operation before it executes
-/// let x = api::ones([1024]).partition([128]);  // Creates 8 partitions
+/// let x = api::ones(&[1024]).partition([128]);  // Creates 8 partitions
 ///
 /// // Use partitioned tensors with kernels for automatic grid inference
 /// let y = api::randn(0.0, 1.0, [256, 256]).partition([64, 64]);  // 4x4 grid
 /// let result = my_kernel(y).await;  // Grid (4, 4, 1) inferred automatically
 /// ```
-pub trait IntoDeviceOperationPartition<I, DI>
+pub trait PartitionOp<I, DI>
 where
     I: Send + IntoPartition + IntoPartitionArc,
-    DI: DeviceOperation<Output = I>,
+    DI: DeviceOp<Output = I>,
 {
     /// Partitions the output of this device operation into tiles of the given shape.
     ///
     /// The partition shape determines how the tensor is divided across CUDA thread blocks.
     fn partition<const RANK: usize>(
         self,
-        partition_shape: [i32; RANK],
+        partition_shape: [usize; RANK],
     ) -> DeviceOperationPartition<RANK, I, DI>;
 }
 
-impl<I, DI> IntoDeviceOperationPartition<I, DI> for DI
+impl<I, DI> PartitionOp<I, DI> for DI
 where
     I: Send + IntoPartition + IntoPartitionArc,
-    DI: DeviceOperation<Output = I>,
+    DI: DeviceOp<Output = I>,
 {
     fn partition<const RANK: usize>(
         self,
-        partition_shape: [i32; RANK],
+        partition_shape: [usize; RANK],
     ) -> DeviceOperationPartition<RANK, I, DI>
     where
         Self: Sized,
@@ -645,42 +634,39 @@ where
 /// ## Examples
 ///
 /// ```rust,ignore
-/// // Create a partitioned tensor asynchronously
-/// let x = api::zeros([1024]).partition([64]);  // DeviceOperationPartition
-/// let partitioned = x.await;  // Partition<Tensor<f32>>
+/// // Create a partitioned tensor operation
+/// let z = api::zeros(&[1024]).partition([64]);
 ///
-/// // Use with kernel that accepts partitioned inputs
-/// let result = zip!(partitioned, other_partitioned)
-///     .apply(my_kernel_apply)
-///     .await;
+/// // Pass directly to kernel — grid inferred from partition
+/// let result = my_kernel(z, x, y).first().unpartition().sync()?;
 /// ```
 pub struct DeviceOperationPartition<const RANK: usize, I, DI>
 where
     I: Send + IntoPartition + IntoPartitionArc,
-    DI: DeviceOperation<Output = I>,
+    DI: DeviceOp<Output = I>,
 {
-    partition_shape: [i32; RANK],
+    partition_shape: [usize; RANK],
     op: DI,
 }
 
 unsafe impl<const RANK: usize, I, DI> Send for DeviceOperationPartition<RANK, I, DI>
 where
     I: Send + IntoPartition + IntoPartitionArc,
-    DI: DeviceOperation<Output = I>,
+    DI: DeviceOp<Output = I>,
 {
 }
 
-impl<const RANK: usize, I, DI> DeviceOperation for DeviceOperationPartition<RANK, I, DI>
+impl<const RANK: usize, I, DI> DeviceOp for DeviceOperationPartition<RANK, I, DI>
 where
     I: Send + IntoPartition + IntoPartitionArc,
-    DI: DeviceOperation<Output = I>,
+    DI: DeviceOp<Output = I>,
 {
     type Output = Partition<I>;
 
     unsafe fn execute(
         self,
         context: &ExecutionContext,
-    ) -> Result<<Self as DeviceOperation>::Output, DeviceError> {
+    ) -> Result<<Self as DeviceOp>::Output, DeviceError> {
         let val = self.op.execute(context)?;
         Ok(val.partition(self.partition_shape))
     }
@@ -689,12 +675,15 @@ where
 impl<const RANK: usize, I, DI> IntoFuture for DeviceOperationPartition<RANK, I, DI>
 where
     I: Send + IntoPartition + IntoPartitionArc,
-    DI: DeviceOperation<Output = I>,
+    DI: DeviceOp<Output = I>,
 {
     type Output = Result<Partition<I>, DeviceError>;
     type IntoFuture = DeviceFuture<Partition<I>, DeviceOperationPartition<RANK, I, DI>>;
     fn into_future(self) -> Self::IntoFuture {
-        match with_default_device_policy(|policy| policy.schedule(self)) {
+        match with_default_device_policy(|policy| {
+            let stream = policy.next_stream()?;
+            Ok(DeviceFuture::scheduled(self, ExecutionContext::new(stream)))
+        }) {
             Ok(Ok(future)) => future,
             Ok(Err(e)) => DeviceFuture::failed(e),
             Err(e) => DeviceFuture::failed(e),
@@ -719,7 +708,7 @@ where
 /// use cutile::tile_async::unwrap_partition;
 ///
 /// // After a kernel operation on partitioned tensors
-/// let x = api::ones([256]).partition([64]);
+/// let x = api::ones(&[256]).partition([64]);
 /// let y = my_kernel(x).await;  // Returns Partition<Tensor<f32>>
 ///
 /// // Unwrap back to a regular tensor
@@ -727,26 +716,23 @@ where
 /// ```
 pub struct UnwrapPartition<I: Send, DI>
 where
-    DI: DeviceOperation<Output = Partition<I>>,
+    DI: DeviceOp<Output = Partition<I>>,
 {
     pub(crate) op: DI,
 }
 
-unsafe impl<I: Send, DI> Send for UnwrapPartition<I, DI> where
-    DI: DeviceOperation<Output = Partition<I>>
-{
-}
+unsafe impl<I: Send, DI> Send for UnwrapPartition<I, DI> where DI: DeviceOp<Output = Partition<I>> {}
 
-impl<I: Send, DI> DeviceOperation for UnwrapPartition<I, DI>
+impl<I: Send, DI> DeviceOp for UnwrapPartition<I, DI>
 where
-    DI: DeviceOperation<Output = Partition<I>>,
+    DI: DeviceOp<Output = Partition<I>>,
 {
     type Output = I;
 
     unsafe fn execute(
         self,
         context: &ExecutionContext,
-    ) -> Result<<Self as DeviceOperation>::Output, DeviceError> {
+    ) -> Result<<Self as DeviceOp>::Output, DeviceError> {
         let val = self.op.execute(context)?;
         Ok(val.unpartition())
     }
@@ -754,12 +740,15 @@ where
 
 impl<I: Send, DI> IntoFuture for UnwrapPartition<I, DI>
 where
-    DI: DeviceOperation<Output = Partition<I>>,
+    DI: DeviceOp<Output = Partition<I>>,
 {
     type Output = Result<I, DeviceError>;
     type IntoFuture = DeviceFuture<I, UnwrapPartition<I, DI>>;
     fn into_future(self) -> Self::IntoFuture {
-        match with_default_device_policy(|policy| policy.schedule(self)) {
+        match with_default_device_policy(|policy| {
+            let stream = policy.next_stream()?;
+            Ok(DeviceFuture::scheduled(self, ExecutionContext::new(stream)))
+        }) {
             Ok(Ok(future)) => future,
             Ok(Err(e)) => DeviceFuture::failed(e),
             Err(e) => DeviceFuture::failed(e),
@@ -788,7 +777,7 @@ where
 /// ```
 pub fn unwrap_partition<I: Send, DI>(op: DI) -> UnwrapPartition<I, DI>
 where
-    DI: DeviceOperation<Output = Partition<I>>,
+    DI: DeviceOp<Output = Partition<I>>,
 {
     UnwrapPartition { op }
 }
@@ -798,26 +787,23 @@ where
 /// A device operation that copies a tensor from device memory to a host `Vec<T>`.
 pub struct TensorToHostVec<T: DType, DI>
 where
-    DI: DeviceOperation<Output = Tensor<T>>,
+    DI: DeviceOp<Output = Tensor<T>>,
 {
     pub(crate) op: DI,
 }
 
-unsafe impl<T: DType, DI> Send for TensorToHostVec<T, DI> where
-    DI: DeviceOperation<Output = Tensor<T>>
-{
-}
+unsafe impl<T: DType, DI> Send for TensorToHostVec<T, DI> where DI: DeviceOp<Output = Tensor<T>> {}
 
-impl<T: DType, DI> DeviceOperation for TensorToHostVec<T, DI>
+impl<T: DType, DI> DeviceOp for TensorToHostVec<T, DI>
 where
-    DI: DeviceOperation<Output = Tensor<T>>,
+    DI: DeviceOp<Output = Tensor<T>>,
 {
     type Output = Vec<T>;
 
     unsafe fn execute(
         self,
         context: &ExecutionContext,
-    ) -> Result<<Self as DeviceOperation>::Output, DeviceError> {
+    ) -> Result<<Self as DeviceOp>::Output, DeviceError> {
         let tensor = self.op.execute(context)?;
         let cu_deviceptr = tensor.cu_deviceptr();
         let size = tensor.size();
@@ -830,12 +816,15 @@ where
 
 impl<T: DType, DI> IntoFuture for TensorToHostVec<T, DI>
 where
-    DI: DeviceOperation<Output = Tensor<T>>,
+    DI: DeviceOp<Output = Tensor<T>>,
 {
     type Output = Result<Vec<T>, DeviceError>;
     type IntoFuture = DeviceFuture<Vec<T>, TensorToHostVec<T, DI>>;
     fn into_future(self) -> Self::IntoFuture {
-        match with_default_device_policy(|policy| policy.schedule(self)) {
+        match with_default_device_policy(|policy| {
+            let stream = policy.next_stream()?;
+            Ok(DeviceFuture::scheduled(self, ExecutionContext::new(stream)))
+        }) {
             Ok(Ok(future)) => future,
             Ok(Err(e)) => DeviceFuture::failed(e),
             Err(e) => DeviceFuture::failed(e),
@@ -844,14 +833,14 @@ where
 }
 
 /// Extension trait for converting a tensor device operation into a host `Vec<T>` operation.
-pub trait TensorDeviceOpToHostVec<T: DType> {
+pub trait ToHostVecOp<T: DType> {
     /// Wraps this operation to copy the resulting tensor to a host `Vec<T>`.
-    fn to_host_vec(self) -> impl DeviceOperation<Output = Vec<T>>
+    fn to_host_vec(self) -> impl DeviceOp<Output = Vec<T>>
     where
-        Self: DeviceOperation<Output = Tensor<T>>,
+        Self: DeviceOp<Output = Tensor<T>>,
     {
         TensorToHostVec { op: self }
     }
 }
 
-impl<T: DType, DI> TensorDeviceOpToHostVec<T> for DI where DI: DeviceOperation<Output = Tensor<T>> {}
+impl<T: DType, DI> ToHostVecOp<T> for DI where DI: DeviceOp<Output = Tensor<T>> {}

--- a/cutile/tests/control_flow_ops.rs
+++ b/cutile/tests/control_flow_ops.rs
@@ -205,7 +205,7 @@ fn compile_control_flow_test() -> () {
 #[test]
 fn compile_if_result_test() -> () {
     common::with_test_stack(|| {
-        let arg: Tensor<i64> = ones([16]).sync().expect("Failed.");
+        let arg: Tensor<i64> = ones(&[16]).sync().expect("Failed.");
         // If true, double and add 2.
         let (result, _) = if_return_test_kernel(arg.partition([4]), true)
             .sync()
@@ -214,7 +214,7 @@ fn compile_if_result_test() -> () {
         assert!(result.iter().all(|x| *x == 4));
 
         // If false, triple and add 3.
-        let arg: Tensor<i64> = ones([16]).sync().expect("Failed.");
+        let arg: Tensor<i64> = ones(&[16]).sync().expect("Failed.");
         let (result, _) = if_return_test_kernel(arg.partition([4]), false)
             .sync()
             .expect("Failed.");
@@ -228,7 +228,7 @@ fn execute_break_test() -> () {
     common::with_test_stack(|| {
         // break_test_kernel loads output, doubles it twice (loop runs 2 iterations then breaks),
         // and stores the result. Starting from 1.0, we expect 1.0 * 2 * 2 = 4.0.
-        let arg: Tensor<f32> = ones([16]).sync().expect("Failed.");
+        let arg: Tensor<f32> = ones(&[16]).sync().expect("Failed.");
         let (result,) = break_test_kernel(arg.partition([4]))
             .sync()
             .expect("Failed.");

--- a/cutile/tests/gpu/tensor.rs
+++ b/cutile/tests/gpu/tensor.rs
@@ -7,17 +7,17 @@
 
 use cutile::api;
 use cutile::tensor::Tensor;
-use cutile::tile_kernel::DeviceOperation;
+use cutile::tile_kernel::DeviceOp;
 use std::mem::forget;
 use std::sync::Arc;
 
 #[test]
 fn reinterpret_rejects_misaligned_storage() {
-    let base = Arc::new(api::zeros::<1, u8>([8]).sync().expect("Failed."));
+    let base = Arc::new(api::zeros::<u8>(&[8]).sync().expect("Failed."));
     // Shift the pointer by one byte so the storage is no longer aligned for u32.
     let misaligned = Arc::new(unsafe {
         Tensor::<u8>::from_raw_parts(
-            base.cu_deviceptr() + 1,
+            base.device_pointer().cu_deviceptr() + 1,
             4,
             base.device_id(),
             vec![4],
@@ -25,7 +25,7 @@ fn reinterpret_rejects_misaligned_storage() {
         )
     });
 
-    assert!(misaligned.try_reinterpret::<u32, 1>([1]).is_err());
+    assert!(misaligned.reinterpret::<u32>(&[1]).is_err());
 
     // The misaligned tensor is a borrowed view onto `base`'s allocation and must not free it.
     forget(misaligned);
@@ -34,11 +34,17 @@ fn reinterpret_rejects_misaligned_storage() {
 #[test]
 #[should_panic(expected = "Tensor logical byte size must match storage byte size.")]
 fn from_raw_parts_rejects_shape_storage_mismatch() {
-    let base = Arc::new(api::zeros::<1, u8>([4]).sync().expect("Failed."));
+    let base = Arc::new(api::zeros::<u8>(&[4]).sync().expect("Failed."));
 
     // Four bytes of storage cannot describe a Tensor<u32> with shape [2], which would
     // logically require eight bytes.
     let _ = unsafe {
-        Tensor::<u32>::from_raw_parts(base.cu_deviceptr(), 4, base.device_id(), vec![2], vec![1])
+        Tensor::<u32>::from_raw_parts(
+            base.device_pointer().cu_deviceptr(),
+            4,
+            base.device_id(),
+            vec![2],
+            vec![1],
+        )
     };
 }

--- a/cutile/tests/tensor_reinterpret.rs
+++ b/cutile/tests/tensor_reinterpret.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use cutile;
 use cutile::api;
 use cutile::tensor::{IntoPartition, ToHostVec};
-use cutile::tile_kernel::DeviceOperation;
+use cutile::tile_kernel::DeviceOp;
 use half::f16;
 
 mod common;
@@ -16,7 +16,6 @@ mod common;
 mod tensor_reinterpret_module {
     use cutile::core::*;
 
-    // This kernel consumes a reinterpreted tensor through the normal immutable launcher path.
     #[cutile::entry()]
     fn passthrough_f32(output: &mut Tensor<f32, { [4] }>, input: &Tensor<f32, { [-1] }>) {
         let tile: Tile<f32, { [4] }> = load_tile_like_1d(input, output);
@@ -27,19 +26,18 @@ mod tensor_reinterpret_module {
 #[test]
 fn reinterpret_is_zero_copy() {
     common::with_test_stack(|| {
-        // These u32 values are IEEE-754 bit patterns for 1.0, 2.0, 3.0, and 4.0.
         let bits: Arc<Vec<u32>> = Arc::new(vec![0x3f800000, 0x40000000, 0x40400000, 0x40800000]);
         let base = Arc::new(api::copy_host_vec_to_device(&bits).sync().expect("Failed."));
-        // Reinterpret the same device bytes as a rank-2 f32 tensor without copying them.
-        let floats_2d = base.reinterpret::<f32, 2>([2, 2]);
+        let floats_2d = base.reinterpret::<f32>(&[2, 2]).unwrap();
 
-        // Reinterpret keeps the same backing storage and only changes dtype/shape metadata.
-        assert_eq!(base.cu_deviceptr(), floats_2d.cu_deviceptr());
-        assert_eq!(floats_2d.shape, vec![2, 2]);
-        assert_eq!(floats_2d.strides, vec![2, 1]);
+        assert_eq!(
+            base.device_pointer().cu_deviceptr(),
+            floats_2d.device_pointer().cu_deviceptr()
+        );
+        assert_eq!(floats_2d.shape(), vec![2, 2]);
+        assert_eq!(floats_2d.strides(), vec![2, 1]);
         assert_eq!(floats_2d.size(), 4);
 
-        // This is a bit reinterpret, not a numeric conversion.
         let host: Vec<f32> = floats_2d.to_host_vec().sync().expect("Failed.");
         assert_eq!(host, vec![1.0, 2.0, 3.0, 4.0]);
     });
@@ -55,9 +53,8 @@ fn reinterpret_rejects_invalid_byte_size() {
                 .expect("Failed."),
         );
 
-        // Reinterpret must preserve the total byte size exactly.
-        assert!(base.try_reinterpret::<u32, 1>([1]).is_err());
-        assert!(base.try_reinterpret_dyn::<u32>(&[1]).is_err());
+        assert!(base.reinterpret::<u32>(&[1]).is_err());
+        assert!(base.reinterpret::<u32>(&[1]).is_err());
     });
 }
 
@@ -65,7 +62,6 @@ fn reinterpret_rejects_invalid_byte_size() {
 fn reinterpret_u8_to_i16_succeeds() {
     common::with_test_stack(|| {
         let expected = vec![0x1234i16, 0x2BCDi16];
-        // Expand each i16 into its native-endian bytes so the source tensor is byte-typed.
         let bytes: Arc<Vec<u8>> = Arc::new(
             expected
                 .iter()
@@ -77,12 +73,12 @@ fn reinterpret_u8_to_i16_succeeds() {
                 .sync()
                 .expect("Failed."),
         );
-        // Reinterpret the same bytes as i16 values; no device allocation or copy should occur.
-        let words = base.reinterpret::<i16, 1>([expected.len()]);
+        let words = base.reinterpret::<i16>(&[expected.len()]).unwrap();
 
-        // Signedness is part of the new view type; the underlying bytes stay unchanged.
-        assert_eq!(base.cu_deviceptr(), words.cu_deviceptr());
-        // Reading back through the i16 view should reconstruct the original signed values.
+        assert_eq!(
+            base.device_pointer().cu_deviceptr(),
+            words.device_pointer().cu_deviceptr()
+        );
         let host: Vec<i16> = words.to_host_vec().sync().expect("Failed.");
         assert_eq!(host, expected);
     });
@@ -103,27 +99,25 @@ fn reinterpret_u8_boundaries_are_enforced() {
                 .sync()
                 .expect("Failed."),
         );
-        let floats = valid.reinterpret::<f32, 1>([2]);
+        let floats = valid.reinterpret::<f32>(&[2]).unwrap();
         let host: Vec<f32> = floats.to_host_vec().sync().expect("Failed.");
         assert_eq!(host, vec![1.0, 2.0]);
 
-        // Six bytes cannot back two f32 values, so this must fail.
         let odd_bytes: Arc<Vec<u8>> = Arc::new(vec![0, 0, 0, 0, 0, 0]);
         let odd = Arc::new(
             api::copy_host_vec_to_device(&odd_bytes)
                 .sync()
                 .expect("Failed."),
         );
-        assert!(odd.try_reinterpret::<f32, 1>([2]).is_err());
+        assert!(odd.reinterpret::<f32>(&[2]).is_err());
 
-        // Three bytes cannot back one i16 plus preserve the original tensor size invariant.
         let odd_words: Arc<Vec<u8>> = Arc::new(vec![1, 2, 3]);
         let odd_words = Arc::new(
             api::copy_host_vec_to_device(&odd_words)
                 .sync()
                 .expect("Failed."),
         );
-        assert!(odd_words.try_reinterpret::<i16, 1>([1]).is_err());
+        assert!(odd_words.reinterpret::<i16>(&[1]).is_err());
     });
 }
 
@@ -138,10 +132,12 @@ fn reinterpret_i16_to_f16_succeeds() {
                 .collect(),
         );
         let base = Arc::new(api::copy_host_vec_to_device(&bits).sync().expect("Failed."));
-        let halfs = base.reinterpret::<f16, 1>([expected.len()]);
+        let halfs = base.reinterpret::<f16>(&[expected.len()]).unwrap();
 
-        // The host-side source uses f16 bit patterns stored in i16 slots.
-        assert_eq!(base.cu_deviceptr(), halfs.cu_deviceptr());
+        assert_eq!(
+            base.device_pointer().cu_deviceptr(),
+            halfs.device_pointer().cu_deviceptr()
+        );
         let host: Vec<f16> = halfs.to_host_vec().sync().expect("Failed.");
         assert_eq!(host, expected);
     });
@@ -150,14 +146,11 @@ fn reinterpret_i16_to_f16_succeeds() {
 #[test]
 fn reinterpreted_tensors_work_with_kernels() {
     common::with_test_stack(|| {
-        //These u32 values are IEEE-754 bit patterns for 1.0, 2.0, 3.0, and 4.0.
         let bits: Arc<Vec<u32>> = Arc::new(vec![0x3f800000, 0x40000000, 0x40400000, 0x40800000]);
         let base = Arc::new(api::copy_host_vec_to_device(&bits).sync().expect("Failed."));
-        let floats = base.reinterpret::<f32, 1>([4]);
+        let floats = base.reinterpret::<f32>(&[4]).unwrap();
 
-        // If launcher validation and argument marshalling accept the reinterpreted view,
-        // kernels can consume it exactly like an ordinary Arc<Tensor<f32>>.
-        let output = api::zeros::<1, f32>([4]).sync().expect("Failed.");
+        let output = api::zeros::<f32>(&[4]).sync().expect("Failed.");
         let (result, _input) =
             tensor_reinterpret_module::passthrough_f32(output.partition([4]), floats)
                 .sync()

--- a/cutile/tests/tensor_views.rs
+++ b/cutile/tests/tensor_views.rs
@@ -7,8 +7,8 @@ use std::sync::Arc;
 
 use cutile;
 use cutile::api;
-use cutile::tensor::{IntoPartition, ToHostVec};
-use cutile::tile_kernel::DeviceOperation;
+use cutile::tensor::{IntoPartition, Reshape, ToHostVec};
+use cutile::tile_kernel::DeviceOp;
 
 mod common;
 
@@ -16,8 +16,6 @@ mod common;
 mod tensor_views_module {
     use cutile::core::*;
 
-    // These kernels let the same backing storage be passed through launchers with
-    // different expected tensor ranks.
     #[cutile::entry()]
     fn passthrough_1d(output: &mut Tensor<f32, { [4] }>, input: &Tensor<f32, { [-1] }>) {
         let tile: Tile<f32, { [4] }> = load_tile_like_1d(input, output);
@@ -35,28 +33,38 @@ mod tensor_views_module {
 fn arc_views_are_zero_copy() {
     common::with_test_stack(|| {
         let base = Arc::new(api::arange::<f32>(8).sync().expect("Failed."));
-        let view = base.view([2, 4]);
-        let dyn_view = base.try_view_dyn(&[4, 2]).expect("Failed.");
-        let flat = view.flatten_view();
+        let view = base.reshape(&[2, 4]).unwrap();
+        let dyn_view = base.reshape(&[4, 2]).unwrap();
+        let flat = base.reshape(&[8]).unwrap();
 
-        // All views must share the same device allocation and only differ in metadata.
-        assert_eq!(base.cu_deviceptr(), view.cu_deviceptr());
-        assert_eq!(base.cu_deviceptr(), dyn_view.cu_deviceptr());
-        assert_eq!(base.cu_deviceptr(), flat.cu_deviceptr());
-        assert_eq!(view.shape, vec![2, 4]);
-        assert_eq!(view.strides, vec![4, 1]);
-        assert_eq!(dyn_view.shape, vec![4, 2]);
-        assert_eq!(dyn_view.strides, vec![2, 1]);
-        assert_eq!(flat.shape, vec![8]);
-        assert_eq!(flat.strides, vec![1]);
+        assert_eq!(
+            base.device_pointer().cu_deviceptr(),
+            view.device_pointer().cu_deviceptr()
+        );
+        assert_eq!(
+            base.device_pointer().cu_deviceptr(),
+            dyn_view.device_pointer().cu_deviceptr()
+        );
+        assert_eq!(
+            base.device_pointer().cu_deviceptr(),
+            flat.device_pointer().cu_deviceptr()
+        );
+        assert_eq!(view.shape(), vec![2, 4]);
+        assert_eq!(view.strides(), vec![4, 1]);
+        assert_eq!(dyn_view.shape(), vec![4, 2]);
+        assert_eq!(dyn_view.strides(), vec![2, 1]);
+        assert_eq!(flat.shape(), vec![8]);
+        assert_eq!(flat.strides(), vec![1]);
 
         let base_host: Vec<f32> = (&base).to_host_vec().sync().expect("Failed.");
         let flat_host: Vec<f32> = flat.to_host_vec().sync().expect("Failed.");
         assert_eq!(base_host, flat_host);
 
-        // A real copy allocates fresh storage, so its pointer must differ from the views above.
-        let copied = base.copy().sync().expect("Failed.");
-        assert_ne!(base.cu_deviceptr(), copied.cu_deviceptr());
+        let copied = base.dup().sync().expect("Failed.");
+        assert_ne!(
+            base.device_pointer().cu_deviceptr(),
+            copied.device_pointer().cu_deviceptr()
+        );
     });
 }
 
@@ -64,8 +72,8 @@ fn arc_views_are_zero_copy() {
 fn invalid_view_shape_is_rejected() {
     common::with_test_stack(|| {
         let base = Arc::new(api::arange::<f32>(8).sync().expect("Failed."));
-        assert!(base.try_view([5]).is_err());
-        assert!(base.try_view_dyn(&[2, 2]).is_err());
+        assert!(base.reshape(&[5]).is_err());
+        assert!(base.reshape(&[2, 2]).is_err());
     });
 }
 
@@ -73,9 +81,7 @@ fn invalid_view_shape_is_rejected() {
 fn shared_storage_blocks_mutable_partition() {
     common::with_test_stack(|| {
         let base = Arc::new(api::arange::<f32>(8).sync().expect("Failed."));
-        let _view = base.view([2, 4]);
-        // Unwrapping the outer Arc gives back a Tensor value, but the backing storage is still
-        // shared with `_view`, so mutable partitioning must be rejected.
+        let _view = base.reshape(&[2, 4]).unwrap();
         let owned = Arc::try_unwrap(base).expect("Expected unique outer Arc.");
         let result = panic::catch_unwind(AssertUnwindSafe(|| {
             let _ = owned.partition([8]);
@@ -88,11 +94,10 @@ fn shared_storage_blocks_mutable_partition() {
 fn arc_views_work_with_different_rank_kernels() {
     common::with_test_stack(|| {
         let base = Arc::new(api::arange::<f32>(4).sync().expect("Failed."));
-        // These are two metadata views over the same storage, shaped to match different kernels.
-        let input_1d = base.view([4]);
-        let input_2d = base.view([2, 2]);
+        let input_1d = base.reshape(&[4]).unwrap();
+        let input_2d = base.reshape(&[2, 2]).unwrap();
 
-        let output_1d = api::zeros::<1, f32>([4]).sync().expect("Failed.");
+        let output_1d = api::zeros::<f32>(&[4]).sync().expect("Failed.");
         let (result_1d, _input_1d) =
             tensor_views_module::passthrough_1d(output_1d.partition([4]), input_1d)
                 .sync()
@@ -103,7 +108,7 @@ fn arc_views_work_with_different_rank_kernels() {
             .sync()
             .expect("Failed.");
 
-        let output_2d = api::zeros::<2, f32>([2, 2]).sync().expect("Failed.");
+        let output_2d = api::zeros::<f32>(&[2, 2]).sync().expect("Failed.");
         let (result_2d, _input_2d) =
             tensor_views_module::passthrough_2d(output_2d.partition([2, 2]), input_2d)
                 .sync()

--- a/cutile/tests/type_conversion_ops.rs
+++ b/cutile/tests/type_conversion_ops.rs
@@ -290,7 +290,7 @@ fn execute_bf16_to_f32_conversion() -> () {
             .sync()
             .expect("Failed.");
         let input = Arc::new(input);
-        let output: Tensor<f32> = zeros([input_host.len()]).sync().expect("Failed.");
+        let output: Tensor<f32> = zeros(&[input_host.len()]).sync().expect("Failed.");
 
         let (result, _) = bf16_to_f32_conversion_kernel(output.partition([4]), input)
             .sync()
@@ -315,7 +315,7 @@ fn execute_f32_to_bf16_conversion() -> () {
             .sync()
             .expect("Failed.");
         let input = Arc::new(input);
-        let output: Tensor<bf16> = zeros([input_host.len()]).sync().expect("Failed.");
+        let output: Tensor<bf16> = zeros(&[input_host.len()]).sync().expect("Failed.");
 
         let (result, _) = f32_to_bf16_conversion_kernel(output.partition([4]), input)
             .sync()


### PR DESCRIPTION
Host-side API redesign for v0.0.2. The kernel DSL is unchanged.

1. **DeviceOp updates**: Renamed from `DeviceOperation`, updated combinators to `futures`-style conventions
2. **Tensor references**: `&Tensor` and `Partition<&mut Tensor>` as kernel params
3. **CUDA graph scope**: `CudaGraph::scope` with `&mut` borrows and `GraphNode` safety
4. **TensorView**: Safe borrowed reshaped views via `tensor.view(&[usize])`, complementing the existing `Arc`-based `reshape()` for async patterns

Full details: [CHANGELOG.md](https://github.com/NVlabs/cutile-rs/blob/cuda-graphs/CHANGELOG.md)