### PR TITLE
Fix divisibility units, nested mutation, if/else expressions, FTZ ops, const latency

### DIFF
--- a/cutile-book/guide/dsl-api.md
+++ b/cutile-book/guide/dsl-api.md
@@ -383,6 +383,7 @@ In addition to operator overloading (`+`, `-`, `*`, `/`), these explicit functio
 | `negi(x)` | `Tile<E, S> -> Tile<E, S>` | Negation (integer) |
 | `negf(x)` | `Tile<E, S> -> Tile<E, S>` | Negation (float) |
 | `fma(a, b, c)` | `(Tile<E, S>, Tile<E, S>, Tile<E, S>) -> Tile<E, S>` | Fused multiply-add: `a * b + c` |
+| `fma_ftz(a, b, c)` | `(Tile<E, S>, Tile<E, S>, Tile<E, S>) -> Tile<E, S>` | Fused multiply-add (flush-to-zero) |
 | `pow(base, exp)` | `(Tile<E, S>, Tile<E, S>) -> Tile<E, S>` | Power |
 | `ceil_div(a, b)` | `(E, E) -> E` | Ceiling division (scalar) |
 | `true_div(a, b)` | `(Tile<E, S>, Tile<E, S>) -> Tile<E, S>` | True (floating-point) division |
@@ -414,7 +415,9 @@ let neg_i: Tile<i32, S> = negi(int_tile);
 | `log(x)` | `Tile<E, S> -> Tile<E, S>` | Natural logarithm |
 | `log2(x)` | `Tile<E, S> -> Tile<E, S>` | Base-2 logarithm |
 | `sqrt(x)` | `Tile<E, S> -> Tile<E, S>` | Square root |
+| `sqrt_ftz(x)` | `Tile<E, S> -> Tile<E, S>` | Square root with flush-to-zero |
 | `rsqrt(x)` | `Tile<E, S> -> Tile<E, S>` | Reciprocal square root (1/sqrt(x)) |
+| `rsqrt_ftz(x)` | `Tile<E, S> -> Tile<E, S>` | Reciprocal square root with flush-to-zero |
 | `sin(x)` | `Tile<E, S> -> Tile<E, S>` | Sine |
 | `cos(x)` | `Tile<E, S> -> Tile<E, S>` | Cosine |
 | `tan(x)` | `Tile<E, S> -> Tile<E, S>` | Tangent |
@@ -427,6 +430,10 @@ let neg_i: Tile<i32, S> = negi(int_tile);
 | `minf(a, b)` | `(Tile<E, S>, Tile<E, S>) -> Tile<E, S>` | Float min |
 | `maxf_ftz(a, b)` | `(Tile<E, S>, Tile<E, S>) -> Tile<E, S>` | Float max (flush-to-zero) |
 | `minf_ftz(a, b)` | `(Tile<E, S>, Tile<E, S>) -> Tile<E, S>` | Float min (flush-to-zero) |
+| `addf_ftz(a, b)` | `(Tile<E, S>, Tile<E, S>) -> Tile<E, S>` | Float add (flush-to-zero) |
+| `subf_ftz(a, b)` | `(Tile<E, S>, Tile<E, S>) -> Tile<E, S>` | Float sub (flush-to-zero) |
+| `mulf_ftz(a, b)` | `(Tile<E, S>, Tile<E, S>) -> Tile<E, S>` | Float mul (flush-to-zero) |
+| `divf_ftz(a, b)` | `(Tile<E, S>, Tile<E, S>) -> Tile<E, S>` | Float div (flush-to-zero) |
 
 ```rust
 // Softmax numerics: subtract max, exponentiate
@@ -447,8 +454,11 @@ let swish: Tile<f32, S> = x / (constant(1.0f32, x.shape()) + exp(negf(x)));
 let log2_e: f32 = 1.4426950408889634f32;
 let fast_exp: Tile<f32, S> = exp2(x * broadcast_scalar(log2_e, x.shape()));
 
-// Flush-to-zero variants: treat denormals as zero (faster on some hardware)
+// Flush-to-zero variants: treat denormals as zero (faster on some hardware, f32 only)
 let clamped: Tile<f32, S> = maxf_ftz(x, broadcast_scalar(0.0f32, x.shape()));
+let sum: Tile<f32, S> = addf_ftz(a, b);
+let product: Tile<f32, S> = mulf_ftz(a, b);
+let fma_result: Tile<f32, S> = fma_ftz(a, b, c);
 ```
 
 ### Comparison

--- a/cutile-compiler/src/compiler/compile_cuda_tile_op.rs
+++ b/cutile-compiler/src/compiler/compile_cuda_tile_op.rs
@@ -376,7 +376,7 @@ impl<'m, 'c> CUDATileFunctionCompiler<'m> {
             }
         }
 
-        // arg[6]: latency (Option<i32>)
+        // arg[6]: latency (Option<i32>) — literal or const generic
         let mut hint_params: HashMap<String, i32> = HashMap::new();
         if let Some(latency_arg) =
             crate::compiler::utils::resolve_option_arg(&call_expr.args[6], ctx)
@@ -384,12 +384,17 @@ impl<'m, 'c> CUDATileFunctionCompiler<'m> {
             if let Expr::Lit(ExprLit {
                 lit: Lit::Int(int_lit),
                 ..
-            }) = latency_arg
+            }) = &latency_arg
             {
                 hint_params.insert(
                     "latency".to_string(),
                     int_lit.base10_parse::<i32>().unwrap(),
                 );
+            } else if let Expr::Path(path) = &latency_arg {
+                let name = path.path.segments.last().unwrap().ident.to_string();
+                if let Some(&v) = generic_args.inst_i32.get(&name) {
+                    hint_params.insert("latency".to_string(), v);
+                }
             }
         }
 
