### PR TITLE
feat!: static op params with type-safe ZST modifiers

### DIFF
--- a/cutile-benchmarks/benches/fmha.rs
+++ b/cutile-benchmarks/benches/fmha.rs
@@ -116,11 +116,11 @@ mod kernels {
             let qk = qk - m_ij.broadcast(const_shape![BM, BN]);
 
             // Apply softmax(mask(scale(q @ k^T))).
-            let p: Tile<f16, { [BM, BN] }> = exp2(qk);
+            let p: Tile<f16, { [BM, BN] }> = exp2(qk, ftz::Disabled);
             let l_ij: Tile<f16, { [BM] }> = reduce_sum(p, 1);
             let l_ij: Tile<f16, { [BM, 1] }> = l_ij.reshape(const_shape![BM, 1]);
-            let alpha: Tile<f16, { [BM, 1] }> = exp2(m_i - m_ij);
-            l_i = fma(l_i, alpha, l_ij);
+            let alpha: Tile<f16, { [BM, 1] }> = exp2(m_i - m_ij, ftz::Disabled);
+            l_i = fma(l_i, alpha, l_ij, rounding::NearestEven, ftz::Disabled);
             let alpha: Tile<f16, { [BM, D] }> = alpha.broadcast(const_shape![BM, D]);
             acc = acc * alpha;
 

--- a/cutile-benchmarks/benches/fmha_causal.rs
+++ b/cutile-benchmarks/benches/fmha_causal.rs
@@ -119,10 +119,10 @@ mod kernels {
             let m_ij: Tile<f16, { [BM, 1] }> = max_tile(m_i, qk_max);
             let qk = qk - m_ij.broadcast(const_shape![BM, BN]);
 
-            let p: Tile<f16, { [BM, BN] }> = exp2(qk);
+            let p: Tile<f16, { [BM, BN] }> = exp2(qk, ftz::Disabled);
             let l_ij: Tile<f16, { [BM] }> = reduce_sum(p, 1);
             let l_ij: Tile<f16, { [BM, 1] }> = l_ij.reshape(const_shape![BM, 1]);
-            let alpha: Tile<f16, { [BM, 1] }> = exp2(m_i - m_ij);
+            let alpha: Tile<f16, { [BM, 1] }> = exp2(m_i - m_ij, ftz::Disabled);
             l_i = l_i * alpha + l_ij;
             acc = acc * alpha.broadcast(const_shape![BM, D]);
 

--- a/cutile-benchmarks/benches/gemm.rs
+++ b/cutile-benchmarks/benches/gemm.rs
@@ -9,7 +9,6 @@ use cutile::api;
 use cutile::core::f16;
 use cutile::tile_kernel::{PartitionOp, TileKernel};
 use kernels::*;
-use std::iter::zip;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 

--- a/cutile-benchmarks/benches/rmsnorm.rs
+++ b/cutile-benchmarks/benches/rmsnorm.rs
@@ -47,7 +47,8 @@ mod kernels {
         let n: f16 = convert_scalar(N);
         let one: f16 = convert_scalar(1.0f32);
         let rms: f16 = one / (rms / n + eps);
-        let rms: Tile<f16, { [] }> = sqrt(scalar_to_tile(rms), "negative_inf");
+        let rms: Tile<f16, { [] }> =
+            sqrt(scalar_to_tile(rms), rounding::NegativeInf, ftz::Disabled);
         let rms: f16 = tile_to_scalar(rms);
         let rms: Tile<f16, { [1, BLOCK_SIZE] }> = broadcast_scalar(rms, tile_shape);
 

--- a/cutile-book/appendix/syntax-reference.md
+++ b/cutile-book/appendix/syntax-reference.md
@@ -281,7 +281,7 @@ let result = fma(x, y, z, "nearest_even");
 
 ```rust
 let y = exp(x);       // e^x
-let y = exp2(x);      // 2^x (faster on GPU)
+let y = exp2(x, ftz::Disabled);      // 2^x (faster on GPU)
 let y = log(x);       // Natural log (ln)
 let y = log2(x);      // Log base 2
 let y = sqrt(x, "negative_inf");   // Square root
@@ -791,9 +791,9 @@ for j in 0i32..num_tiles {
     let qk_max = reduce_max(qk, 1).reshape(const_shape![BM, 1]);
     let m_ij = max_tile(m_i, qk_max);
     let qk = qk - m_ij.broadcast(const_shape![BM, BN]);
-    let p = exp2(qk);
+    let p = exp2(qk, ftz::Disabled);
     let l_ij = reduce_sum(p, 1).reshape(const_shape![BM, 1]);
-    let alpha = exp2(m_i - m_ij);
+    let alpha = exp2(m_i - m_ij, ftz::Disabled);
     l_i = l_i * alpha + l_ij;
     acc = acc * alpha.broadcast(const_shape![BM, D]);
     
@@ -896,7 +896,7 @@ let z_host: Vec<f32> = z.unpartition().await?.to_host_vec().await?;
 | Float | Integer | Description |
 |-------|---------|-------------|
 | `exp(x)` | — | e^x |
-| `exp2(x)` | — | 2^x |
+| `exp2(x, ftz::Disabled)` | — | 2^x |
 | `log(x)` | — | ln(x) |
 | `log2(x)` | — | log₂(x) |
 | `sqrt(x, mode)` | — | √x |

--- a/cutile-book/guide/dsl-api.md
+++ b/cutile-book/guide/dsl-api.md
@@ -383,6 +383,7 @@ In addition to operator overloading (`+`, `-`, `*`, `/`), these explicit functio
 | `negi(x)` | `Tile<E, S> -> Tile<E, S>` | Negation (integer) |
 | `negf(x)` | `Tile<E, S> -> Tile<E, S>` | Negation (float) |
 | `fma(a, b, c)` | `(Tile<E, S>, Tile<E, S>, Tile<E, S>) -> Tile<E, S>` | Fused multiply-add: `a * b + c` |
+| `fma_ftz(a, b, c)` | `(Tile<E, S>, Tile<E, S>, Tile<E, S>) -> Tile<E, S>` | Fused multiply-add (flush-to-zero) |
 | `pow(base, exp)` | `(Tile<E, S>, Tile<E, S>) -> Tile<E, S>` | Power |
 | `ceil_div(a, b)` | `(E, E) -> E` | Ceiling division (scalar) |
 | `true_div(a, b)` | `(Tile<E, S>, Tile<E, S>) -> Tile<E, S>` | True (floating-point) division |
@@ -409,12 +410,14 @@ let neg_i: Tile<i32, S> = negi(int_tile);
 | Function | Signature | Description |
 |---|---|---|
 | `exp(x)` | `Tile<E, S> -> Tile<E, S>` | e^x |
-| `exp2(x)` | `Tile<E, S> -> Tile<E, S>` | 2^x |
+| `exp2(x, ftz::Disabled)` | `Tile<E, S> -> Tile<E, S>` | 2^x |
 | `exp2_ftz(x)` | `Tile<E, S> -> Tile<E, S>` | 2^x with flush-to-zero |
 | `log(x)` | `Tile<E, S> -> Tile<E, S>` | Natural logarithm |
 | `log2(x)` | `Tile<E, S> -> Tile<E, S>` | Base-2 logarithm |
 | `sqrt(x)` | `Tile<E, S> -> Tile<E, S>` | Square root |
+| `sqrt_ftz(x)` | `Tile<E, S> -> Tile<E, S>` | Square root with flush-to-zero |
 | `rsqrt(x)` | `Tile<E, S> -> Tile<E, S>` | Reciprocal square root (1/sqrt(x)) |
+| `rsqrt_ftz(x)` | `Tile<E, S> -> Tile<E, S>` | Reciprocal square root with flush-to-zero |
 | `sin(x)` | `Tile<E, S> -> Tile<E, S>` | Sine |
 | `cos(x)` | `Tile<E, S> -> Tile<E, S>` | Cosine |
 | `tan(x)` | `Tile<E, S> -> Tile<E, S>` | Tangent |
@@ -427,6 +430,10 @@ let neg_i: Tile<i32, S> = negi(int_tile);
 | `minf(a, b)` | `(Tile<E, S>, Tile<E, S>) -> Tile<E, S>` | Float min |
 | `maxf_ftz(a, b)` | `(Tile<E, S>, Tile<E, S>) -> Tile<E, S>` | Float max (flush-to-zero) |
 | `minf_ftz(a, b)` | `(Tile<E, S>, Tile<E, S>) -> Tile<E, S>` | Float min (flush-to-zero) |
+| `addf_ftz(a, b)` | `(Tile<E, S>, Tile<E, S>) -> Tile<E, S>` | Float add (flush-to-zero) |
+| `subf_ftz(a, b)` | `(Tile<E, S>, Tile<E, S>) -> Tile<E, S>` | Float sub (flush-to-zero) |
+| `mulf_ftz(a, b)` | `(Tile<E, S>, Tile<E, S>) -> Tile<E, S>` | Float mul (flush-to-zero) |
+| `divf_ftz(a, b)` | `(Tile<E, S>, Tile<E, S>) -> Tile<E, S>` | Float div (flush-to-zero) |
 
 ```rust
 // Softmax numerics: subtract max, exponentiate
@@ -443,12 +450,15 @@ let rms: Tile<f32, { [1] }> = rsqrt(mean_sq + broadcast_scalar(1e-6f32, const_sh
 let gelu_approx: Tile<f32, S> = x * (constant(1.0f32, x.shape()) + tanh(x));
 let swish: Tile<f32, S> = x / (constant(1.0f32, x.shape()) + exp(negf(x)));
 
-// exp2 is faster than exp on GPU — convert: exp(x) = exp2(x * log2(e))
+// exp2 is faster than exp on GPU — convert: exp(x) = exp2(x * log2(e, ftz::Disabled))
 let log2_e: f32 = 1.4426950408889634f32;
 let fast_exp: Tile<f32, S> = exp2(x * broadcast_scalar(log2_e, x.shape()));
 
-// Flush-to-zero variants: treat denormals as zero (faster on some hardware)
+// Flush-to-zero variants: treat denormals as zero (faster on some hardware, f32 only)
 let clamped: Tile<f32, S> = maxf_ftz(x, broadcast_scalar(0.0f32, x.shape()));
+let sum: Tile<f32, S> = addf_ftz(a, b);
+let product: Tile<f32, S> = mulf_ftz(a, b);
+let fma_result: Tile<f32, S> = fma_ftz(a, b, c);
 ```
 
 ### Comparison

--- a/cutile-book/guide/operations.md
+++ b/cutile-book/guide/operations.md
@@ -79,7 +79,7 @@ let result = fma(a, x, y, rounding_mode);
 
 ```rust
 let y = exp(x);              // e^x
-let y = exp2(x);             // 2^x (faster on GPU)
+let y = exp2(x, ftz::Disabled);             // 2^x (faster on GPU)
 let y = log(x);              // Natural log (ln)
 let y = log2(x);             // Log base 2
 let y = sqrt(x, "rn");       // Square root (requires rounding mode)

--- a/cutile-book/tutorials/06-flash-attention.md
+++ b/cutile-book/tutorials/06-flash-attention.md
@@ -113,7 +113,7 @@ For each Q tile (row block of the output):
 
 > **Implementation note:** The code below uses `exp2` instead of `exp` as a performance
 > optimization — `exp2` is faster on GPU hardware. To compensate, the scale factor is
-> divided by `ln(2)` so that `exp2(x / ln(2)) = exp(x)`. The correction factor `α` and
+> divided by `ln(2)` so that `exp2(x / ln(2, ftz::Disabled)) = exp(x)`. The correction factor `α` and
 > softmax numerator `P` are both computed with `exp2` using this adjusted scale.
 
 ---
@@ -193,10 +193,10 @@ mod fmha_module {
             let qk = qk - m_ij.broadcast(const_shape![BM, BN]);
 
             // Softmax numerator and correction factor
-            let p: Tile<f32, { [BM, BN] }> = exp2(qk);
+            let p: Tile<f32, { [BM, BN] }> = exp2(qk, ftz::Disabled);
             let l_ij: Tile<f32, { [BM] }> = reduce_sum(p, 1);
             let l_ij: Tile<f32, { [BM, 1] }> = l_ij.reshape(const_shape![BM, 1]);
-            let alpha: Tile<f32, { [BM, 1] }> = exp2(m_i - m_ij);
+            let alpha: Tile<f32, { [BM, 1] }> = exp2(m_i - m_ij, ftz::Disabled);
 
             // Update running sum and rescale accumulator
             l_i = l_i * alpha + l_ij;

--- a/cutile-compiler/src/compiler/compile_cuda_tile_op.rs
+++ b/cutile-compiler/src/compiler/compile_cuda_tile_op.rs
@@ -34,6 +34,109 @@ use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
 use syn::{Expr, ExprCall, ExprLit, ItemFn, Lit, Token, Type, UnOp};
 
+/// Resolves `static_params` from a `#[cuda_tile::op]` attribute against call-site arguments.
+///
+/// Each `static_params` entry has the format:
+///   `"param_name={TypeA: attr_name=attr_val, TypeB: attr_name=attr_val}"`
+///
+/// For each entry, this function:
+/// 1. Finds the argument index by matching `param_name` to the function signature
+/// 2. Reads the concrete ZST type name from the call-site expression (e.g., `ftz::Enabled`)
+/// 3. Looks up the type name in the mapping and returns `(attr_name, attr_val)` pairs
+///
+/// Returns a list of `"attr_name=attr_val"` strings to be emitted as MLIR named attributes.
+fn resolve_static_params(
+    static_params: &[String],
+    call_expr: &ExprCall,
+    fn_item: &ItemFn,
+) -> Result<Vec<String>, String> {
+    if static_params.is_empty() {
+        return Ok(vec![]);
+    }
+    let fn_params = get_sig_param_names(&fn_item.sig);
+    let mut attrs = vec![];
+
+    for spec in static_params {
+        // Parse: "param_name={TypeA: attr=val, TypeB: attr=val}"
+        let eq_pos = spec
+            .find('=')
+            .ok_or_else(|| format!("Invalid static_params entry (missing '='): {spec}"))?;
+        let param_name = spec[..eq_pos].trim();
+        let mapping_str = spec[eq_pos + 1..].trim();
+
+        // Find argument index by param name.
+        let Some(arg_idx) = fn_params.iter().position(|s| s == param_name) else {
+            return Err(format!(
+                "static_params: param '{param_name}' not found in function signature"
+            ));
+        };
+        if arg_idx >= call_expr.args.len() {
+            return Err(format!(
+                "static_params: param '{param_name}' at index {arg_idx} but only {} args in call",
+                call_expr.args.len()
+            ));
+        }
+
+        // Extract the ZST type name from the call-site argument.
+        // Expected forms: `ftz::Enabled`, `Enabled`, `Latency::<3>`
+        let arg_expr = &call_expr.args[arg_idx];
+        let type_name = match arg_expr {
+            Expr::Path(path) => {
+                // e.g., `ftz::Enabled` → "Enabled", or just `Enabled` → "Enabled"
+                path.path
+                    .segments
+                    .last()
+                    .map(|s| s.ident.to_string())
+                    .unwrap_or_default()
+            }
+            _ => {
+                return Err(format!(
+                    "static_params: expected path expression for param '{param_name}', got: {}",
+                    arg_expr.to_token_stream()
+                ));
+            }
+        };
+
+        // Look up the type name in the mapping.
+        // Format: "{TypeA: attr=val, TypeB: attr=val}"
+        if !mapping_str.starts_with('{') || !mapping_str.ends_with('}') {
+            return Err(format!(
+                "Invalid static_params mapping (expected {{...}}): {mapping_str}"
+            ));
+        }
+        let inner = &mapping_str[1..mapping_str.len() - 1];
+        // Split on ',' to get individual type mappings.
+        let mut matched = false;
+        for entry in inner.split(',') {
+            let entry = entry.trim();
+            if entry.is_empty() {
+                continue;
+            }
+            // Format: "TypeName: attr_name=attr_val" or "TypeName:" (empty = no attribute)
+            let colon_pos = entry
+                .find(':')
+                .ok_or_else(|| format!("Invalid static_params entry (missing ':'): {entry}"))?;
+            let entry_type = entry[..colon_pos].trim();
+            let entry_attr = entry[colon_pos + 1..].trim();
+
+            if entry_type == type_name {
+                if !entry_attr.is_empty() {
+                    attrs.push(entry_attr.to_string());
+                }
+                matched = true;
+                break;
+            }
+        }
+        // Types with no mapping entry (e.g., ftz::Disabled) emit nothing — that's valid.
+        if !matched {
+            // No mapping found — this is the "omit" case (e.g., Disabled).
+            // This is not an error.
+        }
+    }
+
+    Ok(attrs)
+}
+
 impl<'m, 'c> CUDATileFunctionCompiler<'m> {
     pub fn compile_cuda_tile_op_call(
         &'c self,
@@ -94,6 +197,9 @@ impl<'m, 'c> CUDATileFunctionCompiler<'m> {
         let cuda_tile_op_named_attributes = op_attrs
             .parse_string_arr("named_attributes")
             .unwrap_or_else(|| vec![]);
+        let cuda_tile_op_static_params = op_attrs
+            .parse_string_arr("static_params")
+            .unwrap_or_else(|| vec![]);
         if call_expr.args.len() < cuda_tile_op_params.len() {
             return self.jit_error_result(
                 &call_expr.span(),
@@ -130,6 +236,7 @@ impl<'m, 'c> CUDATileFunctionCompiler<'m> {
             &cuda_tile_op_attribute_params,
             &cuda_tile_op_hint_params,
             &cuda_tile_op_named_attributes,
+            &cuda_tile_op_static_params,
             generic_args,
             ctx,
             return_type,
@@ -376,7 +483,7 @@ impl<'m, 'c> CUDATileFunctionCompiler<'m> {
             }
         }
 
-        // arg[6]: latency (Option<i32>)
+        // arg[6]: latency (Option<i32>) — literal or const generic
         let mut hint_params: HashMap<String, i32> = HashMap::new();
         if let Some(latency_arg) =
             crate::compiler::utils::resolve_option_arg(&call_expr.args[6], ctx)
@@ -384,12 +491,17 @@ impl<'m, 'c> CUDATileFunctionCompiler<'m> {
             if let Expr::Lit(ExprLit {
                 lit: Lit::Int(int_lit),
                 ..
-            }) = latency_arg
+            }) = &latency_arg
             {
                 hint_params.insert(
                     "latency".to_string(),
                     int_lit.base10_parse::<i32>().unwrap(),
                 );
+            } else if let Expr::Path(path) = &latency_arg {
+                let name = path.path.segments.last().unwrap().ident.to_string();
+                if let Some(&v) = generic_args.inst_i32.get(&name) {
+                    hint_params.insert("latency".to_string(), v);
+                }
             }
         }
 
@@ -577,7 +689,7 @@ impl<'m, 'c> CUDATileFunctionCompiler<'m> {
             }
         }
 
-        // arg[6]: latency (Option<i32>)
+        // arg[6]: latency (Option<i32>) — literal or const generic
         let mut hint_params: HashMap<String, i32> = HashMap::new();
         if let Some(latency_arg) =
             crate::compiler::utils::resolve_option_arg(&call_expr.args[6], ctx)
@@ -585,12 +697,17 @@ impl<'m, 'c> CUDATileFunctionCompiler<'m> {
             if let Expr::Lit(ExprLit {
                 lit: Lit::Int(int_lit),
                 ..
-            }) = latency_arg
+            }) = &latency_arg
             {
                 hint_params.insert(
                     "latency".to_string(),
                     int_lit.base10_parse::<i32>().unwrap(),
                 );
+            } else if let Expr::Path(path) = &latency_arg {
+                let name = path.path.segments.last().unwrap().ident.to_string();
+                if let Some(&v) = generic_args.inst_i32.get(&name) {
+                    hint_params.insert("latency".to_string(), v);
+                }
             }
         }
 
