### PR TITLE
feat!: make CudaGraph::launch() return a DeviceOp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - **Unified kernel launcher**: Single function per kernel via `IntoDeviceOp`. Accepts `Tensor<T>`, `Arc<Tensor<T>>`, `&Tensor<T>`, `DeviceOp`s, and scalars interchangeably.
 - **KernelInput trait**: `&Tensor` params accept `Tensor<T>`, `Arc<Tensor<T>>`, or `&Tensor<T>`. Same type in, same type out. `&Tensor<T>` inputs prevent `tokio::spawn` at compile time via Rust's lifetime system.
 - **KernelOutput trait**: `&mut Tensor` params accept `Partition<Tensor<T>>` or `Partition<&mut Tensor<T>>`. Borrowed partitions write in place: No `unpartition()` needed.
-- **CUDA graph capture**: `.graph()` / `.graph_on(stream)` captures any `DeviceOp` into a replayable `CudaGraph<T>`. `graph.update()` + `graph.launch()` for efficient replay.
+- **CUDA graph capture**: `.graph()` / `.graph_on(stream)` captures any `DeviceOp` into a replayable `CudaGraph<T>`. `graph.update()` + `graph.launch().sync_on(&stream)` for efficient replay. `launch()` returns a `DeviceOp`, composable with `.then()`, `.map()`, etc.
 - **`CudaGraph::scope`**: Scoped graph capture with `&mut` borrows. `s.record(op)` records `GraphNode` ops as graph nodes, releasing borrows between calls.
 - **`GraphNode` trait**: Marker trait for operations safe to record in a CUDA graph (kernel launches, `memcpy`). Allocation ops are excluded at compile time.
 - **Thread-local execution lock**: Enforces "only one DeviceOp may be executing at a time per thread." Prevents cross-stream data races from nested execution (e.g., `sync_on` inside a `then` closure). `unsafe then_unchecked` opts out.