@@ -577,7 +582,7 @@ impl<'m, 'c> CUDATileFunctionCompiler<'m> {
             }
         }
 
-        // arg[6]: latency (Option<i32>)
+        // arg[6]: latency (Option<i32>) — literal or const generic
         let mut hint_params: HashMap<String, i32> = HashMap::new();
         if let Some(latency_arg) =
             crate::compiler::utils::resolve_option_arg(&call_expr.args[6], ctx)
@@ -585,12 +590,17 @@ impl<'m, 'c> CUDATileFunctionCompiler<'m> {
             if let Expr::Lit(ExprLit {
                 lit: Lit::Int(int_lit),
                 ..
-            }) = latency_arg
+            }) = &latency_arg
             {
                 hint_params.insert(
                     "latency".to_string(),
                     int_lit.base10_parse::<i32>().unwrap(),
                 );
+            } else if let Expr::Path(path) = &latency_arg {
+                let name = path.path.segments.last().unwrap().ident.to_string();
+                if let Some(&v) = generic_args.inst_i32.get(&name) {
+                    hint_params.insert("latency".to_string(), v);
+                }
             }
         }
 
@@ -1147,22 +1157,40 @@ impl<'m, 'c> CUDATileFunctionCompiler<'m> {
                 );
             };
             // Handle Option<i32> hint params (e.g. latency: Option<i32>).
+            // The inner value can be a literal (Some(4)) or a const generic (Some(L)).
             if let Some(inner) = crate::compiler::utils::resolve_option_arg(&call_expr.args[i], ctx)
             {
-                let Expr::Lit(lit_expr) = &inner else {
+                let value: i32 = if let Expr::Lit(lit_expr) = &inner {
+                    let Lit::Int(int_lit) = &lit_expr.lit else {
+                        return self.jit_error_result(
+                            &lit_expr.span(),
+                            "Non-integer literals not supported",
+                        );
+                    };
+                    int_lit.base10_parse::<i32>().unwrap()
+                } else if let Expr::Path(path) = &inner {
+                    let name = path.path.segments.last().unwrap().ident.to_string();
+                    if let Some(&v) = generic_args.inst_i32.get(&name) {
+                        v
+                    } else {
+                        return self.jit_error_result(
+                            &call_expr.args[i].span(),
+                            &format!(
+                                "Failed to compile hint param {hint_param}: \
+                                 '{name}' is not a literal or resolved const generic."
+                            ),
+                        );
+                    }
+                } else {
                     return self.jit_error_result(
                         &call_expr.args[i].span(),
-                        &format!("Failed to compile hint param {hint_param}, expected literal."),
+                        &format!(
+                            "Failed to compile hint param {hint_param}, \
+                             expected literal or const generic."
+                        ),
                     );
                 };
-                let Lit::Int(int_lit) = &lit_expr.lit else {
-                    return self
-                        .jit_error_result(&lit_expr.span(), "Non-integer literals not supported");
-                };
-                hint_params.insert(
-                    hint_param.to_string(),
-                    int_lit.base10_parse::<i32>().unwrap(),
-                );
+                hint_params.insert(hint_param.to_string(), value);
             }
         }
         // Handle disallow_tma: bool parameter.

--- a/cutile-compiler/src/compiler/compile_expression.rs
+++ b/cutile-compiler/src/compiler/compile_expression.rs
@@ -484,13 +484,10 @@ impl<'m, 'c> CUDATileFunctionCompiler<'m> {
                     Ok(None)
                 }
                 Expr::If(if_expr) => {
-                    let Some(conditional_val) = self.compile_expression(
-                        builder,
-                        &*if_expr.cond,
-                        generic_vars,
-                        ctx,
-                        return_type.clone(),
-                    )?
+                    // The condition is always bool — don't propagate the if
+                    // expression's return type into the condition.
+                    let Some(conditional_val) =
+                        self.compile_expression(builder, &*if_expr.cond, generic_vars, ctx, None)?
                     else {
                         return self.jit_error_result(
                             &if_expr.cond.span(),

--- a/cutile-compiler/src/compiler/utils.rs
+++ b/cutile-compiler/src/compiler/utils.rs
@@ -613,6 +613,44 @@ pub fn collect_mutated_variables_from_block(
                     result.insert(var_name);
                 }
             }
+            // Recurse into nested control flow to find mutations.
+            Stmt::Expr(Expr::ForLoop(for_expr), _) => {
+                for var in collect_mutated_variables_from_block(&for_expr.body)? {
+                    if !local_vars.contains(&var) {
+                        result.insert(var);
+                    }
+                }
+            }
+            Stmt::Expr(Expr::While(while_expr), _) => {
+                for var in collect_mutated_variables_from_block(&while_expr.body)? {
+                    if !local_vars.contains(&var) {
+                        result.insert(var);
+                    }
+                }
+            }
+            Stmt::Expr(Expr::If(if_expr), _) => {
+                for var in collect_mutated_variables_from_block(&if_expr.then_branch)? {
+                    if !local_vars.contains(&var) {
+                        result.insert(var);
+                    }
+                }
+                if let Some((_else, else_expr)) = &if_expr.else_branch {
+                    if let Expr::Block(block_expr) = &**else_expr {
+                        for var in collect_mutated_variables_from_block(&block_expr.block)? {
+                            if !local_vars.contains(&var) {
+                                result.insert(var);
+                            }
+                        }
+                    }
+                }
+            }
+            Stmt::Expr(Expr::Loop(loop_expr), _) => {
+                for var in collect_mutated_variables_from_block(&loop_expr.body)? {
+                    if !local_vars.contains(&var) {
+                        result.insert(var);
+                    }
+                }
+            }
             _ => continue,
         }
     }

