### PR TITLE
Compiler pass manager, name resolver, FP8 types, debug tooling

### DIFF
--- a/cuda-core/src/dtype.rs
+++ b/cuda-core/src/dtype.rs
@@ -11,6 +11,32 @@
 use half::{bf16, f16};
 use std::fmt::{Debug, Display};
 
+// ---------------------------------------------------------------------------
+// GPU-specific type wrappers (no host arithmetic, storage only)
+// ---------------------------------------------------------------------------
+
+/// TensorFloat-32 format (TF32). 19-bit format with FP32 range and FP16 precision.
+/// Used by Ampere+ GPUs for accelerated matrix multiplication.
+#[derive(Copy, Clone, Debug, PartialEq, Default)]
+#[repr(transparent)]
+#[allow(non_camel_case_types)]
+pub struct tf32(pub u32);
+
+/// FP8 E4M3FN format (4-bit exponent, 3-bit mantissa, no infinity).
+/// Used by Hopper+ GPUs for efficient matrix multiplication and quantized inference.
+#[derive(Copy, Clone, Debug, PartialEq, Default)]
+#[repr(transparent)]
+#[allow(non_camel_case_types)]
+pub struct f8e4m3fn(pub u8);
+
+/// FP8 E5M2 format (5-bit exponent, 2-bit mantissa).
+/// Same exponent range as FP16 with reduced precision.
+/// Used by Hopper+ GPUs.
+#[derive(Copy, Clone, Debug, PartialEq, Default)]
+#[repr(transparent)]
+#[allow(non_camel_case_types)]
+pub struct f8e5m2(pub u8);
+
 /// Runtime identifier for a `DType`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum DTypeId {
@@ -26,7 +52,10 @@ pub enum DTypeId {
     F16,
     BF16,
     F32,
+    TF32,
     F64,
+    F8E4M3FN,
+    F8E5M2,
 }
 
 impl DTypeId {
@@ -45,7 +74,10 @@ impl DTypeId {
             DTypeId::F16 => "f16",
             DTypeId::BF16 => "bf16",
             DTypeId::F32 => "f32",
+            DTypeId::TF32 => "tf32",
             DTypeId::F64 => "f64",
+            DTypeId::F8E4M3FN => "f8e4m3fn",
+            DTypeId::F8E5M2 => "f8e5m2",
         }
     }
 
@@ -54,8 +86,9 @@ impl DTypeId {
         match self {
             DTypeId::Bool | DTypeId::U8 | DTypeId::I8 => 1,
             DTypeId::U16 | DTypeId::I16 | DTypeId::F16 | DTypeId::BF16 => 2,
-            DTypeId::U32 | DTypeId::I32 | DTypeId::F32 => 4,
+            DTypeId::U32 | DTypeId::I32 | DTypeId::F32 | DTypeId::TF32 => 4,
             DTypeId::U64 | DTypeId::I64 | DTypeId::F64 => 8,
+            DTypeId::F8E4M3FN | DTypeId::F8E5M2 => 1,
         }
     }
 }
@@ -101,7 +134,10 @@ impl_dtype!(
     f16 => F16, f16::ZERO, f16::ONE,
     bf16 => BF16, bf16::ZERO, bf16::ONE,
     f32 => F32, 0.0, 1.0,
+    tf32 => TF32, tf32(0), tf32(0x3F800000),  // IEEE 754 1.0 in f32 bits
     f64 => F64, 0.0, 1.0,
+    f8e4m3fn => F8E4M3FN, f8e4m3fn(0), f8e4m3fn(0x38),  // 1.0 in E4M3FN
+    f8e5m2 => F8E5M2, f8e5m2(0), f8e5m2(0x3C),          // 1.0 in E5M2
 );
 
 #[cfg(test)]
@@ -122,7 +158,10 @@ mod tests {
         assert_eq!(DTypeId::F16.as_str(), "f16");
         assert_eq!(DTypeId::BF16.as_str(), "bf16");
         assert_eq!(DTypeId::F32.as_str(), "f32");
+        assert_eq!(DTypeId::TF32.as_str(), "tf32");
         assert_eq!(DTypeId::F64.as_str(), "f64");
+        assert_eq!(DTypeId::F8E4M3FN.as_str(), "f8e4m3fn");
+        assert_eq!(DTypeId::F8E5M2.as_str(), "f8e5m2");
     }
 
     #[test]
