### PR TITLE
Remove LLVM setup in CI (no longer required)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -26,7 +26,6 @@ jobs:
         DEBIAN_FRONTEND: noninteractive
     env:
       CUDA_TOOLKIT_PATH: /usr/local/cuda-13
-      CUDA_TILE_USE_LLVM_INSTALL_DIR: /usr/lib/llvm-21
     timeout-minutes: 30
     steps:
       - name: Install basic dependencies
@@ -48,10 +47,6 @@ jobs:
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
           source "${HOME}/.cargo/env"
           rustup default nightly
-          wget https://apt.llvm.org/llvm.sh
-          bash ./llvm.sh 21
-          apt install -y --no-install-recommends libmlir-21-dev mlir-21-tools libpolly-21-dev
-          update-alternatives --install /usr/bin/llvm-config llvm-config /usr/lib/llvm-21/bin/llvm-config 1
 
       - name: Build
         run: |
@@ -76,7 +71,4 @@ jobs:
       - name: CPU only tests
         run: |
           source "${HOME}/.cargo/env"
-
-          # FIXME: Temporary hack for runtime linking
-          export LD_LIBRARY_PATH="${CUDA_TILE_USE_LLVM_INSTALL_DIR}/lib"
           ./scripts/run_cpu_tests.sh

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -33,7 +33,7 @@ jobs:
           apt update
           apt install -y --no-install-recommends curl wget ca-certificates \
             lsb-release git software-properties-common gnupg cmake zlib1g-dev \
-            libzstd-dev git
+            libzstd-dev git libclang-common-18-dev clang
 
       - name: Clone repository
         uses: actions/checkout@v6


### PR DESCRIPTION
This adds in the libclang and clang dependencies needed by the `bindgen`.