--- a/cutile-compiler/src/specialization.rs
+++ b/cutile-compiler/src/specialization.rs
@@ -14,6 +14,9 @@
 ///
 /// Used by the JIT compiler to emit targeted `assume_div_by` operations.
 /// Works for tensor dimensions, strides, pointers, and scalar integers.
+///
+/// `DivHint` is unit-agnostic: the unit of `divisor` depends on context.
+/// See [`SpecializationBits`] for how each field's unit is defined.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 pub struct DivHint {
     /// Max power-of-2 divisor of the value, clamped to `max`.
@@ -33,6 +36,9 @@ impl Default for DivHint {
 
 impl DivHint {
     /// Compute divisibility from an integer value, clamped to 16.
+    ///
+    /// The unit of the result matches the unit of `val`: elements for
+    /// shape/stride values, bytes for pointer addresses cast to i32.
     pub fn from_value(val: i32) -> Self {
         let raw: i32 = max_pow2_divisor_unclamped(val);
         Self {
@@ -42,6 +48,10 @@ impl DivHint {
     }
 
     /// Compute divisibility from a pointer address, clamped to 16.
+    ///
+    /// The result is in **bytes**: a divisor of 16 means the pointer is
+    /// aligned to a 16-byte boundary. This matches cutile-python's
+    /// `base_addr_divisible_by` convention.
     pub fn from_ptr(ptr: u64) -> Self {
         let raw: i32 = max_pow2_divisor_unclamped(ptr as i32);
         Self {
@@ -65,15 +75,24 @@ impl DivHint {
 /// Computed once at tensor construction and recomputed on reshape/view.
 /// Used by the JIT compiler to emit targeted `assume_div_by` operations
 /// and to determine static vs dynamic strides in generated MLIR.
+///
+/// # Units
+///
+/// `shape_div` and `stride_div` are in **elements** (not bytes). This
+/// matches NVT and cutile-python, where divisibility is dtype-independent.
+/// `base_ptr_div` is in **bytes** (raw pointer alignment). This matches
+/// cutile-python's `base_addr_divisible_by` convention.
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct SpecializationBits {
-    /// Per-dimension: divisibility of shape[i].
+    /// Per-dimension: divisibility of shape[i], in **elements**.
     pub shape_div: Vec<DivHint>,
-    /// Per-dimension: divisibility of stride[i] in bytes.
+    /// Per-dimension: divisibility of stride[i], in **elements** (not bytes).
+    /// A stride of 1 element always has divisor 1, regardless of dtype size.
     pub stride_div: Vec<DivHint>,
     /// Per-dimension: whether stride[i] == 1.
     pub stride_one: Vec<bool>,
-    /// Divisibility of the base device pointer.
+    /// Divisibility of the base device pointer, in **bytes**.
+    /// A pointer at 0x1000 has divisor 16 (aligned to 16-byte boundary).
     pub base_ptr_div: DivHint,
     /// True if elements are non-overlapping (strides are non-aliasing).
     pub elements_disjoint: bool,
@@ -121,7 +140,7 @@ pub fn compute_spec(
     base_ptr: u64,
     shape: &[i32],
     strides: &[i32],
-    dtype_bytes: i32,
+    _dtype_bytes: i32,
 ) -> SpecializationBits {
     let ndim = shape.len();
     let mut spec = SpecializationBits {
@@ -133,8 +152,8 @@ pub fn compute_spec(
     };
     for i in 0..ndim {
         spec.shape_div.push(DivHint::from_value(shape[i]));
-        let stride_bytes: i32 = strides[i] * dtype_bytes;
-        spec.stride_div.push(DivHint::from_value(stride_bytes));
+        // Divisibility is in elements, not bytes (matches NVT and cutile-python).
+        spec.stride_div.push(DivHint::from_value(strides[i]));
         spec.stride_one.push(strides[i] == 1);
     }
     // Disjointness: sort by stride, check stride[i+1] >= stride[i] * shape[i].

--- a/cutile-compiler/src/specialization_tests.rs
+++ b/cutile-compiler/src/specialization_tests.rs
@@ -65,7 +65,7 @@ mod tests {
         // 1D tensor: shape=[1024], strides=[1], dtype=f32 (4 bytes), ptr aligned to 16
         let spec = compute_spec(0x1000, &[1024], &[1], 4);
         assert_eq!(spec.shape_div, vec![dh(16)]); // 1024 % 16 == 0
-        assert_eq!(spec.stride_div, vec![dh(4)]); // stride_bytes = 1*4 = 4
+        assert_eq!(spec.stride_div, vec![dh(1)]); // stride=1 in elements
         assert_eq!(spec.stride_one, vec![true]);
         assert_eq!(spec.base_ptr_div, dh(16)); // 0x1000 % 16 == 0
         assert!(spec.elements_disjoint);
@@ -76,7 +76,7 @@ mod tests {
         // 2D tensor: shape=[128, 256], strides=[256, 1], dtype=f16 (2 bytes)
         let spec = compute_spec(0x1000, &[128, 256], &[256, 1], 2);
         assert_eq!(spec.shape_div, vec![dh(16), dh(16)]); // both divisible by 16
-        assert_eq!(spec.stride_div, vec![dh(16), dh(2)]); // 256*2=512 -> 16; 1*2=2 -> 2
+        assert_eq!(spec.stride_div, vec![dh(16), dh(1)]); // stride=[256,1] in elements
         assert_eq!(spec.stride_one, vec![false, true]);
         assert!(spec.elements_disjoint);
     }
@@ -86,7 +86,7 @@ mod tests {
         // shape=[1023], strides=[1], dtype=f32
         let spec = compute_spec(0x1000, &[1023], &[1], 4);
         assert_eq!(spec.shape_div, vec![dh(1)]); // 1023 is odd
-        assert_eq!(spec.stride_div, vec![dh(4)]);
+        assert_eq!(spec.stride_div, vec![dh(1)]); // stride=1 in elements
         assert_eq!(spec.stride_one, vec![true]);
     }
 
@@ -95,6 +95,96 @@ mod tests {
         // ptr not aligned to 16
         let spec = compute_spec(0x1004, &[128], &[1], 4);
         assert_eq!(spec.base_ptr_div, dh(4)); // 0x1004 = 4100, divisible by 4
+    }
+
+    #[test]
+    fn stride_div_is_in_elements_not_bytes() {
+        // stride=1 should have div=1 regardless of dtype_bytes.
+        // Bug: stride_div was computed as DivHint::from_value(stride * dtype_bytes),
+        // giving div=4 for f32 (dtype_bytes=4). Should be div=1 (stride in elements).
+        let spec_f32 = compute_spec(0x1000, &[128], &[1], 4);
+        assert_eq!(
+            spec_f32.stride_div,
+            vec![dh(1)],
+            "stride=1 with f32: div should be 1 (elements), not 4 (bytes)"
+        );
+
+        let spec_f16 = compute_spec(0x1000, &[128], &[1], 2);
+        assert_eq!(
+            spec_f16.stride_div,
+            vec![dh(1)],
+            "stride=1 with f16: div should be 1 (elements), not 2 (bytes)"
+        );
+
+        // stride=256 should have div=16 regardless of dtype.
+        let spec = compute_spec(0x1000, &[128, 256], &[256, 1], 2);
+        assert_eq!(
+            spec.stride_div,
+            vec![dh(16), dh(1)],
+            "stride=[256,1]: divs should be [16,1] in elements"
+        );
+    }
+
+    #[test]
+    fn base_ptr_div_is_in_bytes() {
+        // base_ptr_div measures raw pointer alignment in bytes, not elements.
+        // A pointer at 0x1000 (4096) is 16-byte aligned regardless of dtype.
+        // Matches cutile-python: base_addr_divisible_by=16.
+        let spec_f32 = compute_spec(0x1000, &[128], &[1], 4);
+        assert_eq!(
+            spec_f32.base_ptr_div,
+            dh(16),
+            "0x1000 is 16-byte aligned: base_ptr_div should be 16 (bytes)"
+        );
+
+        let spec_f16 = compute_spec(0x1000, &[128], &[1], 2);
+        assert_eq!(
+            spec_f16.base_ptr_div,
+            dh(16),
+            "same pointer, different dtype: base_ptr_div is still 16 (bytes, not elements)"
+        );
+
+        // 0x1004 = 4100 = 4 * 1025, so 4-byte aligned.
+        let spec = compute_spec(0x1004, &[128], &[1], 4);
+        assert_eq!(
+            spec.base_ptr_div,
+            dh(4),
+            "0x1004 is 4-byte aligned: base_ptr_div should be 4 (bytes)"
+        );
+
+        // 0x1002 = 4098 = 2 * 2049, so 2-byte aligned.
+        let spec = compute_spec(0x1002, &[128], &[1], 2);
+        assert_eq!(
+            spec.base_ptr_div,
+            dh(2),
+            "0x1002 is 2-byte aligned: base_ptr_div should be 2 (bytes)"
+        );
+    }
+
+    #[test]
+    fn units_elements_vs_bytes() {
+        // Combined test: stride_div is in elements, base_ptr_div is in bytes.
+        // For a 2D f32 tensor at 0x1000 with shape=[64,128], strides=[128,1]:
+        //   shape_div:    [16, 16]  — 64 and 128 are both divisible by 16 (elements)
+        //   stride_div:   [16, 1]   — 128 is divisible by 16 (elements), 1 has divisor 1
+        //   base_ptr_div: 16        — 0x1000 is 16-byte aligned (bytes)
+        //
+        // dtype_bytes does NOT affect shape_div or stride_div.
+        let spec_f32 = compute_spec(0x1000, &[64, 128], &[128, 1], 4);
+        let spec_f16 = compute_spec(0x1000, &[64, 128], &[128, 1], 2);
+
+        assert_eq!(
+            spec_f32.shape_div, spec_f16.shape_div,
+            "shape_div is in elements: dtype does not affect it"
+        );
+        assert_eq!(
+            spec_f32.stride_div, spec_f16.stride_div,
+            "stride_div is in elements: dtype does not affect it"
+        );
+        assert_eq!(
+            spec_f32.base_ptr_div, spec_f16.base_ptr_div,
+            "base_ptr_div is in bytes: same pointer → same alignment"
+        );
     }
 
     #[test]

--- a/cutile-macro/src/types.rs
+++ b/cutile-macro/src/types.rs
@@ -723,7 +723,7 @@ pub fn get_variadic_op_data(op_name: &str) -> Option<VariadicOpData> {
             output_map: ("()", &[]),
             return_type: ("()", &[]),
         }),
-        "fma" | "fma_op" => Some(VariadicOpData {
+        "fma" | "fma_op" | "fma_ftz" => Some(VariadicOpData {
             const_length_vars: &["N"],
             cga_map: HashMap::from([("S", "N")]),
             input_map: vec![
@@ -751,13 +751,15 @@ pub fn get_variadic_op_data(op_name: &str) -> Option<VariadicOpData> {
         }),
         // Unary operations.
         "ceil" | "cosh" | "cos" | "exp" | "exp2" | "exp2_ftz" | "log" | "log2" | "rsqrt"
-        | "sinh" | "sin" | "sqrt" | "tanh" | "tan" => Some(VariadicOpData {
-            const_length_vars: &["N"],
-            cga_map: HashMap::from([("S", "N")]),
-            input_map: vec![(0, "Tile", &["S"])],
-            output_map: ("Tile", &["S"]),
-            return_type: ("Tile", &["_", "S"]),
-        }),
+        | "rsqrt_ftz" | "sinh" | "sin" | "sqrt" | "sqrt_ftz" | "tanh" | "tan" => {
+            Some(VariadicOpData {
+                const_length_vars: &["N"],
+                cga_map: HashMap::from([("S", "N")]),
+                input_map: vec![(0, "Tile", &["S"])],
+                output_map: ("Tile", &["S"]),
+                return_type: ("Tile", &["_", "S"]),
+            })
+        }
         // iot is not (yet?) variadic.
         // "iota" => Some(VariadicOpData {
         //     const_length_vars: &["N"],
@@ -794,14 +796,16 @@ pub fn get_variadic_op_data(op_name: &str) -> Option<VariadicOpData> {
             output_map: ("Tile", &["S"]),
             return_type: ("Tile", &["_", "S"]),
         }),
-        "pow" | "maxf" | "maxf_ftz" | "minf" | "minf_ftz" | "andi" | "ori" | "xori" | "shli"
-        | "shri" => Some(VariadicOpData {
-            const_length_vars: &["N"],
-            cga_map: HashMap::from([("S", "N")]),
-            input_map: vec![(0, "Tile", &["S"]), (1, "Tile", &["S"])],
-            output_map: ("Tile", &["S"]),
-            return_type: ("Tile", &["_", "S"]),
-        }),
+        "pow" | "maxf" | "maxf_ftz" | "minf" | "minf_ftz" | "addf_ftz" | "subf_ftz"
+        | "mulf_ftz" | "divf_ftz" | "andi" | "ori" | "xori" | "shli" | "shri" => {
+            Some(VariadicOpData {
+                const_length_vars: &["N"],
+                cga_map: HashMap::from([("S", "N")]),
+                input_map: vec![(0, "Tile", &["S"]), (1, "Tile", &["S"])],
+                output_map: ("Tile", &["S"]),
+                return_type: ("Tile", &["_", "S"]),
+            })
+        }
         "bitcast" => Some(VariadicOpData {
             const_length_vars: &["N"],
             cga_map: HashMap::from([("S", "N")]),

--- a/cutile/src/_core.rs
+++ b/cutile/src/_core.rs
@@ -3200,6 +3200,92 @@ pub mod core {
         unreachable!()
     }
 
+    /// Element-wise floating-point addition with flush-to-zero.
+    ///
+    /// Same as `+` on tiles, but flushes denormal inputs and results to zero.
+    /// Uses `nearest_even` rounding. Only supported for f32.
+    #[cuda_tile::op(name="cuda_tile.addf", params=["lhs", "rhs"], named_attributes=["rounding_mode=#cuda_tile.rounding<nearest_even>", "flush_to_zero=unit"])]
+    #[cuda_tile::variadic_op(N = 6)]
+    pub fn addf_ftz<E: ElementType, const S: [i32; N]>(
+        lhs: Tile<E, S>,
+        rhs: Tile<E, S>,
+    ) -> Tile<E, S> {
+        unreachable!()
+    }
+
+    /// Element-wise floating-point subtraction with flush-to-zero.
+    ///
+    /// Same as `-` on tiles, but flushes denormal inputs and results to zero.
+    /// Uses `nearest_even` rounding. Only supported for f32.
+    #[cuda_tile::op(name="cuda_tile.subf", params=["lhs", "rhs"], named_attributes=["rounding_mode=#cuda_tile.rounding<nearest_even>", "flush_to_zero=unit"])]
+    #[cuda_tile::variadic_op(N = 6)]
+    pub fn subf_ftz<E: ElementType, const S: [i32; N]>(
+        lhs: Tile<E, S>,
+        rhs: Tile<E, S>,
+    ) -> Tile<E, S> {
+        unreachable!()
+    }
+
+    /// Element-wise floating-point multiplication with flush-to-zero.
+    ///
+    /// Same as `*` on tiles, but flushes denormal inputs and results to zero.
+    /// Uses `nearest_even` rounding. Only supported for f32.
+    #[cuda_tile::op(name="cuda_tile.mulf", params=["lhs", "rhs"], named_attributes=["rounding_mode=#cuda_tile.rounding<nearest_even>", "flush_to_zero=unit"])]
+    #[cuda_tile::variadic_op(N = 6)]
+    pub fn mulf_ftz<E: ElementType, const S: [i32; N]>(
+        lhs: Tile<E, S>,
+        rhs: Tile<E, S>,
+    ) -> Tile<E, S> {
+        unreachable!()
+    }
+
+    /// Element-wise floating-point division with flush-to-zero.
+    ///
+    /// Same as `/` on tiles, but flushes denormal inputs and results to zero.
+    /// Uses `nearest_even` rounding. Only supported for f32.
+    #[cuda_tile::op(name="cuda_tile.divf", params=["lhs", "rhs"], named_attributes=["rounding_mode=#cuda_tile.rounding<nearest_even>", "flush_to_zero=unit"])]
+    #[cuda_tile::variadic_op(N = 6)]
+    pub fn divf_ftz<E: ElementType, const S: [i32; N]>(
+        lhs: Tile<E, S>,
+        rhs: Tile<E, S>,
+    ) -> Tile<E, S> {
+        unreachable!()
+    }
+
+    /// Fused multiply-add with flush-to-zero: `result = lhs * rhs + acc`.
+    ///
+    /// Same as [`fma`], but flushes denormal inputs and results to zero.
+    /// Uses `nearest_even` rounding. Only supported for f32.
+    #[cuda_tile::op(name="cuda_tile.fma", params=["lhs", "rhs", "acc"], named_attributes=["rounding_mode=#cuda_tile.rounding<nearest_even>", "flush_to_zero=unit"])]
+    #[cuda_tile::variadic_op(N = 6)]
+    pub fn fma_ftz<E: ElementType, const S: [i32; N]>(
+        lhs: Tile<E, S>,
+        rhs: Tile<E, S>,
+        acc: Tile<E, S>,
+    ) -> Tile<E, S> {
+        unreachable!()
+    }
+
+    /// Element-wise reciprocal square root with flush-to-zero.
+    ///
+    /// Same as [`rsqrt`], but flushes denormal inputs and results to zero.
+    /// Only supported for f32.
+    #[cuda_tile::op(name="cuda_tile.rsqrt", params=["x"], named_attributes=["flush_to_zero=unit"])]
+    #[cuda_tile::variadic_op(N = 6)]
+    pub fn rsqrt_ftz<E: ElementType, const S: [i32; N]>(x: Tile<E, S>) -> Tile<E, S> {
+        unreachable!()
+    }
+
+    /// Element-wise square root with flush-to-zero.
+    ///
+    /// Same as [`sqrt`], but flushes denormal inputs and results to zero.
+    /// Uses `nearest_even` rounding. Only supported for f32.
+    #[cuda_tile::op(name="cuda_tile.sqrt", params=["x"], named_attributes=["rounding_mode=#cuda_tile.rounding<nearest_even>", "flush_to_zero=unit"])]
+    #[cuda_tile::variadic_op(N = 6)]
+    pub fn sqrt_ftz<E: ElementType, const S: [i32; N]>(x: Tile<E, S>) -> Tile<E, S> {
+        unreachable!()
+    }
+
     /// Conditional selection operation.
     ///
     /// Returns `val_if_true` where `cond` is true, otherwise returns `val_if_false`.

--- a/cutile/tests/control_flow_ops.rs
+++ b/cutile/tests/control_flow_ops.rs
@@ -154,9 +154,56 @@ mod control_flow_ops_module {
         let result: Tile<i64, S> = same_tile + constant(1i64, output.shape());
         output.store(result);
     }
+
+    /// Repro: for loop inside if doesn't propagate mutable variable.
+    /// collect_mutated_variables_from_block doesn't recurse into
+    /// nested control flow (for/while/if), so the if op doesn't
+    /// yield acc, and post-if code uses the stale pre-if value.
+    #[cutile::entry()]
+    fn if_for_carry_kernel<const S: [i32; 1]>(output: &mut Tensor<f32, S>, flag: i32) {
+        let mut acc: Tile<f32, S> = constant(0.0f32, output.shape());
+        if flag > 0i32 {
+            for _i in 0i32..10i32 {
+                let ones: Tile<f32, S> = constant(1.0f32, output.shape());
+                acc = acc + ones;
+            }
+        } else {
+            acc = acc;
+        }
+        output.store(acc);
+    }
+
+    /// Same repro but with const generic flag (closer to Yinuo's report).
+    #[cutile::entry()]
+    fn if_for_carry_const_kernel<const S: [i32; 1], const FLAG: i32, const N: i32>(
+        output: &mut Tensor<f32, S>,
+    ) {
+        let mut acc: Tile<f32, S> = constant(0.0f32, output.shape());
+        if FLAG > 0i32 {
+            for _i in 0i32..N {
+                let ones: Tile<f32, S> = constant(1.0f32, output.shape());
+                acc = acc + ones;
+            }
+        } else {
+            acc = acc;
+        }
+        output.store(acc);
+    }
+
+    /// if/else as a tile expression: `let result = if cond { a } else { b };`
+    #[cutile::entry()]
+    fn if_else_tile_expr_kernel<const S: [i32; 1]>(output: &mut Tensor<f32, S>, flag: i32) {
+        let ones: Tile<f32, S> = constant(1.0f32, output.shape());
+        let twos: Tile<f32, S> = constant(2.0f32, output.shape());
+        let result: Tile<f32, S> = if flag > 0i32 { ones } else { twos };
+        output.store(result);
+    }
 }
 
-use control_flow_ops_module::{_module_asts, break_test_kernel, if_return_test_kernel};
+use control_flow_ops_module::{
+    _module_asts, break_test_kernel, if_else_tile_expr_kernel, if_for_carry_const_kernel,
+    if_for_carry_kernel, if_return_test_kernel,
+};
 
 #[test]
 fn compile_control_flow_test() -> () {
@@ -546,5 +593,77 @@ fn compile_assume_same_elements_test() -> () {
         );
 
         println!("\n✓ assume_same_elements operation verified with same_elements<[2, 4]>");
+    });
+}
+
+#[test]
+fn if_for_carry_propagates_mutation() {
+    // Repro: for loop inside if should propagate mutable variable updates.
+    // flag=1 means the if body runs: acc += 1.0 ten times → acc = 10.0.
+    // Bug: acc stays 0.0 because the if op doesn't yield the for's output.
+    common::with_test_stack(|| {
+        let mut output = cutile::api::zeros::<f32>(&[128]).sync().expect("alloc");
+        if_for_carry_kernel((&mut output).partition([128]), 1i32)
+            .sync()
+            .expect("kernel");
+        let host: Vec<f32> = output.dup().to_host_vec().sync().expect("to_host");
+        assert!(
+            (host[0] - 10.0).abs() < 1e-3,
+            "Expected 10.0 (for loop ran 10 times), got {}",
+            host[0]
+        );
+    });
+}
+
+#[test]
+fn if_for_carry_const_propagates_mutation() {
+    // Same as above but with const generic FLAG and N.
+    // FLAG=1, N=10 → acc = 10.0.
+    common::with_test_stack(|| {
+        let mut output = cutile::api::zeros::<f32>(&[128]).sync().expect("alloc");
+        if_for_carry_const_kernel((&mut output).partition([128]))
+            .generics(vec![
+                "128".to_string(), // S
+                "1".to_string(),   // FLAG
+                "10".to_string(),  // N
+            ])
+            .sync()
+            .expect("kernel");
+        let host: Vec<f32> = output.dup().to_host_vec().sync().expect("to_host");
+        assert!(
+            (host[0] - 10.0).abs() < 1e-3,
+            "Expected 10.0 (const FLAG=1, N=10), got {}",
+            host[0]
+        );
+    });
+}
+
+#[test]
+fn if_else_tile_expr_returns_value() {
+    // if/else as an expression: `let result = if flag > 0 { ones } else { twos };`
+    // flag=1 → result = 1.0, flag=0 → result = 2.0.
+    common::with_test_stack(|| {
+        let mut output = cutile::api::zeros::<f32>(&[128]).sync().expect("alloc");
+        if_else_tile_expr_kernel((&mut output).partition([128]), 1i32)
+            .sync()
+            .expect("kernel");
+        let host: Vec<f32> = output.dup().to_host_vec().sync().expect("to_host");
+        assert!(
+            (host[0] - 1.0).abs() < 1e-3,
+            "flag=1: expected 1.0, got {}",
+            host[0]
+        );
+    });
+    common::with_test_stack(|| {
+        let mut output = cutile::api::zeros::<f32>(&[128]).sync().expect("alloc");
+        if_else_tile_expr_kernel((&mut output).partition([128]), 0i32)
+            .sync()
+            .expect("kernel");
+        let host: Vec<f32> = output.dup().to_host_vec().sync().expect("to_host");
+        assert!(
+            (host[0] - 2.0).abs() < 1e-3,
+            "flag=0: expected 2.0, got {}",
+            host[0]
+        );
     });
 }

--- a/cutile/tests/optimization_hints.rs
+++ b/cutile/tests/optimization_hints.rs
@@ -62,6 +62,16 @@ mod opt_hints_module {
         let tile: Tile<f32, S> = constant(1.0f32, output.shape());
         output.store(tile);
     }
+
+    /// Latency as a const generic — specialized at launch time.
+    #[cutile::entry()]
+    fn load_view_const_latency_kernel<const S: [i32; 1], const L: i32>(input: &Tensor<f32, S>) {
+        let token: Token = new_token_unordered();
+        let shape = input.shape();
+        let partition: Partition<f32, S> = make_partition_view(input, shape, token);
+        let idx: [i32; 1] = [0i32];
+        let _tile: Tile<f32, S> = load_from_view(&partition, idx, Some(L), false);
+    }
 }
 
 use opt_hints_module::_module_asts;
@@ -214,6 +224,38 @@ fn different_compile_options_produce_different_mlir() {
         assert_ne!(
             mlir_a, mlir_b,
             "Different CompileOptions should produce different MLIR"
+        );
+    });
+}
+
+#[test]
+fn load_view_const_latency_in_mlir() {
+    // Latency as a const generic: L=5 should appear as `latency = 5` in MLIR.
+    common::with_test_stack(|| {
+        let modules =
+            CUDATileModules::new(_module_asts()).expect("Failed to create CUDATileModules");
+        let gpu_name = get_gpu_name(0);
+        let compiler = CUDATileFunctionCompiler::new(
+            &modules,
+            "opt_hints_module",
+            "load_view_const_latency_kernel",
+            &[128.to_string(), 5.to_string()], // S=128, L=5
+            &[("input", &[1])],
+            &[],
+            &[],
+            None,
+            gpu_name,
+            &CompileOptions::default(),
+        )
+        .expect("Failed to create compiler");
+        let module_op = compiler.compile().expect("Failed to compile");
+        let mlir = module_op.as_operation().to_string();
+        drop(module_op);
+        drop(compiler);
+        println!("{mlir}");
+        assert!(
+            mlir.contains("latency = 5"),
+            "Expected latency=5 from const generic L=5.\nMLIR:\n{mlir}"
         );
     });
 }

--- a/cutile/tests/unary_math_ops.rs
+++ b/cutile/tests/unary_math_ops.rs
@@ -110,6 +110,61 @@ mod unary_math_ops_module {
     }
 
     #[cutile::entry()]
+    fn addf_ftz_kernel<const S: [i32; 1]>(output: &mut Tensor<f32, S>) {
+        let x: Tile<f32, S> = load_tile_mut(output);
+        let y: Tile<f32, S> = load_tile_mut(output);
+        let result: Tile<f32, S> = addf_ftz(x, y);
+        output.store(result);
+    }
+
+    #[cutile::entry()]
+    fn subf_ftz_kernel<const S: [i32; 1]>(output: &mut Tensor<f32, S>) {
+        let x: Tile<f32, S> = load_tile_mut(output);
+        let y: Tile<f32, S> = load_tile_mut(output);
+        let result: Tile<f32, S> = subf_ftz(x, y);
+        output.store(result);
+    }
+
+    #[cutile::entry()]
+    fn mulf_ftz_kernel<const S: [i32; 1]>(output: &mut Tensor<f32, S>) {
+        let x: Tile<f32, S> = load_tile_mut(output);
+        let y: Tile<f32, S> = load_tile_mut(output);
+        let result: Tile<f32, S> = mulf_ftz(x, y);
+        output.store(result);
+    }
+
+    #[cutile::entry()]
+    fn divf_ftz_kernel<const S: [i32; 1]>(output: &mut Tensor<f32, S>) {
+        let x: Tile<f32, S> = load_tile_mut(output);
+        let y: Tile<f32, S> = load_tile_mut(output);
+        let result: Tile<f32, S> = divf_ftz(x, y);
+        output.store(result);
+    }
+
+    #[cutile::entry()]
+    fn fma_ftz_kernel<const S: [i32; 1]>(output: &mut Tensor<f32, S>) {
+        let x: Tile<f32, S> = load_tile_mut(output);
+        let y: Tile<f32, S> = load_tile_mut(output);
+        let z: Tile<f32, S> = load_tile_mut(output);
+        let result: Tile<f32, S> = fma_ftz(x, y, z);
+        output.store(result);
+    }
+
+    #[cutile::entry()]
+    fn rsqrt_ftz_kernel<const S: [i32; 1]>(output: &mut Tensor<f32, S>) {
+        let x: Tile<f32, S> = load_tile_mut(output);
+        let result: Tile<f32, S> = rsqrt_ftz(x);
+        output.store(result);
+    }
+
+    #[cutile::entry()]
+    fn sqrt_ftz_kernel<const S: [i32; 1]>(output: &mut Tensor<f32, S>) {
+        let x: Tile<f32, S> = load_tile_mut(output);
+        let result: Tile<f32, S> = sqrt_ftz(x);
+        output.store(result);
+    }
+
+    #[cutile::entry()]
     fn unary_math_ops_bf16_kernel<const S: [i32; 1]>(output: &mut Tensor<bf16, S>) {
         // Verifies bf16 unary math operation lowering
         let x: Tile<bf16, S> = load_tile_mut(output);
@@ -424,6 +479,78 @@ fn compile_minf_ftz() -> () {
             "Expected flush_to_zero attribute in MLIR output"
         );
     });
+}
+
+/// Helper: compile a kernel and assert it contains the expected op name and flush_to_zero.
+fn assert_ftz_in_mlir(kernel_name: &'static str, expected_op: &'static str) {
+    common::with_test_stack(move || {
+        let modules =
+            CUDATileModules::new(_module_asts()).expect("Failed to create CUDATileModules");
+        let gpu_name = get_gpu_name(0);
+        let compiler = CUDATileFunctionCompiler::new(
+            &modules,
+            "unary_math_ops_module",
+            kernel_name,
+            &[128.to_string()],
+            &[("output", &[1])],
+            &[],
+            &[],
+            None,
+            gpu_name,
+            &CompileOptions::default(),
+        )
+        .expect("Failed.");
+        let module_op_str = compiler
+            .compile()
+            .expect("Failed.")
+            .as_operation()
+            .to_string();
+        println!("\n=== {kernel_name} MLIR ===\n{module_op_str}");
+
+        assert!(
+            module_op_str.contains(expected_op),
+            "Expected {expected_op} operation in MLIR output"
+        );
+        assert!(
+            module_op_str.contains("flush_to_zero"),
+            "Expected flush_to_zero attribute in MLIR output"
+        );
+    });
+}
+
+#[test]
+fn compile_addf_ftz() {
+    assert_ftz_in_mlir("addf_ftz_kernel", "addf");
+}
+
+#[test]
+fn compile_subf_ftz() {
+    assert_ftz_in_mlir("subf_ftz_kernel", "subf");
+}
+
+#[test]
+fn compile_mulf_ftz() {
+    assert_ftz_in_mlir("mulf_ftz_kernel", "mulf");
+}
+
+#[test]
+fn compile_divf_ftz() {
+    assert_ftz_in_mlir("divf_ftz_kernel", "divf");
+}
+
+#[test]
+fn compile_fma_ftz() {
+    assert_ftz_in_mlir("fma_ftz_kernel", "fma");
+}
+
+#[test]
+fn compile_rsqrt_ftz() {
+    assert_ftz_in_mlir("rsqrt_ftz_kernel", "rsqrt");
+}
+
+#[test]
+fn compile_sqrt_ftz() {
+    assert_ftz_in_mlir("sqrt_ftz_kernel", "sqrt");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Fix stride divisibility to use elements (not bytes), matching NVT and cutile-python conventions. Document element vs byte units on DivHint/SpecializationBits.
- Fix collect_mutated_variables to recurse into nested control flow (for/while/if/loop).
- Add FTZ variants for all Tile IR ops that support flush_to_zero: addf, subf, mulf, divf, fma, rsqrt, sqrt.
- Fix if/else as tile expression: condition was compiled with the expression's return type context.
- Support const generic latency hints in load/store ops (load_ptr_tko, store_ptr_tko, load_view_tko, store_view_tko).