@@ -1147,22 +1264,40 @@ impl<'m, 'c> CUDATileFunctionCompiler<'m> {
                 );
             };
             // Handle Option<i32> hint params (e.g. latency: Option<i32>).
+            // The inner value can be a literal (Some(4)) or a const generic (Some(L)).
             if let Some(inner) = crate::compiler::utils::resolve_option_arg(&call_expr.args[i], ctx)
             {
-                let Expr::Lit(lit_expr) = &inner else {
+                let value: i32 = if let Expr::Lit(lit_expr) = &inner {
+                    let Lit::Int(int_lit) = &lit_expr.lit else {
+                        return self.jit_error_result(
+                            &lit_expr.span(),
+                            "Non-integer literals not supported",
+                        );
+                    };
+                    int_lit.base10_parse::<i32>().unwrap()
+                } else if let Expr::Path(path) = &inner {
+                    let name = path.path.segments.last().unwrap().ident.to_string();
+                    if let Some(&v) = generic_args.inst_i32.get(&name) {
+                        v
+                    } else {
+                        return self.jit_error_result(
+                            &call_expr.args[i].span(),
+                            &format!(
+                                "Failed to compile hint param {hint_param}: \
+                                 '{name}' is not a literal or resolved const generic."
+                            ),
+                        );
+                    }
+                } else {
                     return self.jit_error_result(
                         &call_expr.args[i].span(),
-                        &format!("Failed to compile hint param {hint_param}, expected literal."),
+                        &format!(
+                            "Failed to compile hint param {hint_param}, \
+                             expected literal or const generic."
+                        ),
                     );
                 };
-                let Lit::Int(int_lit) = &lit_expr.lit else {
-                    return self
-                        .jit_error_result(&lit_expr.span(), "Non-integer literals not supported");
-                };
-                hint_params.insert(
-                    hint_param.to_string(),
-                    int_lit.base10_parse::<i32>().unwrap(),
-                );
+                hint_params.insert(hint_param.to_string(), value);
             }
         }
         // Handle disallow_tma: bool parameter.