--- a/cuda-async/README.md
+++ b/cuda-async/README.md
@@ -106,13 +106,14 @@ let buffers = graph.take_output().unwrap();
 // Replay loop — single driver call per iteration.
 for token in tokens {
     graph.update(api::memcpy(&mut input_buf, &token))?;
-    graph.launch()?;
+    graph.launch().sync_on(&stream)?;
 }
 ```
 
 All device pointers are baked in at capture time. To vary inputs, copy
 new data into pre-allocated buffers via `graph.update(op)` before each
-`graph.launch()`.
+`graph.launch()`. `launch()` returns a [`DeviceOp`] — use `.sync_on()`,
+`.sync()`, or `.await` to control when and where the graph executes.
 
 ## API Argument Conventions
 

--- a/cuda-async/src/cuda_graph.rs
+++ b/cuda-async/src/cuda_graph.rs
@@ -3,9 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+use crate::device_context::with_default_device_policy;
+use crate::device_future::DeviceFuture;
 use crate::device_operation::{DeviceOp, ExecutionContext, GraphNode};
 use crate::error::DeviceError;
 use cuda_core::{stream, sys, CudaStream, IntoResult};
+use std::future::IntoFuture;
 use std::mem::MaybeUninit;
 use std::sync::Arc;
 
@@ -36,7 +39,7 @@ const CU_STREAM_CAPTURE_MODE_RELAXED: sys::CUstreamCaptureMode = 2;
 /// // Replay loop.
 /// for _ in 0..n_tokens {
 ///     // Optionally: copy new input into a pre-allocated buffer here.
-///     graph.launch()?;
+///     graph.launch().sync_on(&stream)?;
 /// }
 /// ```
 pub struct CudaGraph<T> {
@@ -146,38 +149,80 @@ impl<T: Send> CudaGraph<T> {
     /// Use this to update graph inputs before [`launch`](CudaGraph::launch).
     /// The operation is issued on the same stream the graph will run on, so
     /// stream ordering guarantees it completes before the graph's kernels
-    /// begin. Synchronization happens when `launch()` returns.
+    /// begin.
     ///
     /// # Examples
     ///
     /// ```rust,ignore
     /// // Copy a new embedding into the graph's pre-allocated input buffer.
     /// graph.update(api::memcpy(&mut h_input, &new_embedding))?;
-    /// graph.launch()?;
+    /// graph.launch().sync_on(&stream)?;
     /// ```
     pub fn update<O: Send>(&self, op: impl DeviceOp<Output = O>) -> Result<O, DeviceError> {
         let ctx = ExecutionContext::new(self.stream.clone());
         unsafe { op.execute(&ctx) }
     }
 
-    /// Replay the captured graph and synchronize.
+    /// Return a [`DeviceOp`] that replays the captured graph.
     ///
-    /// Launches the graph on the capture stream and blocks until the GPU
-    /// finishes. Any operations issued via [`update`](CudaGraph::update)
-    /// on the same stream are guaranteed to complete before the graph runs.
-    // TODO: Add `launch_on(&stream)` to support launching on a different
-    // stream than the capture stream (requested by Isaac Gelado).
-    pub fn launch(&self) -> Result<(), DeviceError> {
-        unsafe {
-            sys::cuGraphLaunch(self.cu_graph_exec, self.stream.cu_stream()).result()?;
+    /// The graph launches on whichever stream the returned op is executed
+    /// on. Use the standard [`DeviceOp`] methods to control execution:
+    ///
+    /// ```rust,ignore
+    /// graph.launch().sync_on(&stream)?;          // explicit stream, blocking
+    /// graph.launch().sync()?;                    // default policy, blocking
+    /// graph.launch().then(next_op).sync()?;      // compose with other ops
+    /// ```
+    ///
+    /// Any operations issued via [`update`](CudaGraph::update) on the same
+    /// stream are guaranteed to complete before the graph runs.
+    pub fn launch(&self) -> GraphLaunch {
+        GraphLaunch {
+            cu_graph_exec: self.cu_graph_exec,
         }
-        self.stream.synchronize()?;
-        Ok(())
     }
 
     /// Returns a reference to the stream this graph was captured on.
     pub fn stream(&self) -> &Arc<CudaStream> {
         &self.stream
+    }
+}
+
+/// A [`DeviceOp`] that replays a captured CUDA graph.
+///
+/// Created by [`CudaGraph::launch`]. The graph executes on whichever stream
+/// the op is scheduled on (via `.sync_on(&stream)`, `.sync()`, or `.await`).
+pub struct GraphLaunch {
+    cu_graph_exec: sys::CUgraphExec,
+}
+
+// CUgraphExec is an opaque CUDA driver handle, safe to send across threads.
+unsafe impl Send for GraphLaunch {}
+
+impl DeviceOp for GraphLaunch {
+    type Output = ();
+
+    unsafe fn execute(self, context: &ExecutionContext) -> Result<(), DeviceError> {
+        sys::cuGraphLaunch(self.cu_graph_exec, context.get_cuda_stream().cu_stream()).result()?;
+        Ok(())
+    }
+}
+
+impl IntoFuture for GraphLaunch {
+    type Output = Result<(), DeviceError>;
+    type IntoFuture = DeviceFuture<(), GraphLaunch>;
+    fn into_future(self) -> Self::IntoFuture {
+        match with_default_device_policy(|policy| {
+            let stream = policy.next_stream()?;
+            let mut f = DeviceFuture::new();
+            f.device_operation = Some(self);
+            f.execution_context = Some(ExecutionContext::new(stream));
+            Ok(f)
+        }) {
+            Ok(Ok(future)) => future,
+            Ok(Err(e)) => DeviceFuture::failed(e),
+            Err(e) => DeviceFuture::failed(e),
+        }
     }
 }
 
@@ -214,7 +259,7 @@ impl<T> Drop for CudaGraph<T> {
 ///     Ok(())
 /// })?;
 ///
-/// graph.launch()?;
+/// graph.launch().sync_on(&stream)?;
 /// ```
 ///
 /// # Safety proof: why `record` is safe
@@ -351,7 +396,7 @@ impl CudaGraph<()> {
     ///     Ok(())
     /// })?;
     ///
-    /// graph.launch()?;
+    /// graph.launch().sync_on(&stream)?;
     /// ```
     ///
     /// See [`Scope`] for the safety proof and edge-case behavior.
@@ -502,7 +547,7 @@ impl CudaGraph<()> {
 ///         self.graph.update(
 ///             api::memcpy(&mut self.h_input, &input)
 ///         )?;
-///         self.graph.launch()?;
+///         self.graph.launch().sync_on(self.graph.stream())?;
 ///         Ok(self.output.clone())
 ///     }
 /// }

--- a/cuda-async/src/prelude.rs
+++ b/cuda-async/src/prelude.rs
@@ -40,7 +40,7 @@ pub use crate::device_operation::SharedDeviceOp;
 pub use crate::device_operation::Value;
 
 // CUDA graph capture
-pub use crate::cuda_graph::{CudaGraph, Scope};
+pub use crate::cuda_graph::{CudaGraph, GraphLaunch, Scope};
 
 // Error type
 pub use crate::error::DeviceError;

--- a/cuda-async/tests/cuda_graph.rs
+++ b/cuda-async/tests/cuda_graph.rs
@@ -29,7 +29,7 @@ fn scope_empty_closure() {
         let stream = ctx.new_stream().unwrap();
 
         let graph = CudaGraph::scope(&stream, |_s| Ok(())).unwrap();
-        graph.launch().unwrap();
+        graph.launch().sync_on(&stream).unwrap();
     });
 }
 
@@ -53,7 +53,7 @@ fn scope_records_value_ops() {
         .unwrap();
 
         assert_eq!(recorded, vec![42, 5]);
-        graph.launch().unwrap();
+        graph.launch().sync_on(&stream).unwrap();
     });
 }
 
@@ -122,7 +122,7 @@ fn scope_multiple_launches() {
         let graph = CudaGraph::scope(&stream, |_s| Ok(())).unwrap();
 
         for _ in 0..10 {
-            graph.launch().unwrap();
+            graph.launch().sync_on(&stream).unwrap();
         }
     });
 }

