### PR TITLE
feat: add flush-to-zero variants for exp2, maxf, minf

### DIFF
--- a/cutile-macro/src/types.rs
+++ b/cutile-macro/src/types.rs
@@ -750,8 +750,8 @@ pub fn get_variadic_op_data(op_name: &str) -> Option<VariadicOpData> {
             return_type: ("Tile", &["_", "R"]),
         }),
         // Unary operations.
-        "ceil" | "cosh" | "cos" | "exp" | "exp2" | "log" | "log2" | "rsqrt" | "sinh" | "sin"
-        | "sqrt" | "tanh" | "tan" => Some(VariadicOpData {
+        "ceil" | "cosh" | "cos" | "exp" | "exp2" | "exp2_ftz" | "log" | "log2" | "rsqrt"
+        | "sinh" | "sin" | "sqrt" | "tanh" | "tan" => Some(VariadicOpData {
             const_length_vars: &["N"],
             cga_map: HashMap::from([("S", "N")]),
             input_map: vec![(0, "Tile", &["S"])],
@@ -794,15 +794,14 @@ pub fn get_variadic_op_data(op_name: &str) -> Option<VariadicOpData> {
             output_map: ("Tile", &["S"]),
             return_type: ("Tile", &["_", "S"]),
         }),
-        "pow" | "maxf" | "minf" | "andi" | "ori" | "xori" | "shli" | "shri" => {
-            Some(VariadicOpData {
-                const_length_vars: &["N"],
-                cga_map: HashMap::from([("S", "N")]),
-                input_map: vec![(0, "Tile", &["S"]), (1, "Tile", &["S"])],
-                output_map: ("Tile", &["S"]),
-                return_type: ("Tile", &["_", "S"]),
-            })
-        }
+        "pow" | "maxf" | "maxf_ftz" | "minf" | "minf_ftz" | "andi" | "ori" | "xori" | "shli"
+        | "shri" => Some(VariadicOpData {
+            const_length_vars: &["N"],
+            cga_map: HashMap::from([("S", "N")]),
+            input_map: vec![(0, "Tile", &["S"]), (1, "Tile", &["S"])],
+            output_map: ("Tile", &["S"]),
+            return_type: ("Tile", &["_", "S"]),
+        }),
         "bitcast" => Some(VariadicOpData {
             const_length_vars: &["N"],
             cga_map: HashMap::from([("S", "N")]),

--- a/cutile/src/_core.rs
+++ b/cutile/src/_core.rs
@@ -3041,6 +3041,23 @@ pub mod core {
         unreachable!()
     }
 
+    /// Computes element-wise base-2 exponential (2^x) with flush-to-zero.
+    ///
+    /// Same as [`exp2`], but flushes denormal results to zero. This can
+    /// improve performance on GPU hardware. Only supported for f32.
+    ///
+    /// ## Examples
+    ///
+    /// ```rust,ignore
+    /// let x: Tile<f32, {[128]}> = ...; // [0.0, 1.0, 2.0, ...]
+    /// let result = exp2_ftz(x); // [1.0, 2.0, 4.0, ...]
+    /// ```
+    #[cuda_tile::op(name="cuda_tile.exp2", params=["x"], named_attributes=["flush_to_zero=unit"])]
+    #[cuda_tile::variadic_op(N = 6)]
+    pub fn exp2_ftz<E: ElementType, const S: [i32; N]>(x: Tile<E, S>) -> Tile<E, S> {
+        unreachable!()
+    }
+
     /// Computes element-wise base-2 logarithm of floating-point tiles.
     ///
     /// Returns a tile where each element is the base-2 logarithm of the
@@ -3133,15 +3150,22 @@ pub mod core {
     /// let result = maxf(a, b); // [2.0, 5.0, 6.0, ...]
     /// ```
     ///
-    /// ## TODO (np)
-    ///
-    /// Add support for optional unit attributes `propagate_nan` and `flush_to_zero`:
-    /// - `propagate_nan`: Controls NaN handling (IEEE 754-2019 maximum vs maximumNumber)
-    /// - `flush_to_zero`: Flushes denormals to zero (f32 only)
-    /// These require implementing a mechanism for user-controllable unit attributes.
     #[cuda_tile::op(name="cuda_tile.maxf", params=["lhs", "rhs"])]
     #[cuda_tile::variadic_op(N = 6)]
     pub fn maxf<E: ElementType, const S: [i32; N]>(lhs: Tile<E, S>, rhs: Tile<E, S>) -> Tile<E, S> {
+        unreachable!()
+    }
+
+    /// Element-wise floating-point maximum with flush-to-zero.
+    ///
+    /// Same as [`maxf`], but flushes denormal inputs and results to zero.
+    /// Only supported for f32.
+    #[cuda_tile::op(name="cuda_tile.maxf", params=["lhs", "rhs"], named_attributes=["flush_to_zero=unit"])]
+    #[cuda_tile::variadic_op(N = 6)]
+    pub fn maxf_ftz<E: ElementType, const S: [i32; N]>(
+        lhs: Tile<E, S>,
+        rhs: Tile<E, S>,
+    ) -> Tile<E, S> {
         unreachable!()
     }
 
@@ -3157,16 +3181,22 @@ pub mod core {
     /// let b: Tile<f32, {[128]}> = ...; // [2.0, 4.0, 6.0, ...]
     /// let result = minf(a, b); // [1.0, 4.0, 3.0, ...]
     /// ```
-    ///
-    /// ## TODO (np)
-    ///
-    /// Add support for optional unit attributes `propagate_nan` and `flush_to_zero`:
-    /// - `propagate_nan`: Controls NaN handling (IEEE 754-2019 minimum vs minimumNumber)
-    /// - `flush_to_zero`: Flushes denormals to zero (f32 only)
-    /// These require implementing a mechanism for user-controllable unit attributes.
     #[cuda_tile::op(name="cuda_tile.minf", params=["lhs", "rhs"])]
     #[cuda_tile::variadic_op(N = 6)]
     pub fn minf<E: ElementType, const S: [i32; N]>(lhs: Tile<E, S>, rhs: Tile<E, S>) -> Tile<E, S> {
+        unreachable!()
+    }
+
+    /// Element-wise floating-point minimum with flush-to-zero.
+    ///
+    /// Same as [`minf`], but flushes denormal inputs and results to zero.
+    /// Only supported for f32.
+    #[cuda_tile::op(name="cuda_tile.minf", params=["lhs", "rhs"], named_attributes=["flush_to_zero=unit"])]
+    #[cuda_tile::variadic_op(N = 6)]
+    pub fn minf_ftz<E: ElementType, const S: [i32; N]>(
+        lhs: Tile<E, S>,
+        rhs: Tile<E, S>,
+    ) -> Tile<E, S> {
         unreachable!()
     }
 

--- a/cutile/tests/unary_math_ops.rs
+++ b/cutile/tests/unary_math_ops.rs
@@ -87,6 +87,29 @@ mod unary_math_ops_module {
     }
 
     #[cutile::entry()]
+    fn exp2_ftz_kernel<const S: [i32; 1]>(output: &mut Tensor<f32, S>) {
+        let x: Tile<f32, S> = load_tile_mut(output);
+        let result: Tile<f32, S> = exp2_ftz(x);
+        output.store(result);
+    }
+
+    #[cutile::entry()]
+    fn maxf_ftz_kernel<const S: [i32; 1]>(output: &mut Tensor<f32, S>) {
+        let x: Tile<f32, S> = load_tile_mut(output);
+        let y: Tile<f32, S> = load_tile_mut(output);
+        let result: Tile<f32, S> = maxf_ftz(x, y);
+        output.store(result);
+    }
+
+    #[cutile::entry()]
+    fn minf_ftz_kernel<const S: [i32; 1]>(output: &mut Tensor<f32, S>) {
+        let x: Tile<f32, S> = load_tile_mut(output);
+        let y: Tile<f32, S> = load_tile_mut(output);
+        let result: Tile<f32, S> = minf_ftz(x, y);
+        output.store(result);
+    }
+
+    #[cutile::entry()]
     fn unary_math_ops_bf16_kernel<const S: [i32; 1]>(output: &mut Tensor<bf16, S>) {
         // Verifies bf16 unary math operation lowering
         let x: Tile<bf16, S> = load_tile_mut(output);
@@ -279,6 +302,111 @@ fn compile_pow() -> () {
         );
 
         println!("\n✓ pow operation verified in MLIR output");
+    });
+}
+
+#[test]
+fn compile_exp2_ftz() -> () {
+    common::with_test_stack(|| {
+        let modules =
+            CUDATileModules::new(_module_asts()).expect("Failed to create CUDATileModules");
+        let gpu_name = get_gpu_name(0);
+        let compiler = CUDATileFunctionCompiler::new(
+            &modules,
+            "unary_math_ops_module",
+            "exp2_ftz_kernel",
+            &[128.to_string()],
+            &[("output", &[1])],
+            None,
+            gpu_name,
+            &CompileOptions::default(),
+        )
+        .expect("Failed.");
+        let module_op_str = compiler
+            .compile()
+            .expect("Failed.")
+            .as_operation()
+            .to_string();
+        println!("\n=== EXP2 FTZ MLIR ===\n{}", module_op_str);
+
+        assert!(
+            module_op_str.contains("exp2"),
+            "Expected exp2 operation in MLIR output"
+        );
+        assert!(
+            module_op_str.contains("flush_to_zero"),
+            "Expected flush_to_zero attribute in MLIR output"
+        );
+    });
+}
+
+#[test]
+fn compile_maxf_ftz() -> () {
+    common::with_test_stack(|| {
+        let modules =
+            CUDATileModules::new(_module_asts()).expect("Failed to create CUDATileModules");
+        let gpu_name = get_gpu_name(0);
+        let compiler = CUDATileFunctionCompiler::new(
+            &modules,
+            "unary_math_ops_module",
+            "maxf_ftz_kernel",
+            &[128.to_string()],
+            &[("output", &[1])],
+            None,
+            gpu_name,
+            &CompileOptions::default(),
+        )
+        .expect("Failed.");
+        let module_op_str = compiler
+            .compile()
+            .expect("Failed.")
+            .as_operation()
+            .to_string();
+        println!("\n=== MAXF FTZ MLIR ===\n{}", module_op_str);
+
+        assert!(
+            module_op_str.contains("maxf"),
+            "Expected maxf operation in MLIR output"
+        );
+        assert!(
+            module_op_str.contains("flush_to_zero"),
+            "Expected flush_to_zero attribute in MLIR output"
+        );
+    });
+}
+
+#[test]
+fn compile_minf_ftz() -> () {
+    common::with_test_stack(|| {
+        let modules =
+            CUDATileModules::new(_module_asts()).expect("Failed to create CUDATileModules");
+        let gpu_name = get_gpu_name(0);
+        let compiler = CUDATileFunctionCompiler::new(
+            &modules,
+            "unary_math_ops_module",
+            "minf_ftz_kernel",
+            &[128.to_string()],
+            &[("output", &[1])],
+            None,
+            gpu_name,
+            &CompileOptions::default(),
+        )
+        .expect("Failed.");
+        let module_op_str = compiler
+            .compile()
+            .expect("Failed.")
+            .as_operation()
+            .to_string();
+        println!("\n=== MINF FTZ MLIR ===\n{}", module_op_str);
+
+        assert!(
+            module_op_str.contains("minf"),
+            "Expected minf operation in MLIR output"
+        );
+        assert!(
+            module_op_str.contains("flush_to_zero"),
+            "Expected flush_to_zero attribute in MLIR output"
+        );
     });
 }
 


### PR DESCRIPTION
## Summary

- Add `exp2_ftz`, `maxf_ftz`, `minf_ftz` ops that emit `flush_to_zero` unit attribute on corresponding MLIR operations
- Uses existing `named_attributes` mechanism: `named_attributes=["flush_to_zero=unit"]`
- Removes stale TODO comments from `maxf`/`minf` (the mechanism now exists)
- Includes compilation tests verifying the attribute appears in MLIR output

Motivated by ~7% perf gain on flash attention with `exp2` ftz (reported by Yinuo Liu).

## Test plan

- [ ] `cargo check -p cutile --tests` passes
- [ ] `compile_exp2_ftz`, `compile_maxf_ftz`, `compile_minf_ftz` tests verify `flush_to_zero` in MLIR output
- [ ] Verify on GPU: `exp2_ftz` in flash attention kernel shows expected perf improvement