@@ -137,6 +176,7 @@ mod tests {
         assert_eq!(DTypeId::U32.size_in_bytes(), 4);
         assert_eq!(DTypeId::I32.size_in_bytes(), 4);
         assert_eq!(DTypeId::F32.size_in_bytes(), 4);
+        assert_eq!(DTypeId::TF32.size_in_bytes(), 4);
         assert_eq!(DTypeId::U64.size_in_bytes(), 8);
         assert_eq!(DTypeId::I64.size_in_bytes(), 8);
         assert_eq!(DTypeId::F64.size_in_bytes(), 8);

--- a/cutile-compiler/README.md
+++ b/cutile-compiler/README.md
@@ -1,13 +1,57 @@
 # cuTile Rust Compiler
 
-This crate contains the compiler support for cuTile Rust.
-It lowers the Rust DSL into CUDA Tile MLIR and provides runtime helpers for turning that IR into executable GPU binaries.
+This crate compiles Rust DSL kernels into Tile IR bytecode for GPU execution
+via `tileiras`. Most users interact with it indirectly through `cutile` and
+`cutile-macro`.
 
-# Typical Usage
-
-Most users interact with this crate indirectly through `cutile` and `cutile-macro`.
-If you are working on the compiler itself, the most useful test command is:
+## Testing
 
 ```bash
 cargo test -p cutile-compiler
 ```
+
+## Debugging
+
+Set `CUTILE_DUMP` to inspect the compiler's internal state after each pass.
+Output goes to stderr.
+
+```bash
+# Dump the Tile IR (MLIR-like text) for all kernels:
+CUTILE_DUMP=ir cargo test -p cutile --test my_test -- --nocapture
+
+# Dump multiple stages:
+CUTILE_DUMP=resolved,typed,ir cargo test ...
+
+# Dump everything:
+CUTILE_DUMP=all cargo test ...
+```
+
+### Stages
+
+| Stage | Description |
+|-------|------------|
+| `ast` | Raw syn AST before any passes |
+| `resolved` | After name resolution (paths resolved) |
+| `typed` | After type inference (types annotated) |
+| `instantiated` | After monomorphization (no generics remain) |
+| `ir` | cutile-ir Module (MLIR-like text) |
+| `bytecode` / `bc` | Decoded bytecode |
+
+### Filtering
+
+Use `CUTILE_DUMP_FILTER` to limit output to specific kernels:
+
+```bash
+# By function name (matches in any module):
+CUTILE_DUMP=ir CUTILE_DUMP_FILTER=my_kernel cargo test ...
+
+# By qualified path (module::function):
+CUTILE_DUMP=ir CUTILE_DUMP_FILTER=my_module::my_kernel cargo test ...
+
+# Multiple filters (comma-separated):
+CUTILE_DUMP=ir CUTILE_DUMP_FILTER=add,gemm cargo test ...
+```
+
+### Legacy
+
+`TILE_IR_DUMP=1` is still supported as an alias for `CUTILE_DUMP=ir`.

--- a/cutile-compiler/src/compiler/_function.rs
+++ b/cutile-compiler/src/compiler/_function.rs
@@ -68,7 +68,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
         compile_options: &crate::hints::CompileOptions,
     ) -> Result<Self, JITError> {
         // 1. Check module exists.
-        if !modules.modules.contains_key(module_name) {
+        if !modules.modules().contains_key(module_name) {
             return Err(JITError::Generic(format!(
                 "Undefined module: {module_name}"
             )));
@@ -79,7 +79,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
 
         // 3. Look up function.
         let (_, function) = modules
-            .functions
+            .functions()
             .get(kernel_naming.public_name())
             .with_context(|| format!("Undefined function: {function_name}"))?;
 
@@ -136,13 +136,13 @@ impl<'m> CUDATileFunctionCompiler<'m> {
             &stride_args,
             &spec_args_map,
             &scalar_hints_map,
-            &modules.primitives,
+            &modules.primitives(),
             &optimization_hints,
         )?;
 
         // 10. Check namespace collision.
         if modules
-            .functions
+            .functions()
             .get(kernel_naming.entry_name().as_str())
             .is_some()
         {
@@ -459,7 +459,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
         };
         let Some(const_ty_str) = get_cuda_tile_element_type_from_rust_primitive_str(
             &type_inst.rust_element_instance_ty,
-            &self.modules.primitives,
+            &self.modules.primitives(),
         ) else {
             return self
                 .jit_error_result(&tr_ty.rust_ty.span(), "failed to compile constant value");

--- a/cutile-compiler/src/compiler/_module.rs
+++ b/cutile-compiler/src/compiler/_module.rs
@@ -3,212 +3,118 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-//! Module registry: collects and indexes all parsed DSL modules, structs, trait impls,
-//! and functions for lookup during compilation.
+//! Module registry: thin wrapper around [`NameResolver`] that preserves
+//! the compiler's existing lookup API.
+//!
+//! All item storage and name resolution lives in the [`NameResolver`]
+//! (Pass 1 output). This struct provides backward-compatible accessors
+//! so the rest of the compiler doesn't need to change yet.
 
 use crate::ast::{Module, SourceLocation, SpanBase};
 use crate::error::{JITError, SpannedJITError};
 use crate::generics::{GenericVars, TypeInstance};
 use crate::kernel_naming::KernelNaming;
+use crate::passes::name_resolution::NameResolver;
 use crate::syn_utils::*;
 use std::collections::HashMap;
 use syn::spanned::Spanned;
-use syn::{
-    ExprMethodCall, ImplItem, ImplItemFn, Item, ItemFn, ItemImpl, ItemMod, ItemStruct, Type,
-};
+use syn::{ExprMethodCall, ImplItem, ImplItemFn, ItemFn, ItemImpl, ItemMod, ItemStruct, Type};
 
-/// Aggregated index of all DSL modules, types, impls, and functions available to the compiler.
+/// Aggregated index of all DSL modules, types, impls, and functions.
+///
+/// Internally delegates to [`NameResolver`] for all item storage and
+/// name resolution. The flat accessors (`primitives`, `structs`, etc.)
+/// are backward-compatible shims that will be removed as the compiler
+/// migrates to path-based resolution.
 pub struct CUDATileModules {
-    pub(crate) modules: HashMap<String, ItemMod>,
-    // Rust primitives marked as cuda tile types.
-    // These are trait impls with the "cuda_tile::ty" annotation.
-    pub(crate) primitives: HashMap<(String, String), ItemImpl>,
-    // User-defined structs.
-    // This also contains structs for cuda tile types.
-    // They are structs with the "cuda_tile::ty" annotation.
-    pub(crate) structs: HashMap<String, ItemStruct>,
-    // User-defined struct impls.
-    // This also contains impls for cuda tile types.
-    pub(crate) struct_impls: HashMap<String, Vec<(String, ItemImpl)>>,
-    // Internal trait impls. User-defined traits are not supported.
-    pub(crate) trait_impls: HashMap<(String, String), (String, ItemImpl)>,
-    // User-defined functions.
-    // This also contains functions for cuda tile ops.
-    // These are functions with the "cuda_tile::op" annotation.
-    pub(crate) functions: HashMap<String, (String, ItemFn)>,
-    // Span bases captured at proc macro expansion time.
-    // Keyed by module name → SpanBase, which stores the (file, base_line,
-    // base_col) anchor needed to convert any runtime syn span in that
-    // module's AST into an absolute source location.
+    /// The name resolver (Pass 1 output). Owns all items and resolves paths.
+    pub(crate) name_resolver: NameResolver,
+
+    /// Span bases for source location mapping.
     pub(crate) span_bases: HashMap<String, SpanBase>,
 }
 
+// ---------------------------------------------------------------------------
+// Backward-compatible field-like accessors
+// ---------------------------------------------------------------------------
+
+impl CUDATileModules {
+    /// Flat map of all modules: name → ItemMod.
+    /// Compatibility shim — prefer `name_resolver.module(name)`.
+    pub fn modules(&self) -> &HashMap<String, ItemMod> {
+        self.name_resolver.all_modules()
+    }
+
+    /// Flat map of all primitives: (trait, type) → ItemImpl.
+    /// Compatibility shim — passed to generics/types functions.
+    pub fn primitives(&self) -> &HashMap<(String, String), ItemImpl> {
+        self.name_resolver.primitives()
+    }
+
+    /// Flat map of all structs: name → ItemStruct.
+    /// Compatibility shim.
+    pub fn structs(&self) -> &HashMap<String, ItemStruct> {
+        self.name_resolver.structs()
+    }
+
+    /// Flat map of all struct impls: struct_name → [(module, ItemImpl)].
+    /// Compatibility shim.
+    pub fn struct_impls(&self) -> &HashMap<String, Vec<(String, ItemImpl)>> {
+        self.name_resolver.struct_impls()
+    }
+
+    /// Flat map of all functions: name → (module, ItemFn).
+    /// Compatibility shim.
+    pub fn functions(&self) -> &HashMap<String, (String, ItemFn)> {
+        self.name_resolver.functions()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Constructor
+// ---------------------------------------------------------------------------
+
 impl CUDATileModules {
     pub fn new(modules_vec: Vec<Module>) -> Result<Self, JITError> {
-        let mut modules: HashMap<String, ItemMod> = HashMap::new();
-        let mut structs: HashMap<String, ItemStruct> = HashMap::new();
-        let mut struct_impls: HashMap<String, Vec<(String, ItemImpl)>> = HashMap::new();
-        let mut trait_impls: HashMap<(String, String), (String, ItemImpl)> = HashMap::new();
-        let mut primitives: HashMap<(String, String), ItemImpl> = HashMap::new();
-        let mut functions: HashMap<String, (String, ItemFn)> = HashMap::new();
+        // Collect module ASTs and span bases.
+        let mut module_asts: Vec<(String, ItemMod)> = Vec::new();
         let mut span_bases: HashMap<String, SpanBase> = HashMap::new();
 
         for module in &modules_vec {
-            let module_ast = module.ast();
-            // println!("module_ast: {:#?}", module_ast);
             let module_name = module.name().to_string();
-            match &module_ast.content {
-                Some(content) => {
-                    for item in &content.1 {
-                        match item {
-                            Item::Struct(struct_item) => {
-                                let struct_name = struct_item.ident.to_string();
-                                structs.insert(struct_name.clone(), struct_item.clone());
-                            }
-                            Item::Fn(function_item) => {
-                                let fn_name = function_item.sig.ident.to_string();
-                                if functions
-                                    .insert(
-                                        fn_name.clone(),
-                                        (module_name.clone(), function_item.clone()),
-                                    )
-                                    .is_some()
-                                {
-                                    return Err(JITError::generic_err(
-                                        format!("duplicate functions are not supported; try renaming your function: {fn_name}").as_str()
-                                    ));
-                                };
-                            }
-                            Item::Trait(_trait_item) => {
-                                // TODO (hme): Do we need to collect variadic traits?
-                                //  The impl contains all the information we need.
-                            }
-                            Item::Impl(impl_item) => {
-                                let self_ident_str = get_type_str(&*impl_item.self_ty);
-                                let trait_ident_str = match &impl_item.trait_ {
-                                    Some((_, trait_path, _)) => {
-                                        let last_seg = trait_path.segments.last().unwrap();
-                                        Some(last_seg.ident.to_string())
-                                    }
-                                    None => None,
-                                };
-                                // This may be an impl for types with trait bound ElementType.
-                                match (self_ident_str, trait_ident_str) {
-                                    (Some(self_ident_str), Some(trait_ident_str)) => {
-                                        if let Some(_attribute_list) =
-                                            get_meta_list("cuda_tile :: ty", &impl_item.attrs)
-                                        {
-                                            // println!("primitive type trait impl: {trait_ident_str} for {}", self_ident_str);
-                                            // An impl with a type annotation and self ident is a Rust type tagged for compilation to cuda tile.
-                                            if primitives
-                                                .insert(
-                                                    (
-                                                        trait_ident_str.clone(),
-                                                        self_ident_str.clone(),
-                                                    ),
-                                                    impl_item.clone(),
-                                                )
-                                                .is_some()
-                                            {
-                                                return module.resolve_span(&impl_item.span())
-                                                    .jit_error_result(&format!(
-                                                        "duplicate primitive type trait impl: `{trait_ident_str}` for `{self_ident_str}`"
-                                                    ));
-                                            }
-                                        } else if let Some(_attribute_list) = get_meta_list(
-                                            "cuda_tile :: variadic_trait_impl",
-                                            &impl_item.attrs,
-                                        ) {
-                                            if trait_impls
-                                                .insert(
-                                                    (
-                                                        trait_ident_str.clone(),
-                                                        self_ident_str.clone(),
-                                                    ),
-                                                    (module_name.clone(), impl_item.clone()),
-                                                )
-                                                .is_some()
-                                            {
-                                                return module.resolve_span(&impl_item.span())
-                                                    .jit_error_result(&format!(
-                                                        "duplicate trait impl: `{trait_ident_str}` for `{self_ident_str}`"
-                                                    ));
-                                            }
-                                        }
-                                    }
-                                    (Some(self_ident_str), None) => {
-                                        // println!("struct impl: {self_ident_str}");
-                                        if !struct_impls.contains_key(self_ident_str.as_str()) {
-                                            struct_impls.insert(
-                                                self_ident_str.clone(),
-                                                vec![(module_name.clone(), impl_item.clone())],
-                                            );
-                                        } else {
-                                            struct_impls
-                                                .get_mut(&self_ident_str)
-                                                .unwrap()
-                                                .push((module_name.clone(), impl_item.clone()));
-                                        }
-                                    }
-                                    (None, Some(trait_ident_str)) => {
-                                        return module
-                                            .resolve_span(&impl_item.span())
-                                            .jit_error_result(&format!(
-                                            "impl block for trait `{trait_ident_str}` is missing a Self type"
-                                        ));
-                                    }
-                                    (None, None) => {
-                                        return module
-                                            .resolve_span(&impl_item.span())
-                                            .jit_error_result(
-                                            "impl block is missing both a Self type and a trait",
-                                        );
-                                    }
-                                }
-                            }
-                            // Unsupported items for user-defined modules are rejected by the macro.
-                            _ => continue,
-                        }
-                    }
-                }
-                None => {
-                    return module
-                        .resolve_span(&module_ast.span())
-                        .jit_error_result(&format!(
-                            "module `{module_name}` must have a body (non-empty content)"
-                        ));
-                }
+            let module_ast = module.ast();
+
+            if module_ast.content.is_none() {
+                return module
+                    .resolve_span(&module_ast.span())
+                    .jit_error_result(&format!(
+                        "module `{module_name}` must have a body (non-empty content)"
+                    ));
             }
-            modules.insert(module_name.clone(), module_ast.clone());
+
+            module_asts.push((module_name.clone(), module_ast.clone()));
             span_bases.insert(module_name, module.span_base().clone());
         }
+
+        // Pass 1: Build the name resolver (indexes all items, processes imports).
+        let name_resolver = NameResolver::build(&module_asts)?;
+
         Ok(CUDATileModules {
-            modules,
-            primitives,
-            structs,
-            struct_impls,
-            trait_impls,
-            functions,
+            name_resolver,
             span_bases,
         })
     }
+}
 
-    /// Get the [`SpanBase`] for a module, if one was captured.
+// ---------------------------------------------------------------------------
+// Span / location utilities
+// ---------------------------------------------------------------------------
+
+impl CUDATileModules {
     pub fn get_span_base(&self, module_name: &str) -> Option<&SpanBase> {
         self.span_bases.get(module_name)
     }
 
-    /// Resolve any `proc_macro2::Span` from the given module's AST to an
-    /// absolute [`SourceLocation`].
-    ///
-    /// The span's line/column are string-relative (produced by
-    /// `syn::parse_str` on the verbatim source text).  The module's
-    /// [`SpanBase`] supplies the file path and base offset so that:
-    ///
-    /// ```text
-    /// abs_line = base_line + (span_line - 1)
-    /// abs_col  = if span_line == 1 { base_col + span_col } else { span_col }
-    /// ```
     pub fn resolve_span(&self, module_name: &str, span: &proc_macro2::Span) -> SourceLocation {
         match self.span_bases.get(module_name) {
             Some(base) => base.resolve_span(span),
@@ -216,7 +122,6 @@ impl CUDATileModules {
         }
     }
 
-    /// Get the source file path for a module, if available.
     pub fn get_source_file(&self, module_name: &str) -> Option<&str> {
         self.span_bases.get(module_name).and_then(|sb| {
             if sb.file.is_empty() {
@@ -226,40 +131,33 @@ impl CUDATileModules {
             }
         })
     }
+}
 
+// ---------------------------------------------------------------------------
+// Item lookup (backward-compatible methods)
+// ---------------------------------------------------------------------------
+
+impl CUDATileModules {
     pub fn get_primitives_attrs(
         &self,
         trait_name: &str,
         rust_type_name: &str,
     ) -> Option<SingleMetaList> {
-        match self
-            .primitives
-            .get(&(trait_name.to_string(), rust_type_name.to_string()))
-        {
-            Some(item_impl) => get_meta_list("cuda_tile :: ty", &item_impl.attrs),
-            None => None,
-        }
+        self.name_resolver
+            .get_primitive_attrs(trait_name, rust_type_name)
     }
 
     pub fn get_cuda_tile_type_attrs(&self, ident: &str) -> Option<SingleMetaList> {
-        // TODO (hme): This is slow but flexible.
-        match self.structs.get(ident) {
-            Some(item_struct) => get_meta_list("cuda_tile :: ty", &item_struct.attrs),
-            None => None,
-        }
+        self.name_resolver.get_type_attrs(ident)
     }
 
     pub fn get_function_by_name(&self, function_name: &str) -> Option<&(String, ItemFn)> {
         let canonical_name = KernelNaming::canonical_public_name(function_name);
-        self.functions.get(canonical_name.as_str())
+        self.name_resolver.functions().get(canonical_name.as_str())
     }
 
     pub fn get_cuda_tile_op_attrs(&self, ident: &str) -> Option<SingleMetaList> {
-        // TODO (hme): This is slow but flexible.
-        match self.get_function_by_name(ident) {
-            Some((_, item_fn)) => get_meta_list("cuda_tile :: op", &item_fn.attrs),
-            None => None,
-        }
+        self.name_resolver.get_op_attrs(ident)
     }
 
     pub fn get_fn_item(
@@ -267,7 +165,7 @@ impl CUDATileModules {
         module_name: &str,
         function_name: &str,
     ) -> Result<&(String, ItemFn), JITError> {
-        if !self.modules.contains_key(module_name) {
+        if !self.name_resolver.has_module(module_name) {
             return JITError::generic(&format!("undefined module: `{module_name}`"));
         }
         match self.get_function_by_name(function_name) {
@@ -311,13 +209,13 @@ impl CUDATileModules {
         receiver_rust_ty: &syn::Type,
         method_call_expr: &ExprMethodCall,
         generic_vars: &GenericVars,
-        // String is module_name.
-    ) -> Result<Option<(String, ItemImpl, ImplItemFn)>, crate::error::JITError> {
+    ) -> Result<Option<(String, ItemImpl, ImplItemFn)>, JITError> {
         // Check if we're calling a method on a primitive type trait impl.
-        let impls = match generic_vars.instantiate_type(receiver_rust_ty, &self.primitives)? {
+        let impls = match generic_vars.instantiate_type(receiver_rust_ty, self.primitives())? {
             TypeInstance::ElementType(_elem_ty) => {
                 match self
-                    .trait_impls
+                    .name_resolver
+                    .trait_impls()
                     .get(&("BroadcastScalar".to_string(), "E".to_string()))
                 {
                     Some(trait_impl) => Some(&vec![trait_impl.clone()]),
@@ -325,12 +223,12 @@ impl CUDATileModules {
                 }
             }
             _ => {
-                let ident = get_type_ident(&receiver_rust_ty);
+                let ident = get_type_ident(receiver_rust_ty);
                 if ident.is_none() {
                     return Ok(None);
                 }
                 let receiver_type_str = ident.unwrap().to_string();
-                self.struct_impls.get(&receiver_type_str)
+                self.name_resolver.struct_impls().get(&receiver_type_str)
             }
         };
         let impls_vec = impls.unwrap();
@@ -356,18 +254,7 @@ impl CUDATileModules {
     }
 
     pub fn get_struct_field_type(&self, struct_name: &str, field_name: &str) -> Option<Type> {
-        let s = self
-            .structs
-            .get(struct_name)
-            .expect(format!("{struct_name} doesn't exist.").as_str());
-        for field in &s.fields {
-            let Some(curr_field_ident) = &field.ident else {
-                continue;
-            };
-            if field_name == curr_field_ident.to_string().as_str() {
-                return Some(field.ty.clone());
-            }
-        }
-        None
+        self.name_resolver
+            .get_struct_field_type(struct_name, field_name)
     }
 }

--- a/cutile-compiler/src/compiler/_type.rs
+++ b/cutile-compiler/src/compiler/_type.rs
@@ -30,8 +30,12 @@ pub fn scalar_from_name(name: &str) -> Option<ScalarType> {
         "f64" => Some(ScalarType::F64),
         "f8e4m3fn" | "f8E4M3FN" => Some(ScalarType::F8E4M3FN),
         "f8e5m2" | "f8E5M2" => Some(ScalarType::F8E5M2),
-        // Rust-facing names
+        // Rust-facing names (unsigned maps to signed CUDA types)
         "bool" => Some(ScalarType::I1),
+        "u8" => Some(ScalarType::I8),
+        "u16" => Some(ScalarType::I16),
+        "u32" => Some(ScalarType::I32),
+        "u64" => Some(ScalarType::I64),
         _ => None,
     }
 }

--- a/cutile-compiler/src/compiler/compile_binary_op.rs
+++ b/cutile-compiler/src/compiler/compile_binary_op.rs
@@ -157,7 +157,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
         let operand_type = lhs.ty.clone();
         let operand_rust_ty = &operand_type.rust_ty;
         let Some(operand_rust_element_type) =
-            operand_type.get_instantiated_rust_element_type(&self.modules.primitives)
+            operand_type.get_instantiated_rust_element_type(&self.modules.primitives())
         else {
             return self.jit_error_result(
                 span,
@@ -183,7 +183,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
         let operand_result_ty = module.value_type(lhs_value).clone();
 
         let Some(operand_cuda_tile_element_type) =
-            operand_type.get_cuda_tile_element_type(&self.modules.primitives)?
+            operand_type.get_cuda_tile_element_type(&self.modules.primitives())?
         else {
             return self.jit_error_result(
                 span,

--- a/cutile-compiler/src/compiler/compile_cuda_tile_op.rs
+++ b/cutile-compiler/src/compiler/compile_cuda_tile_op.rs
@@ -780,7 +780,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
 
         let elem_ty_prefix = ptr_value
             .ty
-            .get_cuda_tile_element_type_prefix(&self.modules.primitives)?;
+            .get_cuda_tile_element_type_prefix(&self.modules.primitives())?;
         let atomic_mode = AtomicMode::new(mode.as_str(), elem_ty_prefix)? as i64;
 
         let mut operands = vec![ptrs, arg];
@@ -1382,7 +1382,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
             .unwrap();
         let elem_ty_str = operand_value
             .ty
-            .get_cuda_tile_element_type(&self.modules.primitives)?
+            .get_cuda_tile_element_type(&self.modules.primitives())?
             .unwrap();
         let elem_ir_ty = super::_type::make_scalar_tile_type(&elem_ty_str)
             .expect("failed to build scalar tile type for reduce element");
@@ -1542,7 +1542,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
             .expect("failed to convert scan result type");
         let elem_ty_str = operand_value
             .ty
-            .get_cuda_tile_element_type(&self.modules.primitives)?
+            .get_cuda_tile_element_type(&self.modules.primitives())?
             .unwrap();
         let elem_ir_ty = super::_type::make_scalar_tile_type(&elem_ty_str)
             .expect("failed to build scalar tile type for scan element");
@@ -1860,13 +1860,13 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                     .get(0)
                     .and_then(|arg| {
                         arg.ty
-                            .get_instantiated_rust_element_type(&self.modules.primitives)
+                            .get_instantiated_rust_element_type(&self.modules.primitives())
                     })
                     .expect("Failed to get element type for signedness inference.");
                 for arg in &compiled_args {
                     let arg_elem_ty = arg
                         .ty
-                        .get_instantiated_rust_element_type(&self.modules.primitives)
+                        .get_instantiated_rust_element_type(&self.modules.primitives())
                         .expect("Operand types are not all equivalent.");
                     if arg_elem_ty != elem_ty {
                         return self.jit_error_result(&call_expr.span(), &format!("Element type mismatch for signedness inference: expected {elem_ty}, got {arg_elem_ty}"));
@@ -2075,7 +2075,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                     };
                     // Build a DenseElements attribute from the literal value.
                     let elem_ty_str = return_type
-                        .get_cuda_tile_element_type(&self.modules.primitives)?
+                        .get_cuda_tile_element_type(&self.modules.primitives())?
                         .unwrap_or("i32".to_string());
                     let result_ir_ty = super::_type::scalar_from_name(&elem_ty_str)
                         .map(|sc| {
@@ -2347,7 +2347,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                     let Some(tile_element_type_instance) =
                         get_cuda_tile_element_type_from_rust_primitive_str(
                             &rust_element_type_instance,
-                            &self.modules.primitives,
+                            &self.modules.primitives(),
                         )
                     else {
                         return self.jit_error_result(&mac.span(), &format!("unable to determine tile element type for `{rust_element_type_instance}`"));

--- a/cutile-compiler/src/compiler/compile_expression.rs
+++ b/cutile-compiler/src/compiler/compile_expression.rs
@@ -21,6 +21,7 @@ use super::tile_rust_type::TileRustType;
 use crate::bounds::Bounds;
 use crate::error::JITError;
 use crate::generics::{GenericVars, TypeInstance, TypeInstanceUserType};
+use crate::passes::name_resolution::{DefKind, Res};
 use crate::syn_utils::*;
 use crate::types::*;
 
@@ -1053,50 +1054,70 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                     Ok(Some(TileRustValue::new_compound(values, return_type)))
                 }
                 Expr::Path(path_expr) => {
-                    // For qualified paths (e.g., `ftz::Enabled`, `rounding::NearestEven`),
-                    // use the last segment as the variable name. These are ZST marker types
-                    // used by static_params -- they have no tile-ir representation.
                     let var_name = path_expr.path.segments.last().unwrap().ident.to_string();
 
-                    // Handle None specially - it's a Rust Option::None value, not a variable
+                    // Handle None specially — Rust Option::None, not a variable.
                     if var_name == "None" {
-                        // None is used for optional parameters - return None to indicate absence
                         return Ok(None);
                     }
 
-                    let value = match ctx.vars.get(&var_name) {
-                        Some(ct_value) => ct_value,
-                        None => {
-                            // Qualified paths like `ftz::Enabled` or `rounding::NearestEven`
-                            // are ZST marker types for static_params. They carry no tile-ir
-                            // value -- like string literals, they're compile-time constants
-                            // consumed by the op compilation path to emit tile-ir attributes.
-                            //
-                            // Return a String-kinded placeholder so arg indexing is preserved
-                            // in callers (type derivation, inline path). Validation happens
-                            // in resolve_static_params, which checks the type name against
-                            // the function's static_params mapping.
-                            if path_expr.path.segments.len() > 1 {
-                                let path_ty: syn::Type = syn::Type::Path(syn::TypePath {
-                                    qself: None,
-                                    path: path_expr.path.clone(),
-                                });
-                                let type_instance = TypeInstance::UserType(TypeInstanceUserType {
-                                    maybe_generic_ty: path_ty,
-                                });
-                                let ty = TileRustType::new_string(type_instance);
-                                return Ok(Some(TileRustValue::new_string(
-                                    Expr::Path(path_expr.clone()),
-                                    ty,
-                                )));
-                            }
-                            return self.jit_error_result(
-                                &path_expr.span(),
-                                &format!("undefined variable `{}`", var_name),
-                            );
+                    // 1. Local variable (single-segment paths, locals shadow module items).
+                    if path_expr.path.segments.len() == 1 {
+                        if let Some(value) = ctx.vars.get(&var_name) {
+                            return Ok(Some(value.clone()));
                         }
-                    };
-                    Ok(Some(value.clone()))
+                    }
+
+                    // 2. Resolve via name resolver (module-level structs, functions, etc.).
+                    let res = self
+                        .modules
+                        .name_resolver
+                        .resolve_path(&path_expr.path, &self.module_name);
+                    match res {
+                        Res::Def(DefKind::Struct, _) => {
+                            // ZST marker type (ftz::Enabled, rounding::NearestEven, etc.).
+                            // Return a String-kinded placeholder for static_params —
+                            // consumed by resolve_static_params during op compilation.
+                            let path_ty: syn::Type = syn::Type::Path(syn::TypePath {
+                                qself: None,
+                                path: path_expr.path.clone(),
+                            });
+                            let type_instance = TypeInstance::UserType(TypeInstanceUserType {
+                                maybe_generic_ty: path_ty,
+                            });
+                            let ty = TileRustType::new_string(type_instance);
+                            return Ok(Some(TileRustValue::new_string(
+                                Expr::Path(path_expr.clone()),
+                                ty,
+                            )));
+                        }
+                        _ => {}
+                    }
+
+                    // 3. Single-segment fallback: might be a local variable we missed
+                    //    (e.g. function params not yet in ctx.vars during type derivation).
+                    if path_expr.path.segments.len() == 1 {
+                        if let Some(value) = ctx.vars.get(&var_name) {
+                            return Ok(Some(value.clone()));
+                        }
+                    }
+
+                    // 4. Not found anywhere.
+                    let suggestion = self.modules.name_resolver.find_all_definitions(&var_name);
+                    if suggestion.is_empty() {
+                        return self.jit_error_result(
+                            &path_expr.span(),
+                            &format!("undefined variable `{var_name}`"),
+                        );
+                    } else {
+                        return self.jit_error_result(
+                            &path_expr.span(),
+                            &format!(
+                                "undefined variable `{var_name}` (did you mean the function defined in {}?)",
+                                suggestion.join(", ")
+                            ),
+                        );
+                    }
                 }
                 Expr::Call(call_expr) => {
                     let call_expr_func_str = call_expr.func.to_token_stream().to_string();
@@ -1302,8 +1323,8 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                                     )
                                 }
                             };
-                            let Some(cuda_tile_ty) =
-                                return_type.get_cuda_tile_element_type(&self.modules.primitives)?
+                            let Some(cuda_tile_ty) = return_type
+                                .get_cuda_tile_element_type(&self.modules.primitives())?
                             else {
                                 return self.jit_error_result(
                                     &lit_expr.span(),
@@ -1364,7 +1385,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                         .unwrap();
                     let src_elem_ty: String = src_expr
                         .ty
-                        .get_instantiated_rust_element_type(&self.modules.primitives)
+                        .get_instantiated_rust_element_type(&self.modules.primitives())
                         .unwrap();
                     let dst_elem_ty: String = get_rust_element_type_primitive(&cast_expr.ty);
                     match (src_elem_ty.as_str(), dst_elem_ty.as_str()) {
@@ -1426,7 +1447,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                         }
                     };
                     let Some(cuda_tile_ty) =
-                        return_type.get_cuda_tile_element_type(&self.modules.primitives)?
+                        return_type.get_cuda_tile_element_type(&self.modules.primitives())?
                     else {
                         return self.jit_error_result(
                             &lit_expr.span(),

--- a/cutile-compiler/src/compiler/compile_inline.rs
+++ b/cutile-compiler/src/compiler/compile_inline.rs
@@ -144,7 +144,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                 generic_arg_inference.map_args_to_params(&call_arg_rust_tys, None);
                 // println!("inline_function_call {:#?}: generic_vars={generic_vars:#?} \nexpr_generic_args={expr_generic_args:#?} \ngeneric_arg_inference={generic_arg_inference:#?}", fn_item.sig.ident.to_string());
                 generic_arg_inference
-                    .get_generic_vars_instance(&generic_vars, &self.modules.primitives)
+                    .get_generic_vars_instance(&generic_vars, &self.modules.primitives())
             };
             // Add function call const generics as variables.
             for (key, value) in &call_generic_vars.inst_i32 {
@@ -295,7 +295,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                 generic_arg_inference.map_args_to_params(&call_arg_rust_tys, Some(self_ty));
                 // println!("sig={} \nargs={} \narg_map={:#?}", impl_method.sig.to_token_stream().to_string(), args.to_token_stream().to_string(), generic_arg_inference.param2arg);
                 let inferred_generics = generic_arg_inference
-                    .get_generic_vars_instance(&generic_vars, &self.modules.primitives);
+                    .get_generic_vars_instance(&generic_vars, &self.modules.primitives());
 
                 // If there are generics passed as part of the method call, capture them.
                 if method_call_turbofish.is_some() {

--- a/cutile-compiler/src/compiler/compile_intrinsic.rs
+++ b/cutile-compiler/src/compiler/compile_intrinsic.rs
@@ -33,7 +33,7 @@ use syn::{Expr, ExprCall, ExprPath, GenericArgument, ItemFn, Lit, PathArguments}
 /// Helper: determine signedness string from a Rust element type name.
 fn get_signedness_str(element_type_str: &str) -> &'static str {
     match element_type_str {
-        "bool" | "u32" | "u64" => "unsigned",
+        "bool" | "u8" | "u16" | "u32" | "u64" => "unsigned",
         _ => "signed",
     }
 }
@@ -98,7 +98,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                 let out = operands.remove(0);
                 let out_type = out.ty.clone();
                 let Some(out_rust_element_type) =
-                    out_type.get_instantiated_rust_element_type(&self.modules.primitives)
+                    out_type.get_instantiated_rust_element_type(&self.modules.primitives())
                 else {
                     return self.jit_error_result(
                         &call_expr.span(),
@@ -118,7 +118,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                     );
                 };
                 let Some(out_cuda_tile_element_type) =
-                    out_type.get_cuda_tile_element_type(&self.modules.primitives)?
+                    out_type.get_cuda_tile_element_type(&self.modules.primitives())?
                 else {
                     return self.jit_error_result(
                         &call_expr.span(),
@@ -135,7 +135,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                 } else if !out_is_float {
                     let Some(lhs_elem_ty) = lhs
                         .ty
-                        .get_instantiated_rust_element_type(&self.modules.primitives)
+                        .get_instantiated_rust_element_type(&self.modules.primitives())
                     else {
                         return self.jit_error_result(
                             &call_expr.span(),
@@ -144,7 +144,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                     };
                     let Some(rhs_elem_ty) = lhs
                         .ty
-                        .get_instantiated_rust_element_type(&self.modules.primitives)
+                        .get_instantiated_rust_element_type(&self.modules.primitives())
                     else {
                         return self.jit_error_result(
                             &call_expr.span(),
@@ -641,7 +641,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                     }
                     "tile_to_scalar" => {
                         let Some(element_type) =
-                            get_element_type_structured(&old_type, &self.modules.primitives)
+                            get_element_type_structured(&old_type, &self.modules.primitives())
                         else {
                             return self.jit_error_result(
                                 &call_expr.span(),
@@ -671,7 +671,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                     }
                     "tile_to_pointer" => {
                         let Some(element_type) =
-                            get_element_type_structured(&old_type, &self.modules.primitives)
+                            get_element_type_structured(&old_type, &self.modules.primitives())
                         else {
                             return self.jit_error_result(
                                 &call_expr.span(),
@@ -786,16 +786,16 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                             return Ok(Some(arg));
                         }
                         let output_type =
-                            tile_ir_type_from_trt(&new_type_compiled, &self.modules.primitives)
+                            tile_ir_type_from_trt(&new_type_compiled, &self.modules.primitives())
                                 .ok_or_else(|| {
-                                    self.jit_error(
-                                        &call_expr.span(),
-                                        &format!(
-                                            "Failed to obtain tile-ir type for convert {}",
-                                            call_expr.to_token_stream().to_string()
-                                        ),
-                                    )
-                                })?;
+                                self.jit_error(
+                                    &call_expr.span(),
+                                    &format!(
+                                        "Failed to obtain tile-ir type for convert {}",
+                                        call_expr.to_token_stream().to_string()
+                                    ),
+                                )
+                            })?;
                         // These aren't required for all ops.
                         let (op_id, results) = match (
                             old_element_type_str.as_str(),
@@ -820,22 +820,13 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                                     ),
                                 );
                             }
-                            ("i32", "bf16")
-                            | ("u32", "bf16")
-                            | ("i64", "bf16")
-                            | ("u64", "bf16")
-                            | ("i32", "f16")
-                            | ("u32", "f16")
-                            | ("i64", "f16")
-                            | ("u64", "f16")
-                            | ("i32", "f32")
-                            | ("u32", "f32")
-                            | ("i64", "f32")
-                            | ("u64", "f32")
-                            | ("i32", "f64")
-                            | ("u32", "f64")
-                            | ("i64", "f64")
-                            | ("u64", "f64") => {
+                            // Integer → float: IToF with signedness from source type.
+                            (from, to)
+                                if super::_type::scalar_from_name(from)
+                                    .map_or(false, |s| s.is_integer())
+                                    && super::_type::scalar_from_name(to)
+                                        .map_or(false, |s| s.is_float()) =>
+                            {
                                 let signedness = signedness_attr(
                                     "signedness",
                                     get_signedness_str(&old_element_type_str),
@@ -859,22 +850,13 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                                     .result(output_type)
                                     .build(module)
                             }
-                            ("bf16", "i32")
-                            | ("bf16", "u32")
-                            | ("bf16", "i64")
-                            | ("bf16", "u64")
-                            | ("f16", "i32")
-                            | ("f16", "u32")
-                            | ("f16", "i64")
-                            | ("f16", "u64")
-                            | ("f32", "i32")
-                            | ("f32", "u32")
-                            | ("f32", "i64")
-                            | ("f32", "u64")
-                            | ("f64", "i32")
-                            | ("f64", "u32")
-                            | ("f64", "i64")
-                            | ("f64", "u64") => {
+                            // Float → integer: FToI with signedness from target type.
+                            (from, to)
+                                if super::_type::scalar_from_name(from)
+                                    .map_or(false, |s| s.is_float())
+                                    && super::_type::scalar_from_name(to)
+                                        .map_or(false, |s| s.is_integer()) =>
+                            {
                                 let signedness = signedness_attr(
                                     "signedness",
                                     get_signedness_str(&new_element_type_str),
@@ -899,20 +881,16 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                                     .result(output_type)
                                     .build(module)
                             }
-                            ("bf16", "f16")
-                            | ("bf16", "f32")
-                            | ("bf16", "f64")
-                            | ("f16", "bf16")
-                            | ("f16", "f32")
-                            | ("f16", "f64")
-                            | ("f32", "bf16")
-                            | ("f32", "f16")
-                            | ("f32", "f64")
-                            | ("f64", "bf16")
-                            | ("f64", "f16")
-                            | ("f64", "f32")
-                            | ("f32", "tf32")
-                            | ("tf32", "f32") => {
+                            // Float → float: all float type pairs use FToF
+                            // with NEAREST_EVEN rounding. This covers f16, bf16,
+                            // f32, f64, tf32, f8e4m3fn, f8e5m2 — matching
+                            // cutile-python's _get_type_conversion_encoder.
+                            (from, to)
+                                if super::_type::scalar_from_name(from)
+                                    .map_or(false, |s| s.is_float())
+                                    && super::_type::scalar_from_name(to)
+                                        .map_or(false, |s| s.is_float()) =>
+                            {
                                 let rounding = rounding_mode_attr("nearest_even");
                                 let Some(input_value) = arg.value else {
                                     return self.jit_error_result(

--- a/cutile-compiler/src/compiler/compile_type.rs
+++ b/cutile-compiler/src/compiler/compile_type.rs
@@ -41,7 +41,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                     let unknown_type_instance = TypeInstanceUserType::instantiate(
                         &ty,
                         generic_vars,
-                        &self.modules.primitives,
+                        &self.modules.primitives(),
                     )
                     .unwrap();
                     let type_instance = TypeInstance::UserType(unknown_type_instance);
@@ -49,16 +49,22 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                 }
             }
             syn::Type::Array(_) => {
-                let unknown_type_instance =
-                    TypeInstanceUserType::instantiate(&ty, generic_vars, &self.modules.primitives)
-                        .unwrap();
+                let unknown_type_instance = TypeInstanceUserType::instantiate(
+                    &ty,
+                    generic_vars,
+                    &self.modules.primitives(),
+                )
+                .unwrap();
                 let type_instance = TypeInstance::UserType(unknown_type_instance);
                 return Ok(Some(TileRustType::new_compound(type_instance)));
             }
             syn::Type::Slice(_) => {
-                let unknown_type_instance =
-                    TypeInstanceUserType::instantiate(&ty, generic_vars, &self.modules.primitives)
-                        .unwrap();
+                let unknown_type_instance = TypeInstanceUserType::instantiate(
+                    &ty,
+                    generic_vars,
+                    &self.modules.primitives(),
+                )
+                .unwrap();
                 let type_instance = TypeInstance::UserType(unknown_type_instance);
                 return Ok(Some(TileRustType::new_compound(type_instance)));
             }
@@ -75,13 +81,13 @@ impl<'m> CUDATileFunctionCompiler<'m> {
             syn::Type::Path(_) => match get_type_ident(ty) {
                 Some(ident) => {
                     let type_name = ident.to_string();
-                    if let Some(item_struct) = self.modules.structs.get(type_name.as_str()) {
+                    if let Some(item_struct) = self.modules.structs().get(type_name.as_str()) {
                         ty_attrs = self.modules.get_cuda_tile_type_attrs(type_name.as_str());
                         if ty_attrs.is_none() {
                             let unknown_type_instance = TypeInstanceUserType::instantiate(
                                 &ty,
                                 generic_vars,
-                                &self.modules.primitives,
+                                &self.modules.primitives(),
                             )
                             .unwrap();
                             let type_instance = TypeInstance::UserType(unknown_type_instance);
@@ -92,10 +98,10 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                         }
                         structure = Some((type_name.clone(), &item_struct));
                         type_instance =
-                            Some(generic_vars.instantiate_type(ty, &self.modules.primitives)?);
+                            Some(generic_vars.instantiate_type(ty, &self.modules.primitives())?);
                     } else {
                         let local_type_instance =
-                            generic_vars.instantiate_type(ty, &self.modules.primitives)?;
+                            generic_vars.instantiate_type(ty, &self.modules.primitives())?;
                         if let TypeInstance::StringType(_string_inst) = local_type_instance {
                             return Ok(Some(TileRustType::new_string(TypeInstance::StringType(
                                 _string_inst,
@@ -106,7 +112,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                         else {
                             return self.jit_error_result(&ty.span(), "Failed to compile type");
                         };
-                        if let Some(element_type_impl) = self.modules.primitives.get(&(
+                        if let Some(element_type_impl) = self.modules.primitives().get(&(
                             "ElementType".to_string(),
                             element_type_instance_str.to_string(),
                         )) {
@@ -131,13 +137,13 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                 }
                 let type_name = type_name.unwrap().to_string();
                 let local_type_instance =
-                    generic_vars.instantiate_type(ty, &self.modules.primitives)?;
+                    generic_vars.instantiate_type(ty, &self.modules.primitives())?;
                 let Some(element_type_instance_str) =
                     local_type_instance.get_rust_element_instance_ty()
                 else {
                     return self.jit_error_result(&ty.span(), "Failed to compile type");
                 };
-                if let Some(element_type_impl) = self.modules.primitives.get(&(
+                if let Some(element_type_impl) = self.modules.primitives().get(&(
                     "ElementType".to_string(),
                     element_type_instance_str.to_string(),
                 )) {
@@ -236,7 +242,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
             return Ok(Some(TileRustType::new_structured_type(
                 type_name,
                 generic_vars,
-                &self.modules.primitives,
+                &self.modules.primitives(),
                 args,
                 type_instance,
             )?));
@@ -267,7 +273,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
             return Ok(Some(TileRustType::new_primitive_type(
                 type_name,
                 generic_vars,
-                &self.modules.primitives,
+                &self.modules.primitives(),
                 args,
                 TypeInstance::ElementType(element_instance),
             )?));
@@ -297,7 +303,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
             return Ok(Some(TileRustType::new_primitive_type(
                 type_name,
                 generic_vars,
-                &self.modules.primitives,
+                &self.modules.primitives(),
                 args,
                 TypeInstance::PtrType(ptr_instance),
             )?));

--- a/cutile-compiler/src/cuda_tile_runtime_utils.rs
+++ b/cutile-compiler/src/cuda_tile_runtime_utils.rs
@@ -33,9 +33,12 @@ pub fn compile_tile_ir_module(module: &cutile_ir::Module, gpu_name: &str) -> Str
         .verify_bytecode_indices()
         .expect("tile-ir bytecode value-index verification failed");
 
-    if std::env::var("TILE_IR_DUMP").is_ok() {
-        eprintln!("{}", module.to_mlir_text());
-    }
+    // Dump IR via unified CUTILE_DUMP mechanism (also honors legacy TILE_IR_DUMP).
+    crate::dump::dump_module(
+        crate::dump::DumpStage::Ir,
+        &module.name,
+        &module.to_mlir_text(),
+    );
 
     cutile_ir::write_bytecode_to_file(module, bc_filename.as_str())
         .expect(&format!("Failed to write bytecode for {bc_filename}"));

--- a/cutile-compiler/src/dump.rs
+++ b/cutile-compiler/src/dump.rs
@@ -1,0 +1,241 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Debug dump tooling for inspecting compiler state after each pass.
+//!
+//! Controlled by environment variables:
+//! - `CUTILE_DUMP` — comma-separated list of stages to dump, or `"all"`
+//! - `CUTILE_DUMP_FILTER` — comma-separated list of function names or
+//!   module-qualified paths (`my_module::my_kernel`)
+//!
+//! ```bash
+//! CUTILE_DUMP=ir cargo test -p cutile --test my_test
+//! CUTILE_DUMP=resolved,typed CUTILE_DUMP_FILTER=my_module::add cargo test ...
+//! ```
+
+use std::collections::HashSet;
+use std::sync::OnceLock;
+
+/// A stage in the compilation pipeline that can be dumped.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum DumpStage {
+    /// Raw syn AST before any passes.
+    Ast,
+    /// After name resolution (paths resolved).
+    Resolved,
+    /// After type inference (types annotated).
+    Typed,
+    /// After monomorphization (no generics remain).
+    Instantiated,
+    /// cutile-ir Module (MLIR-like text).
+    Ir,
+    /// Decoded bytecode.
+    Bytecode,
+}
+
+impl DumpStage {
+    fn from_str(s: &str) -> Option<Self> {
+        match s.trim().to_lowercase().as_str() {
+            "ast" => Some(Self::Ast),
+            "resolved" => Some(Self::Resolved),
+            "typed" => Some(Self::Typed),
+            "instantiated" => Some(Self::Instantiated),
+            "ir" => Some(Self::Ir),
+            "bytecode" | "bc" => Some(Self::Bytecode),
+            _ => None,
+        }
+    }
+
+    fn label(&self) -> &'static str {
+        match self {
+            Self::Ast => "ast",
+            Self::Resolved => "resolved",
+            Self::Typed => "typed",
+            Self::Instantiated => "instantiated",
+            Self::Ir => "ir",
+            Self::Bytecode => "bytecode",
+        }
+    }
+}
+
+/// A filter entry: either a bare name or a module::name qualified path.
+#[derive(Debug, Clone)]
+enum FilterEntry {
+    /// Matches any function with this name, regardless of module.
+    Bare(String),
+    /// Matches only module::name exactly.
+    Qualified { module: String, name: String },
+}
+
+impl FilterEntry {
+    fn parse(s: &str) -> Self {
+        let s = s.trim();
+        if let Some((module, name)) = s.rsplit_once("::") {
+            FilterEntry::Qualified {
+                module: module.to_string(),
+                name: name.to_string(),
+            }
+        } else {
+            FilterEntry::Bare(s.to_string())
+        }
+    }
+
+    fn matches(&self, fn_name: &str, module_name: &str) -> bool {
+        match self {
+            FilterEntry::Bare(name) => fn_name == name,
+            FilterEntry::Qualified { module, name } => fn_name == name && module_name == module,
+        }
+    }
+}
+
+/// Parsed configuration from environment variables.
+struct DumpConfig {
+    /// Which stages are enabled. Empty = nothing enabled.
+    stages: HashSet<DumpStage>,
+    /// Function filter. None = dump all functions. Some = only matching.
+    filter: Option<Vec<FilterEntry>>,
+}
+
+impl DumpConfig {
+    fn from_env() -> Self {
+        let stages = match std::env::var("CUTILE_DUMP") {
+            Ok(val) => {
+                let val = val.trim();
+                if val.eq_ignore_ascii_case("all") {
+                    [
+                        DumpStage::Ast,
+                        DumpStage::Resolved,
+                        DumpStage::Typed,
+                        DumpStage::Instantiated,
+                        DumpStage::Ir,
+                        DumpStage::Bytecode,
+                    ]
+                    .into_iter()
+                    .collect()
+                } else {
+                    val.split(',').filter_map(DumpStage::from_str).collect()
+                }
+            }
+            Err(_) => {
+                // Backward compat: TILE_IR_DUMP enables the IR stage.
+                if std::env::var("TILE_IR_DUMP").is_ok() {
+                    [DumpStage::Ir].into_iter().collect()
+                } else {
+                    HashSet::new()
+                }
+            }
+        };
+
+        let filter = std::env::var("CUTILE_DUMP_FILTER")
+            .ok()
+            .map(|val| val.split(',').map(FilterEntry::parse).collect());
+
+        DumpConfig { stages, filter }
+    }
+}
+
+static CONFIG: OnceLock<DumpConfig> = OnceLock::new();
+
+fn config() -> &'static DumpConfig {
+    CONFIG.get_or_init(DumpConfig::from_env)
+}
+
+/// Check if dumping is enabled for this stage.
+pub fn should_dump(stage: DumpStage) -> bool {
+    config().stages.contains(&stage)
+}
+
+/// Check if a function matches the dump filter.
+///
+/// - `fn_name`: the function name (e.g. `"my_kernel"`)
+/// - `module_name`: the module name (e.g. `"my_module"`)
+///
+/// Returns true if no filter is set (dump all) or if the function matches.
+pub fn matches_filter(fn_name: &str, module_name: &str) -> bool {
+    match &config().filter {
+        None => true,
+        Some(entries) => entries.iter().any(|e| e.matches(fn_name, module_name)),
+    }
+}
+
+/// Dump output for a compilation stage.
+///
+/// Prints to stderr with a labeled header. No-op if the stage isn't
+/// enabled or the function doesn't match the filter.
+pub fn dump(stage: DumpStage, fn_name: &str, module_name: &str, content: &str) {
+    if !should_dump(stage) || !matches_filter(fn_name, module_name) {
+        return;
+    }
+    let label = stage.label();
+    let qualified = if module_name.is_empty() {
+        fn_name.to_string()
+    } else {
+        format!("{module_name}::{fn_name}")
+    };
+    eprintln!("=== CUTILE DUMP: {label} ({qualified}) ===");
+    eprintln!("{content}");
+    eprintln!("=== END {label} ===\n");
+}
+
+/// Dump without a function context (e.g. module-level dumps).
+pub fn dump_module(stage: DumpStage, module_name: &str, content: &str) {
+    if !should_dump(stage) {
+        return;
+    }
+    // Module-level dump: only filter if a filter is set AND no entry matches.
+    if let Some(entries) = &config().filter {
+        let any_match = entries.iter().any(|e| match e {
+            FilterEntry::Qualified { module, .. } => module == module_name,
+            FilterEntry::Bare(_) => true, // bare names can't exclude modules
+        });
+        if !any_match {
+            return;
+        }
+    }
+    let label = stage.label();
+    eprintln!("=== CUTILE DUMP: {label} ({module_name}) ===");
+    eprintln!("{content}");
+    eprintln!("=== END {label} ===\n");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_stage_names() {
+        assert_eq!(DumpStage::from_str("ast"), Some(DumpStage::Ast));
+        assert_eq!(DumpStage::from_str("IR"), Some(DumpStage::Ir));
+        assert_eq!(
+            DumpStage::from_str("  Bytecode  "),
+            Some(DumpStage::Bytecode)
+        );
+        assert_eq!(DumpStage::from_str("bc"), Some(DumpStage::Bytecode));
+        assert_eq!(DumpStage::from_str("nonsense"), None);
+    }
+
+    #[test]
+    fn filter_bare_name() {
+        let entry = FilterEntry::parse("my_kernel");
+        assert!(entry.matches("my_kernel", "any_module"));
+        assert!(entry.matches("my_kernel", "other_module"));
+        assert!(!entry.matches("other_kernel", "any_module"));
+    }
+
+    #[test]
+    fn filter_qualified_name() {
+        let entry = FilterEntry::parse("my_module::my_kernel");
+        assert!(entry.matches("my_kernel", "my_module"));
+        assert!(!entry.matches("my_kernel", "other_module"));
+        assert!(!entry.matches("other_kernel", "my_module"));
+    }
+
+    #[test]
+    fn filter_nested_path() {
+        let entry = FilterEntry::parse("cutile::core::reshape");
+        // rsplit_once on "::" splits at the last ::
+        assert!(entry.matches("reshape", "cutile::core"));
+    }
+}

--- a/cutile-compiler/src/lib.rs
+++ b/cutile-compiler/src/lib.rs
@@ -21,5 +21,7 @@ pub mod train_map;
 pub mod types;
 
 pub mod compiler;
+pub mod dump;
+pub mod passes;
 pub mod specialization;
 pub use compiler::utils;

--- a/cutile-compiler/src/passes/mod.rs
+++ b/cutile-compiler/src/passes/mod.rs
@@ -1,0 +1,24 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! AST pass pipeline for the cuTile compiler.
+//!
+//! Passes transform or annotate the syn AST in a defined order before IR
+//! emission. Each pass reads the previous pass's output and produces a
+//! progressively more resolved form.
+//!
+//! ```text
+//! Raw syn AST (from proc macro)
+//!     ↓
+//! [Pass 1: Name Resolution]  — build symbol table, resolve imports
+//!     ↓
+//! [Pass 2: Type Inference]   — (future) every expression typed
+//!     ↓
+//! [Pass 3: Instantiation]    — (future) no generics remain
+//!     ↓
+//! [IR Emission]              — translation to cutile-ir
+//! ```
+
+pub mod name_resolution;

--- a/cutile-compiler/src/passes/name_resolution.rs
+++ b/cutile-compiler/src/passes/name_resolution.rs
@@ -1,0 +1,732 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Pass 1: Name Resolution
+//!
+//! Mirrors rustc's name resolution architecture (simplified for the DSL):
+//!
+//! - [`DefId`] identifies any top-level definition (module + name)
+//! - [`Res`] is the result of resolving a `syn::Path`
+//! - [`Namespace`] separates types from values
+//! - [`NameResolver`] takes `syn::Path` + calling module → `Res`
+//! - Items are stored per-module in [`ModuleItems`] (out-of-band, like HIR)
+//!
+//! Reference: <https://rustc-dev-guide.rust-lang.org/name-resolution.html>
+
+use crate::error::JITError;
+use crate::syn_utils::*;
+use std::collections::HashMap;
+use syn::{ImplItem, ImplItemFn, Item, ItemFn, ItemImpl, ItemMod, ItemStruct, UseTree};
+
+// ---------------------------------------------------------------------------
+// Core types (rustc equivalents)
+// ---------------------------------------------------------------------------
+
+/// Identifies a top-level definition. Equivalent to rustc's `DefId`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct DefId {
+    /// The module that defines this item.
+    pub module: String,
+    /// The item's name within that module.
+    pub name: String,
+}
+
+/// What kind of definition a [`DefId`] refers to. Equivalent to rustc's `DefKind`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DefKind {
+    /// A function (including `#[cuda_tile::op]` functions).
+    Fn,
+    /// A struct (including `#[cuda_tile::ty]` structs).
+    Struct,
+    /// A trait definition.
+    Trait,
+    /// An associated function (method on a struct).
+    AssocFn,
+}
+
+/// The result of resolving a name or path. Equivalent to rustc's `Res`.
+#[derive(Debug, Clone)]
+pub enum Res {
+    /// A top-level definition.
+    Def(DefKind, DefId),
+    /// A local variable or function parameter (resolved during compilation,
+    /// not during Pass 1 — included here for completeness).
+    Local(String),
+    /// A primitive type (`f32`, `i32`, etc.).
+    PrimTy(String),
+    /// Resolution failed.
+    Err,
+}
+
+impl Res {
+    /// Get the DefId if this is a Def resolution.
+    pub fn def_id(&self) -> Option<&DefId> {
+        match self {
+            Res::Def(_, id) => Some(id),
+            _ => None,
+        }
+    }
+
+    /// Get the DefKind if this is a Def resolution.
+    pub fn def_kind(&self) -> Option<DefKind> {
+        match self {
+            Res::Def(kind, _) => Some(*kind),
+            _ => None,
+        }
+    }
+}
+
+/// Namespace for name resolution. Types and values don't collide.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Namespace {
+    /// Structs, type aliases, traits.
+    Type,
+    /// Functions, variables, constants.
+    Value,
+}
+
+// ---------------------------------------------------------------------------
+// Per-module item storage (out-of-band, like HIR)
+// ---------------------------------------------------------------------------
+
+/// All items defined in a single module, indexed for fast lookup.
+pub struct ModuleItems {
+    pub functions: HashMap<String, ItemFn>,
+    pub structs: HashMap<String, ItemStruct>,
+    pub struct_impls: HashMap<String, Vec<ItemImpl>>,
+    pub trait_impls: HashMap<(String, String), ItemImpl>,
+    pub primitives: HashMap<(String, String), ItemImpl>,
+}
+
+impl ModuleItems {
+    fn new() -> Self {
+        Self {
+            functions: HashMap::new(),
+            structs: HashMap::new(),
+            struct_impls: HashMap::new(),
+            trait_impls: HashMap::new(),
+            primitives: HashMap::new(),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Name resolver
+// ---------------------------------------------------------------------------
+
+/// Resolves `syn::Path` values to [`Res`] results using per-module indexes
+/// and import maps. This is Pass 1 of the compilation pipeline.
+///
+/// Mirrors rustc's `Resolver` — paths stay intact in the AST, resolution
+/// is a side-table lookup, items are in flat maps keyed by [`DefId`].
+pub struct NameResolver {
+    /// Per-module item indexes (our HIR items maps).
+    items: HashMap<String, ModuleItems>,
+    /// Module ASTs.
+    modules: HashMap<String, ItemMod>,
+    /// Per-module import maps: module_name → { local_name → source_module }.
+    imports: HashMap<String, HashMap<String, String>>,
+    /// The core module name (has `#[cuda_tile::ty]` annotations).
+    core_module: Option<String>,
+
+    // -- Cached flat maps for backward compatibility --
+    /// All primitives across all modules, flattened.
+    cached_primitives: HashMap<(String, String), ItemImpl>,
+    /// All functions across all modules: name → (module_name, ItemFn).
+    cached_functions: HashMap<String, (String, ItemFn)>,
+    /// All structs across all modules: name → ItemStruct.
+    cached_structs: HashMap<String, ItemStruct>,
+    /// All struct impls across all modules: struct_name → [(module_name, ItemImpl)].
+    cached_struct_impls: HashMap<String, Vec<(String, ItemImpl)>>,
+    /// All trait impls across all modules: (trait, self_ty) → (module_name, ItemImpl).
+    cached_trait_impls: HashMap<(String, String), (String, ItemImpl)>,
+}
+
+impl NameResolver {
+    /// Build the resolver from parsed module ASTs. This is Pass 1.
+    pub fn build(module_asts: &[(String, ItemMod)]) -> Result<Self, JITError> {
+        let mut items: HashMap<String, ModuleItems> = HashMap::new();
+        let mut modules: HashMap<String, ItemMod> = HashMap::new();
+        let mut core_module: Option<String> = None;
+
+        // Also build the cached flat maps during indexing.
+        let mut cached_primitives: HashMap<(String, String), ItemImpl> = HashMap::new();
+        let mut cached_functions: HashMap<String, (String, ItemFn)> = HashMap::new();
+        let mut cached_structs: HashMap<String, ItemStruct> = HashMap::new();
+        let mut cached_struct_impls: HashMap<String, Vec<(String, ItemImpl)>> = HashMap::new();
+        let mut cached_trait_impls: HashMap<(String, String), (String, ItemImpl)> = HashMap::new();
+
+        // Phase 1: Index all items per module.
+        for (module_name, module_ast) in module_asts {
+            modules.insert(module_name.clone(), module_ast.clone());
+            let mut mi = ModuleItems::new();
+            let Some(content) = &module_ast.content else {
+                items.insert(module_name.clone(), mi);
+                continue;
+            };
+
+            let mut has_cuda_tile_ty = false;
+            for item in &content.1 {
+                match item {
+                    Item::Fn(f) => {
+                        let name = f.sig.ident.to_string();
+                        mi.functions.insert(name.clone(), f.clone());
+                        // Flat cache: duplicate check matches old behavior.
+                        if cached_functions
+                            .insert(name.clone(), (module_name.clone(), f.clone()))
+                            .is_some()
+                        {
+                            return Err(JITError::generic_err(
+                                &format!("duplicate functions are not supported; try renaming your function: {name}"),
+                            ));
+                        }
+                    }
+                    Item::Struct(s) => {
+                        let name = s.ident.to_string();
+                        mi.structs.insert(name.clone(), s.clone());
+                        cached_structs.insert(name, s.clone());
+                    }
+                    Item::Impl(impl_item) => {
+                        let self_ident = get_type_str(&impl_item.self_ty);
+                        let trait_ident = impl_item
+                            .trait_
+                            .as_ref()
+                            .map(|(_, path, _)| path.segments.last().unwrap().ident.to_string());
+
+                        match (&self_ident, &trait_ident) {
+                            (Some(self_name), Some(trait_name)) => {
+                                if get_meta_list("cuda_tile :: ty", &impl_item.attrs).is_some() {
+                                    has_cuda_tile_ty = true;
+                                    let key = (trait_name.clone(), self_name.clone());
+                                    mi.primitives.insert(key.clone(), impl_item.clone());
+                                    cached_primitives.insert(key, impl_item.clone());
+                                } else if get_meta_list(
+                                    "cuda_tile :: variadic_trait_impl",
+                                    &impl_item.attrs,
+                                )
+                                .is_some()
+                                {
+                                    let key = (trait_name.clone(), self_name.clone());
+                                    mi.trait_impls.insert(key.clone(), impl_item.clone());
+                                    cached_trait_impls
+                                        .insert(key, (module_name.clone(), impl_item.clone()));
+                                }
+                            }
+                            (Some(self_name), None) => {
+                                mi.struct_impls
+                                    .entry(self_name.clone())
+                                    .or_default()
+                                    .push(impl_item.clone());
+                                cached_struct_impls
+                                    .entry(self_name.clone())
+                                    .or_default()
+                                    .push((module_name.clone(), impl_item.clone()));
+                            }
+                            _ => {}
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            if has_cuda_tile_ty {
+                core_module = Some(module_name.clone());
+            }
+            items.insert(module_name.clone(), mi);
+        }
+
+        // Phase 2: Process `use` statements to build import maps.
+        let mut imports: HashMap<String, HashMap<String, String>> = HashMap::new();
+        for (module_name, module_ast) in module_asts {
+            let mut module_imports: HashMap<String, String> = HashMap::new();
+            if let Some(content) = &module_ast.content {
+                for item in &content.1 {
+                    if let Item::Use(use_item) = item {
+                        Self::process_use_tree(&use_item.tree, &[], &items, &mut module_imports);
+                    }
+                }
+            }
+            imports.insert(module_name.clone(), module_imports);
+        }
+
+        Ok(NameResolver {
+            items,
+            modules,
+            imports,
+            core_module,
+            cached_primitives,
+            cached_functions,
+            cached_structs,
+            cached_struct_impls,
+            cached_trait_impls,
+        })
+    }
+
+    // -----------------------------------------------------------------------
+    // Path resolution (the new API)
+    // -----------------------------------------------------------------------
+
+    /// Resolve a `syn::Path` to a [`Res`] in the context of `calling_module`.
+    ///
+    /// Handles:
+    /// - Unqualified: `reshape` → local → imports → core → global
+    /// - Qualified: `core::reshape` → look in module `core`
+    /// - Fully qualified: `cutile::core::reshape` → strip crate prefix
+    pub fn resolve_path(&self, path: &syn::Path, calling_module: &str) -> Res {
+        let segments: Vec<String> = path.segments.iter().map(|s| s.ident.to_string()).collect();
+
+        match segments.len() {
+            0 => Res::Err,
+            1 => {
+                // Unqualified name: resolve through scope chain.
+                let name = &segments[0];
+                self.resolve_unqualified(name, calling_module)
+            }
+            2 => {
+                // module::item or Type::method
+                let (qualifier, name) = (&segments[0], &segments[1]);
+                // Try as module::item first.
+                if let Some(res) = self.resolve_in_module(name, qualifier) {
+                    return res;
+                }
+                // Try as Type::method (associated function).
+                if let Some((module, _, _method)) = self.find_method(qualifier, name) {
+                    return Res::Def(
+                        DefKind::AssocFn,
+                        DefId {
+                            module: module.to_string(),
+                            name: name.clone(),
+                        },
+                    );
+                }
+                // Might be a qualified marker path like `ftz::Enabled` — not a
+                // function/struct, so return Err for now (the compiler handles
+                // these specially via UserType).
+                Res::Err
+            }
+            _ => {
+                // 3+ segments: strip crate-level prefixes and retry.
+                // `cutile::core::reshape` → try `core::reshape` → try `reshape` in core.
+                // Walk from the end to find a module match.
+                for i in 0..segments.len() - 1 {
+                    let candidate_module = &segments[i];
+                    let item_name = &segments[segments.len() - 1];
+                    if let Some(res) = self.resolve_in_module(item_name, candidate_module) {
+                        return res;
+                    }
+                }
+                // Fallback: try the last segment as unqualified.
+                let name = &segments[segments.len() - 1];
+                self.resolve_unqualified(name, calling_module)
+            }
+        }
+    }
+
+    /// Resolve an unqualified name through the scope chain:
+    /// local module → imports → core → global fallback.
+    fn resolve_unqualified(&self, name: &str, calling_module: &str) -> Res {
+        // 1. Local definition.
+        if let Some(res) = self.resolve_in_module(name, calling_module) {
+            return res;
+        }
+
+        // 2. Explicit import.
+        if let Some(module_imports) = self.imports.get(calling_module) {
+            if let Some(source_module) = module_imports.get(name) {
+                if let Some(res) = self.resolve_in_module(name, source_module) {
+                    return res;
+                }
+            }
+        }
+
+        // 3. Implicit core import.
+        if let Some(core) = &self.core_module {
+            if calling_module != core {
+                if let Some(res) = self.resolve_in_module(name, core) {
+                    return res;
+                }
+            }
+        }
+
+        // 4. Global fallback (backward compatibility).
+        for (module_name, mi) in &self.items {
+            if let Some(res) = Self::lookup_in_items(name, module_name, mi) {
+                return res;
+            }
+        }
+
+        Res::Err
+    }
+
+    /// Try to resolve `name` in a specific module.
+    fn resolve_in_module(&self, name: &str, module: &str) -> Option<Res> {
+        let mi = self.items.get(module)?;
+        Self::lookup_in_items(name, module, mi)
+    }
+
+    /// Look up a name in a module's items, returning a Res.
+    fn lookup_in_items(name: &str, module: &str, mi: &ModuleItems) -> Option<Res> {
+        if mi.functions.contains_key(name) {
+            return Some(Res::Def(
+                DefKind::Fn,
+                DefId {
+                    module: module.to_string(),
+                    name: name.to_string(),
+                },
+            ));
+        }
+        if mi.structs.contains_key(name) {
+            return Some(Res::Def(
+                DefKind::Struct,
+                DefId {
+                    module: module.to_string(),
+                    name: name.to_string(),
+                },
+            ));
+        }
+        None
+    }
+
+    // -----------------------------------------------------------------------
+    // Item accessors (given a DefId, return the item)
+    // -----------------------------------------------------------------------
+
+    /// Get a function by its DefId.
+    pub fn get_fn(&self, def_id: &DefId) -> Option<&ItemFn> {
+        self.items.get(&def_id.module)?.functions.get(&def_id.name)
+    }
+
+    /// Get a struct by its DefId.
+    pub fn get_struct(&self, def_id: &DefId) -> Option<&ItemStruct> {
+        self.items.get(&def_id.module)?.structs.get(&def_id.name)
+    }
+
+    /// Find a method on a struct. Searches all modules' impls.
+    pub fn find_method(
+        &self,
+        struct_name: &str,
+        method_name: &str,
+    ) -> Option<(&str, &ItemImpl, ImplItemFn)> {
+        for (module_name, mi) in &self.items {
+            if let Some(impls) = mi.struct_impls.get(struct_name) {
+                for impl_item in impls {
+                    for item in &impl_item.items {
+                        if let ImplItem::Fn(f) = item {
+                            if f.sig.ident == method_name {
+                                return Some((module_name.as_str(), impl_item, f.clone()));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        None
+    }
+
+    /// Get a primitive type impl by (trait_name, rust_type_name).
+    pub fn get_primitive(&self, trait_name: &str, rust_type: &str) -> Option<&ItemImpl> {
+        let key = (trait_name.to_string(), rust_type.to_string());
+        for mi in self.items.values() {
+            if let Some(impl_item) = mi.primitives.get(&key) {
+                return Some(impl_item);
+            }
+        }
+        None
+    }
+
+    /// Get `#[cuda_tile::ty]` attrs on a primitive type.
+    pub fn get_primitive_attrs(&self, trait_name: &str, rust_type: &str) -> Option<SingleMetaList> {
+        let impl_item = self.get_primitive(trait_name, rust_type)?;
+        get_meta_list("cuda_tile :: ty", &impl_item.attrs)
+    }
+
+    /// Get a trait impl by (trait_name, self_type).
+    pub fn get_trait_impl(&self, trait_name: &str, self_type: &str) -> Option<(&str, &ItemImpl)> {
+        let key = (trait_name.to_string(), self_type.to_string());
+        for (module_name, mi) in &self.items {
+            if let Some(impl_item) = mi.trait_impls.get(&key) {
+                return Some((module_name.as_str(), impl_item));
+            }
+        }
+        None
+    }
+
+    /// Get `#[cuda_tile::ty]` attrs on a struct.
+    pub fn get_type_attrs(&self, struct_name: &str) -> Option<SingleMetaList> {
+        for mi in self.items.values() {
+            if let Some(s) = mi.structs.get(struct_name) {
+                return get_meta_list("cuda_tile :: ty", &s.attrs);
+            }
+        }
+        None
+    }
+
+    /// Get `#[cuda_tile::op]` attrs on a function.
+    pub fn get_op_attrs(&self, fn_name: &str) -> Option<SingleMetaList> {
+        for mi in self.items.values() {
+            if let Some(f) = mi.functions.get(fn_name) {
+                return get_meta_list("cuda_tile :: op", &f.attrs);
+            }
+        }
+        None
+    }
+
+    /// Get struct field type by struct and field name.
+    pub fn get_struct_field_type(&self, struct_name: &str, field_name: &str) -> Option<syn::Type> {
+        for mi in self.items.values() {
+            if let Some(s) = mi.structs.get(struct_name) {
+                for field in &s.fields {
+                    if let Some(ident) = &field.ident {
+                        if ident == field_name {
+                            return Some(field.ty.clone());
+                        }
+                    }
+                }
+            }
+        }
+        None
+    }
+
+    // -----------------------------------------------------------------------
+    // Module access
+    // -----------------------------------------------------------------------
+
+    pub fn module(&self, name: &str) -> Option<&ItemMod> {
+        self.modules.get(name)
+    }
+
+    pub fn has_module(&self, name: &str) -> bool {
+        self.modules.contains_key(name)
+    }
+
+    pub fn core_module(&self) -> Option<&str> {
+        self.core_module.as_deref()
+    }
+
+    // -----------------------------------------------------------------------
+    // Backward-compatible flat map accessors
+    // -----------------------------------------------------------------------
+
+    /// Flat map of all primitives. Compatibility shim for code that passes
+    /// `&self.modules.primitives` to generics/types functions.
+    pub fn primitives(&self) -> &HashMap<(String, String), ItemImpl> {
+        &self.cached_primitives
+    }
+
+    /// Flat map of all functions: name → (module_name, ItemFn).
+    pub fn functions(&self) -> &HashMap<String, (String, ItemFn)> {
+        &self.cached_functions
+    }
+
+    /// Flat map of all structs: name → ItemStruct.
+    pub fn structs(&self) -> &HashMap<String, ItemStruct> {
+        &self.cached_structs
+    }
+
+    /// Flat map of all struct impls: struct_name → [(module_name, ItemImpl)].
+    pub fn struct_impls(&self) -> &HashMap<String, Vec<(String, ItemImpl)>> {
+        &self.cached_struct_impls
+    }
+
+    /// Flat map of all trait impls: (trait, self_ty) → (module, ItemImpl).
+    pub fn trait_impls(&self) -> &HashMap<(String, String), (String, ItemImpl)> {
+        &self.cached_trait_impls
+    }
+
+    /// All module ASTs.
+    pub fn all_modules(&self) -> &HashMap<String, ItemMod> {
+        &self.modules
+    }
+
+    // -----------------------------------------------------------------------
+    // Diagnostics
+    // -----------------------------------------------------------------------
+
+    /// List all modules that define a given name.
+    pub fn find_all_definitions(&self, name: &str) -> Vec<&str> {
+        self.items
+            .iter()
+            .filter(|(_, mi)| mi.functions.contains_key(name) || mi.structs.contains_key(name))
+            .map(|(module_name, _)| module_name.as_str())
+            .collect()
+    }
+
+    // -----------------------------------------------------------------------
+    // Use-tree processing
+    // -----------------------------------------------------------------------
+
+    fn process_use_tree(
+        tree: &UseTree,
+        path_prefix: &[String],
+        items: &HashMap<String, ModuleItems>,
+        imports: &mut HashMap<String, String>,
+    ) {
+        match tree {
+            UseTree::Path(path) => {
+                let mut prefix = path_prefix.to_vec();
+                prefix.push(path.ident.to_string());
+                Self::process_use_tree(&path.tree, &prefix, items, imports);
+            }
+            UseTree::Name(name) => {
+                if let Some(source) = path_prefix.last() {
+                    imports.insert(name.ident.to_string(), source.clone());
+                }
+            }
+            UseTree::Glob(_) => {
+                if let Some(source) = path_prefix.last() {
+                    if let Some(mi) = items.get(source) {
+                        for name in mi.functions.keys() {
+                            imports.insert(name.clone(), source.clone());
+                        }
+                        for name in mi.structs.keys() {
+                            imports.insert(name.clone(), source.clone());
+                        }
+                    }
+                }
+            }
+            UseTree::Group(group) => {
+                for tree in &group.items {
+                    Self::process_use_tree(tree, path_prefix, items, imports);
+                }
+            }
+            UseTree::Rename(rename) => {
+                if let Some(source) = path_prefix.last() {
+                    imports.insert(rename.rename.to_string(), source.clone());
+                }
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use syn::parse_quote;
+
+    fn make_module(name: &str, items_vec: Vec<Item>) -> (String, ItemMod) {
+        let ident = syn::Ident::new(name, proc_macro2::Span::call_site());
+        let module: ItemMod = parse_quote! {
+            mod #ident {
+                #(#items_vec)*
+            }
+        };
+        (name.to_string(), module)
+    }
+
+    fn parse_path(s: &str) -> syn::Path {
+        syn::parse_str(s).unwrap()
+    }
+
+    #[test]
+    fn resolve_unqualified_local() {
+        let (name, module) = make_module("test_mod", vec![parse_quote! { fn my_func() {} }]);
+        let resolver = NameResolver::build(&[(name, module)]).unwrap();
+        let res = resolver.resolve_path(&parse_path("my_func"), "test_mod");
+        match res {
+            Res::Def(DefKind::Fn, def_id) => {
+                assert_eq!(def_id.module, "test_mod");
+                assert_eq!(def_id.name, "my_func");
+            }
+            _ => panic!("expected Def(Fn, ...), got {:?}", res),
+        }
+    }
+
+    #[test]
+    fn resolve_qualified_module_item() {
+        let (a, a_mod) = make_module("mod_a", vec![parse_quote! { fn helper() {} }]);
+        let (b, b_mod) = make_module("mod_b", vec![parse_quote! { fn other() {} }]);
+        let resolver = NameResolver::build(&[(a, a_mod), (b, b_mod)]).unwrap();
+
+        // Qualified: mod_a::helper from mod_b.
+        let res = resolver.resolve_path(&parse_path("mod_a::helper"), "mod_b");
+        match res {
+            Res::Def(DefKind::Fn, def_id) => assert_eq!(def_id.module, "mod_a"),
+            _ => panic!("expected Def, got {:?}", res),
+        }
+    }
+
+    #[test]
+    fn resolve_unknown_returns_err() {
+        let (name, module) = make_module("test_mod", vec![parse_quote! { fn my_func() {} }]);
+        let resolver = NameResolver::build(&[(name, module)]).unwrap();
+        assert!(matches!(
+            resolver.resolve_path(&parse_path("nonexistent"), "test_mod"),
+            Res::Err
+        ));
+    }
+
+    #[test]
+    fn duplicate_function_names_rejected() {
+        // The flat cache (backward compat) rejects duplicate function names.
+        // Once the compiler fully migrates to module-scoped lookup, this
+        // restriction can be relaxed.
+        let (a, a_mod) = make_module("mod_a", vec![parse_quote! { fn dup() -> i32 { 1 } }]);
+        let (b, b_mod) = make_module("mod_b", vec![parse_quote! { fn dup() -> i32 { 2 } }]);
+        assert!(NameResolver::build(&[(a, a_mod), (b, b_mod)]).is_err());
+    }
+
+    #[test]
+    fn cross_module_resolution() {
+        // mod_a defines helper, mod_b defines other. mod_b can find helper via fallback.
+        let (a, a_mod) = make_module("mod_a", vec![parse_quote! { fn helper() {} }]);
+        let (b, b_mod) = make_module("mod_b", vec![parse_quote! { fn other() {} }]);
+        let resolver = NameResolver::build(&[(a, a_mod), (b, b_mod)]).unwrap();
+
+        match resolver.resolve_path(&parse_path("helper"), "mod_b") {
+            Res::Def(_, def_id) => assert_eq!(def_id.module, "mod_a"),
+            _ => panic!("expected Def"),
+        }
+        // mod_b resolves its own function locally.
+        match resolver.resolve_path(&parse_path("other"), "mod_b") {
+            Res::Def(_, def_id) => assert_eq!(def_id.module, "mod_b"),
+            _ => panic!("expected Def"),
+        }
+    }
+
+    #[test]
+    fn resolve_struct() {
+        let (name, module) = make_module("test_mod", vec![parse_quote! { struct Foo {} }]);
+        let resolver = NameResolver::build(&[(name, module)]).unwrap();
+        match resolver.resolve_path(&parse_path("Foo"), "test_mod") {
+            Res::Def(DefKind::Struct, def_id) => {
+                assert_eq!(def_id.name, "Foo");
+                assert!(resolver.get_struct(&def_id).is_some());
+            }
+            _ => panic!("expected Def(Struct, ...)"),
+        }
+    }
+
+    #[test]
+    fn cached_flat_maps_populated() {
+        let (a, a_mod) = make_module(
+            "mod_a",
+            vec![
+                parse_quote! { fn alpha() {} },
+                parse_quote! { struct Beta {} },
+            ],
+        );
+        let (b, b_mod) = make_module("mod_b", vec![parse_quote! { fn gamma() {} }]);
+        let resolver = NameResolver::build(&[(a, a_mod), (b, b_mod)]).unwrap();
+
+        assert!(resolver.functions().contains_key("alpha"));
+        assert!(resolver.functions().contains_key("gamma"));
+        assert!(resolver.structs().contains_key("Beta"));
+    }
+
+    #[test]
+    fn get_fn_via_def_id() {
+        let (name, module) = make_module("test_mod", vec![parse_quote! { fn my_func() {} }]);
+        let resolver = NameResolver::build(&[(name, module)]).unwrap();
+        let def_id = DefId {
+            module: "test_mod".into(),
+            name: "my_func".into(),
+        };
+        let f = resolver.get_fn(&def_id).unwrap();
+        assert_eq!(f.sig.ident, "my_func");
+    }
+}

--- a/cutile/src/_core.rs
+++ b/cutile/src/_core.rs
@@ -275,18 +275,24 @@ pub mod core {
     impl ElementType for u64 {}
     #[cuda_tile::ty(name = "f64")]
     impl ElementType for f64 {}
+    #[cuda_tile::ty(name = "i16")]
+    impl ElementType for i16 {}
+    #[cuda_tile::ty(name = "i16")]
+    impl ElementType for u16 {}
     #[cuda_tile::ty(name = "i1")]
     impl ElementType for bool {}
 
-    /// TensorFloat-32 format (TF32) for matrix operations.
-    ///
-    /// TF32 is a special format used by NVIDIA Ampere and later GPUs for
-    /// accelerated matrix multiplication. It has the range of FP32 but the
-    /// precision of FP16.
-    #[derive(Copy, Clone)]
-    pub struct tf32(u32);
+    // GPU-specific types: re-exported from cuda-core.
+    pub use cuda_core::f8e4m3fn;
+    pub use cuda_core::f8e5m2;
+    pub use cuda_core::tf32;
+
     #[cuda_tile::ty(name = "tf32")]
     impl ElementType for tf32 {}
+    #[cuda_tile::ty(name = "f8e4m3fn")]
+    impl ElementType for f8e4m3fn {}
+    #[cuda_tile::ty(name = "f8e5m2")]
+    impl ElementType for f8e5m2 {}
 
     /// Marker trait for scalar values that can be broadcast to tiles.
     ///

--- a/cutile/tests/dtype_float_ops.rs
+++ b/cutile/tests/dtype_float_ops.rs
@@ -1,0 +1,238 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Tests that all float ElementTypes can:
+//! 1. Create a 1D tensor of ones
+//! 2. Add two such tensors in a kernel
+//! 3. Convert the result to f32
+//! 4. Verify correctness on the host
+
+use cuda_core::{f8e4m3fn, f8e5m2};
+use cutile;
+use cutile::tensor::PartitionMut;
+use cutile::tile_kernel::{DeviceOp, ToHostVecOp};
+use half::{bf16, f16};
+use std::sync::Arc;
+
+mod common;
+
+#[cutile::module]
+mod float_add_module {
+    use cutile::core::*;
+
+    #[cutile::entry()]
+    fn add_f16<const B: i32>(
+        out: &mut Tensor<f16, { [B] }>,
+        a: &Tensor<f16, { [-1] }>,
+        b: &Tensor<f16, { [-1] }>,
+    ) {
+        let pid = get_tile_block_id().0;
+        let tile_a = a.load_tile(const_shape![B], [pid]);
+        let tile_b = b.load_tile(const_shape![B], [pid]);
+        out.store(tile_a + tile_b);
+    }
+
+    #[cutile::entry()]
+    fn add_bf16<const B: i32>(
+        out: &mut Tensor<bf16, { [B] }>,
+        a: &Tensor<bf16, { [-1] }>,
+        b: &Tensor<bf16, { [-1] }>,
+    ) {
+        let pid = get_tile_block_id().0;
+        let tile_a = a.load_tile(const_shape![B], [pid]);
+        let tile_b = b.load_tile(const_shape![B], [pid]);
+        out.store(tile_a + tile_b);
+    }
+
+    #[cutile::entry()]
+    fn add_f32<const B: i32>(
+        out: &mut Tensor<f32, { [B] }>,
+        a: &Tensor<f32, { [-1] }>,
+        b: &Tensor<f32, { [-1] }>,
+    ) {
+        let pid = get_tile_block_id().0;
+        let tile_a = a.load_tile(const_shape![B], [pid]);
+        let tile_b = b.load_tile(const_shape![B], [pid]);
+        out.store(tile_a + tile_b);
+    }
+
+    #[cutile::entry()]
+    fn add_f64<const B: i32>(
+        out: &mut Tensor<f64, { [B] }>,
+        a: &Tensor<f64, { [-1] }>,
+        b: &Tensor<f64, { [-1] }>,
+    ) {
+        let pid = get_tile_block_id().0;
+        let tile_a = a.load_tile(const_shape![B], [pid]);
+        let tile_b = b.load_tile(const_shape![B], [pid]);
+        out.store(tile_a + tile_b);
+    }
+
+    // Note: FP8 types (f8e4m3fn, f8e5m2) don't support direct arithmetic
+    // on GPU — they're storage/quantization formats. FP8 add kernels are
+    // not included here. Use convert to f16/f32 for compute.
+}
+
+use float_add_module::{add_bf16, add_f16, add_f32, add_f64};
+
+#[test]
+fn add_ones_f16_and_convert_to_f32() {
+    common::with_test_stack(|| {
+        let a = cutile::api::ones::<f16>(&[128]).sync().expect("alloc a");
+        let b = cutile::api::ones::<f16>(&[128]).sync().expect("alloc b");
+        let mut out = cutile::api::zeros::<f16>(&[128]).sync().expect("alloc out");
+
+        add_f16((&mut out).partition([128]), &a, &b)
+            .sync()
+            .expect("add_f16 failed");
+
+        let result_f32: Vec<f32> = cutile::api::convert::<f16, f32>(Arc::new(out))
+            .sync()
+            .expect("convert failed")
+            .dup()
+            .to_host_vec()
+            .sync()
+            .expect("to_host");
+
+        assert_eq!(result_f32.len(), 128);
+        for (i, &v) in result_f32.iter().enumerate() {
+            assert!(
+                (v - 2.0).abs() < 1e-3,
+                "f16: element {i} = {v}, expected 2.0"
+            );
+        }
+    });
+}
+
+#[test]
+fn add_ones_bf16_and_convert_to_f32() {
+    common::with_test_stack(|| {
+        let a = cutile::api::ones::<bf16>(&[128]).sync().expect("alloc a");
+        let b = cutile::api::ones::<bf16>(&[128]).sync().expect("alloc b");
+        let mut out = cutile::api::zeros::<bf16>(&[128])
+            .sync()
+            .expect("alloc out");
+
+        add_bf16((&mut out).partition([128]), &a, &b)
+            .sync()
+            .expect("add_bf16 failed");
+
+        let result_f32: Vec<f32> = cutile::api::convert::<bf16, f32>(Arc::new(out))
+            .sync()
+            .expect("convert failed")
+            .dup()
+            .to_host_vec()
+            .sync()
+            .expect("to_host");
+
+        assert_eq!(result_f32.len(), 128);
+        for (i, &v) in result_f32.iter().enumerate() {
+            assert!(
+                (v - 2.0).abs() < 1e-2,
+                "bf16: element {i} = {v}, expected 2.0"
+            );
+        }
+    });
+}
+
+#[test]
+fn add_ones_f32_direct() {
+    common::with_test_stack(|| {
+        let a = cutile::api::ones::<f32>(&[128]).sync().expect("alloc a");
+        let b = cutile::api::ones::<f32>(&[128]).sync().expect("alloc b");
+        let mut out = cutile::api::zeros::<f32>(&[128]).sync().expect("alloc out");
+
+        add_f32((&mut out).partition([128]), &a, &b)
+            .sync()
+            .expect("add_f32 failed");
+
+        let host: Vec<f32> = out.dup().to_host_vec().sync().expect("to_host");
+        assert_eq!(host.len(), 128);
+        for (i, &v) in host.iter().enumerate() {
+            assert!(
+                (v - 2.0).abs() < 1e-5,
+                "f32: element {i} = {v}, expected 2.0"
+            );
+        }
+    });
+}
+
+#[test]
+fn add_ones_f64_and_convert_to_f32() {
+    common::with_test_stack(|| {
+        let a = cutile::api::ones::<f64>(&[128]).sync().expect("alloc a");
+        let b = cutile::api::ones::<f64>(&[128]).sync().expect("alloc b");
+        let mut out = cutile::api::zeros::<f64>(&[128]).sync().expect("alloc out");
+
+        add_f64((&mut out).partition([128]), &a, &b)
+            .sync()
+            .expect("add_f64 failed");
+
+        let result_f32: Vec<f32> = cutile::api::convert::<f64, f32>(Arc::new(out))
+            .sync()
+            .expect("convert failed")
+            .dup()
+            .to_host_vec()
+            .sync()
+            .expect("to_host");
+
+        assert_eq!(result_f32.len(), 128);
+        for (i, &v) in result_f32.iter().enumerate() {
+            assert!(
+                (v - 2.0).abs() < 1e-5,
+                "f64: element {i} = {v}, expected 2.0"
+            );
+        }
+    });
+}
+
+// FP8 types don't support direct arithmetic (addf) on GPU — they're
+// storage formats. Test the create → convert → check pipeline instead.
+
+#[test]
+fn create_ones_f8e4m3fn_and_convert_to_f32() {
+    common::with_test_stack(|| {
+        let ones = cutile::api::ones::<f8e4m3fn>(&[128]).sync().expect("alloc");
+
+        let result_f32: Vec<f32> = cutile::api::convert::<f8e4m3fn, f32>(Arc::new(ones))
+            .sync()
+            .expect("convert failed")
+            .dup()
+            .to_host_vec()
+            .sync()
+            .expect("to_host");
+
+        assert_eq!(result_f32.len(), 128);
+        for (i, &v) in result_f32.iter().enumerate() {
+            assert!(
+                (v - 1.0).abs() < 0.5,
+                "f8e4m3fn: element {i} = {v}, expected 1.0"
+            );
+        }
+    });
+}
+
+#[test]
+fn create_ones_f8e5m2_and_convert_to_f32() {
+    common::with_test_stack(|| {
+        let ones = cutile::api::ones::<f8e5m2>(&[128]).sync().expect("alloc");
+
+        let result_f32: Vec<f32> = cutile::api::convert::<f8e5m2, f32>(Arc::new(ones))
+            .sync()
+            .expect("convert failed")
+            .dup()
+            .to_host_vec()
+            .sync()
+            .expect("to_host");
+
+        assert_eq!(result_f32.len(), 128);
+        for (i, &v) in result_f32.iter().enumerate() {
+            assert!(
+                (v - 1.0).abs() < 0.5,
+                "f8e5m2: element {i} = {v}, expected 1.0"
+            );
+        }
+    });
+}


### PR DESCRIPTION
## Summary

- **Name resolver** — rustc-inspired `DefId`/`Res`/`Namespace` architecture for module-aware path resolution. Replaces flat global HashMap lookups. `CUDATileModules` is now a thin wrapper delegating to the resolver.
- **Path resolution in compiler** — `Expr::Path` handling uses the resolver to distinguish local variables from ZST marker types (`ftz::Enabled`), removing the segment-count heuristic.
- **FP8/TF32 type support** — `f8e4m3fn`, `f8e5m2`, `tf32` newtype wrappers in `cuda-core` with `DType` impls. `ElementType` impls for all `ScalarType` variants. Type conversions refactored from exhaustive pair enumeration to `is_float()`/`is_integer()` classification.
- **Debug tooling** — `CUTILE_DUMP=ir,resolved,...` and `CUTILE_DUMP_FILTER=module::kernel` for inspecting compiler state after each pass. Replaces `TILE_IR_DUMP`.
- **Float dtype tests** — end-to-end tests for f16, bf16, f32, f64, f8e4m3fn, f8e5m2: create ones, add/convert, verify on host.