### PR TITLE
fix:remove stale cutile-compiler -test gpu step from run_gpu_tests.sh

### DIFF
--- a/scripts/run_gpu_tests.sh
+++ b/scripts/run_gpu_tests.sh
@@ -13,8 +13,6 @@ run_step \
     "cutile error-quality tests" \
     cargo test -p cutile --test error_quality
 
-
-
 run_step \
     "cutile doc tests" \
     cargo test -p cutile --doc

--- a/scripts/run_gpu_tests.sh
+++ b/scripts/run_gpu_tests.sh
@@ -13,9 +13,7 @@ run_step \
     "cutile error-quality tests" \
     cargo test -p cutile --test error_quality
 
-run_step \
-    "cutile-compiler GPU runtime tests" \
-    cargo test -p cutile-compiler --test gpu
+
 
 run_step \
     "cutile doc tests" \


### PR DESCRIPTION
## Problem

`cutile-compiler/tests/gpu.rs` was deleted in #93, but `scripts/run_gpu_tests.sh` still has:

    run_step \
        "cutile-compiler GPU runtime tests" \
        cargo test -p cutile-compiler --test gpu

This causes the script to fail with:

    error: no test target named `gpu` in `cutile-compiler` package

## Fix

Remove the stale `run_step` block. The equivalent tests now live in `cutile/tests/gpu.rs`, already covered later in the script by  `cargo test -p cutile --test gpu`.