--- a/cutile-book/guide/deviceop-reference.md
+++ b/cutile-book/guide/deviceop-reference.md
@@ -353,7 +353,7 @@ let output = graph.take_output().unwrap();
 // Replay loop — no graph rebuilding, no kernel re-compilation.
 for token in tokens {
     graph.update(api::memcpy(&mut input_buf, &token))?;
-    graph.launch()?;
+    graph.launch().sync_on(&stream)?;
 }
 ```
 
@@ -376,7 +376,7 @@ let graph = CudaGraph::scope(&stream, |s| {
     Ok(())
 })?;
 
-graph.launch()?;
+graph.launch().sync_on(&stream)?;
 ```
 
 `record` only accepts operations that implement `GraphNode` — kernel
@@ -404,7 +404,7 @@ implement it:
 | `s.record(op: impl GraphNode)` | Record a graph node inside a scope |
 | `graph.take_output()` | Retrieve the output from the capture execution |
 | `graph.update(op)` | Run a `DeviceOp` on the graph's stream (e.g., copy new input) |
-| `graph.launch()` | Replay the captured graph and synchronize |
+| `graph.launch()` | Returns a `DeviceOp` that replays the captured graph |
 
 All device pointers are baked in at capture time. To vary inputs, pre-allocate
 a buffer, pass it into the operation, and `memcpy` new data before each

--- a/cutile-book/tutorials/10-cuda-graphs.md
+++ b/cutile-book/tutorials/10-cuda-graphs.md
@@ -250,7 +250,7 @@ impl Module for GraphModel {
         // Copy new embedding into the baked-in input buffer.
         self.graph.update(api::memcpy(&mut self.input, &input))?;
         // Replay the entire forward pass with a single driver call.
-        self.graph.launch()?;
+        self.graph.launch().sync_on(self.graph.stream())?;
         Ok(self.output.clone())
     }
 }
@@ -261,7 +261,7 @@ Each `forward` call:
 1. **`graph.update(memcpy(…))`** — Copies new input data into the
    pre-allocated input buffer. This runs on the graph's stream, so it
    completes before the graph launches.
-2. **`graph.launch()`** — Replays all captured kernels. The GPU sees the
+2. **`graph.launch().sync_on(…)`** — Replays all captured kernels. The GPU sees the
    full operation sequence and can schedule aggressively.
 3. **Returns `output.clone()`** — The output `Arc` points to the same
    device memory the graph wrote into. No copy needed.
@@ -347,7 +347,7 @@ let graph = CudaGraph::scope(&stream, |s| {
     Ok(())
 })?;
 
-graph.launch()?;
+graph.launch().sync_on(&stream)?;
 ```
 
 Key differences from the combinator approach:
@@ -384,7 +384,7 @@ at compile time because their addresses may change on graph replay.
 | **`DeviceOp` graph** | Lazy composition of GPU work — no execution until driven |
 | **`.graph_on(stream)`** | Capture the entire operation into a replayable `CudaGraph` |
 | **`CudaGraph::scope`** | Imperative graph capture with `&mut` borrows |
-| **`graph.launch()`** | Replay all captured work with a single driver call |
+| **`graph.launch()`** | Returns a `DeviceOp` that replays all captured work — execute with `.sync_on()`, `.sync()`, or `.await` |
 | **`graph.update(op)`** | Run a DeviceOp on the graph's stream before replay (e.g., memcpy new input) |
 | **Pre-allocated buffers** | Graph writes into fixed memory; vary inputs via `memcpy` |
 | **`.shared()` in graphs** | Each intermediate executes once during capture; clones share the result |

--- a/cutile-examples/examples/cuda_graphs.rs
+++ b/cutile-examples/examples/cuda_graphs.rs
@@ -223,7 +223,7 @@ impl GraphModel {
 
     fn forward(&mut self, embedding: &Tensor<f32>) -> Result<(), DeviceError> {
         self.graph.update(api::memcpy(&mut self.input, embedding))?;
-        self.graph.launch()?;
+        self.graph.launch().sync_on(self.graph.stream())?;
         Ok(())
     }
 }

--- a/cutile-examples/examples/cuda_graphs_deviceop.rs
+++ b/cutile-examples/examples/cuda_graphs_deviceop.rs
@@ -208,7 +208,7 @@ impl GraphModel {
     /// Copy a new embedding into the input buffer and replay the graph.
     fn forward(&mut self, embedding: &Tensor<f32>) -> Result<(), DeviceError> {
         self.graph.update(api::memcpy(&mut self.input, embedding))?;
-        self.graph.launch()?;
+        self.graph.launch().sync_on(self.graph.stream())?;
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

- `CudaGraph::launch()` now returns a `GraphLaunch` op instead of eagerly calling `cuGraphLaunch` + `stream.synchronize()`. Callers execute the graph using the standard `DeviceOp` methods (`.sync_on()`, `.sync()`, `.await`, `.then()`).
- Enables composing graph replay with other ops (e.g., `graph.launch().then(sample).sync_on(&stream)?`) without an intermediate CPU stall.
- Graph can now launch on any stream, not just the capture stream, resolving the `launch_on` TODO.