@@ -1745,6 +1880,7 @@ impl<'m, 'c> CUDATileFunctionCompiler<'m> {
         cuda_tile_op_attribute_params: &[String],
         _cuda_tile_op_hint_params: &[String],
         cuda_tile_op_named_attributes: &[String],
+        cuda_tile_op_static_params: &[String],
         generic_args: &GenericVars,
         ctx: &mut CompilerContext<'c, 'c>,
         return_type: Option<TileRustType<'c>>,
@@ -1947,6 +2083,18 @@ impl<'m, 'c> CUDATileFunctionCompiler<'m> {
             } else {
                 op_builder =
                     op_builder.add_attributes(&[self.parse_named_attr(attr_name, attr_value)?]);
+            }
+        }
+
+        // Resolve static_params: ZST marker types → MLIR attributes.
+        let resolved_static_attrs =
+            resolve_static_params(cuda_tile_op_static_params, call_expr, fn_item)
+                .map_err(|e| JITError::Generic(e))?;
+        for attr_str in &resolved_static_attrs {
+            let parts = attr_str.splitn(2, '=').collect::<Vec<&str>>();
+            if parts.len() == 2 {
+                op_builder = op_builder
+                    .add_attributes(&[self.parse_named_attr(parts[0].trim(), parts[1].trim())?]);
             }
         }
 

--- a/cutile-compiler/src/compiler/compile_expression.rs
+++ b/cutile-compiler/src/compiler/compile_expression.rs
@@ -484,13 +484,10 @@ impl<'m, 'c> CUDATileFunctionCompiler<'m> {
                     Ok(None)
                 }
                 Expr::If(if_expr) => {
-                    let Some(conditional_val) = self.compile_expression(
-                        builder,
-                        &*if_expr.cond,
-                        generic_vars,
-                        ctx,
-                        return_type.clone(),
-                    )?
+                    // The condition is always bool — don't propagate the if
+                    // expression's return type into the condition.
+                    let Some(conditional_val) =
+                        self.compile_expression(builder, &*if_expr.cond, generic_vars, ctx, None)?
                     else {
                         return self.jit_error_result(
                             &if_expr.cond.span(),
@@ -1080,12 +1077,9 @@ impl<'m, 'c> CUDATileFunctionCompiler<'m> {
                     Ok(Some(TileRustValue::new_compound(values, return_type)))
                 }
                 Expr::Path(path_expr) => {
-                    if path_expr.path.segments.len() != 1 {
-                        return self.jit_error_result(
-                            &path_expr.span(),
-                            "qualified paths (e.g. `module::name`) are not supported here; use a simple variable name",
-                        );
-                    }
+                    // For qualified paths (e.g., `ftz::Enabled`, `rounding::NearestEven`),
+                    // use the last segment as the variable name. These are ZST marker types
+                    // used by static_params — they have no MLIR representation.
                     let var_name = path_expr.path.segments.last().unwrap().ident.to_string();
 
                     // Handle None specially - it's a Rust Option::None value, not a variable
@@ -1098,10 +1092,35 @@ impl<'m, 'c> CUDATileFunctionCompiler<'m> {
                     let value = match ctx.vars.get(&var_name) {
                         Some(ct_value) => ct_value,
                         None => {
+                            // Qualified paths like `ftz::Enabled` or `rounding::NearestEven`
+                            // are ZST marker types for static_params. They carry no MLIR
+                            // value — like string literals, they're compile-time constants
+                            // consumed by the op compilation path to emit MLIR attributes.
+                            //
+                            // Return a String-kinded placeholder so arg indexing is preserved
+                            // in callers (type derivation, inline path). Validation happens
+                            // in resolve_static_params, which checks the type name against
+                            // the function's static_params mapping.
+                            if path_expr.path.segments.len() > 1 {
+                                let path_ty: syn::Type = syn::Type::Path(syn::TypePath {
+                                    qself: None,
+                                    path: path_expr.path.clone(),
+                                });
+                                let type_instance = crate::generics::TypeInstance::UserType(
+                                    crate::generics::TypeInstanceUserType {
+                                        maybe_generic_ty: path_ty,
+                                    },
+                                );
+                                let ty = TileRustType::new_string(&self.context, type_instance);
+                                return Ok(Some(TileRustValue::new_string(
+                                    Expr::Path(path_expr.clone()),
+                                    ty,
+                                )));
+                            }
                             return self.jit_error_result(
                                 &path_expr.span(),
                                 &format!("undefined variable `{}`", var_name),
-                            )
+                            );
                         }
                     };
                     Ok(Some(value.clone()))

--- a/cutile-compiler/src/compiler/utils.rs
+++ b/cutile-compiler/src/compiler/utils.rs
@@ -613,6 +613,44 @@ pub fn collect_mutated_variables_from_block(
                     result.insert(var_name);
                 }
             }
+            // Recurse into nested control flow to find mutations.
+            Stmt::Expr(Expr::ForLoop(for_expr), _) => {
+                for var in collect_mutated_variables_from_block(&for_expr.body)? {
+                    if !local_vars.contains(&var) {
+                        result.insert(var);
+                    }
+                }
+            }
+            Stmt::Expr(Expr::While(while_expr), _) => {
+                for var in collect_mutated_variables_from_block(&while_expr.body)? {
+                    if !local_vars.contains(&var) {
+                        result.insert(var);
+                    }
+                }
+            }
+            Stmt::Expr(Expr::If(if_expr), _) => {
+                for var in collect_mutated_variables_from_block(&if_expr.then_branch)? {
+                    if !local_vars.contains(&var) {
+                        result.insert(var);
+                    }
+                }
+                if let Some((_else, else_expr)) = &if_expr.else_branch {
+                    if let Expr::Block(block_expr) = &**else_expr {
+                        for var in collect_mutated_variables_from_block(&block_expr.block)? {
+                            if !local_vars.contains(&var) {
+                                result.insert(var);
+                            }
+                        }
+                    }
+                }
+            }
+            Stmt::Expr(Expr::Loop(loop_expr), _) => {
+                for var in collect_mutated_variables_from_block(&loop_expr.body)? {
+                    if !local_vars.contains(&var) {
+                        result.insert(var);
+                    }
+                }
+            }
             _ => continue,
         }
     }

--- a/cutile-compiler/src/specialization.rs
+++ b/cutile-compiler/src/specialization.rs
@@ -14,6 +14,9 @@
 ///
 /// Used by the JIT compiler to emit targeted `assume_div_by` operations.
 /// Works for tensor dimensions, strides, pointers, and scalar integers.
+///
+/// `DivHint` is unit-agnostic: the unit of `divisor` depends on context.
+/// See [`SpecializationBits`] for how each field's unit is defined.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 pub struct DivHint {
     /// Max power-of-2 divisor of the value, clamped to `max`.
@@ -33,6 +36,9 @@ impl Default for DivHint {
 
 impl DivHint {
     /// Compute divisibility from an integer value, clamped to 16.
+    ///
+    /// The unit of the result matches the unit of `val`: elements for
+    /// shape/stride values, bytes for pointer addresses cast to i32.
     pub fn from_value(val: i32) -> Self {
         let raw: i32 = max_pow2_divisor_unclamped(val);
         Self {
@@ -42,6 +48,10 @@ impl DivHint {
     }
 
     /// Compute divisibility from a pointer address, clamped to 16.
+    ///
+    /// The result is in **bytes**: a divisor of 16 means the pointer is
+    /// aligned to a 16-byte boundary. This matches cutile-python's
+    /// `base_addr_divisible_by` convention.
     pub fn from_ptr(ptr: u64) -> Self {
         let raw: i32 = max_pow2_divisor_unclamped(ptr as i32);
         Self {
@@ -65,15 +75,24 @@ impl DivHint {
 /// Computed once at tensor construction and recomputed on reshape/view.
 /// Used by the JIT compiler to emit targeted `assume_div_by` operations
 /// and to determine static vs dynamic strides in generated MLIR.
+///
+/// # Units
+///
+/// `shape_div` and `stride_div` are in **elements** (not bytes). This
+/// matches NVT and cutile-python, where divisibility is dtype-independent.
+/// `base_ptr_div` is in **bytes** (raw pointer alignment). This matches
+/// cutile-python's `base_addr_divisible_by` convention.
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct SpecializationBits {
-    /// Per-dimension: divisibility of shape[i].
+    /// Per-dimension: divisibility of shape[i], in **elements**.
     pub shape_div: Vec<DivHint>,
-    /// Per-dimension: divisibility of stride[i] in bytes.
+    /// Per-dimension: divisibility of stride[i], in **elements** (not bytes).
+    /// A stride of 1 element always has divisor 1, regardless of dtype size.
     pub stride_div: Vec<DivHint>,
     /// Per-dimension: whether stride[i] == 1.
     pub stride_one: Vec<bool>,
-    /// Divisibility of the base device pointer.
+    /// Divisibility of the base device pointer, in **bytes**.
+    /// A pointer at 0x1000 has divisor 16 (aligned to 16-byte boundary).
     pub base_ptr_div: DivHint,
     /// True if elements are non-overlapping (strides are non-aliasing).
     pub elements_disjoint: bool,
@@ -121,7 +140,7 @@ pub fn compute_spec(
     base_ptr: u64,
     shape: &[i32],
     strides: &[i32],
-    dtype_bytes: i32,
+    _dtype_bytes: i32,
 ) -> SpecializationBits {
     let ndim = shape.len();
     let mut spec = SpecializationBits {
@@ -133,8 +152,8 @@ pub fn compute_spec(
     };
     for i in 0..ndim {
         spec.shape_div.push(DivHint::from_value(shape[i]));
-        let stride_bytes: i32 = strides[i] * dtype_bytes;
-        spec.stride_div.push(DivHint::from_value(stride_bytes));
+        // Divisibility is in elements, not bytes (matches NVT and cutile-python).
+        spec.stride_div.push(DivHint::from_value(strides[i]));
         spec.stride_one.push(strides[i] == 1);
     }
     // Disjointness: sort by stride, check stride[i+1] >= stride[i] * shape[i].

--- a/cutile-compiler/src/specialization_tests.rs
+++ b/cutile-compiler/src/specialization_tests.rs
@@ -65,7 +65,7 @@ mod tests {
         // 1D tensor: shape=[1024], strides=[1], dtype=f32 (4 bytes), ptr aligned to 16
         let spec = compute_spec(0x1000, &[1024], &[1], 4);
         assert_eq!(spec.shape_div, vec![dh(16)]); // 1024 % 16 == 0
-        assert_eq!(spec.stride_div, vec![dh(4)]); // stride_bytes = 1*4 = 4
+        assert_eq!(spec.stride_div, vec![dh(1)]); // stride=1 in elements
         assert_eq!(spec.stride_one, vec![true]);
         assert_eq!(spec.base_ptr_div, dh(16)); // 0x1000 % 16 == 0
         assert!(spec.elements_disjoint);
@@ -76,7 +76,7 @@ mod tests {
         // 2D tensor: shape=[128, 256], strides=[256, 1], dtype=f16 (2 bytes)
         let spec = compute_spec(0x1000, &[128, 256], &[256, 1], 2);
         assert_eq!(spec.shape_div, vec![dh(16), dh(16)]); // both divisible by 16
-        assert_eq!(spec.stride_div, vec![dh(16), dh(2)]); // 256*2=512 -> 16; 1*2=2 -> 2
+        assert_eq!(spec.stride_div, vec![dh(16), dh(1)]); // stride=[256,1] in elements
         assert_eq!(spec.stride_one, vec![false, true]);
         assert!(spec.elements_disjoint);
     }
@@ -86,7 +86,7 @@ mod tests {
         // shape=[1023], strides=[1], dtype=f32
         let spec = compute_spec(0x1000, &[1023], &[1], 4);
         assert_eq!(spec.shape_div, vec![dh(1)]); // 1023 is odd
-        assert_eq!(spec.stride_div, vec![dh(4)]);
+        assert_eq!(spec.stride_div, vec![dh(1)]); // stride=1 in elements
         assert_eq!(spec.stride_one, vec![true]);
     }
 
@@ -95,6 +95,96 @@ mod tests {
         // ptr not aligned to 16
         let spec = compute_spec(0x1004, &[128], &[1], 4);
         assert_eq!(spec.base_ptr_div, dh(4)); // 0x1004 = 4100, divisible by 4
+    }
+
+    #[test]
+    fn stride_div_is_in_elements_not_bytes() {
+        // stride=1 should have div=1 regardless of dtype_bytes.
+        // Bug: stride_div was computed as DivHint::from_value(stride * dtype_bytes),
+        // giving div=4 for f32 (dtype_bytes=4). Should be div=1 (stride in elements).
+        let spec_f32 = compute_spec(0x1000, &[128], &[1], 4);
+        assert_eq!(
+            spec_f32.stride_div,
+            vec![dh(1)],
+            "stride=1 with f32: div should be 1 (elements), not 4 (bytes)"
+        );
+
+        let spec_f16 = compute_spec(0x1000, &[128], &[1], 2);
+        assert_eq!(
+            spec_f16.stride_div,
+            vec![dh(1)],
+            "stride=1 with f16: div should be 1 (elements), not 2 (bytes)"
+        );
+
+        // stride=256 should have div=16 regardless of dtype.
+        let spec = compute_spec(0x1000, &[128, 256], &[256, 1], 2);
+        assert_eq!(
+            spec.stride_div,
+            vec![dh(16), dh(1)],
+            "stride=[256,1]: divs should be [16,1] in elements"
+        );
+    }
+
+    #[test]
+    fn base_ptr_div_is_in_bytes() {
+        // base_ptr_div measures raw pointer alignment in bytes, not elements.
+        // A pointer at 0x1000 (4096) is 16-byte aligned regardless of dtype.
+        // Matches cutile-python: base_addr_divisible_by=16.
+        let spec_f32 = compute_spec(0x1000, &[128], &[1], 4);
+        assert_eq!(
+            spec_f32.base_ptr_div,
+            dh(16),
+            "0x1000 is 16-byte aligned: base_ptr_div should be 16 (bytes)"
+        );
+
+        let spec_f16 = compute_spec(0x1000, &[128], &[1], 2);
+        assert_eq!(
+            spec_f16.base_ptr_div,
+            dh(16),
+            "same pointer, different dtype: base_ptr_div is still 16 (bytes, not elements)"
+        );
+
+        // 0x1004 = 4100 = 4 * 1025, so 4-byte aligned.
+        let spec = compute_spec(0x1004, &[128], &[1], 4);
+        assert_eq!(
+            spec.base_ptr_div,
+            dh(4),
+            "0x1004 is 4-byte aligned: base_ptr_div should be 4 (bytes)"
+        );
+
+        // 0x1002 = 4098 = 2 * 2049, so 2-byte aligned.
+        let spec = compute_spec(0x1002, &[128], &[1], 2);
+        assert_eq!(
+            spec.base_ptr_div,
+            dh(2),
+            "0x1002 is 2-byte aligned: base_ptr_div should be 2 (bytes)"
+        );
+    }
+
+    #[test]
+    fn units_elements_vs_bytes() {
+        // Combined test: stride_div is in elements, base_ptr_div is in bytes.
+        // For a 2D f32 tensor at 0x1000 with shape=[64,128], strides=[128,1]:
+        //   shape_div:    [16, 16]  — 64 and 128 are both divisible by 16 (elements)
+        //   stride_div:   [16, 1]   — 128 is divisible by 16 (elements), 1 has divisor 1
+        //   base_ptr_div: 16        — 0x1000 is 16-byte aligned (bytes)
+        //
+        // dtype_bytes does NOT affect shape_div or stride_div.
+        let spec_f32 = compute_spec(0x1000, &[64, 128], &[128, 1], 4);
+        let spec_f16 = compute_spec(0x1000, &[64, 128], &[128, 1], 2);
+
+        assert_eq!(
+            spec_f32.shape_div, spec_f16.shape_div,
+            "shape_div is in elements: dtype does not affect it"
+        );
+        assert_eq!(
+            spec_f32.stride_div, spec_f16.stride_div,
+            "stride_div is in elements: dtype does not affect it"
+        );
+        assert_eq!(
+            spec_f32.base_ptr_div, spec_f16.base_ptr_div,
+            "base_ptr_div is in bytes: same pointer → same alignment"
+        );
     }
 
     #[test]

--- a/cutile-examples/examples/book_examples.rs
+++ b/cutile-examples/examples/book_examples.rs
@@ -329,10 +329,10 @@ mod fmha_module {
             let m_ij: Tile<f32, { [BM, 1] }> = max_tile(m_i, qk_max);
             let qk = qk - m_ij.broadcast(const_shape![BM, BN]);
 
-            let p: Tile<f32, { [BM, BN] }> = exp2(qk);
+            let p: Tile<f32, { [BM, BN] }> = exp2(qk, ftz::Disabled);
             let l_ij: Tile<f32, { [BM] }> = reduce_sum(p, 1);
             let l_ij: Tile<f32, { [BM, 1] }> = l_ij.reshape(const_shape![BM, 1]);
-            let alpha: Tile<f32, { [BM, 1] }> = exp2(m_i - m_ij);
+            let alpha: Tile<f32, { [BM, 1] }> = exp2(m_i - m_ij, ftz::Disabled);
 
             l_i = l_i * alpha + l_ij;
             let alpha: Tile<f32, { [BM, D] }> = alpha.broadcast(const_shape![BM, D]);

--- a/cutile-examples/examples/cuda_graphs.rs
+++ b/cutile-examples/examples/cuda_graphs.rs
@@ -46,7 +46,8 @@ mod kernels {
         let s: f32 = tile_to_scalar(s.reshape(const_shape![]));
         let n: f32 = convert_scalar(D);
         let inv: f32 = 1.0f32 / (s / n + eps);
-        let inv_tile: Tile<f32, { [] }> = sqrt(scalar_to_tile(inv), "negative_inf");
+        let inv_tile: Tile<f32, { [] }> =
+            sqrt(scalar_to_tile(inv), rounding::NegativeInf, ftz::Disabled);
         let inv: f32 = tile_to_scalar(inv_tile);
         let scale: Tile<f32, { [1, BS] }> = inv.broadcast(shape);
         let w_part: Partition<f32, { [BS] }> = w.partition(const_shape![BS]);

--- a/cutile-examples/examples/cuda_graphs_deviceop.rs
+++ b/cutile-examples/examples/cuda_graphs_deviceop.rs
@@ -44,7 +44,8 @@ mod kernels {
         let s: f32 = tile_to_scalar(s.reshape(const_shape![]));
         let n: f32 = convert_scalar(D);
         let inv: f32 = 1.0f32 / (s / n + eps);
-        let inv_tile: Tile<f32, { [] }> = sqrt(scalar_to_tile(inv), "negative_inf");
+        let inv_tile: Tile<f32, { [] }> =
+            sqrt(scalar_to_tile(inv), rounding::NegativeInf, ftz::Disabled);
         let inv: f32 = tile_to_scalar(inv_tile);
         let scale: Tile<f32, { [1, BS] }> = inv.broadcast(shape);
         let w_part: Partition<f32, { [BS] }> = w.partition(const_shape![BS]);

--- a/cutile-examples/examples/flash_attention.rs
+++ b/cutile-examples/examples/flash_attention.rs
@@ -117,10 +117,10 @@ mod my_module {
             let qk = qk - m_ij.broadcast(const_shape![BM, BN]);
 
             // Apply softmax(mask(scale(q @ k^T))).
-            let p: Tile<f32, { [BM, BN] }> = exp2(qk);
+            let p: Tile<f32, { [BM, BN] }> = exp2(qk, ftz::Disabled);
             let l_ij: Tile<f32, { [BM] }> = reduce_sum(p, 1);
             let l_ij: Tile<f32, { [BM, 1] }> = l_ij.reshape(const_shape![BM, 1]);
-            let alpha: Tile<f32, { [BM, 1] }> = exp2(m_i - m_ij);
+            let alpha: Tile<f32, { [BM, 1] }> = exp2(m_i - m_ij, ftz::Disabled);
             l_i = l_i * alpha + l_ij;
             let alpha: Tile<f32, { [BM, D] }> = alpha.broadcast(const_shape![BM, D]);
             acc = acc * alpha;

--- a/cutile-examples/examples/flash_attention_causal.rs
+++ b/cutile-examples/examples/flash_attention_causal.rs
@@ -117,10 +117,10 @@ mod my_module {
             let m_ij: Tile<f32, { [BM, 1] }> = max_tile(m_i, qk_max);
             let qk = qk - m_ij.broadcast(const_shape![BM, BN]);
 
-            let p: Tile<f32, { [BM, BN] }> = exp2(qk);
+            let p: Tile<f32, { [BM, BN] }> = exp2(qk, ftz::Disabled);
             let l_ij: Tile<f32, { [BM] }> = reduce_sum(p, 1);
             let l_ij: Tile<f32, { [BM, 1] }> = l_ij.reshape(const_shape![BM, 1]);
-            let alpha: Tile<f32, { [BM, 1] }> = exp2(m_i - m_ij);
+            let alpha: Tile<f32, { [BM, 1] }> = exp2(m_i - m_ij, ftz::Disabled);
             l_i = l_i * alpha + l_ij;
             acc = acc * alpha.broadcast(const_shape![BM, D]);
 

--- a/cutile-examples/examples/rms_norm.rs
+++ b/cutile-examples/examples/rms_norm.rs
@@ -42,7 +42,8 @@ mod my_module {
         let rms: f32 = tile_to_scalar(rms);
         let n: f32 = convert_scalar(N);
         let rms: f32 = 1.0f32 / (rms / n + eps);
-        let rms: Tile<f32, { [] }> = sqrt(scalar_to_tile(rms), "negative_inf");
+        let rms: Tile<f32, { [] }> =
+            sqrt(scalar_to_tile(rms), rounding::NegativeInf, ftz::Disabled);
         let rms: f32 = tile_to_scalar(rms);
         let rms: Tile<f32, { [1, BLOCK_SIZE] }> = rms.broadcast(tile_shape);
 

--- a/cutile-macro/src/types.rs
+++ b/cutile-macro/src/types.rs
@@ -723,7 +723,7 @@ pub fn get_variadic_op_data(op_name: &str) -> Option<VariadicOpData> {
             output_map: ("()", &[]),
             return_type: ("()", &[]),
         }),
-        "fma" | "fma_op" => Some(VariadicOpData {
+        "fma" => Some(VariadicOpData {
             const_length_vars: &["N"],
             cga_map: HashMap::from([("S", "N")]),
             input_map: vec![
@@ -750,8 +750,8 @@ pub fn get_variadic_op_data(op_name: &str) -> Option<VariadicOpData> {
             return_type: ("Tile", &["_", "R"]),
         }),
         // Unary operations.
-        "ceil" | "cosh" | "cos" | "exp" | "exp2" | "exp2_ftz" | "log" | "log2" | "rsqrt"
-        | "sinh" | "sin" | "sqrt" | "tanh" | "tan" => Some(VariadicOpData {
+        "ceil" | "cosh" | "cos" | "exp" | "exp2" | "log" | "log2" | "rsqrt" | "sinh" | "sin"
+        | "sqrt" | "tanh" | "tan" => Some(VariadicOpData {
             const_length_vars: &["N"],
             cga_map: HashMap::from([("S", "N")]),
             input_map: vec![(0, "Tile", &["S"])],
@@ -794,8 +794,8 @@ pub fn get_variadic_op_data(op_name: &str) -> Option<VariadicOpData> {
             output_map: ("Tile", &["S"]),
             return_type: ("Tile", &["_", "S"]),
         }),
-        "pow" | "maxf" | "maxf_ftz" | "minf" | "minf_ftz" | "andi" | "ori" | "xori" | "shli"
-        | "shri" => Some(VariadicOpData {
+        "pow" | "maxf" | "minf" | "addf" | "subf" | "mulf" | "divf" | "andi" | "ori" | "xori"
+        | "shli" | "shri" => Some(VariadicOpData {
             const_length_vars: &["N"],
             cga_map: HashMap::from([("S", "N")]),
             input_map: vec![(0, "Tile", &["S"]), (1, "Tile", &["S"])],

--- a/cutile/src/_core.rs
+++ b/cutile/src/_core.rs
@@ -178,9 +178,58 @@
 ///
 /// - [`tile_async`](crate::tile_async) - Async execution and kernel compilation
 /// - [`kernels`](crate::kernels) - Pre-built kernel examples
+// ---------------------------------------------------------------
+// Static operation parameter modules
+//
+// Defined outside the proc-macro-processed `core` module because the
+// module macro doesn't support nested `mod` items. Re-exported from
+// `core` via `pub use`.
+//
+// Each module defines a trait (`Mode`) and zero-sized marker structs.
+// Binary switches use Enabled/Disabled. Multi-valued parameters use
+// descriptive names.
+// ---------------------------------------------------------------
+
+/// Flush-to-zero modifier. Flushes denormal inputs and results to
+/// sign-preserving zero. Only supported for f32.
+pub mod ftz {
+    pub trait Mode {}
+    pub struct Enabled;
+    pub struct Disabled;
+    impl Mode for Enabled {}
+    impl Mode for Disabled {}
+}
+
+/// Rounding mode for floating-point operations.
+pub mod rounding {
+    pub trait Mode {}
+    pub struct NearestEven;
+    pub struct PositiveInf;
+    pub struct NegativeInf;
+    pub struct Zero;
+    pub struct Approx;
+    impl Mode for NearestEven {}
+    impl Mode for PositiveInf {}
+    impl Mode for NegativeInf {}
+    impl Mode for Zero {}
+    impl Mode for Approx {}
+}
+
+/// NaN propagation for maxf/minf operations.
+pub mod nan {
+    pub trait Mode {}
+    pub struct Enabled;
+    pub struct Disabled;
+    impl Mode for Enabled {}
+    impl Mode for Disabled {}
+}
+
 #[cutile_macro::module(core = true, tile_rust_crate = true)]
 pub mod core {
 
+    pub use super::ftz;
+    pub use super::nan;
+    pub use super::rounding;
     pub use half::{bf16, f16};
     use std::marker::PhantomData;
     use std::ops;
@@ -2342,11 +2391,11 @@ pub mod core {
     /// let x: Tile<f32, {[128]}> = ...; // [1.2, 2.7, -1.5, ...]
     /// let result = ceil(x, "nearest_even"); // [2.0, 3.0, -1.0, ...]
     /// ```
-    #[cuda_tile::op(name="cuda_tile.ceil", params=["x"], attribute_params=["rounding_mode:rounding"])]
+    #[cuda_tile::op(name="cuda_tile.ceil", params=["x"], static_params=["rounding={NearestEven: rounding_mode=#cuda_tile.rounding<nearest_even>, PositiveInf: rounding_mode=#cuda_tile.rounding<positive_inf>, NegativeInf: rounding_mode=#cuda_tile.rounding<negative_inf>, Zero: rounding_mode=#cuda_tile.rounding<zero>, Approx: rounding_mode=#cuda_tile.rounding<approx>}"])]
     #[cuda_tile::variadic_op(N = 6)]
-    pub fn ceil<E: ElementType, const S: [i32; N]>(
+    pub fn ceil<E: ElementType, const S: [i32; N], R: rounding::Mode>(
         x: Tile<E, S>,
-        rounding_mode: &str,
+        rounding: R,
     ) -> Tile<E, S> {
         unreachable!()
     }
@@ -2409,9 +2458,12 @@ pub mod core {
     /// let x: Tile<f32, {[128]}> = ...; // [4.0, 9.0, 16.0, ...]
     /// let result = rsqrt(x); // [0.5, 0.333..., 0.25, ...]
     /// ```
-    #[cuda_tile::op(name="cuda_tile.rsqrt", params=["x"])]
+    #[cuda_tile::op(name="cuda_tile.rsqrt", params=["x"], static_params=["ftz={Enabled: flush_to_zero=unit}"])]
     #[cuda_tile::variadic_op(N = 6)]
-    pub fn rsqrt<E: ElementType, const S: [i32; N]>(x: Tile<E, S>) -> Tile<E, S> {
+    pub fn rsqrt<E: ElementType, const S: [i32; N], F: ftz::Mode>(
+        x: Tile<E, S>,
+        ftz: F,
+    ) -> Tile<E, S> {
         unreachable!()
     }
     /// Computes element-wise sine of floating-point tiles.
@@ -2446,11 +2498,12 @@ pub mod core {
     /// let x: Tile<f32, {[128]}> = ...; // [4.0, 9.0, 16.0, ...]
     /// let result = sqrt(x, "negative_inf"); // [2.0, 3.0, 4.0, ...]
     /// ```
-    #[cuda_tile::op(name="cuda_tile.sqrt", params=["x"], attribute_params=["rounding_mode:rounding"])]
+    #[cuda_tile::op(name="cuda_tile.sqrt", params=["x"], static_params=["rounding={NearestEven: rounding_mode=#cuda_tile.rounding<nearest_even>, PositiveInf: rounding_mode=#cuda_tile.rounding<positive_inf>, NegativeInf: rounding_mode=#cuda_tile.rounding<negative_inf>, Zero: rounding_mode=#cuda_tile.rounding<zero>, Approx: rounding_mode=#cuda_tile.rounding<approx>}", "ftz={Enabled: flush_to_zero=unit}"])]
     #[cuda_tile::variadic_op(N = 6)]
-    pub fn sqrt<E: ElementType, const S: [i32; N]>(
+    pub fn sqrt<E: ElementType, const S: [i32; N], R: rounding::Mode, F: ftz::Mode>(
         x: Tile<E, S>,
-        rounding_mode: &str,
+        rounding: R,
+        ftz: F,
     ) -> Tile<E, S> {
         unreachable!()
     }
@@ -3033,28 +3086,14 @@ pub mod core {
     ///
     /// ```rust,ignore
     /// let x: Tile<f32, {[128]}> = ...; // [0.0, 1.0, 2.0, ...]
-    /// let result = exp2(x); // [1.0, 2.0, 4.0, ...]
+    /// let result = exp2(x, ftz::Disabled); // [1.0, 2.0, 4.0, ...]
     /// ```
-    #[cuda_tile::op(name="cuda_tile.exp2", params=["x"])]
+    #[cuda_tile::op(name="cuda_tile.exp2", params=["x"], static_params=["ftz={Enabled: flush_to_zero=unit}"])]
     #[cuda_tile::variadic_op(N = 6)]
-    pub fn exp2<E: ElementType, const S: [i32; N]>(x: Tile<E, S>) -> Tile<E, S> {
-        unreachable!()
-    }
-
-    /// Computes element-wise base-2 exponential (2^x) with flush-to-zero.
-    ///
-    /// Same as [`exp2`], but flushes denormal results to zero. This can
-    /// improve performance on GPU hardware. Only supported for f32.
-    ///
-    /// ## Examples
-    ///
-    /// ```rust,ignore
-    /// let x: Tile<f32, {[128]}> = ...; // [0.0, 1.0, 2.0, ...]
-    /// let result = exp2_ftz(x); // [1.0, 2.0, 4.0, ...]
-    /// ```
-    #[cuda_tile::op(name="cuda_tile.exp2", params=["x"], named_attributes=["flush_to_zero=unit"])]
-    #[cuda_tile::variadic_op(N = 6)]
-    pub fn exp2_ftz<E: ElementType, const S: [i32; N]>(x: Tile<E, S>) -> Tile<E, S> {
+    pub fn exp2<E: ElementType, const S: [i32; N], F: ftz::Mode>(
+        x: Tile<E, S>,
+        ftz: F,
+    ) -> Tile<E, S> {
         unreachable!()
     }
 
@@ -3095,23 +3134,14 @@ pub mod core {
     /// let c: Tile<f32, {[128]}> = ...; // [1.0, 1.0, 1.0, ...]
     /// let result = fma_op(a, b, c, "nearest_even"); // [3.0, 7.0, 13.0, ...]
     /// ```
-    #[cuda_tile::op(name="cuda_tile.fma", params=["lhs", "rhs", "acc"], attribute_params=["rounding_mode:rounding"])]
+    #[cuda_tile::op(name="cuda_tile.fma", params=["lhs", "rhs", "acc"], static_params=["rounding={NearestEven: rounding_mode=#cuda_tile.rounding<nearest_even>, PositiveInf: rounding_mode=#cuda_tile.rounding<positive_inf>, NegativeInf: rounding_mode=#cuda_tile.rounding<negative_inf>, Zero: rounding_mode=#cuda_tile.rounding<zero>, Approx: rounding_mode=#cuda_tile.rounding<approx>}", "ftz={Enabled: flush_to_zero=unit}"])]
     #[cuda_tile::variadic_op(N = 6)]
-    pub fn fma_op<E: ElementType, const S: [i32; N]>(
+    pub fn fma<E: ElementType, const S: [i32; N], R: rounding::Mode, F: ftz::Mode>(
         lhs: Tile<E, S>,
         rhs: Tile<E, S>,
         acc: Tile<E, S>,
-        rounding_mode: &str,
-    ) -> Tile<E, S> {
-        unreachable!()
-    }
-
-    #[cuda_tile::op(name="cuda_tile.fma", params=["lhs", "rhs", "acc"], named_attributes=["rounding_mode=#cuda_tile.rounding<nearest_even>"])]
-    #[cuda_tile::variadic_op(N = 6)]
-    pub fn fma<E: ElementType, const S: [i32; N]>(
-        lhs: Tile<E, S>,
-        rhs: Tile<E, S>,
-        acc: Tile<E, S>,
+        rounding: R,
+        ftz: F,
     ) -> Tile<E, S> {
         unreachable!()
     }
@@ -3150,21 +3180,13 @@ pub mod core {
     /// let result = maxf(a, b); // [2.0, 5.0, 6.0, ...]
     /// ```
     ///
-    #[cuda_tile::op(name="cuda_tile.maxf", params=["lhs", "rhs"])]
+    #[cuda_tile::op(name="cuda_tile.maxf", params=["lhs", "rhs"], static_params=["nan={Enabled: propagate_nan=unit}", "ftz={Enabled: flush_to_zero=unit}"])]
     #[cuda_tile::variadic_op(N = 6)]
-    pub fn maxf<E: ElementType, const S: [i32; N]>(lhs: Tile<E, S>, rhs: Tile<E, S>) -> Tile<E, S> {
-        unreachable!()
-    }
-
-    /// Element-wise floating-point maximum with flush-to-zero.
-    ///
-    /// Same as [`maxf`], but flushes denormal inputs and results to zero.
-    /// Only supported for f32.
-    #[cuda_tile::op(name="cuda_tile.maxf", params=["lhs", "rhs"], named_attributes=["flush_to_zero=unit"])]
-    #[cuda_tile::variadic_op(N = 6)]
-    pub fn maxf_ftz<E: ElementType, const S: [i32; N]>(
+    pub fn maxf<E: ElementType, const S: [i32; N], P: nan::Mode, F: ftz::Mode>(
         lhs: Tile<E, S>,
         rhs: Tile<E, S>,
+        nan: P,
+        ftz: F,
     ) -> Tile<E, S> {
         unreachable!()
     }
@@ -3179,23 +3201,63 @@ pub mod core {
     /// ```rust,ignore
     /// let a: Tile<f32, {[128]}> = ...; // [1.0, 5.0, 3.0, ...]
     /// let b: Tile<f32, {[128]}> = ...; // [2.0, 4.0, 6.0, ...]
-    /// let result = minf(a, b); // [1.0, 4.0, 3.0, ...]
+    /// let result = minf(a, b, nan::Disabled, ftz::Disabled); // [1.0, 4.0, 3.0, ...]
     /// ```
-    #[cuda_tile::op(name="cuda_tile.minf", params=["lhs", "rhs"])]
+    #[cuda_tile::op(name="cuda_tile.minf", params=["lhs", "rhs"], static_params=["nan={Enabled: propagate_nan=unit}", "ftz={Enabled: flush_to_zero=unit}"])]
     #[cuda_tile::variadic_op(N = 6)]
-    pub fn minf<E: ElementType, const S: [i32; N]>(lhs: Tile<E, S>, rhs: Tile<E, S>) -> Tile<E, S> {
+    pub fn minf<E: ElementType, const S: [i32; N], P: nan::Mode, F: ftz::Mode>(
+        lhs: Tile<E, S>,
+        rhs: Tile<E, S>,
+        nan: P,
+        ftz: F,
+    ) -> Tile<E, S> {
         unreachable!()
     }
 
-    /// Element-wise floating-point minimum with flush-to-zero.
-    ///
-    /// Same as [`minf`], but flushes denormal inputs and results to zero.
-    /// Only supported for f32.
-    #[cuda_tile::op(name="cuda_tile.minf", params=["lhs", "rhs"], named_attributes=["flush_to_zero=unit"])]
+    /// Element-wise floating-point addition with explicit rounding and FTZ control.
+    #[cuda_tile::op(name="cuda_tile.addf", params=["lhs", "rhs"], static_params=["rounding={NearestEven: rounding_mode=#cuda_tile.rounding<nearest_even>, PositiveInf: rounding_mode=#cuda_tile.rounding<positive_inf>, NegativeInf: rounding_mode=#cuda_tile.rounding<negative_inf>, Zero: rounding_mode=#cuda_tile.rounding<zero>, Approx: rounding_mode=#cuda_tile.rounding<approx>}", "ftz={Enabled: flush_to_zero=unit}"])]
     #[cuda_tile::variadic_op(N = 6)]
-    pub fn minf_ftz<E: ElementType, const S: [i32; N]>(
+    pub fn addf<E: ElementType, const S: [i32; N], R: rounding::Mode, F: ftz::Mode>(
         lhs: Tile<E, S>,
         rhs: Tile<E, S>,
+        rounding: R,
+        ftz: F,
+    ) -> Tile<E, S> {
+        unreachable!()
+    }
+
+    /// Element-wise floating-point subtraction with explicit rounding and FTZ control.
+    #[cuda_tile::op(name="cuda_tile.subf", params=["lhs", "rhs"], static_params=["rounding={NearestEven: rounding_mode=#cuda_tile.rounding<nearest_even>, PositiveInf: rounding_mode=#cuda_tile.rounding<positive_inf>, NegativeInf: rounding_mode=#cuda_tile.rounding<negative_inf>, Zero: rounding_mode=#cuda_tile.rounding<zero>, Approx: rounding_mode=#cuda_tile.rounding<approx>}", "ftz={Enabled: flush_to_zero=unit}"])]
+    #[cuda_tile::variadic_op(N = 6)]
+    pub fn subf<E: ElementType, const S: [i32; N], R: rounding::Mode, F: ftz::Mode>(
+        lhs: Tile<E, S>,
+        rhs: Tile<E, S>,
+        rounding: R,
+        ftz: F,
+    ) -> Tile<E, S> {
+        unreachable!()
+    }
+
+    /// Element-wise floating-point multiplication with explicit rounding and FTZ control.
+    #[cuda_tile::op(name="cuda_tile.mulf", params=["lhs", "rhs"], static_params=["rounding={NearestEven: rounding_mode=#cuda_tile.rounding<nearest_even>, PositiveInf: rounding_mode=#cuda_tile.rounding<positive_inf>, NegativeInf: rounding_mode=#cuda_tile.rounding<negative_inf>, Zero: rounding_mode=#cuda_tile.rounding<zero>, Approx: rounding_mode=#cuda_tile.rounding<approx>}", "ftz={Enabled: flush_to_zero=unit}"])]
+    #[cuda_tile::variadic_op(N = 6)]
+    pub fn mulf<E: ElementType, const S: [i32; N], R: rounding::Mode, F: ftz::Mode>(
+        lhs: Tile<E, S>,
+        rhs: Tile<E, S>,
+        rounding: R,
+        ftz: F,
+    ) -> Tile<E, S> {
+        unreachable!()
+    }
+
+    /// Element-wise floating-point division with explicit rounding and FTZ control.
+    #[cuda_tile::op(name="cuda_tile.divf", params=["lhs", "rhs"], static_params=["rounding={NearestEven: rounding_mode=#cuda_tile.rounding<nearest_even>, PositiveInf: rounding_mode=#cuda_tile.rounding<positive_inf>, NegativeInf: rounding_mode=#cuda_tile.rounding<negative_inf>, Zero: rounding_mode=#cuda_tile.rounding<zero>, Approx: rounding_mode=#cuda_tile.rounding<approx>}", "ftz={Enabled: flush_to_zero=unit}"])]
+    #[cuda_tile::variadic_op(N = 6)]
+    pub fn divf<E: ElementType, const S: [i32; N], R: rounding::Mode, F: ftz::Mode>(
+        lhs: Tile<E, S>,
+        rhs: Tile<E, S>,
+        rounding: R,
+        ftz: F,
     ) -> Tile<E, S> {
         unreachable!()
     }

--- a/cutile/tests/binary_math_ops.rs
+++ b/cutile/tests/binary_math_ops.rs
@@ -19,8 +19,8 @@ mod binary_math_ops_module {
         // Test min and max operations
         let x: Tile<f32, S> = load_tile_mut(output);
         let y: Tile<f32, S> = load_tile_mut(output);
-        let max_result: Tile<f32, S> = maxf(x, y);
-        let min_result: Tile<f32, S> = minf(max_result, y);
+        let max_result: Tile<f32, S> = maxf(x, y, nan::Disabled, ftz::Disabled);
+        let min_result: Tile<f32, S> = minf(max_result, y, nan::Disabled, ftz::Disabled);
         output.store(min_result);
     }
 
@@ -34,7 +34,7 @@ mod binary_math_ops_module {
         let _one: Tile<f32, S> = constant(1.0, output.shape());
 
         // Simplified to avoid bool literal issue
-        let result: Tile<f32, S> = maxf(x, y);
+        let result: Tile<f32, S> = maxf(x, y, nan::Disabled, ftz::Disabled);
         output.store(result);
     }
 

--- a/cutile/tests/control_flow_ops.rs
+++ b/cutile/tests/control_flow_ops.rs
@@ -154,9 +154,56 @@ mod control_flow_ops_module {
         let result: Tile<i64, S> = same_tile + constant(1i64, output.shape());
         output.store(result);
     }
+
+    /// Repro: for loop inside if doesn't propagate mutable variable.
+    /// collect_mutated_variables_from_block doesn't recurse into
+    /// nested control flow (for/while/if), so the if op doesn't
+    /// yield acc, and post-if code uses the stale pre-if value.
+    #[cutile::entry()]
+    fn if_for_carry_kernel<const S: [i32; 1]>(output: &mut Tensor<f32, S>, flag: i32) {
+        let mut acc: Tile<f32, S> = constant(0.0f32, output.shape());
+        if flag > 0i32 {
+            for _i in 0i32..10i32 {
+                let ones: Tile<f32, S> = constant(1.0f32, output.shape());
+                acc = acc + ones;
+            }
+        } else {
+            acc = acc;
+        }
+        output.store(acc);
+    }
+
+    /// Same repro but with const generic flag (closer to Yinuo's report).
+    #[cutile::entry()]
+    fn if_for_carry_const_kernel<const S: [i32; 1], const FLAG: i32, const N: i32>(
+        output: &mut Tensor<f32, S>,
+    ) {
+        let mut acc: Tile<f32, S> = constant(0.0f32, output.shape());
+        if FLAG > 0i32 {
+            for _i in 0i32..N {
+                let ones: Tile<f32, S> = constant(1.0f32, output.shape());
+                acc = acc + ones;
+            }
+        } else {
+            acc = acc;
+        }
+        output.store(acc);
+    }
+
+    /// if/else as a tile expression: `let result = if cond { a } else { b };`
+    #[cutile::entry()]
+    fn if_else_tile_expr_kernel<const S: [i32; 1]>(output: &mut Tensor<f32, S>, flag: i32) {
+        let ones: Tile<f32, S> = constant(1.0f32, output.shape());
+        let twos: Tile<f32, S> = constant(2.0f32, output.shape());
+        let result: Tile<f32, S> = if flag > 0i32 { ones } else { twos };
+        output.store(result);
+    }
 }
 
-use control_flow_ops_module::{_module_asts, break_test_kernel, if_return_test_kernel};
+use control_flow_ops_module::{
+    _module_asts, break_test_kernel, if_else_tile_expr_kernel, if_for_carry_const_kernel,
+    if_for_carry_kernel, if_return_test_kernel,
+};
 
 #[test]
 fn compile_control_flow_test() -> () {
@@ -546,5 +593,77 @@ fn compile_assume_same_elements_test() -> () {
         );
 
         println!("\n✓ assume_same_elements operation verified with same_elements<[2, 4]>");
+    });
+}
+
+#[test]
+fn if_for_carry_propagates_mutation() {
+    // Repro: for loop inside if should propagate mutable variable updates.
+    // flag=1 means the if body runs: acc += 1.0 ten times → acc = 10.0.
+    // Bug: acc stays 0.0 because the if op doesn't yield the for's output.
+    common::with_test_stack(|| {
+        let mut output = cutile::api::zeros::<f32>(&[128]).sync().expect("alloc");
+        if_for_carry_kernel((&mut output).partition([128]), 1i32)
+            .sync()
+            .expect("kernel");
+        let host: Vec<f32> = output.dup().to_host_vec().sync().expect("to_host");
+        assert!(
+            (host[0] - 10.0).abs() < 1e-3,
+            "Expected 10.0 (for loop ran 10 times), got {}",
+            host[0]
+        );
+    });
+}
+
+#[test]
+fn if_for_carry_const_propagates_mutation() {
+    // Same as above but with const generic FLAG and N.
+    // FLAG=1, N=10 → acc = 10.0.
+    common::with_test_stack(|| {
+        let mut output = cutile::api::zeros::<f32>(&[128]).sync().expect("alloc");
+        if_for_carry_const_kernel((&mut output).partition([128]))
+            .generics(vec![
+                "128".to_string(), // S
+                "1".to_string(),   // FLAG
+                "10".to_string(),  // N
+            ])
+            .sync()
+            .expect("kernel");
+        let host: Vec<f32> = output.dup().to_host_vec().sync().expect("to_host");
+        assert!(
+            (host[0] - 10.0).abs() < 1e-3,
+            "Expected 10.0 (const FLAG=1, N=10), got {}",
+            host[0]
+        );
+    });
+}
+
+#[test]
+fn if_else_tile_expr_returns_value() {
+    // if/else as an expression: `let result = if flag > 0 { ones } else { twos };`
+    // flag=1 → result = 1.0, flag=0 → result = 2.0.
+    common::with_test_stack(|| {
+        let mut output = cutile::api::zeros::<f32>(&[128]).sync().expect("alloc");
+        if_else_tile_expr_kernel((&mut output).partition([128]), 1i32)
+            .sync()
+            .expect("kernel");
+        let host: Vec<f32> = output.dup().to_host_vec().sync().expect("to_host");
+        assert!(
+            (host[0] - 1.0).abs() < 1e-3,
+            "flag=1: expected 1.0, got {}",
+            host[0]
+        );
+    });
+    common::with_test_stack(|| {
+        let mut output = cutile::api::zeros::<f32>(&[128]).sync().expect("alloc");
+        if_else_tile_expr_kernel((&mut output).partition([128]), 0i32)
+            .sync()
+            .expect("kernel");
+        let host: Vec<f32> = output.dup().to_host_vec().sync().expect("to_host");
+        assert!(
+            (host[0] - 2.0).abs() < 1e-3,
+            "flag=0: expected 2.0, got {}",
+            host[0]
+        );
     });
 }

--- a/cutile/tests/optimization_hints.rs
+++ b/cutile/tests/optimization_hints.rs
@@ -62,6 +62,16 @@ mod opt_hints_module {
         let tile: Tile<f32, S> = constant(1.0f32, output.shape());
         output.store(tile);
     }
+
+    /// Latency as a const generic — specialized at launch time.
+    #[cutile::entry()]
+    fn load_view_const_latency_kernel<const S: [i32; 1], const L: i32>(input: &Tensor<f32, S>) {
+        let token: Token = new_token_unordered();
+        let shape = input.shape();
+        let partition: Partition<f32, S> = make_partition_view(input, shape, token);
+        let idx: [i32; 1] = [0i32];
+        let _tile: Tile<f32, S> = load_from_view(&partition, idx, Some(L), false);
+    }
 }
 
 use opt_hints_module::_module_asts;
@@ -214,6 +224,38 @@ fn different_compile_options_produce_different_mlir() {
         assert_ne!(
             mlir_a, mlir_b,
             "Different CompileOptions should produce different MLIR"
+        );
+    });
+}
+
+#[test]
+fn load_view_const_latency_in_mlir() {
+    // Latency as a const generic: L=5 should appear as `latency = 5` in MLIR.
+    common::with_test_stack(|| {
+        let modules =
+            CUDATileModules::new(_module_asts()).expect("Failed to create CUDATileModules");
+        let gpu_name = get_gpu_name(0);
+        let compiler = CUDATileFunctionCompiler::new(
+            &modules,
+            "opt_hints_module",
+            "load_view_const_latency_kernel",
+            &[128.to_string(), 5.to_string()], // S=128, L=5
+            &[("input", &[1])],
+            &[],
+            &[],
+            None,
+            gpu_name,
+            &CompileOptions::default(),
+        )
+        .expect("Failed to create compiler");
+        let module_op = compiler.compile().expect("Failed to compile");
+        let mlir = module_op.as_operation().to_string();
+        drop(module_op);
+        drop(compiler);
+        println!("{mlir}");
+        assert!(
+            mlir.contains("latency = 5"),
+            "Expected latency=5 from const generic L=5.\nMLIR:\n{mlir}"
         );
     });
 }

--- a/cutile/tests/reduce_scan_ops.rs
+++ b/cutile/tests/reduce_scan_ops.rs
@@ -69,7 +69,7 @@ mod reduce_scan_ops_module {
         // Use closure for max reduction with NEG_INFINITY as identity
         // f32::NEG_INFINITY works as identity because max(NEG_INFINITY, x) = x for any x
         //
-        // TODO (np): Using maxf(acc, x) here gives "cannot find function" error even though
+        // TODO (np): Using maxf(acc, x, nan::Disabled, ftz::Disabled) here gives "cannot find function" error even though
         // it's imported via `use cutile::core::{*}`. This appears to be a scoping bug
         // where some functions aren't visible inside reduce/scan closures. Using max()
         // (scalar version) works correctly and is the right function for this context anyway.

--- a/cutile/tests/specialization_bits.rs
+++ b/cutile/tests/specialization_bits.rs
@@ -36,7 +36,7 @@ mod spec_test_module {
 
     /// Kernel with a scalar integer param — used to test DivHint on scalars.
     #[cutile::entry(print_ir = true)]
-    fn scalar_kernel<const S: [i32; 1]>(output: &mut Tensor<f32, S>, n: i32) {
+    fn scalar_kernel<const S: [i32; 1]>(output: &mut Tensor<f32, S>, _n: i32) {
         let tile: Tile<f32, S> = constant(1.0f32, output.shape());
         output.store(tile);
     }

--- a/cutile/tests/unary_math_ops.rs
+++ b/cutile/tests/unary_math_ops.rs
@@ -22,11 +22,11 @@ mod unary_math_ops_module {
         // Arithmetic operations
         let t1: Tile<f32, S> = absf(x); // absolute value (float)
         let t2: Tile<f32, S> = negf(t1); // negation (float)
-        let t3: Tile<f32, S> = rsqrt(t2); // reciprocal square root
+        let t3: Tile<f32, S> = rsqrt(t2, ftz::Disabled); // reciprocal square root
 
         // Exponential and logarithmic
         let t4: Tile<f32, S> = exp(t3); // exponential (e^x)
-        let t5: Tile<f32, S> = exp2(t4); // base-2 exponential (2^x)
+        let t5: Tile<f32, S> = exp2(t4, ftz::Disabled); // base-2 exponential (2^x)
         let t6: Tile<f32, S> = log(t5); // natural log
         let t7: Tile<f32, S> = log2(t6); // base-2 log
 
@@ -41,7 +41,7 @@ mod unary_math_ops_module {
         let t13: Tile<f32, S> = tanh(t12); // hyperbolic tangent
 
         // Rounding
-        let t14: Tile<f32, S> = ceil(t13, "nearest_even"); // ceiling
+        let t14: Tile<f32, S> = ceil(t13, rounding::NearestEven); // ceiling
         let result: Tile<f32, S> = floor(t14); // floor
 
         output.store(result);
@@ -63,7 +63,7 @@ mod unary_math_ops_module {
     fn sqrt_kernel<const S: [i32; 1]>(output: &mut Tensor<f32, S>) {
         // Test sqrt operation
         let x: Tile<f32, S> = load_tile_mut(output);
-        let result: Tile<f32, S> = sqrt(x, "negative_inf"); // square root
+        let result: Tile<f32, S> = sqrt(x, rounding::NegativeInf, ftz::Disabled); // square root
         output.store(result);
     }
 
@@ -73,7 +73,7 @@ mod unary_math_ops_module {
         let x: Tile<f32, S> = load_tile_mut(output);
         let y: Tile<f32, S> = load_tile_mut(output);
         let z: Tile<f32, S> = load_tile_mut(output);
-        let result: Tile<f32, S> = fma_op(x, y, z, "nearest_even"); // x * y + z
+        let result: Tile<f32, S> = fma(x, y, z, rounding::NearestEven, ftz::Disabled); // x * y + z
         output.store(result);
     }
 
@@ -89,7 +89,7 @@ mod unary_math_ops_module {
     #[cutile::entry()]
     fn exp2_ftz_kernel<const S: [i32; 1]>(output: &mut Tensor<f32, S>) {
         let x: Tile<f32, S> = load_tile_mut(output);
-        let result: Tile<f32, S> = exp2_ftz(x);
+        let result: Tile<f32, S> = exp2(x, ftz::Enabled);
         output.store(result);
     }
 
@@ -97,7 +97,7 @@ mod unary_math_ops_module {
     fn maxf_ftz_kernel<const S: [i32; 1]>(output: &mut Tensor<f32, S>) {
         let x: Tile<f32, S> = load_tile_mut(output);
         let y: Tile<f32, S> = load_tile_mut(output);
-        let result: Tile<f32, S> = maxf_ftz(x, y);
+        let result: Tile<f32, S> = maxf(x, y, nan::Disabled, ftz::Enabled);
         output.store(result);
     }
 
@@ -105,7 +105,62 @@ mod unary_math_ops_module {
     fn minf_ftz_kernel<const S: [i32; 1]>(output: &mut Tensor<f32, S>) {
         let x: Tile<f32, S> = load_tile_mut(output);
         let y: Tile<f32, S> = load_tile_mut(output);
-        let result: Tile<f32, S> = minf_ftz(x, y);
+        let result: Tile<f32, S> = minf(x, y, nan::Disabled, ftz::Enabled);
+        output.store(result);
+    }
+
+    #[cutile::entry()]
+    fn addf_ftz_kernel<const S: [i32; 1]>(output: &mut Tensor<f32, S>) {
+        let x: Tile<f32, S> = load_tile_mut(output);
+        let y: Tile<f32, S> = load_tile_mut(output);
+        let result: Tile<f32, S> = addf(x, y, rounding::NearestEven, ftz::Enabled);
+        output.store(result);
+    }
+
+    #[cutile::entry()]
+    fn subf_ftz_kernel<const S: [i32; 1]>(output: &mut Tensor<f32, S>) {
+        let x: Tile<f32, S> = load_tile_mut(output);
+        let y: Tile<f32, S> = load_tile_mut(output);
+        let result: Tile<f32, S> = subf(x, y, rounding::NearestEven, ftz::Enabled);
+        output.store(result);
+    }
+
+    #[cutile::entry()]
+    fn mulf_ftz_kernel<const S: [i32; 1]>(output: &mut Tensor<f32, S>) {
+        let x: Tile<f32, S> = load_tile_mut(output);
+        let y: Tile<f32, S> = load_tile_mut(output);
+        let result: Tile<f32, S> = mulf(x, y, rounding::NearestEven, ftz::Enabled);
+        output.store(result);
+    }
+
+    #[cutile::entry()]
+    fn divf_ftz_kernel<const S: [i32; 1]>(output: &mut Tensor<f32, S>) {
+        let x: Tile<f32, S> = load_tile_mut(output);
+        let y: Tile<f32, S> = load_tile_mut(output);
+        let result: Tile<f32, S> = divf(x, y, rounding::NearestEven, ftz::Enabled);
+        output.store(result);
+    }
+
+    #[cutile::entry()]
+    fn fma_ftz_kernel<const S: [i32; 1]>(output: &mut Tensor<f32, S>) {
+        let x: Tile<f32, S> = load_tile_mut(output);
+        let y: Tile<f32, S> = load_tile_mut(output);
+        let z: Tile<f32, S> = load_tile_mut(output);
+        let result: Tile<f32, S> = fma(x, y, z, rounding::NearestEven, ftz::Enabled);
+        output.store(result);
+    }
+
+    #[cutile::entry()]
+    fn rsqrt_ftz_kernel<const S: [i32; 1]>(output: &mut Tensor<f32, S>) {
+        let x: Tile<f32, S> = load_tile_mut(output);
+        let result: Tile<f32, S> = rsqrt(x, ftz::Enabled);
+        output.store(result);
+    }
+
+    #[cutile::entry()]
+    fn sqrt_ftz_kernel<const S: [i32; 1]>(output: &mut Tensor<f32, S>) {
+        let x: Tile<f32, S> = load_tile_mut(output);
+        let result: Tile<f32, S> = sqrt(x, rounding::NearestEven, ftz::Enabled);
         output.store(result);
     }
 
@@ -424,6 +479,78 @@ fn compile_minf_ftz() -> () {
             "Expected flush_to_zero attribute in MLIR output"
         );
     });
+}
+
+/// Helper: compile a kernel and assert it contains the expected op name and flush_to_zero.
+fn assert_ftz_in_mlir(kernel_name: &'static str, expected_op: &'static str) {
+    common::with_test_stack(move || {
+        let modules =
+            CUDATileModules::new(_module_asts()).expect("Failed to create CUDATileModules");
+        let gpu_name = get_gpu_name(0);
+        let compiler = CUDATileFunctionCompiler::new(
+            &modules,
+            "unary_math_ops_module",
+            kernel_name,
+            &[128.to_string()],
+            &[("output", &[1])],
+            &[],
+            &[],
+            None,
+            gpu_name,
+            &CompileOptions::default(),
+        )
+        .expect("Failed.");
+        let module_op_str = compiler
+            .compile()
+            .expect("Failed.")
+            .as_operation()
+            .to_string();
+        println!("\n=== {kernel_name} MLIR ===\n{module_op_str}");
+
+        assert!(
+            module_op_str.contains(expected_op),
+            "Expected {expected_op} operation in MLIR output"
+        );
+        assert!(
+            module_op_str.contains("flush_to_zero"),
+            "Expected flush_to_zero attribute in MLIR output"
+        );
+    });
+}
+
+#[test]
+fn compile_addf_ftz() {
+    assert_ftz_in_mlir("addf_ftz_kernel", "addf");
+}
+
+#[test]
+fn compile_subf_ftz() {
+    assert_ftz_in_mlir("subf_ftz_kernel", "subf");
+}
+
+#[test]
+fn compile_mulf_ftz() {
+    assert_ftz_in_mlir("mulf_ftz_kernel", "mulf");
+}
+
+#[test]
+fn compile_divf_ftz() {
+    assert_ftz_in_mlir("divf_ftz_kernel", "divf");
+}
+
+#[test]
+fn compile_fma_ftz() {
+    assert_ftz_in_mlir("fma_ftz_kernel", "fma");
+}
+
+#[test]
+fn compile_rsqrt_ftz() {
+    assert_ftz_in_mlir("rsqrt_ftz_kernel", "rsqrt");
+}
+
+#[test]
+fn compile_sqrt_ftz() {
+    assert_ftz_in_mlir("sqrt_ftz_kernel", "sqrt");
 }
 
 #[test]


### PR DESCRIPTION
Replaces string-based and hardcoded operation modifiers (rounding mode, flush-to-zero, NaN propagation) with zero-sized type generics resolved at compile time via a new static_params attribute, eliminating _ftz/_op function variants and enabling the compiler to map marker types directly to MLIR attributes.