### PR TITLE
docs(book): reorganize for progressive flow and unified reference section

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -37,7 +37,7 @@ jobs:
         run: sphinx-build -b html cutile-book cutile-book/_build/html
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@v4
         with:
           path: cutile-book/_build/html
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -26,6 +26,7 @@ jobs:
         DEBIAN_FRONTEND: noninteractive
     env:
       CUDA_TOOLKIT_PATH: /usr/local/cuda-13
+      CUDA_TILE_USE_LLVM_INSTALL_DIR: /usr/lib/llvm-21
     timeout-minutes: 30
     steps:
       - name: Install basic dependencies
@@ -33,7 +34,7 @@ jobs:
           apt update
           apt install -y --no-install-recommends curl wget ca-certificates \
             lsb-release git software-properties-common gnupg cmake zlib1g-dev \
-            libzstd-dev git libclang-common-18-dev clang
+            libzstd-dev git
 
       - name: Clone repository
         uses: actions/checkout@v6
@@ -47,6 +48,10 @@ jobs:
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
           source "${HOME}/.cargo/env"
           rustup default nightly
+          wget https://apt.llvm.org/llvm.sh
+          bash ./llvm.sh 21
+          apt install -y --no-install-recommends libmlir-21-dev mlir-21-tools libpolly-21-dev
+          update-alternatives --install /usr/bin/llvm-config llvm-config /usr/lib/llvm-21/bin/llvm-config 1
 
       - name: Build
         run: |
@@ -71,4 +76,7 @@ jobs:
       - name: CPU only tests
         run: |
           source "${HOME}/.cargo/env"
+
+          # FIXME: Temporary hack for runtime linking
+          export LD_LIBRARY_PATH="${CUDA_TILE_USE_LLVM_INSTALL_DIR}/lib"
           ./scripts/run_cpu_tests.sh

--- a/README.md
+++ b/README.md
@@ -1,17 +1,29 @@
-# cuTile Rust
-cuTile Rust (`cutile-rs`) is a research project for writing tile-based GPU kernels in Rust.
+<div align="center">
+
+<h1>cuTile Rust</h1>
+
+[![Crates.io](https://img.shields.io/crates/v/cutile.svg)](https://crates.io/crates/cutile)
+[![Docs](https://img.shields.io/github/actions/workflow/status/NVlabs/cutile-rs/pages.yml?branch=main&label=docs)](https://nvlabs.github.io/cutile-rs/)
+[![Build](https://img.shields.io/github/actions/workflow/status/NVlabs/cutile-rs/pr.yml?event=push&label=build)](https://github.com/NVlabs/cutile-rs/actions/workflows/pr.yml)
+[![GitHub stars](https://img.shields.io/github/stars/NVlabs/cutile-rs?style=social)](https://github.com/NVlabs/cutile-rs/stargazers)
+
+| [**Documentation**](https://nvlabs.github.io/cutile-rs/) | [**Quick Start**](#quick-start) | [**Setup**](#setup) | [**Examples**](cutile-examples/examples) |
+
+</div>
+
+cuTile Rust (`cutile-rs`) is a research project which lets you write tile-based GPU kernels in Rust.
 The workspace combines:
 
 - a safe user-facing DSL for authoring kernels
 - a safe host-side API for asynchronously executing kernel functions
 - a pure Rust compiler pipeline backed by the CUDA Tile compiler
 
-# Project Status
+## Project Status
 We are excited to release this research project as a demonstration of how GPU programming can be made available in the Rust ecosystem. The software is in an early stage (`-alpha`) and under active development: you should expect bugs, incomplete features, and API breakage as we work to improve it. That being said, we hope you'll be interested to try it in your work and help shape its direction by providing feedback on your experience.
 
 Please see [CONTRIBUTING.md](CONTRIBUTING.md) if you're interested in contributing to the project.
 
-# Quick Start
+## Quick Start
 
 ```rust
 use cutile::prelude::*;
@@ -50,13 +62,13 @@ The `#[cutile::module]` macro transforms the `add` function into a GPU kernel. O
 - Run the above example via `cargo run -p cutile-examples --example add_refs`.
 - More kernels and usage examples of the host-side API can be found [here](cutile-examples/examples).
 
-# Built with cuTile Rust
+## Built with cuTile Rust
 
 - [Grout](https://github.com/huggingface/grout) — Qwen 3 inference engine in Rust by Hugging Face
 
-# Setup
+## Setup
 
-## Requirements
+### Requirements
 
 - **NVIDIA GPU** with compute capability `sm_80` or higher (minimum supported architecture: `sm_80`).
   - `sm_100+` is supported by CUDA 13.1+.
@@ -66,9 +78,9 @@ The `#[cutile::module]` macro transforms the `add` function into a GPU kernel. O
 - **Rust** 1.89+
 - **Linux** (tested on Ubuntu 24.04)
 
-## Install
+### Install
 
-### Rust
+#### Rust
 
 To install Rust:
 ```bash
@@ -76,30 +88,12 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 rustup default stable
 ```
 
-### CUDA
+#### CUDA
 
 Install CUDA 13.2 for your OS by following the official instructions:
 https://developer.nvidia.com/cuda-downloads
 
-### libclang (for `cuda-bindings`)
-
-The `cuda-bindings` crate uses `bindgen`, which loads `libclang` at build time and
-needs clang's compiler-builtin headers (`stddef.h`, `stdarg.h`, ...). On
-Debian/Ubuntu these are not pulled in by `libclang*` alone; install them
-explicitly (use the version matching your installed `libclang*`):
-
-```bash
-sudo apt-get install -y libclang-common-18-dev clang
-```
-
-If you can't install these packages, you can instead point bindgen at any
-existing clang resource directory:
-
-```bash
-export BINDGEN_EXTRA_CLANG_ARGS="-I$(clang -print-resource-dir)/include"
-```
-
-## Configure Environment
+### Configure Environment
 
 Set `CUDA_TOOLKIT_PATH` to your CUDA 13.2 install directory.
 
@@ -109,7 +103,7 @@ Example `.cargo/config.toml`:
 CUDA_TOOLKIT_PATH = { value = "/usr/local/cuda-13.2", relative = false }
 ```
 
-## Verifying Installation
+### Verifying Installation
 
 Run the hello world example:
 
@@ -119,7 +113,7 @@ cargo run -p cutile-examples --example hello_world
 
 If everything works, you should see: `Hello, I am tile <0, 0, 0> in a kernel with <1, 1, 1> tiles.`
 
-# Via Nix
+## Via Nix
 
 We provide a Nix flake for easy setup and development. Flakes must be enabled in your Nix configuration, if not already, add to `~/.config/nix/nix.conf`:
 ```
@@ -141,7 +135,7 @@ nix develop
 
 The flake automatically locates host NVIDIA driver libraries on both NixOS and non-NixOS systems.
 
-# Tests
+## Tests
 - cuTile IR: `cargo test --package cutile-ir`
 - cuTile Rust Compiler: `cargo test --package cutile-compiler`
 - cuTile Rust Library: `cargo test --package cutile`
@@ -149,7 +143,7 @@ The flake automatically locates host NVIDIA driver libraries on both NixOS and n
 - Benchmarks: `cargo bench`
 - Everything: `./scripts/run_all.sh` (or pipe to a log file: `./scripts/run_all.sh 2>&1 | tee test_run.log`)
 
-## Workspace Crates
+### Workspace Crates
 
 ```
 cutile                 User-facing crate for authoring and executing tile kernels
@@ -177,6 +171,6 @@ cuda-core              Idiomatic safe CUDA API
 cuda-bindings          NVIDIA CUDA bindings
 ```
 
-# License
+## License
 The `cuda-bindings` crate is licensed under NVIDIA Software License: [LICENSE-NVIDIA](LICENSE-NVIDIA).
 All other crates are licensed under the Apache License, Version 2.0 https://www.apache.org/licenses/LICENSE-2.0

--- a/cuda-bindings/build.rs
+++ b/cuda-bindings/build.rs
@@ -29,35 +29,13 @@ fn run() -> Result<(), Box<dyn Error>> {
     println!("cargo:rustc-link-lib=dylib=cuda");
     println!("cargo:rustc-link-lib=dylib=curand");
 
-    let bindings = bindgen::builder()
+    bindgen::builder()
         .header("wrapper.h")
         .clang_arg(format!("-I{}/include", cuda_toolkit_dir()))
         .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
         .generate()
-        .map_err(|e| -> Box<dyn Error> {
-            let msg = e.to_string();
-            // Common case: libclang runtime is installed but the matching
-            // clang builtin headers (stddef.h, stdarg.h, ...) are missing.
-            // On Debian/Ubuntu these live in `libclang-common-<N>-dev`.
-            if msg.contains("'stddef.h' file not found")
-                || msg.contains("'stdarg.h' file not found")
-            {
-                return format!(
-                    "bindgen failed to parse CUDA headers: {msg}\n\n\
-                     hint: clang's builtin headers appear to be missing. \
-                     On Debian/Ubuntu install them alongside libclang, e.g.:\n    \
-                         sudo apt-get install -y libclang-common-18-dev clang\n\
-                     (use the version matching your installed `libclang*` package). \
-                     Alternatively, set BINDGEN_EXTRA_CLANG_ARGS to point at a \
-                     clang resource directory containing these headers, e.g.:\n    \
-                         export BINDGEN_EXTRA_CLANG_ARGS=\"-I$(clang -print-resource-dir)/include\"\n"
-                )
-                .into();
-            }
-            format!("bindgen failed to generate CUDA bindings: {msg}").into()
-        })?;
-
-    bindings.write_to_file(Path::new(&env::var("OUT_DIR")?).join("bindings.rs"))?;
+        .unwrap()
+        .write_to_file(Path::new(&env::var("OUT_DIR")?).join("bindings.rs"))?;
 
     Ok(())
 }

--- a/cutile-benchmarks/benches/fmha_causal.rs
+++ b/cutile-benchmarks/benches/fmha_causal.rs
@@ -18,11 +18,11 @@ mod kernels {
     use cutile::core::*;
 
     #[cutile::entry(print_ir=false,
-                       unchecked_accesses=false,
+                       unchecked_accesses=true,
                        optimization_hints = (
-                         sm_120 = (num_cta_in_cga=1,),
+                         sm_120 = (occupancy=1,),
                        ))]
-    fn fmha_causal<
+    unsafe fn fmha_causal<
         const BM: i32, // Query sequence tile size.
         const BN: i32, // KV sequence tile size.
         const D: i32,  // Head dimension.

--- a/cutile-book/_static/css/custom.css
+++ b/cutile-book/_static/css/custom.css
@@ -48,7 +48,7 @@
     color: var(--pst-color-heading);
 }
 
-/* Section captions (Tutorials, User Guide, Appendix) - BIGGER */
+/* Section captions (Tutorials, User Guide, Reference) - BIGGER */
 .sidebar-tree .caption {
     font-weight: 600;
     font-size: 1.05rem;

--- a/cutile-book/guide/debugging.md
+++ b/cutile-book/guide/debugging.md
@@ -1,4 +1,4 @@
-# Debugging
+# Debugging and Profiling
 
 This guide covers techniques for debugging cuTile Rust programs, organized by the typical debugging workflow: inspect the error, inspect values, verify correctness, then profile performance.
 
@@ -380,7 +380,7 @@ The JIT kernel cache is in-memory per process. Restart the process to force reco
 
 ## Next Steps
 
-- See [Performance Tuning](performance-tuning.md) for optimization techniques
-- See [Interoperability](interoperability.md) for integrating custom CUDA kernels
-- Review [Syntax Reference](../appendix/syntax-reference.md) for the complete API
+- Review [Tuning for Performance](performance-tuning.md) for optimization techniques
+- Review [Integrating with CUDA C++](interoperability.md) for integrating custom CUDA kernels
+- Look up APIs in the [DSL API Reference](../reference/dsl-api.md) and [DeviceOp API Reference](../reference/deviceop-reference.md)
 - Try the [Tutorials](../tutorials/01-hello-world.md) for working examples

--- a/cutile-book/guide/device-operations.md
+++ b/cutile-book/guide/device-operations.md
@@ -1,0 +1,683 @@
+# Orchestrating Device Operations
+
+A `DeviceOp` is the host-side handle for GPU work: it describes a computation lazily, composes with other `DeviceOp`s on the host, and then runs when you choose how. Every host-side API that returns a future (`api::zeros`, kernel launchers, `.then()` / `.shared()` / `unzip`) produces a `DeviceOp`.
+
+This chapter covers three things in sequence:
+
+1. **Constructing** operations: what a `DeviceOp` is, how to compose them into lazy computation graphs before any GPU work starts.
+2. **Executing** them: `.sync()` blocks the thread, `.await` runs under an async runtime, and `.graph_on(&stream)` records the operation into a CUDA graph for replay.
+3. **Scheduling** them: how the default round-robin stream pool distributes work across streams, and how `.sync_on(&stream)` / `.then()` let you enforce ordering when data dependencies require it.
+
+## Two Worlds: Host and Device
+
+GPU programming involves two processors working together:
+
+- **Host (CPU)** — Constructs and schedules operations, launches kernels, manages memory
+- **Device (GPU)** — Executes kernels in massively parallel fashion
+
+![Host-device execution: how kernel calls flow from the host to the GPU](../_static/images/async-host-device.svg)
+
+This separation is fundamental: your Rust code runs on the CPU and schedules work on the GPU.
+
+---
+
+## Streams: Queues for GPU Work
+
+A **stream** is a sequence of operations that execute in order on the GPU:
+
+```rust
+let ctx = CudaContext::new(0)?;      // Connect to GPU device 0
+let stream = ctx.new_stream()?;       // Create a work queue
+```
+
+Key properties of streams:
+- Operations on the **same stream** execute in order
+- Operations on **different streams** may execute concurrently
+- Synchronization points wait for stream completion
+
+---
+
+## DeviceOps: Lazy Computation Graphs
+
+The core abstraction is `DeviceOp` — a lazy operation that describes GPU work without executing it.
+
+### What's a DeviceOp?
+
+Think of it as a recipe that hasn't been cooked yet:
+
+```rust
+let z = api::zeros(&[64, 64]);  // DeviceOp<Output=Tensor<f32>>
+// Nothing happened yet! Just built a description of what to do.
+
+let result = z.await;  // NOW it executes: allocates GPU memory, fills with zeros
+```
+
+### The Key Trait
+
+```rust
+pub trait DeviceOp: Send + Sized + IntoFuture
+where Self::Output: Send {
+    // ...
+}
+```
+
+Every `DeviceOp` implements `IntoFuture`, which means every operation is awaitable.
+
+---
+
+## The Execution Flow
+
+When you `.await` a DeviceOp, here's what happens:
+
+```{raw} html
+<style>
+.seq-box {
+  background: #161b22;
+  border-radius: 8px;
+  padding: 24px 28px;
+  margin: 1em 0;
+  cursor: zoom-in;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+  overflow-x: auto;
+}
+.seq-box:hover { box-shadow: 0 8px 32px rgba(0,0,0,0.4); }
+.seq-box.zoomed {
+  position: fixed; top: 50%; left: 50%;
+  transform: translate(-50%, -50%) scale(1.5);
+  z-index: 9999; cursor: zoom-out;
+  box-shadow: 0 0 0 9999px rgba(0,0,0,0.9);
+}
+.seq-box pre {
+  margin: 0;
+  font-family: 'JetBrains Mono', 'Fira Code', 'SF Mono', 'Roboto Mono', monospace;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 1.8;
+  color: #8b949e;
+}
+.seq-box .r { color: #f97583; }
+.seq-box .b { color: #79c0ff; }
+.seq-box .p { color: #d2a8ff; }
+.seq-box .g { color: #56d364; }
+.seq-box .w { color: #c9d1d9; }
+.seq-box .h { font-weight: 700; }
+</style>
+<div class="seq-box" onclick="this.classList.toggle('zoomed')">
+<pre>
+<span class="r h">Your Code</span>             <span class="b h">Tokio Runtime</span>            <span class="p h">cuTile Rust</span>            <span class="g h">GPU</span>
+    <span class="r">|</span>                       <span class="b">|</span>                       <span class="p">|</span>                   <span class="g">|</span>
+<span class="r h">.await</span>  ---------------> <span class="b h">into_future()</span>            <span class="p">|</span>                   <span class="g">|</span>
+    <span class="r">|</span>                   <span class="w">(immediate)</span>               <span class="p">|</span>                   <span class="g">|</span>
+    <span class="r">|</span>                       <span class="b">|</span>                       <span class="p">|</span>                   <span class="g">|</span>
+    <span class="r">|</span>                       <span class="b">|</span> -------------------> <span class="p h">schedule()</span>          <span class="g">|</span>
+    <span class="r">|</span>                       <span class="b">|</span>                    <span class="p">DevicePolicy</span>         <span class="g">|</span>
+    <span class="r">|</span>                       <span class="b">|</span>                       <span class="p">|</span>                   <span class="g">|</span>
+    <span class="r">|</span>                       <span class="b">|</span> <------------------- <span class="p h">DeviceFuture</span>        <span class="g">|</span>
+    <span class="r">|</span>                       <span class="b">|</span>                       <span class="p">|</span>                   <span class="g">|</span>
+    <span class="r">|</span>                 <span class="b h">first poll()</span> ---------------> <span class="p h">execute()</span>           <span class="g">|</span>
+    <span class="r">|</span>                       <span class="b">|</span>                       <span class="p">|</span>                   <span class="g">|</span>
+    <span class="r">|</span>                       <span class="b">|</span>                       <span class="p">|</span> ----------------> <span class="g h">GPU WORK!</span>
+    <span class="r">|</span>                       <span class="b">|</span>                       <span class="p">|</span>                   <span class="g">|</span>
+    <span class="r">|</span>              <span class="b h">subsequent polls</span> <-- - - - - -<span class="p">|</span>- - - - - - --><span class="g">|</span> <span class="g">checking...</span>
+    <span class="r">|</span>                       <span class="b">|</span>                       <span class="p">|</span>                   <span class="g">|</span>
+    <span class="r">|</span>                       <span class="b">|</span>                       <span class="p">|</span>                   <span class="g">|</span>
+<span class="r h">Returns</span> <span class="g"><--------------</span> <span class="b h">Ready!</span> <span class="g"><------------------</span><span class="p">|</span><span class="g">------------------+</span>
+</pre>
+<div style="margin-top: 20px; padding-top: 16px; border-top: 1px solid #30363d; display: flex; align-items: center; gap: 14px;">
+  <span style="background: #76B900; color: white; padding: 6px 14px; border-radius: 4px; font-weight: 700; font-size: 13px;">KEY INSIGHT</span>
+  <span style="color: #e6edf3; font-size: 14px; font-weight: 600;">GPU work starts at <code style="color: #d2a8ff; font-weight: 700;">execute()</code>, not at <code style="color: #f97583; font-weight: 700;">.await</code>!</span>
+</div>
+<div style="margin-top: 10px; color: #6e7681; font-size: 11px;">Click to zoom</div>
+</div>
+```
+
+**Step-by-step:**
+
+1. **`.await`** converts to `IntoFuture::into_future()`
+2. **`into_future()`** immediately calls `DevicePolicy::schedule()` and returns a `DeviceFuture`
+3. **Tokio's first poll** calls `DeviceFuture::poll()` → this triggers `execute()`
+4. **`execute()`** submits work to the GPU (kernel launch, memory copy, etc.)
+5. **Subsequent polls** check if GPU work is complete
+6. When done, returns `Poll::Ready(result)`
+
+---
+
+## When Does GPU Work Actually Happen?
+
+Consider the following snippet:
+
+```rust
+let x: Tensor<f32> = api::randn(0.0f32, 1.0f32, &[m, k]).await?;
+```
+
+This is what each method does:
+
+| Step | Code | GPU Work? |
+|------|------|-----------|
+| 1 | `api::randn(...)` | ❌ Creates lazy DeviceOp |
+| 2 | `.await` | ❌ Creates DeviceFuture |
+| 3 | First poll | ✅ **NOW** allocates GPU memory, generates random values |
+| 4 | Completion | Returns tensor |
+
+GPU work happens during the **first poll**, not when you call `.await`!
+
+---
+
+## Starting with `.sync()`
+
+The simplest way to run a kernel is `.sync()`:
+
+```rust
+let x = api::ones::<f32>(&[1024]).sync()?;
+let y = api::ones::<f32>(&[1024]).sync()?;
+let mut z = api::zeros::<f32>(&[1024]).sync()?;
+
+add((&mut z).partition([128]), &x, &y).sync()?;
+```
+
+This is the right choice for scripts, debugging, and learning. Each `.sync()` call launches work on the GPU and blocks the CPU until it finishes.
+
+### Why sync-per-op is expensive
+
+In a multi-layer model, calling `.sync()` after every kernel creates a gap where *both* the CPU and GPU are idle — the CPU is waiting for the GPU, and the GPU has nothing queued:
+
+```text
+CPU:  [launch] [wait......] [launch] [wait......] [launch] [wait......]
+GPU:           [kernel████]          [kernel████]          [kernel████]
+                          ↑                      ↑
+                     idle gap                idle gap
+```
+
+For inference, this overhead dominates — kernels are fast (microseconds), but sync round-trips are not. A 22-layer transformer with 6 kernels per layer means 132 sync gaps per token.
+
+### The fix: compose first, sync once
+
+Build the entire operation graph lazily, then execute in one shot:
+
+```rust
+// No GPU work yet — just building the graph.
+let result = rms_norm(out1, hidden.clone(), weight.clone(), eps)
+    .first()
+    .unpartition()
+    .shared();
+
+let q = matvec(out2, result.clone(), wq.clone())
+    .first()
+    .unpartition()
+    .shared();
+
+// NOW execute everything on one stream, no gaps.
+let output = q.sync_on(&stream)?;
+```
+
+```text
+CPU:  [build graph...] [launch all]  [wait]
+GPU:                    [norm████][mv████][add████]
+                         no gaps — work is pipelined
+```
+
+The rest of this guide explains the tools for building these graphs:
+`.then()`, `zip!`, `.shared()`, `.await`, and stream scheduling.
+
+### Synchronous: `.sync()` / `.sync_on()`
+
+```rust
+kernel(args...).sync()?;          // default device, default stream policy
+kernel(args...).sync_on(&stream)?; // explicit stream
+```
+
+### Asynchronous: `.await`
+
+```rust
+let result = kernel(args...).await?;  // non-blocking in async context
+```
+
+Or compose lazily and await the final result:
+
+```rust
+let result = step1(args)
+    .then(|out| step2(out))
+    .then(|out| step3(out))
+    .await?;
+```
+
+### CUDA Graphs: `.graph_on(&stream)`
+
+For repetitive workloads — the same `DeviceOp` chain run many times — record it as a CUDA graph once and replay with minimal launch overhead. This is how you get the lowest possible per-invocation cost for hot paths (e.g., inference loops where the same pipeline runs per token).
+
+```rust
+let stream = ctx.new_stream()?;
+let graph = pipeline(input).graph_on(&stream)?;
+
+for _ in 0..iterations {
+    graph.launch(&stream)?;  // replay — no per-op dispatch
+}
+```
+
+Graph recording captures exact kernel launches and memory operations at build time; subsequent launches skip CPU-side dispatch. See [CUDA Graph Integration in the DeviceOp API Reference](../reference/deviceop-reference.md#cuda-graph-integration) for the combinator (`.graph_on`) and scope-based (`CudaGraph::scope`) approaches, and [Tutorial 10](../tutorials/10-cuda-graphs.md) for a worked example.
+
+---
+
+## Building Computation Graphs
+
+DeviceOps compose into computation graphs:
+
+```rust
+// Build lazy computation graph — no GPU work yet
+let z = api::zeros(&[m, n]).partition([bm, bn]);
+let x = api::randn(0.0, 1.0, &[m, k]);
+let y = api::randn(0.0, 1.0, &[k, n]);
+
+// Chain kernel invocations — output-first convention, direct calls
+let result = matmul(z, x, y)
+    .then(|(z, _x, _y)| activation(z))
+    .then(|(z,)| normalize(z));
+
+// Execute entire graph in one shot
+let output = result.await?;
+```
+
+![Lazy computation graph showing how DeviceOps compose](../_static/images/computation-graph.svg)
+
+**Benefits:**
+- Operations can be fused
+- Memory can be reused
+- Scheduling can be optimized
+
+---
+
+## Splitting and Sharing Operations
+
+`zip!` combines multiple `DeviceOp`s into one. But what about the reverse — taking a single operation's output and feeding it into multiple downstream branches? That's what `unzip` and `.shared()` are for.
+
+### unzip: Fan-Out from a Tuple
+
+`unzip` takes an operation that produces a tuple and splits it into independent operations, one per element:
+
+```rust
+// A kernel returns (output, weight, bias) as a 3-tuple.
+let (output, weight, bias) = kernel(args).unzip();
+
+// Each is now an independent DeviceOp.
+let result = output.unpartition().await?;
+let w = weight.await?;
+```
+
+`unzip` is the inverse of `zip!`:
+
+```text
+  zip! (fan-in)                     unzip (fan-out)
+
+    op_a ─┐                           ┌── branch_a
+           ├─ zip! ─── (a, b)    (a, b) ── unzip ──┤
+    op_b ─┘                           └── branch_b
+```
+
+### The Execute-Once Guarantee
+
+When you `unzip`, the ancestor operation that produces the tuple is **executed at most once**, regardless of how many branches consume it. Internally, `unzip` uses a shared gate (`Select`) that runs the ancestor on the first branch to execute and caches the results for the remaining branches:
+
+```text
+                                      ┌── SelectLeft ── .sync()  ─── runs ancestor,
+  ancestor_op ────── Select (shared) ─┤                               caches both results
+                                      └── SelectRight ── .sync() ─── finds cached result,
+                                                                      no re-execution
+```
+
+This means fan-out patterns like "compute once, use in two places" are safe and efficient:
+
+```rust
+let (z, x, y) = zip!(z_op, x_op, y_op)
+    .then(my_kernel)
+    .unzip();
+
+// The kernel runs once. z, x, and y each take their portion of the result.
+let output = z.unpartition().to_host_vec().sync()?;
+```
+
+### .shared(): Cloneable, Execute-Once Operations
+
+`.shared()` converts any `DeviceOp` into a `SharedDeviceOp<T>` that implements `Clone`. The underlying operation executes at most once — every clone gets `Arc::clone()` of the cached result. This follows the `FutureExt::shared()` convention from the `futures` crate.
+
+```rust
+// Create a shared operation — cloneable, execute-once.
+let x = api::ones(&[32, 32]).shared();
+
+// Pass to multiple consumers without consuming the original.
+let a = kernel_a(x.clone()).sync()?;  // x executes here (once)
+let b = kernel_b(x.clone()).sync()?;  // Uses the cached Arc — no re-execution
+let c = kernel_c(x).sync()?;          // Also uses the cached result
+```
+
+Unlike `unzip` (which splits a fixed tuple), `.shared()` supports unlimited consumers. The result is always `Arc<T>`, so shared reads are cheap.
+
+For pre-computed values (e.g., weight tensors already in `Arc`), use the `shared()` constructor:
+
+```rust
+let w: SharedDeviceOp<Tensor<f32>> = cuda_async::device_operation::shared(weight_arc);
+```
+
+### Common Patterns
+
+```text
+Diamond (fan-out then fan-in):
+
+  op_a ─┐              ┌─ transform_a ─┐
+         ├── zip! ── unzip              ├── zip! ── result
+  op_b ─┘              └─ transform_b ─┘
+
+Broadcast (.shared() into parallel kernels):
+
+                     ┌── kernel_a ── result_a
+  x.shared() ──────┤
+                     ├── kernel_b ── result_b
+                     └── kernel_c ── result_c
+```
+
+### Limitations
+
+The execute-once mechanism relies on **sequential execution** — the normal mode for `cuda-async`, where operations are `.sync()`'d or `.await`'d one at a time from a single thread. Under this model, the shared gate is guaranteed to see only one caller at a time.
+
+If two branches of an `unzip` were somehow executed **concurrently on different OS threads** (e.g., via `tokio::spawn` on a multi-threaded runtime), the gate is not safe — it uses a non-atomic check-then-act pattern internally. In practice, this is not triggerable because device contexts are thread-local, so scheduling an operation from a thread that hasn't initialized its device context will fail before reaching the gate. However, avoid designs that would poll both sides of an `unzip` from different threads.
+
+---
+
+## Sync Points and Memory Management
+
+### When to Sync
+
+You need synchronization when:
+1. Reading results back to CPU
+2. Before modifying data that's still being read
+3. At computation boundaries
+
+```rust
+// Bad: No sync before reading
+let z = kernel(x, y).sync_on(&stream);
+let data = z.to_host_vec();  // ❌ May read incomplete data!
+
+// Good: Sync before reading
+let z = kernel(x, y).sync_on(&stream);
+let data = z.to_host_vec().sync_on(&stream);  // ✅ Waits for completion
+```
+
+### Passing Tensors to Kernels
+
+Kernel `&Tensor` params accept three input forms, and `&mut Tensor` params
+accept two partition forms. You get back the same type you put in.
+
+**Inputs (`&Tensor`):**
+
+```rust
+// Owned — single use, no Arc overhead.
+let x: Tensor<f32> = ones(&[32, 32]).sync_on(&stream)?;
+let (_, x) = kernel(out, x).sync_on(&stream)?;  // x is Tensor<f32>
+
+// Shared — use the same tensor in multiple kernels.
+let x: Arc<Tensor<f32>> = ones(&[32, 32]).sync_on(&stream)?.into();
+let z1 = kernel1(out1, x.clone()).sync_on(&stream)?;
+let z2 = kernel2(out2, x.clone()).sync_on(&stream)?;
+
+// Borrowed — no allocation, borrow checker enforces lifetime.
+let x: Tensor<f32> = ones(&[32, 32]).sync_on(&stream)?;
+let _ = kernel(out, &x).sync_on(&stream)?;  // x still available
+```
+
+**Outputs (`&mut Tensor`):**
+
+```rust
+// Owned partition — must unpartition() to get the tensor back.
+let z = zeros(&[32, 32]).sync_on(&stream)?.partition([4, 4]);
+let (z, ..) = kernel(z, &x).sync_on(&stream)?;
+let tensor = z.unpartition();
+
+// Borrowed partition — writes in place, no unpartition() needed.
+let mut z = zeros(&[32, 32]).sync_on(&stream)?;
+let _ = kernel((&mut z).partition([4, 4]), &x).sync_on(&stream)?;
+// z already has the result.
+```
+
+Borrowed inputs (`&Tensor<T>`) and borrowed partitions (`Partition<&mut Tensor<T>>`)
+are not `'static`, so `tokio::spawn` rejects them at compile time — use `Arc`
+and owned partitions for spawned tasks.
+
+See the [DeviceOp API Reference](../reference/deviceop-reference.md#ownership-model)
+for the full ownership model.
+
+---
+
+## Streams and Scheduling
+
+This section explains **when GPU operations run in order** and **when they can overlap**. Understanding this is critical for both correctness and performance.
+
+### The One Rule of CUDA Streams
+
+A CUDA **stream** is an ordered queue of GPU work. The rule is simple:
+
+> Operations on the **same stream** always execute in submission order.
+> Operations on **different streams** may execute concurrently — the GPU is free to overlap them.
+
+This means the stream an operation lands on determines its ordering guarantees with respect to other operations.
+
+### Default Behavior: Round-Robin Stream Pool
+
+When you call `.await` or `.sync()`, cutile does **not** put every operation on a single stream. Instead, it uses a **round-robin scheduling policy** that rotates through a pool of streams:
+
+```text
+                         ┌─────────────────────────────────────────┐
+  Your Code              │          GPU (4-stream pool)            │
+ ─────────────           │                                         │
+                         │  Stream 0: ████████                     │
+  op_a.await  ──────────►│  Stream 1:    ████████                  │
+  op_b.await  ──────────►│  Stream 2:       ████████               │
+  op_c.await  ──────────►│  Stream 3:          ████████            │
+  op_d.await  ──────────►│  Stream 0:             ████████         │
+  op_e.await  ──────────►│                                         │
+                         └─────────────────────────────────────────┘
+```
+
+The default pool has **4 streams**. Each new operation goes to the next stream in rotation (0 → 1 → 2 → 3 → 0 → …). Because they land on different streams, **independent operations can overlap** — the GPU can work on multiple kernels or memory transfers simultaneously.
+
+### When Operations Serialize
+
+Even with the round-robin pool, operations **will** run in order in these cases:
+
+**1. Same stream (wrap-around)**
+
+Every 4th operation lands on the same stream. If `op_a` and `op_e` are both on Stream 0, `op_e` waits for `op_a` to finish:
+
+```text
+Stream 0: ████████ (op_a)         ████████ (op_e waits for op_a)
+Stream 1:    ████████ (op_b)
+Stream 2:       ████████ (op_c)
+Stream 3:          ████████ (op_d)
+```
+
+**2. Chained with `.then()`**
+
+Operations composed with `.then()` share a single stream, so the second operation always sees the first one's output:
+
+```rust
+let result = allocate_tensor()
+    .then(|tensor| fill_with_ones(tensor))  // same stream → ordered
+    .then(|tensor| run_kernel(tensor))       // same stream → ordered
+    .await;
+```
+
+**3. Explicit stream with `.sync_on()`**
+
+When you pass the same stream to multiple `.sync_on()` calls, all operations serialize on that stream:
+
+```rust
+let stream = ctx.new_stream()?;
+
+let a = op_a.sync_on(&stream);  // Stream X: runs first
+let b = op_b.sync_on(&stream);  // Stream X: waits for op_a
+let c = op_c.sync_on(&stream);  // Stream X: waits for op_b
+```
+
+**4. Awaiting sequentially**
+
+Each `.await` blocks the host until its GPU work completes (the `DeviceFuture` polls until the stream callback fires). So even though `op_a` and `op_b` may be on different streams, awaiting them one-by-one means `op_b` is not submitted until `op_a`'s result is ready on the host:
+
+```rust
+let a = op_a.await;  // Host waits for GPU to finish op_a
+let b = op_b.await;  // op_b submitted after op_a is confirmed done
+// These effectively serialize, even on different streams.
+```
+
+### When Operations Can Overlap
+
+Overlap requires two things: (1) operations land on different streams, and (2) they are submitted to the GPU before waiting for each other.
+
+**Building a lazy graph — direct kernel call:**
+
+```rust
+// The unified launcher accepts both DeviceOps and plain values.
+// No need for zip! or value() wrapping.
+let result = my_kernel(
+    zeros(&[1024, 1024]).partition([64, 64]),
+    x,
+    y,
+)
+.first()
+.unpartition()
+.await?;
+```
+
+**Using `tokio::join!` for independent work:**
+
+```rust
+// Both futures are polled concurrently by the async runtime.
+// They will likely land on different streams and overlap on the GPU.
+let (result_a, result_b) = tokio::join!(
+    kernel_a(x.clone()),
+    kernel_b(y.clone()),
+);
+```
+
+### Data Dependencies: Your Responsibility
+
+The round-robin policy does **not** track data dependencies. If operation B reads the output of operation A, you must ensure A finishes before B starts. Otherwise B may read stale or partially-written data.
+
+**Safe patterns for dependent operations:**
+
+```rust
+// Pattern 1: Chain with .then() — same stream, automatic ordering
+let result = create_tensor()
+    .then(|t| process(t))
+    .await;
+
+// Pattern 2: Await sequentially — host ensures ordering
+let tensor = create_tensor().await;
+let result = process(tensor).await;
+
+// Pattern 3: Pin to the same stream — CUDA guarantees ordering
+let stream = ctx.new_stream()?;
+let tensor = create_tensor().sync_on(&stream);
+let result = process(tensor).sync_on(&stream);
+```
+
+**Unsafe pattern to avoid:**
+
+```rust
+// ⚠️ DANGER: op_b may start before op_a finishes if they land on different streams!
+let future_a = op_a.into_future();  // Submitted to Stream 0
+let future_b = op_b_reads_a_output.into_future();  // Submitted to Stream 1
+let (a, b) = tokio::join!(future_a, future_b);
+// op_b might read incomplete data from op_a.
+```
+
+### Choosing the Right Execution Method
+
+| Method               | Stream assignment           | Ordering guarantee          | Best for                           |
+|----------------------|-----------------------------|-----------------------------|------------------------------------|
+| `.then()`        | Shares parent's stream      | **Strict** — same stream    | Dependent operations               |
+| `.sync_on(&stream)`  | Your explicit stream        | **Strict** — if same stream | Debugging, deterministic pipelines |
+| `.sync()`            | Policy picks (round-robin)  | **None** between calls      | Quick scripts                      |
+| `.await`             | Policy picks (round-robin)  | **None** between awaits     | Async code (see note below)        |
+| `zip!` + `.then()`  | Single stream for the graph | **Strict** within the graph | Kernel launch patterns             |
+
+:::{tip}
+Sequential `.await` calls *appear* ordered from the host's perspective (each waits before the next starts), but the GPU work for each `.await` runs on whichever stream the policy assigns. For truly independent operations you want to overlap, use `zip!` or `tokio::join!`.
+:::
+
+---
+
+## Performance Tips
+
+### 1. Batch Operations
+
+```rust
+// Bad: Many small syncs
+for i in 0..1000 {
+    let result = kernel(data[i]).sync_on(&stream);
+}
+
+// Good: Build graph, sync once
+let ops: Vec<_> = (0..1000).map(|i| kernel(data[i])).collect();
+let results = join_all(ops).await;
+```
+
+### 2. Overlap Computation and Memory Transfers
+
+The default round-robin policy already enables this — consecutive operations land on different streams, so a kernel on Stream 0 can overlap with a memory transfer on Stream 1:
+
+```rust
+// These naturally overlap with the default 4-stream pool:
+let compute_op = heavy_kernel(input.clone());
+let transfer_op = api::zeros(&[next_batch_size, dim]);
+
+// Submit both before waiting for either:
+let (result, next_buffer) = tokio::join!(compute_op, transfer_op);
+```
+
+For explicit control, create dedicated streams:
+
+```rust
+let compute_stream = ctx.new_stream()?;
+let transfer_stream = ctx.new_stream()?;
+
+let result = heavy_kernel(input).sync_on(&compute_stream);
+let next_batch = load_data().sync_on(&transfer_stream); // overlaps!
+```
+
+### 3. Use Appropriate Grid Sizes
+
+```rust
+// Match grid to your data size
+let num_tiles = data.len() / tile_size;
+launcher.grid((num_tiles as u32, 1, 1)).sync_on(&stream);
+```
+
+---
+
+## Summary
+
+| Concept                   | What it is                                                  |
+|---------------------------|-------------------------------------------------------------|
+| **DeviceOp**       | Lazy computation description                                |
+| **Stream**                | Ordered queue of GPU work                                   |
+| **SchedulingPolicy**      | Decides which stream each operation uses                    |
+| **Round-Robin (default)** | Rotates across 4 streams — enables overlap                  |
+| **SingleStream**          | All ops on one stream — strict ordering                     |
+| **sync_on()**             | Execute on an explicit stream and wait                      |
+| **await**                 | Execute via the default device's scheduling policy (async)  |
+| **.then()**           | Chain operations on the same stream                         |
+| **zip!**                  | Combine multiple operations into one (fan-in)               |
+| **unzip**                 | Split a tuple operation into independent branches (fan-out) |
+| **.shared()**             | Cloneable, execute-once operation — share data across N branches |
+| **.map(f)**               | Transform output without new GPU work                       |
+| **.first()** / **.last()**| Extract first/last element from tuple output                |
+| **.boxed()**              | Type-erase an operation for heterogeneous collections       |
+
+**Key takeaways:**
+
+1. The default policy distributes work across **4 streams** — consecutive operations can overlap.
+2. Operations on the **same stream** are always ordered; operations on **different streams** are not.
+3. Use `.then()`, sequential `.await`, or `.sync_on()` with a shared stream to enforce ordering between dependent operations.
+4. Use `zip!`, `.then()`, or `tokio::join!` to enable overlap for independent operations.
+
+---
+
+Continue to [Tuning for Performance](performance-tuning.md) for optimization techniques. For the full `DeviceOp` API, see the [DeviceOp API Reference](../reference/deviceop-reference.md).

--- a/cutile-book/guide/execution-model.md
+++ b/cutile-book/guide/execution-model.md
@@ -1,4 +1,4 @@
-# Execution Model
+# How Kernels Run on the GPU
 
 This page describes how cuTile Rust programs execute on NVIDIA GPUs.
 
@@ -163,25 +163,9 @@ These can vary at runtime:
 - **Tensor data** — Actual element values.
 - **Grid size** — Number of tile blocks to launch.
 
-## Python Subset (Comparison)
-
-If you're familiar with [cuTile Python](https://docs.nvidia.com/cuda/cutile-python/), here's how concepts map:
-
-| cuTile Python | cuTile Rust |
-|---------------|-----------|
-| `@ct.kernel` | `#[cutile::entry()]` |
-| `ct.load()` | `load_tile_like_2d()` |
-| `ct.store()` | `tensor.store()` |
-| `ct.bid(0)` | Implicit via partition |
-| `ct.launch()` | Async operation + `.await` |
-
-Both use the same underlying compilation pipeline and generate equivalent GPU code.
-
----
-
 ## Next Steps
 
-- Learn about the [Data Model](data-model.md) for details on types and shapes
-- Explore [Memory Hierarchy](memory-hierarchy.md) for performance optimization
-- See [Async Execution](async-execution.md) for concurrent CPU/GPU work
-- See [Interoperability](interoperability.md) for integrating custom CUDA kernels into the `DeviceOp` model
+- Continue to [Orchestrating Device Operations](device-operations.md) for the host-side execution story
+- Review [Working with Data](working-with-data.md) for details on types and shapes
+- Review [Where Data Lives](memory-hierarchy.md) for memory layout details
+- See [Integrating with CUDA C++](interoperability.md) for combining custom CUDA kernels with the `DeviceOp` model

--- a/cutile-book/guide/interoperability.md
+++ b/cutile-book/guide/interoperability.md
@@ -1,4 +1,4 @@
-# Interoperability
+# Integrating with CUDA C++
 
 The tile model handles dense tensor algebra well — GEMM, element-wise operations, reductions, convolutions — but some algorithms depend on **warp-level primitives** (`__shfl_sync`, `__ballot_sync`, `__reduce_sync`) for things like custom scan/prefix-sum, cooperative groups, or irregular data access patterns. For these, write the kernel in CUDA C++ and integrate it using the approach below.
 
@@ -242,4 +242,20 @@ let function = Arc::new(module.load_function("gemm_kernel")?);
 
 ---
 
-Continue to [Debugging](debugging.md) for troubleshooting, or see [Performance Tuning](performance-tuning.md) for optimization techniques. This chapter builds on the `DeviceOp` model introduced in [Async Execution](async-execution.md).
+## Coming from cuTile Python
+
+If you're familiar with [cuTile Python](https://docs.nvidia.com/cuda/cutile-python/), here's how the kernel-side concepts map to cuTile Rust:
+
+| cuTile Python | cuTile Rust |
+|---------------|-------------|
+| `@ct.kernel` | `#[cutile::entry()]` |
+| `ct.load()` | `load_tile_like_2d()` |
+| `ct.store()` | `tensor.store()` |
+| `ct.bid(0)` | Implicit via partition |
+| `ct.launch()` | Async operation + `.await` |
+
+Both front-ends use the same underlying Tile IR compilation pipeline and generate equivalent GPU code; the difference is the host language and its type system.
+
+---
+
+Continue to [Debugging and Profiling](debugging.md) for troubleshooting. This chapter builds on the `DeviceOp` model introduced in [Orchestrating Device Operations](device-operations.md).

--- a/cutile-book/guide/introduction.md
+++ b/cutile-book/guide/introduction.md
@@ -1,4 +1,4 @@
-# Introduction to cuTile Rust
+# Introduction
 
 ## What is cuTile Rust?
 
@@ -167,10 +167,10 @@ This pattern is key to performance: global memory is slow compared to on-chip re
 - You need maximum portability across GPU *vendors*
 - Your team is deeply invested in the CUDA C++ ecosystem
 
-> **Note**: For algorithms requiring warp-level primitives or custom CUDA C++ kernels, cuTile Rust provides an [Interoperability](interoperability.md) that lets you integrate pre-compiled kernels into the same async execution model.
+> **Note**: For algorithms requiring warp-level primitives or custom CUDA C++ kernels, see [Integrating with CUDA C++](interoperability.md); custom kernels can participate in the same `DeviceOp` execution model as your tile kernels.
 
 ---
 
 ## Next Steps
 
-Continue to learn about the [Tile Programming Model](tile-programming-model.md) or jump straight to the [Tutorials](../tutorials/01-hello-world.md).
+Continue to [Thinking in Tiles](thinking-in-tiles.md), or jump straight to the [Tutorials](../tutorials/01-hello-world.md).

--- a/cutile-book/guide/memory-hierarchy.md
+++ b/cutile-book/guide/memory-hierarchy.md
@@ -1,4 +1,4 @@
-# Memory Hierarchy
+# Where Data Lives: The GPU Memory Hierarchy
 
 Understanding GPU memory is essential for writing fast kernels. The key insight: **data locality determines performance**.
 
@@ -256,4 +256,4 @@ fn gemm<E: ElementType, const BM: i32, const BN: i32, const BK: i32, const K: i3
 
 ---
 
-Continue to [Operations](operations.md) to see what you can do with tiles.
+Continue to [Working with Data](working-with-data.md) to meet the tensor and tile abstractions that sit on top of this hierarchy.

--- a/cutile-book/guide/performance-tuning.md
+++ b/cutile-book/guide/performance-tuning.md
@@ -1,4 +1,4 @@
-# Performance Tuning
+# Tuning for Performance
 
 This guide covers techniques for optimizing cuTile Rust kernel performance. For algorithms where peak performance requires warp-level control or integration with hand-tuned CUDA C++ kernels, see [Interoperability](interoperability.md).
 
@@ -425,7 +425,7 @@ fn fast_matmul<const S: [i32; 2]>(
 
 ## Next Steps
 
-- See [Memory Hierarchy](memory-hierarchy.md) for detailed memory optimization
-- Learn about [Async Execution](async-execution.md) for overlapping operations
-- Read [Interoperability](interoperability.md) for integrating custom CUDA kernels when tile programming isn't enough
-- Check [Debugging](debugging.md) for troubleshooting performance issues
+- Continue to [Integrating with CUDA C++](interoperability.md) for the escape hatch when tile programming isn't enough
+- Review [Where Data Lives](memory-hierarchy.md) for memory-layout optimization
+- Review [Orchestrating Device Operations](device-operations.md) for overlapping operations across kernels
+- Check [Debugging and Profiling](debugging.md) for troubleshooting performance issues

--- a/cutile-book/guide/thinking-in-tiles.md
+++ b/cutile-book/guide/thinking-in-tiles.md
@@ -1,0 +1,165 @@
+# Thinking in Tiles
+
+The fundamental unit of computation in cuTile Rust is the **tile** — an immutable multi-dimensional array fragment that lives in GPU registers during kernel execution. You load data from tensors into tiles, compute on tiles, and store the results back. The compiler maps tiles onto the hardware memory hierarchy — including shared memory, caches, and registers — so you never manage these resources yourself.
+
+![Thread-centric vs Tile-centric programming mental model](../_static/images/mental-model-shift.svg)
+
+## Tile-Based vs Thread-Based Programming
+
+Traditional CUDA programming asks you to think in terms of individual threads and explicit thread indices:
+
+```cpp
+__global__ void add(float* a, float* b, float* c, int n) {
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i < n) {
+        c[i] = a[i] + b[i];
+    }
+}
+```
+
+cuTile Rust shifts the model to tiles of data:
+
+```rust
+#[cutile::entry()]
+fn add<const S: [i32; 2]>(
+    c: &mut Tensor<f32, S>,
+    a: &Tensor<f32, {[-1, -1]}>,
+    b: &Tensor<f32, {[-1, -1]}>
+) {
+    let tile_a = load_tile_like_2d(a, c);
+    let tile_b = load_tile_like_2d(b, c);
+    c.store(tile_a + tile_b);
+}
+```
+
+Instead of managing thread indices directly, you describe what should happen to one tile-shaped region of the data. The compiler and runtime handle how that work is mapped onto the underlying GPU execution model.
+
+## Tile Blocks and Tile Threads
+
+A **tile block** is a logical thread and the basic unit of concurrent execution on the GPU. Each tile block runs the kernel function once, operating on one partition of the data. A tile block is identified by its coordinates, obtained via `get_tile_block_id()`:
+
+```rust
+let pid: (i32, i32, i32) = get_tile_block_id();    // This block's (x, y, z) coordinates
+let npids: (i32, i32, i32) = get_num_tile_blocks(); // Total grid dimensions
+```
+
+The cuTile Rust compiler maps each tile block to one or more underlying CUDA execution units (thread blocks, clusters, or warps) depending on the target architecture — but from the programmer's perspective, a tile block is simply a single-threaded context that processes one tile of data.
+
+The terms **tile block** and **tile thread** are interchangeable. The API uses `get_tile_block_id()` and `get_num_tile_blocks()`, while the guides often say "tile thread" to emphasize the single-threaded programming model.
+
+## Partitioning
+
+To process a large tensor, you **partition** it — dividing the tensor into a grid of equally sized sub-regions, each of which is processed by one tile block. Partitioning works differently for mutable outputs and read-only inputs.
+
+### Host-Side Partitioning (Mutable Tensors)
+
+Mutable tensors must be partitioned on the host side before kernel launch:
+
+```rust
+let tensor = zeros(&[1024, 1024]).sync_on(&stream)?;
+let partitioned = tensor.partition([64, 64]);  // 16×16 = 256 sub-tensors
+```
+
+![Partitioning divides data among tiles for parallel processing](../_static/images/vector-addition-partitioning.svg)
+
+Calling `.partition([M, N])` on a `Tensor<T>` produces a `Partition<Tensor<T>>` — a host-side wrapper that records the `partition_shape` alongside the original tensor. The `partition_shape` determines the static shape `S` that the kernel sees: passing a `Partition` with `partition_shape = [64, 64]` means the kernel receives a `&mut Tensor<T, {[64, 64]}>`.
+
+Only mutable tensors must be partitioned on the host side. This is because each `&mut Tensor` sub-region is written to by exactly one tile block, satisfying Rust's exclusive access requirement for mutable memory: at most one writer may access a given region at a time. By partitioning before launch, the system guarantees that no two tile blocks write to overlapping memory.
+
+The generated launcher code accepts `Partition<Tensor<T>>` for every `&mut Tensor` parameter and `Arc<Tensor<T>>` for every `&Tensor` parameter.
+
+### Device-Side Partitioning (Read-Only Tensors)
+
+Read-only inputs are passed as `Arc<Tensor<T>>` on the host side — no host-side partitioning required. Multiple tile blocks may safely read from the same tensor or overlapping regions simultaneously, so there is no exclusive-access constraint to enforce.
+
+Instead, read-only tensors are partitioned **inside the kernel** using `.partition(const_shape![M, N])`:
+
+```rust
+let part_x = x.partition(const_shape![BM, BK]);
+let tile = part_x.load([pid.0, i]);
+```
+
+Because the partitioning happens on the device side, the same `&Tensor` can be partitioned in different ways within the same kernel. For example, in GEMM the input matrices `x` and `y` are each partitioned with a different shape inside the kernel body (`const_shape![BM, BK]` and `const_shape![BK, BN]` respectively), even though both were passed as plain `Arc<Tensor<T>>` from the host.
+
+## The Grid
+
+The **grid** determines how many tile blocks run. It can be specified explicitly or inferred from the partitioned tensors passed to the kernel.
+
+### Grid Inference
+
+A host-side partition's grid is computed by dividing the tensor's shape by the partition shape, rounding up:
+
+```text
+grid[i] = ceil(tensor_shape[i] / partition_shape[i])
+```
+
+The result is mapped to a 3D tuple `(x, y, z)`, with trailing dimensions set to 1 for tensors of rank less than 3. The mapping is direct and order-preserving: tensor dimension 0 maps to grid `x`, dimension 1 to `y`, and dimension 2 to `z`.
+
+For example, a `[128, 256]` tensor partitioned with `[32, 64]` produces a grid of `(4, 4, 1)`:
+
+```text
+Tensor shape:    [128, 256]
+Partition shape: [ 32,  64]
+Grid:            (ceil(128/32), ceil(256/64), 1) = (4, 4, 1)
+```
+
+### From Grid Coordinates to Sub-Tensors
+
+Inside the kernel, `get_tile_block_id()` returns the tile block's `(x, y, z)` coordinates in the grid. These coordinates correspond directly to the sub-tensor indices in the partition. For the example above, tile block `(2, 1, 0)` processes the sub-tensor at rows `2×32..3×32` and columns `1×64..2×64` — that is, the region `[64:96, 64:128]` of the original tensor.
+
+For a `&mut Tensor`, this mapping is implicit — the kernel receives the sub-tensor directly, and loads and stores operate within the sub-tensor's bounds. For a `&Tensor` partitioned on the device side, you use the tile block ID to index into the partition explicitly:
+
+```rust
+let pid: (i32, i32, i32) = get_tile_block_id();
+
+// For a &mut Tensor, the sub-tensor is passed directly:
+let tile_z = z.load();       // Loads this block's sub-tensor
+
+// For a &Tensor, use pid to index into a device-side partition:
+let part_x = x.partition(const_shape![BM, BK]);
+let tile_x = part_x.load([pid.0, i]);  // Loads tile at row pid.0, column i
+```
+
+### Launch Grid Inference
+
+At kernel launch time, the launcher calls `.grid()` on each `&mut Tensor` parameter's host-side `Partition` and collects the resulting grids. If no explicit grid is specified via `.grid()` or `.const_grid()`, the launch grid is **inferred** from these partition grids:
+
+```rust
+// Grid is inferred from z's partition: (16, 16, 1)
+let z = zeros(&[1024, 1024]).sync_on(&stream)?.partition([64, 64]);
+let (z, _x, _y) = add(z, x, y).sync_on(&stream)?;
+```
+
+When multiple `&mut Tensor` parameters are present, all of their inferred grids must match or the launch will fail with an error.
+
+### Explicit Grid
+
+You can also set the grid manually, which overrides inference:
+
+```rust
+launcher.grid((16, 16, 1)).sync_on(&stream)?;
+```
+
+Each tile block receives unique 3-dimensional coordinates within the grid via `get_tile_block_id()`.
+
+## Concurrent and Parallel Execution
+
+When a kernel launches, the GPU's hardware scheduler assigns tile blocks to Streaming Multiprocessors (SMs) as resources become available. Tile blocks that fit on available SMs run **in parallel** — simultaneously on separate hardware units. The full set of tile blocks runs **concurrently** — their relative order of execution is unspecified and they are independent of one another.
+
+This matches Rust's distinction between concurrency and parallelism: parallelism is work happening at the exact same time on different hardware, while concurrency is independently executing tasks making progress over time.
+
+## Tile Types
+
+| Type | Description | Lives In |
+|------|-------------|----------|
+| `Tensor<E, S>` | Multi-dimensional array in global memory; passed as kernel arguments | GPU DRAM (HBM) |
+| `Partition<E, S>` | Logical division of a tensor into sub-regions | Metadata only |
+| `Tile<E, S>` | Immutable data fragment for computation; compile-time static shapes | GPU registers |
+
+The flow is always: **Tensor → Partition → Tile → Compute → Store**
+
+You only load from and store to HBM (global memory). The underlying [Tile IR](https://docs.nvidia.com/cuda/tile-ir/latest/) runtime handles mapping your tiles onto the hardware memory hierarchy — including shared memory, caches, and registers — so you never need to manage these resources yourself.
+
+---
+
+Continue to [Where Data Lives](memory-hierarchy.md) to understand the GPU memory model that tiles map onto.

--- a/cutile-book/guide/working-with-data.md
+++ b/cutile-book/guide/working-with-data.md
@@ -1,0 +1,511 @@
+# Working with Data: Tensors, Tiles, and Partitions
+
+cuTile Rust leverages Rust's type system to catch errors at compile time. Shape mismatches, type errors, and many common GPU programming bugs are caught before your code even runs.
+
+## Tensors vs Tiles
+
+cuTile Rust has two fundamental data abstractions that represent data at different levels of the memory hierarchy:
+
+| Property | Tensor | Tile |
+|----------|--------|------|
+| **Location** | Global Memory (HBM) | GPU registers |
+| **Mutability** | Mutable (`&mut`) or read-only (`&`) | Immutable |
+| **Shape** | Mixed static / dynamic | Compile-time (static) |
+| **Operations** | Load, Store | Arithmetic, Reduction, etc. |
+| **Lifetime** | Persists across kernels | Exists only during kernel |
+| **Addressable** | Yes (pointers) | No (compiler-managed) |
+
+```rust
+// Tensors: live in global memory, passed as kernel arguments
+fn kernel(
+    output: &mut Tensor<f32, S>,      // Mutable tensor (can store to)
+    input: &Tensor<f32, {[-1, -1]}>   // Immutable tensor (read-only)
+) {
+    // Tiles: live in registers, created by loading
+    let tile = load_tile_like_2d(input, output);  // Load creates a tile
+    let result = tile * 2.0;                      // Operations create new tiles
+    output.store(result);                         // Store tile back to tensor
+}
+```
+
+---
+
+## Core Types
+
+The `Tensor` and `Partition` types exist on both the host side (CPU) and the device side (GPU kernel), but they are different Rust types with similar semantics. Host-side types are parameterized by element type only; device-side types carry shape information in the type system for compile-time optimization.
+
+### Tensor Creation
+
+The `api` module provides functions for creating tensors on the GPU:
+
+```rust
+use cutile::api;
+
+// Constant-filled tensors
+let z = api::zeros::<f32>(&[1024]).sync_on(&stream)?;     // all zeros
+let o = api::ones::<f32>(&[256, 256]).sync_on(&stream)?;  // all ones
+let f = api::full(3.14f32, &[512]).sync_on(&stream)?;     // fill with value
+
+// Sequential and evenly spaced values
+let r = api::arange::<i32>(1024).sync_on(&stream)?;       // [0, 1, 2, ..., 1023]
+let l = api::linspace(0.0, 1.0, 256).sync_on(&stream)?;   // 256 values from 0 to 1
+
+// Identity matrices
+let I = api::eye(64).sync_on(&stream)?;                    // 64x64 identity
+let R = api::eye_rect(32, 64).sync_on(&stream)?;           // 32x64, ones on diagonal
+
+// Random tensors
+let u = api::rand::<f32, 1>(&[1024]).sync_on(&stream)?;   // uniform [0, 1)
+let n = api::randn::<f32, 1>(&[1024]).sync_on(&stream)?;  // normal (0, 1)
+```
+
+### Views and Slices
+
+`TensorView` provides zero-copy borrowed views of tensors with different
+shape or offset. Views borrow the underlying tensor — the tensor cannot be
+mutated while a view exists.
+
+```rust
+let tensor = api::arange::<f32>(1024).sync_on(&stream)?;
+
+// Reshape without copying
+let matrix = tensor.view(&[32, 32])?;
+
+// Slice: borrow a subregion (numpy-style ranges)
+let first_half = tensor.slice(&[0..512])?;           // elements 0-511
+let row_slice = matrix.slice(&[1..3])?;              // rows 1-2, all columns
+let block = matrix.slice(&[1..3, 2..6])?;            // rows 1-2, cols 2-5
+
+// Chained slices accumulate offsets
+let inner = tensor.slice(&[100..200])?.slice(&[10..20])?;  // = tensor[110..120]
+```
+
+Views and slices can be passed to kernels as `&Tensor` parameters. The
+offset is applied host-side — the kernel receives a pointer to the correct
+starting address.
+
+### Host-Side Types
+
+On the host, you allocate tensors, partition them, and pass them to kernel launchers:
+
+```rust
+// Host-side Tensor<T> — parameterized by element type only
+let mut tensor: Tensor<f32> = zeros(&[1024, 1024]).sync_on(&stream)?;
+
+// Owned partition — moves the tensor into the partition
+let partitioned: Partition<Tensor<f32>> = tensor.partition([16, 16]);
+
+// Borrowed partition — borrows mutably, tensor written in place
+let partitioned_ref = (&mut tensor).partition([16, 16]);
+
+// Read-only inputs: borrow, Arc, or owned
+let input: &Tensor<f32> = &tensor;           // borrow
+let shared: Arc<Tensor<f32>> = Arc::new(tensor);  // shared ownership
+```
+
+The generated launcher accepts multiple forms for each parameter type.
+`&Tensor` params accept `&Tensor<T>`, `Arc<Tensor<T>>`, or `Tensor<T>`.
+`&mut Tensor` params accept `Partition<Tensor<T>>` or `Partition<&mut Tensor<T>>`.
+
+### Device-Side Types
+
+Inside a kernel, tensors and tiles carry their shape as a type parameter. This enables compile-time shape checking and optimization:
+
+```rust
+// Device-side Tensor<E, S> — element type + shape
+fn kernel(
+    output: &mut Tensor<f32, { [BM, BN] }>,  // Static shape from partition
+    input: &Tensor<f32, { [-1, -1] }>,       // Dynamic shape
+) {
+    // Device-side Partition<E, S> — view of a tensor as tiles
+    let part = input.partition(const_shape![BM, BK]);
+    let tile = part.load([pid.0, i]);
+
+    // Tile<E, S> — immutable data fragment in registers
+    let tile_a: Tile<f32, { [BM, BN] }> = load_tile_like_2d(input, output);
+    let result = tile_a * 2.0;       // Operations create new tiles
+    output.store(result);
+}
+```
+
+| Type | Side | Parameterized By | Description |
+|------|------|-----------------|-------------|
+| `Tensor<T>` | Host | Element type | Tensor in global memory; allocated and managed on the CPU |
+| `Partition<Tensor<T>>` | Host | Element type | Host-side wrapper recording a tensor and its partition shape |
+| `Arc<Tensor<T>>` | Host | Element type | Shared reference for read-only kernel inputs |
+| `Tensor<E, S>` | Device | Element type + shape | Kernel parameter; `S` is static or dynamic (`-1`) |
+| `Partition<E, S>` | Device | Element type + shape | Read-only view of a `&Tensor` divided into tiles inside a kernel |
+| `Tile<E, S>` | Device | Element type + shape (always static) | Immutable data fragment in GPU registers |
+
+---
+
+## Element Types
+
+cuTile Rust supports various numeric types for GPU computation:
+
+### Floating Point Types
+
+| Type | Size | Description | Use Case |
+|------|------|-------------|----------|
+| `f16` | 16-bit | Half precision | Training, inference (2× Tensor Core throughput) |
+| `bf16` | 16-bit | Brain float (FP16 range, less precision) | Training (better range than `f16`) |
+| `f32` | 32-bit | Single precision | General purpose, debugging |
+| `f64` | 64-bit | Double precision | Scientific computing |
+| `tf32` | 19-bit | TensorFloat-32 | Tensor Core operations |
+| `f8e4m3fn` | 8-bit | FP8 E4M3FN (no infinity) | Quantized storage; convert to `f16`/`f32` for compute |
+| `f8e5m2` | 8-bit | FP8 E5M2 | Quantized storage; convert to `f16`/`f32` for compute |
+
+### Integer Types
+
+| Type | Size | Description |
+|------|------|-------------|
+| `i8` / `u8` | 8-bit | Signed/unsigned byte |
+| `i16` / `u16` | 16-bit | Signed/unsigned short |
+| `i32` / `u32` | 32-bit | Signed/unsigned int |
+| `i64` / `u64` | 64-bit | Signed/unsigned long |
+
+### Boolean Type
+
+| Type | Description |
+|------|-------------|
+| `bool` | Boolean (true/false), maps to `i1` |
+
+### Choosing Element Types
+
+| Type | Performance | Precision | Recommendation |
+|------|-------------|-----------|----------------|
+| `f32` | Baseline | High | Development, debugging |
+| `f16` | 2× on Tensor Cores | Medium | Inference |
+| `bf16` | 2× on Tensor Cores | Medium (better range) | Training |
+| `i32` | Native integer ops | Exact | Indexing, control flow |
+
+---
+
+## Shapes
+
+Shapes define the dimensions of tensors and tiles.
+
+### Static Shapes (Compile-Time)
+
+When you know the shape at compile time, use const generics:
+
+```rust
+fn kernel<const BM: i32, const BN: i32>(
+    output: &mut Tensor<f32, { [BM, BN] }>,  // Static shape
+) {
+    // BM and BN are known at compile time
+    // Compiler can optimize layout and access patterns
+}
+```
+
+**Benefits:**
+- Compiler can optimize layout and access patterns
+- Shape errors caught at compile time
+- Zero runtime overhead for shape checks
+
+**Drawbacks:**
+- Kernels are re-compiled whenever their type or const generics change. 
+- Too many consts which change across kernel launches will trigger excessive re-compilation, 
+  which may not be desirable/optimal for all applications.
+
+### Dynamic Shapes (Runtime)
+
+When the shape is only known at runtime:
+
+```rust
+fn kernel(
+    input: &Tensor<f32, { [-1, -1] }>,  // Dynamic shape
+) {
+    // -1 means "determined at runtime"
+    let shape = input.shape();  // Query actual dimensions
+}
+```
+
+Dynamic shape dimensions which vary across kernel launches do not trigger re-compilation.
+
+### Common Tile Sizes
+
+For optimal performance, tile dimensions are typically powers of two:
+
+| Shape | Total Elements | Use Case |
+|-------|----------------|----------|
+| `[64, 64]` | 4,096 | General matrix ops |
+| `[128, 128]` | 16,384 | Large matrix ops |
+| `[256, 64]` | 16,384 | Tall tiles |
+| `[64, 256]` | 16,384 | Wide tiles |
+| `[1024]` | 1,024 | 1D vectors |
+
+### The Common Pattern: Static Output, Dynamic Input
+
+```rust
+#[cutile::entry()]
+fn add<const S: [i32; 2]>(
+    z: &mut Tensor<f32, S>,           // Static: tile knows its size
+    x: &Tensor<f32, {[-1, -1]}>,      // Dynamic: full tensor
+    y: &Tensor<f32, {[-1, -1]}>,      // Dynamic: full tensor
+) {
+    let tile_x = load_tile_like_2d(x, z);  // Load matching z's shape
+    let tile_y = load_tile_like_2d(y, z);
+    z.store(tile_x + tile_y);
+}
+```
+
+---
+
+## Shape Broadcasting
+
+When operating on tiles of different shapes, cuTile Rust uses **broadcasting** rules similar to NumPy:
+
+### Broadcasting Rules
+
+1. **Align dimensions from the right**
+2. **Dimensions are compatible if they're equal or one is 1**
+3. **The result shape is the maximum along each dimension**
+
+```rust
+// Example: [64, 64] + [1, 64] -> [64, 64]
+let tile_a: Tile<f32, [64, 64]> = ...;
+let tile_b: Tile<f32, [1, 64]> = ...;
+let result = tile_a + tile_b.broadcast(const_shape![64, 64]);  // Result is [64, 64], B broadcast along dim 0
+```
+
+<!--
+### Broadcasting Examples
+
+```
+Shape A      Shape B      Result
+[64, 64]  +  [64, 64]  -> [64, 64]   (exact match)
+[64, 64]  +  [1, 64]   -> [64, 64]   (broadcast B along dim 0)
+[64, 64]  +  [64, 1]   -> [64, 64]   (broadcast B along dim 1)
+[64, 64]  +  [1, 1]    -> [64, 64]   (broadcast B along both dims)
+[64, 1]   +  [1, 64]   -> [64, 64]   (broadcast both)
+```
+-->
+
+<!--
+### Arithmetic Promotion
+
+When operating on tiles with different dtypes, automatic promotion occurs:
+
+```rust
+// f16 + f32 -> f32
+let a: Tile<f16, S> = ...;
+let b: Tile<f32, S> = ...;
+let c = a + b;  // c is Tile<f32, S>
+```
+
+**Promotion Hierarchy:**
+```
+f16 < bf16 < f32 < f64
+i8 < i16 < i32 < i64
+```
+-->
+
+---
+
+## Type Safety
+
+### Compile-Time Shape Checking
+
+The compiler catches shape mismatches:
+
+```rust
+// ❌ Won't compile: shapes don't match
+let a: Tile<f32, {[4, 4]}> = ...;
+let b: Tile<f32, {[8, 8]}> = ...;
+let c = a + b;  // Error: cannot add [4,4] and [8,8]
+
+// ✅ Correct: same shapes
+let a: Tile<f32, {[4, 4]}> = ...;
+let b: Tile<f32, {[4, 4]}> = ...;
+let c = a + b;  // OK: both [4,4]
+```
+
+### Element Type Checking
+
+```rust
+// ❌ Won't compile: type mismatch without conversion
+let x: Tile<f32, {[4, 4]}> = ...;
+let y: Tile<i32, {[4, 4]}> = ...;
+let z = x + y;  // Error: cannot add f32 and i32
+
+// ✅ Correct: explicit conversion
+let y_float: Tile<f32, {[4, 4]}> = convert_tile(y);
+let z = x + y_float;  // OK
+```
+
+### Matrix Multiplication Shape Rules
+
+For `C = A @ B`:
+- A shape: `[M, K]`
+- B shape: `[K, N]`
+- C shape: `[M, N]`
+
+The inner dimension K must match:
+
+```rust
+// ❌ Won't compile: inner dimensions don't match
+let a: Tile<f32, {[16, 8]}>;   // [M=16, K=8]
+let b: Tile<f32, {[16, 32]}>;  // [K=16, N=32]  K mismatch!
+let c = mma(a, b, zeros);      // Error!
+
+// ✅ Correct: K dimensions match
+let a: Tile<f32, {[16, 8]}>;   // [M=16, K=8]
+let b: Tile<f32, {[8, 32]}>;   // [K=8, N=32]   K matches!
+let c = mma(a, b, zeros);      // OK: result is [16, 32]
+```
+
+---
+
+## Type Conversions
+
+### Explicit Casting
+
+Convert between types explicitly:
+
+```rust
+let float_tile: Tile<f32, S> = ...;
+
+// Float to integer
+let int_tile: Tile<i32, S> = convert_tile(float_tile);
+
+// Integer extension
+let i8_tile: Tile<i8, S> = ...;
+let i32_tile: Tile<i32, S> = convert_tile(i8_tile);
+```
+
+<!--
+### Conversion Operations
+
+| Operation | Description |
+|-----------|-------------|
+| `trunci::<T>()` | Truncate to smaller integer type |
+| `exti::<T>()` | Sign-extend to larger integer type |
+| `cast::<T>()` | General type conversion |
+-->
+
+---
+
+## Generic Kernels
+
+Use generics to specify flexible, reusable kernels:
+
+```rust
+#[cutile::entry()]
+fn flexible_gemm<
+    E: ElementType,              // Any element type
+    const BM: i32,               // Tile rows
+    const BN: i32,               // Tile cols
+    const BK: i32,               // Inner tile dim
+    const K: i32,                // Full inner dim
+>(
+    z: &mut Tensor<E, {[BM, BN]}>,
+    x: &Tensor<E, {[-1, K]}>,
+    y: &Tensor<E, {[K, -1]}>,
+) {
+    // Works for any element type and tile sizes!
+}
+```
+
+Launch with specific types:
+
+```rust
+let generics = vec![
+    "f32".to_string(),  // E
+    "16".to_string(),   // BM
+    "16".to_string(),   // BN
+    "8".to_string(),    // BK
+    "128".to_string(),  // K
+];
+gemm(z, x, y).generics(generics).sync_on(&stream);
+```
+
+### The ElementType Trait
+
+Custom element types must implement `ElementType`:
+
+```rust
+pub trait ElementType: Copy + Clone {}
+
+// Built-in implementations:
+impl ElementType for f32 { ... }
+impl ElementType for f16 { ... }
+impl ElementType for i32 { ... }
+// etc.
+```
+
+---
+
+## Memory Layout
+
+### Tensor Memory Layout
+
+Tensors in global memory use row-major (C-style) layout:
+
+```{figure} ../_static/images/tensor-memory-layout.svg
+:width: 100%
+:alt: Tensor memory layout showing row-major ordering
+```
+
+**Key insight:** Consecutive elements in a row are adjacent in memory, enabling coalesced memory access when threads read along rows.
+
+### Tile Register Layout
+
+Tiles exist in registers without a specific addressable layout. The compiler optimizes register usage automatically.
+
+---
+
+## Shape Utilities
+
+### const_shape! Macro
+
+Create compile-time shapes:
+
+```rust
+use cutile::core::const_shape;
+
+let shape = const_shape![64, 64];       // [64, 64]
+let shape_3d = const_shape![8, 16, 32]; // [8, 16, 32]
+```
+
+### Shape Operations
+
+```rust
+// Get shape at runtime
+let dims = tensor.shape();  // Returns shape info
+
+// Reshape (total elements must match)
+let reshaped = tile.reshape(const_shape![8, 8]);
+
+// Broadcast (expand dimensions)
+let scalar: Tile<f32, {[]}> = constant(2.0f32, const_shape![]);
+let expanded = scalar.broadcast(const_shape![64, 64]);
+```
+
+---
+
+## Summary
+
+| Concept | Purpose |
+|---------|---------|
+| **Static shapes** `{[M, N]}` | Compile-time known, fully optimized |
+| **Dynamic shapes** `{[-1, -1]}` | Runtime determined |
+| **Tensor\<T\>** (host) | Tensor in global memory, allocated and managed on the CPU |
+| **Tensor\<E, S\>** (device) | Kernel parameter with element type and shape |
+| **Partition\<Tensor\<T\>\>** (host) | Wrapper recording a tensor and its partition shape |
+| **Partition\<E, S\>** (device) | Read-only view of a tensor divided into tiles inside a kernel |
+| **Tile\<E, S\>** (device only) | Immutable data fragment in GPU registers |
+| **Const generics** | Flexible, type-safe kernels |
+| **Broadcasting** | Automatic shape expansion |
+
+**Key benefits:**
+- Catch shape mismatches at compile time
+- Zero runtime overhead for static shapes
+- Generic kernels work with any valid configuration
+
+---
+
+## Next Steps
+
+- Continue to [Writing Computations on Tiles](writing-computations.md) for the operations you can apply
+- Look up individual operations in the [DSL API Reference](../reference/dsl-api.md)

--- a/cutile-book/guide/writing-computations.md
+++ b/cutile-book/guide/writing-computations.md
@@ -1,0 +1,398 @@
+# Writing Computations on Tiles
+
+cuTile Rust provides a rich set of operations for GPU computation. All operations work on tiles and leverage GPU parallelism.
+
+## Loading and Storing
+
+### Basic Load/Store
+
+```rust
+// Load entire output tile
+let tile = load_tile_mut(tensor);
+
+// Store result
+tensor.store(tile);
+```
+
+### Load Like (Positional Loading)
+
+Load from a dynamic tensor at the position matching another tile:
+
+```rust
+// Load from x at the same position as output tile z
+let tile_x = load_tile_like_2d(x, z);
+let tile_y = load_tile_like_2d(y, z);
+```
+
+This is the most common pattern for element-wise operations.
+
+### Partitioned Loading
+
+For explicit control over which tile to load:
+
+```rust
+let part = tensor.partition(const_shape![16, 16]);
+let tile = part.load([row_idx, col_idx]);
+```
+
+---
+
+## Elementwise Operations
+
+Standard math operations work element-by-element on tiles:
+
+### Arithmetic
+
+```rust
+let c = a + b;    // Addition
+let c = a - b;    // Subtraction
+let c = a * b;    // Multiplication
+let c = a / b;    // Division
+```
+
+### With Scalars
+
+```rust
+let scale = 2.0f32;
+let scaled = tile * scale;           // Multiply by scalar
+let shifted = tile + 1.0f32;         // Add scalar
+```
+
+### Compound Operations
+
+```rust
+// SAXPY: y = a*x + y
+let result = a * x + y;
+
+// Fused multiply-add (more accurate)
+let result = fma(a, x, y);
+
+// Fused multiply-add with rounding mode
+let result = fma(a, x, y, rounding_mode);
+```
+
+---
+
+## Mathematical Functions
+
+### Exponential and Logarithmic
+
+```rust
+let y = exp(x);              // e^x
+let y = exp2(x, ftz::Disabled);             // 2^x (faster on GPU)
+let y = log(x);              // Natural log (ln)
+let y = log2(x);             // Log base 2
+let y = sqrt(x, "rn");       // Square root (requires rounding mode)
+let y = rsqrt(x);            // 1/sqrt(x) (fast reciprocal sqrt)
+```
+
+### Trigonometric
+
+```rust
+let y = sin(x);      // Sine
+let y = cos(x);      // Cosine
+let y = tanh(x);     // Hyperbolic tangent
+```
+
+### Other
+
+```rust
+let y = absf(x);             // Absolute value (float)
+let y = absi(x);             // Absolute value (integer)
+let y = negf(x);             // Negation (float)
+let y = negi(x);             // Negation (integer)
+let y = ceil(x, "rn");       // Ceiling (requires rounding mode)
+let y = floor(x);            // Floor
+```
+
+---
+
+## Reduction Operations
+
+Reduce along an axis to produce a smaller tile:
+
+### Max and Sum
+
+```rust
+// Input: Tile<f32, {[BM, BN]}>
+
+// Reduce across columns (axis=1) → Tile<f32, {[BM]}>
+let row_max = reduce_max(tile, 1i32);
+let row_sum = reduce_sum(tile, 1);
+
+// Reduce across rows (axis=0) → Tile<f32, {[BN]}>
+let col_max = reduce_max(tile, 0i32);
+let col_sum = reduce_sum(tile, 0);
+```
+
+![Reduction operations along axis 0 (columns) and axis 1 (rows)](../_static/images/reduction-axes.svg)
+
+### Min
+
+```rust
+let row_min = reduce_min(tile, 1);
+let col_min = reduce_min(tile, 0);
+```
+
+### Prod
+
+```rust
+let row_prod = reduce_prod(tile, 1);
+let col_prod = reduce_prod(tile, 0);
+```
+
+---
+
+## Matrix Operations
+
+### Matrix Multiply-Accumulate (MMA)
+
+The workhorse of GPU computing:
+
+```rust
+// C = A @ B + C
+let c = mma(a, b, c);
+
+// For accumulation loop:
+let mut acc = constant(0.0f32, const_shape![BM, BN]);
+for i in 0..K {
+    let a_tile = load_a(i);
+    let b_tile = load_b(i);
+    acc = mma(a_tile, b_tile, acc);
+}
+```
+
+**Shape requirements:**
+- A: `[M, K]`
+- B: `[K, N]`
+- C: `[M, N]`
+- Result: `[M, N]`
+
+### Transpose / Permute
+
+```rust
+// Define permutation
+let transpose: Array<{[1, 0]}> = Array::<{[1, 0]}> {
+    dims: &[1i32, 0i32],
+};
+
+// Apply transpose
+let transposed = permute(tile, transpose);
+// [M, N] → [N, M]
+```
+
+---
+
+## Broadcasting
+
+Expand a smaller tile to match a larger shape:
+
+### Scalar Broadcasting
+
+```rust
+// Broadcast scalar to tile
+let scalar = 2.0f32;
+let tile = scalar.broadcast(const_shape![64, 64]);
+// Creates 64×64 tile filled with 2.0
+```
+
+### Dimension Broadcasting
+
+```rust
+// Broadcast [BM] to [BM, BN]
+let row_values: Tile<f32, {[BM]}> = ...;
+let expanded = row_values
+    .reshape(const_shape![BM, 1])
+    .broadcast(const_shape![BM, BN]);
+```
+
+### Common Pattern: Softmax Normalization
+
+```rust
+// Get max per row: [BM, BN] → [BM]
+let row_max = reduce_max(tile, 1);
+
+// Broadcast back: [BM] → [BM, BN]
+let max_broadcast = row_max
+    .reshape(const_shape![BM, 1])
+    .broadcast(tile.shape());
+
+// Subtract max from each element
+let normalized = tile - max_broadcast;
+```
+
+---
+
+## Shape Operations
+
+### Reshape
+
+Change shape without changing data (total elements must match):
+
+```rust
+// Flatten 2D to 1D
+let flat = tile.reshape(const_shape![BM * BN]);
+
+// Reshape for broadcasting
+let col_vector = row.reshape(const_shape![BM, 1]);
+```
+
+### Get Shape
+
+```rust
+let shape = tensor.shape();
+let dim_0 = get_shape_dim(tensor.shape(), 0i32);
+```
+
+---
+
+## Comparison Operations
+
+```rust
+// Element-wise comparisons return bool tiles
+let mask = gt_tile(a, b);    // a > b
+let mask = ge_tile(a, b);    // a >= b
+let mask = lt_tile(a, b);    // a < b
+let mask = le_tile(a, b);    // a <= b
+let mask = eq_tile(a, b);    // a == b
+```
+
+### Select (Conditional)
+
+```rust
+// Select elements based on mask
+let result = select(mask, if_true, if_false);
+```
+
+---
+
+## Control Flow Operations
+
+### Tile-Level Max/Min
+
+```rust
+// Element-wise max/min of two tiles
+let result = max_tile(a, b);
+let result = min_tile(a, b);
+```
+
+---
+
+## Constants
+
+```rust
+// Create constant tile
+let zeros = constant(0.0f32, const_shape![64, 64]);
+let ones = constant(1.0f32, const_shape![64, 64]);
+let neg_inf = constant(f32::NEG_INFINITY, const_shape![BM, 1]);
+```
+
+### Iota (Index Generation)
+
+```rust
+// Create [0, 1, 2, 3, ...] tile
+let indices: Tile<i32, {[64]}> = iota(const_shape![64]);
+```
+
+---
+
+## Utility Operations
+
+### Print (Debugging)
+
+```rust
+cuda_tile_print!("Value at tile ({}, {}): {}\n", 
+    pid.0, pid.1, some_value);
+```
+
+:::{warning}
+GPU printing is slow and should only be used for debugging small grids.
+:::
+
+### Type Conversion
+
+```rust
+let float_tile: Tile<f32, S> = convert_tile(int_tile);
+let half_tile: Tile<f16, S> = convert_tile(float_tile);
+```
+
+---
+
+## Common Operation Patterns
+
+### Element-wise with Broadcast
+
+```rust
+fn scale_and_shift<const S: [i32; 2]>(
+    x: Tile<f32, S>, scale: f32, shift: f32
+) -> Tile<f32, S> {
+    let s = scale.broadcast(x.shape());
+    let b = shift.broadcast(x.shape());
+    x * s + b
+}
+```
+
+### Numerically Stable Softmax
+
+```rust
+fn softmax<const BM: i32, const BN: i32>(
+    x: Tile<f32, { [BM, BN] }>
+) -> Tile<f32, { [BM, BN] }> {
+    // Subtract max for numerical stability
+    let max: Tile<f32, { [BM, BN] }> = reduce_max(x, 1i32)
+        .reshape(const_shape![BM, 1])
+        .broadcast(const_shape![BM, BN]);
+    let stable = x - max;
+
+    // Compute softmax
+    let exp_x = exp(stable);
+    let sum: Tile<f32, { [BM, BN] }> = reduce_sum(exp_x, 1)
+        .reshape(const_shape![BM, 1])
+        .broadcast(const_shape![BM, BN]);
+
+    true_div(exp_x, sum)
+}
+```
+
+### Tiled Matrix Multiply
+
+```rust
+fn tiled_gemm<E: ElementType, const BM: i32, const BN: i32, const BK: i32, const K: i32>(
+    z: &mut Tensor<E, { [BM, BN] }>,
+    x: &Tensor<E, { [-1, K] }>,
+    y: &Tensor<E, { [K, -1] }>,
+) {
+    let part_x = x.partition(const_shape![BM, BK]);
+    let part_y = y.partition(const_shape![BK, BN]);
+    let pid: (i32, i32, i32) = get_tile_block_id();
+
+    let mut acc = constant(0.0f32, const_shape![BM, BN]);
+    for i in 0i32..(K / BK) {
+        let tile_x = part_x.load([pid.0, i]);
+        let tile_y = part_y.load([i, pid.1]);
+        acc = mma(tile_x, tile_y, acc);
+    }
+
+    z.store(acc);
+}
+```
+
+---
+
+## Summary
+
+| Category | Key Operations |
+|----------|---------------|
+| **Load/Store** | `load_tile_mut`, `load_tile_like_2d`, `partition().load()`, `store` |
+| **Arithmetic** | `+`, `-`, `*`, `/`, `fma`, `true_div` |
+| **Math** | `exp`, `exp2`, `log`, `log2`, `sqrt`, `rsqrt`, `sin`, `cos`, `tanh` |
+| **Reduction** | `reduce_max`, `reduce_sum`, `reduce_min`, `reduce_prod` |
+| **Matrix** | `mma`, `permute` |
+| **Shape** | `reshape`, `broadcast`, `const_shape!` |
+| **Compare** | `gt_tile`, `ge_tile`, `lt_tile`, `le_tile`, `eq_tile`, `select` |
+| **Element-wise** | `max_tile`, `min_tile`, `absf`, `negf`, `floor`, `ceil` |
+| **Constants** | `constant`, `iota`, `convert_tile` |
+
+---
+
+Continue to [How Kernels Run on the GPU](execution-model.md) to see how these operations map onto the hardware. For the full catalog of operations with signatures, see the [DSL API Reference](../reference/dsl-api.md).

--- a/cutile-book/index.md
+++ b/cutile-book/index.md
@@ -91,14 +91,12 @@ tutorials/10-cuda-graphs
 :caption: User Guide
 
 guide/introduction
-guide/tile-programming-model
-guide/data-model
-guide/execution-model
+guide/thinking-in-tiles
 guide/memory-hierarchy
-guide/operations
-guide/dsl-api
-guide/async-execution
-guide/deviceop-reference
+guide/working-with-data
+guide/writing-computations
+guide/execution-model
+guide/device-operations
 guide/performance-tuning
 guide/interoperability
 guide/debugging
@@ -106,9 +104,10 @@ guide/debugging
 
 ```{toctree}
 :hidden:
-:maxdepth: 1
-:caption: Appendix
+:maxdepth: 2
+:caption: Reference
 
-appendix/definitions
-appendix/syntax-reference
+reference/dsl-api
+reference/deviceop-reference
+reference/glossary
 ```

--- a/cutile-book/reference/deviceop-reference.md
+++ b/cutile-book/reference/deviceop-reference.md
@@ -1,0 +1,420 @@
+# DeviceOp API Reference
+
+Quick-reference for the `DeviceOp` trait and its combinators. For a
+tutorial-style introduction, see [Orchestrating Device Operations](../guide/device-operations.md).
+
+---
+
+## The Futures Analogy
+
+`DeviceOp` is to GPU work what `Future` is to async I/O. Both are lazy
+descriptions of work that don't execute until driven:
+
+| Concept | `std::future::Future` | `DeviceOp` |
+|---|---|---|
+| What it represents | Async computation | GPU computation |
+| When it runs | On `.await` or `poll()` | On `.sync()`, `.sync_on()`, or `.await` |
+| Chaining | `.then()`, `.map()` via `FutureExt` | `.then()`, `.map()` on `DeviceOp` |
+| Fan-in | `join!` | `zip!` |
+| Fan-out | N/A (single consumer) | `.unzip()` |
+| Shared access | `FutureExt::shared()` | `.shared()` |
+| Type erasure | `BoxFuture` | `.boxed()` → `BoxedDeviceOp` |
+| Output wrapper | `Poll<T>` | `Result<T, DeviceError>` |
+
+The key difference: a `Future` is pulled by an async runtime via `poll()`,
+while a `DeviceOp` is pushed to the GPU via `execute()`. When you convert
+a `DeviceOp` to a `Future` (via `.await` or `.into_future()`), cuTile bridges
+the two models — the runtime polls a `DeviceFuture` that checks whether the
+GPU has finished.
+
+---
+
+## Combinator Reference
+
+All combinators follow established Rust conventions. The "Precedent" column
+shows which standard library or `futures` crate method inspired the design.
+
+### Composition
+
+| Combinator | Signature | Precedent | What it does |
+|---|---|---|---|
+| `zip!(a, b, …)` | `(impl DeviceOp, …) → impl DeviceOp<Output=(A, B, …)>` | `Iterator::zip` | Combine N operations into a single tuple-producing operation |
+| `.unzip()` | `impl DeviceOp<Output=(A, B, …)> → (impl DeviceOp<Output=A>, …)` | `Iterator::unzip` | Split a tuple operation into independent per-element operations |
+| `.then(f)` | `self → f(Self::Output) → impl DeviceOp<Output=O>` | `FutureExt::then` | Chain follow-up GPU work **on the same stream** |
+| `.map(f)` | `self → f(Self::Output) → O` (no GPU work) | `FutureExt::map` | Transform output without issuing GPU work |
+| `.inspect(f)` | `self → f(&Self::Output)` (passthrough) | `FutureExt::inspect` | Peek at output for debugging; returns it unchanged |
+
+### Selection
+
+| Combinator | Signature | Precedent | What it does |
+|---|---|---|---|
+| `.first()` | `impl DeviceOp<Output=(A, B, …)> → impl DeviceOp<Output=A>` | `slice::first` | Extract the first element of a tuple output |
+| `.last()` | `impl DeviceOp<Output=(A, B, …)> → impl DeviceOp<Output=Z>` | `slice::last` | Extract the last element of a tuple output |
+
+### Sharing and Erasure
+
+| Combinator | Signature | Precedent | What it does |
+|---|---|---|---|
+| `.shared()` | `self → SharedDeviceOp<Self::Output>` | `FutureExt::shared` | Cloneable, execute-once; output is `Arc<T>` |
+| `shared(arc)` | `Arc<T> → SharedDeviceOp<T>` | — | Wrap an existing `Arc` as a pre-computed `SharedDeviceOp` |
+| `.boxed()` | `self → BoxedDeviceOp<Self::Output>` | `FutureExt::boxed` | Type-erase for heterogeneous collections |
+
+### Execution
+
+| Method | Stream chosen by | Blocks? | Use case |
+|---|---|---|---|
+| `.sync()` | Default policy (round-robin) | Yes | Quick scripts |
+| `.sync_on(&stream)` | The explicit stream | Yes | Deterministic ordering, debugging |
+| `.await` | Default policy (round-robin) | No (suspends task) | Async production code |
+| `.into_future()` | Default policy | No (returns `DeviceFuture`) | Manual future handling |
+| `.schedule(policy)` | The policy you provide | No (returns `DeviceFuture`) | Multi-device dispatch |
+| `.graph()` | Default policy (round-robin) | Yes (captures + syncs) | CUDA graph capture |
+| `.graph_on(stream)` | The explicit stream | Yes (captures + syncs) | CUDA graph capture on specific stream |
+
+:::{note}
+If any kernel input is `&Tensor<T>` (borrowed), the operation is not
+`'static` and cannot be used with `tokio::spawn`. Use `.sync_on()` or
+`.await` in the same scope, or switch to `Arc<Tensor<T>>` for spawned tasks.
+:::
+
+---
+
+## Supported Kernel Parameter Types
+
+| Kernel param | Host type | Return type |
+|---|---|---|
+| `&Tensor<T, S>` | `Tensor<T>`, `Arc<Tensor<T>>`, or `&Tensor<T>` | Same as input |
+| `&mut Tensor<T, S>` | `Partition<Tensor<T>>` or `Partition<&mut Tensor<T>>` | Same as input |
+| Scalar (`f32`, `i32`, etc.) | Same scalar | Same scalar |
+| `*mut T` (unsafe only) | `DevicePointer<T>` | `DevicePointer<T>` |
+
+The borrowed partition form (`Partition<&mut Tensor<T>>`) writes in place — no
+`unpartition()` needed. Create it with `(&mut tensor).partition(shape)`.
+
+---
+
+## Ownership Model
+
+The core invariant: **you get back what you put in**.
+
+### Read-only inputs (`&Tensor` params)
+
+| Input | Returned | `tokio::spawn`? |
+|---|---|---|
+| `Tensor<T>` | `Tensor<T>` | Yes |
+| `Arc<Tensor<T>>` | `Arc<Tensor<T>>` | Yes |
+| `&'a Tensor<T>` | `&'a Tensor<T>` | No (not `'static`) |
+
+### Mutable outputs (`&mut Tensor` params)
+
+| Input | Returned | `unpartition()` needed? |
+|---|---|---|
+| `Partition<Tensor<T>>` (owned) | `Partition<Tensor<T>>` | Yes |
+| `Partition<&'a mut Tensor<T>>` (borrowed) | `Partition<&'a mut Tensor<T>>` | No — tensor is written in place |
+
+The borrowed form is created with `(&mut tensor).partition(shape)`:
+
+### Owned: `Tensor<T>`
+
+Pass a tensor directly — the launcher wraps it in `Arc` internally for the
+kernel, then unwraps it back afterward (safe because refcount is 1):
+
+```rust
+let output = my_kernel(
+    api::zeros(&[1024]).partition([128]),
+    api::ones::<f32>(&[1024]),  // DeviceOp<Output=Tensor<f32>>
+)
+.first()
+.unpartition()
+.sync_on(&stream)?;
+```
+
+Use this for single-use tensors where you don't need shared access.
+
+### Shared: `Arc<Tensor<T>>`
+
+Wrap in `Arc` when the same tensor is passed to multiple kernels:
+
+```rust
+let x: Arc<Tensor<f32>> = api::ones(&[1024]).sync_on(&stream)?.into();
+
+let a = kernel_a(out_a, x.clone()).sync_on(&stream)?;
+let b = kernel_b(out_b, x.clone()).sync_on(&stream)?;
+```
+
+This is the most common pattern in existing code.
+
+### Borrowed: `&Tensor<T>`
+
+Pass a reference when you want to retain ownership and avoid `Arc` overhead.
+The borrow checker ensures the tensor outlives the kernel:
+
+```rust
+let weights: Tensor<f32> = api::ones(&[1024]).sync_on(&stream)?;
+
+// Borrow — no Arc allocation, no refcount.
+let result = my_kernel(out_partition, &weights).sync_on(&stream)?;
+
+// weights is still available here.
+```
+
+**Key safety property**: because `&Tensor<T>` is not `'static`,
+`tokio::spawn` rejects operations that borrow tensors:
+
+```rust
+let op = my_kernel(out, &weights);  // borrows weights
+tokio::spawn(op);                    // ← compile error: not 'static
+```
+
+This is enforced at compile time by Rust's lifetime system — no runtime
+checks needed.
+
+### `.shared()`: Clone + Execute-Once
+
+`.shared()` converts a `DeviceOp` into a `SharedDeviceOp<T>` that is
+`Clone`. The underlying operation runs **at most once**; every clone
+receives `Arc::clone()` of the cached result:
+
+```rust
+let x = api::ones::<f32>(&[32, 32]).shared();
+
+let a = kernel_a(x.clone()).sync()?;  // x executes here (first clone to run)
+let b = kernel_b(x.clone()).sync()?;  // uses cached Arc<Tensor<f32>>
+```
+
+Output type changes: `DeviceOp<Output=T>` becomes
+`SharedDeviceOp` with `Output=Arc<T>`.
+
+For pre-computed values (e.g., weight tensors), use the
+`shared()` free function to wrap an `Arc<T>` directly:
+
+```rust
+use cuda_async::device_operation::shared;
+
+let w: Arc<Tensor<f32>> = /* loaded weights */;
+let w_op: SharedDeviceOp<Tensor<f32>> = shared(w);
+```
+
+### `.unwrap_arc()`
+
+`.shared()` and `unzip` produce `Arc<T>` outputs. When you need owned `T`
+back (e.g., to partition a tensor), use `.unwrap_arc()`:
+
+```rust
+let x: Arc<Tensor<f32>> = api::ones(&[1024]).shared().sync()?;
+
+let owned: Tensor<f32> = value(x).unwrap_arc().sync()?;
+let partitioned = owned.partition([128]);
+```
+
+Panics if the Arc has multiple owners.
+
+### IntoDeviceOp: Automatic Wrapping
+
+The `IntoDeviceOp` trait lets kernel launchers accept both `DeviceOp`s and
+plain values:
+
+| Type | Wraps as |
+|---|---|
+| Any `impl DeviceOp<Output=T>` | Pass-through |
+| `Tensor<T>` | `Value<Tensor<T>>` |
+| `Arc<T>` | `Value<Arc<T>>` |
+| `&'a Tensor<T>` | `Value<&'a Tensor<T>>` |
+| `&Arc<T>` | `Value<Arc<T>>` (clones the Arc) |
+| `f32`, `f64`, `i32`, `i64`, `u32`, `u64`, `usize` | `Value<T>` |
+| `Partition<Tensor<T>>` | `Value<Partition<Tensor<T>>>` |
+
+```rust
+// All of these work as inputs to a &Tensor kernel param:
+my_kernel(out, tensor);              // Tensor<T>
+my_kernel(out, arc_tensor);          // Arc<Tensor<T>>
+my_kernel(out, &tensor);             // &Tensor<T>
+my_kernel(out, api::ones(&[1024]));  // DeviceOp<Output=Tensor<T>>
+```
+
+---
+
+## Scheduling Model
+
+### How Streams Are Chosen
+
+When you call `.sync()` or `.await`, the operation asks the **default
+device's scheduling policy** for a stream. The default policy is
+`StreamPoolRoundRobin` with 4 streams:
+
+```text
+op_a.sync()  →  Stream 0
+op_b.sync()  →  Stream 1
+op_c.sync()  →  Stream 2
+op_d.sync()  →  Stream 3
+op_e.sync()  →  Stream 0  (wraps around)
+```
+
+Consecutive independent operations land on different streams, enabling GPU
+overlap. Operations chained with `.then()` share the parent's stream,
+preserving data-dependency ordering.
+
+### Explicit Stream: `.sync_on()`
+
+Bypasses the policy entirely. All operations given the same stream execute
+in call order:
+
+```rust
+let stream = ctx.new_stream()?;
+let a = op_a.sync_on(&stream)?;  // Stream X
+let b = op_b.sync_on(&stream)?;  // Stream X — guaranteed after op_a
+```
+
+### Available Policies
+
+| Policy | Behavior |
+|---|---|
+| `StreamPoolRoundRobin` (default) | Rotates through N streams (default 4) |
+| `SingleStream` | All operations on one stream — strict ordering |
+| Custom `impl SchedulingPolicy` | Implement `fn next_stream()` for your own strategy |
+
+### `.then()` Guarantees
+
+`.then()` is the recommended way to express data dependencies. Both
+operations share a single stream, so the second is guaranteed to see the
+first's output fully written — no manual synchronization needed:
+
+```rust
+let result = allocate_buffer()
+    .then(|buf| fill_kernel(buf))      // same stream
+    .then(|buf| process_kernel(buf))   // same stream
+    .sync()?;
+```
+
+**Non-reentrancy:** On any given thread, only one DeviceOp may be
+executing at a time. Calling `sync_on`, `sync`, or `.await` inside a
+`then` closure will return a runtime error. This prevents CUDA data
+races from cross-stream access to in-flight tensors. If you need
+nested execution and have verified there are no cross-stream data
+races, use `unsafe then_unchecked`.
+
+---
+
+## Error Propagation
+
+All execution methods return `Result<T, DeviceError>`. Errors propagate
+through combinators: if any operation in a `.then()` chain fails, the
+error short-circuits to the caller.
+
+### DeviceError Variants
+
+| Variant | When it occurs |
+|---|---|
+| `Driver(DriverError)` | CUDA driver call failed (OOM, invalid argument, etc.) |
+| `Context { device_id, message }` | Device context assertion failed |
+| `KernelCache(String)` | Kernel compilation or cache lookup failed |
+| `Scheduling(String)` | No stream available or policy misconfigured |
+| `Launch(String)` | Kernel launch precondition violated |
+| `Internal(String)` | Bug in cuda-async internals |
+| `Anyhow(String)` | Converted from `anyhow::Error` |
+
+### Error Handling Patterns
+
+```rust
+// Pattern 1: Propagate with ?
+let x = api::zeros(&[1024]).sync_on(&stream)?;
+
+// Pattern 2: Match specific errors
+match my_kernel(args).sync_on(&stream) {
+    Ok(result) => { /* use result */ }
+    Err(DeviceError::Launch(msg)) => {
+        eprintln!("kernel launch failed: {msg}");
+    }
+    Err(e) => return Err(e.into()),
+}
+```
+
+### cutile::error::Error vs DeviceError
+
+`cutile::error::Error` is the top-level error type that wraps
+`DeviceError` alongside other error categories (I/O, shape mismatches,
+etc.). Functions that only do GPU work return `DeviceError`; functions
+that mix host and device work (like the examples) return
+`cutile::error::Error`.
+
+---
+
+## CUDA Graph Integration
+
+### Combinator approach: `.graph_on(stream)`
+
+Any `DeviceOp` can be captured into a replayable CUDA graph:
+
+```rust
+let forward_op = build_forward(&cfg, &weights, input, buffers);
+let mut graph = forward_op.graph_on(stream.clone())?;
+let output = graph.take_output().unwrap();
+
+// Replay loop — no graph rebuilding, no kernel re-compilation.
+for token in tokens {
+    graph.update(api::memcpy(&mut input_buf, &token))?;
+    graph.launch().sync_on(&stream)?;
+}
+```
+
+This requires `Arc<Tensor<T>>` + `try_partition` for shared buffers.
+
+### Scope approach: `CudaGraph::scope`
+
+`CudaGraph::scope` provides an imperative alternative using `&mut` borrows
+instead of `Arc`. Each `s.record(op)` records a graph node and releases
+borrows immediately. A buffer written by one `record` call can be read
+by the next:
+
+```rust
+let mut output = api::zeros::<f32>(&[d]).sync_on(&stream)?;
+let weights = api::ones::<f32>(&[d]).sync_on(&stream)?;
+
+let graph = CudaGraph::scope(&stream, |s| {
+    s.record(kernel1((&mut output).partition([128]), &weights))?;
+    s.record(kernel2((&mut output).partition([64]), &weights))?;
+    Ok(())
+})?;
+
+graph.launch().sync_on(&stream)?;
+```
+
+`record` only accepts operations that implement `GraphNode` — kernel
+launches and `memcpy`. Allocation ops (`zeros`, `ones`, `dup`) are
+rejected at compile time because their addresses may change on replay.
+
+### `GraphNode` trait
+
+`GraphNode` is a marker trait for operations safe to record in a CUDA
+graph. Only operations that do not allocate or free device memory
+implement it:
+
+| Implements `GraphNode` | Why safe |
+|---|---|
+| Macro-generated kernel launchers | Kernel launch only — no alloc/free |
+| `Memcpy` (`api::memcpy`) | Copy between pre-allocated buffers |
+| `Value<T>` (`value(x)`) | No GPU work |
+
+### CudaGraph methods
+
+| Method | What it does |
+|---|---|
+| `.graph()` / `.graph_on(stream)` | Capture a `DeviceOp` into a `CudaGraph<T>` |
+| `CudaGraph::scope(&stream, \|s\| { … })` | Scoped capture with `&mut` borrows |
+| `s.record(op: impl GraphNode)` | Record a graph node inside a scope |
+| `graph.take_output()` | Retrieve the output from the capture execution |
+| `graph.update(op)` | Run a `DeviceOp` on the graph's stream (e.g., copy new input) |
+| `graph.launch()` | Returns a `DeviceOp` that replays the captured graph |
+
+All device pointers are baked in at capture time. To vary inputs, pre-allocate
+a buffer, pass it into the operation, and `memcpy` new data before each
+launch. See [Tutorial 10: CUDA Graphs](../tutorials/10-cuda-graphs.md) for a
+complete walkthrough.
+
+---
+
+## See Also
+
+- [Orchestrating Device Operations](../guide/device-operations.md) — tutorial-style guide to streams, scheduling, and composition patterns
+- [Tutorial 10: CUDA Graphs](../tutorials/10-cuda-graphs.md) — end-to-end CUDA graph example
+- [Integrating with CUDA C++](../guide/interoperability.md) — integrating custom CUDA C++ kernels into the DeviceOp model

--- a/cutile-book/reference/dsl-api.md
+++ b/cutile-book/reference/dsl-api.md
@@ -1,0 +1,718 @@
+# DSL API Reference
+
+> **Status**: This API is under active development. Expect changes.
+
+The cuTile Rust DSL lets you write GPU kernel code in Rust syntax that compiles to [CUDA Tile IR](https://docs.nvidia.com/cuda/tile-ir/latest/). Inside a `#[cutile::module]` block, you write Rust-like code using the types and operations documented here. The compiler translates this code into MLIR, which is then compiled to PTX/SASS for execution on NVIDIA GPUs.
+
+All DSL types and functions are available via `use cutile::core::*;` inside a module block.
+
+---
+
+## Functions
+
+### Modules and Entry Points
+
+GPU kernels are defined inside `#[cutile::module]` blocks. Each function marked with `#[cutile::entry()]` becomes a launchable kernel.
+
+```rust
+#[cutile::module]
+mod my_kernels {
+    use cutile::core::*;
+
+    #[cutile::entry()]
+    fn add<const S: [i32; 1]>(
+        output: &mut Tensor<f32, S>,       // mutable: partitioned output
+        a: &Tensor<f32, { [-1] }>,         // immutable: read-only input
+        b: &Tensor<f32, { [-1] }>,         // immutable: read-only input
+    ) {
+        let pid: (i32, i32, i32) = get_tile_block_id();
+        let tile_a: Tile<f32, S> = a.load_tile(const_shape!(S), [pid.0]);
+        let tile_b: Tile<f32, S> = b.load_tile(const_shape!(S), [pid.0]);
+        output.store(tile_a + tile_b);
+    }
+}
+```
+
+**Entry point parameters:**
+
+| Parameter type | Description | Host-side type |
+|---|---|---|
+| `&mut Tensor<E, S>` | Mutable output (must be first) | `Partition<Tensor<E>>` or `Partition<&mut Tensor<E>>` |
+| `&Tensor<E, S>` | Immutable input | `&Tensor<E>`, `Arc<Tensor<E>>`, `Tensor<E>`, or `&TensorView<E>` |
+| `f32`, `i32`, etc. | Scalar value | Same type, passed by value |
+| `*mut T`, `*const T` | Raw device pointer | `DevicePointer<T>` |
+
+**Convention:** The mutable output tensor is always the first parameter.
+
+**Entry attributes:**
+
+| Attribute | Type | Description |
+|---|---|---|
+| `print_ir = true` | bool | Print three stages at JIT compile time: (1) the generated entry point wrapper (Rust), (2) the original kernel function, (3) the compiled Tile IR MLIR |
+| `unchecked_accesses` | bool | Disable partition bounds checks. Requires `unsafe fn`. Removes runtime assertions on partition index ranges |
+| `optimization_hints = expr` | expr | Pass an `OptimizationHints` expression to the compiler for target-specific optimization |
+| `dump_mlir_dir = "path"` | string | Write the compiled MLIR to a file in the specified directory |
+
+```rust
+#[cutile::entry(print_ir = true)]
+fn debug_kernel<const S: [i32; 1]>(output: &mut Tensor<f32, S>) { ... }
+
+#[cutile::entry(unchecked_accesses)]
+unsafe fn fast_kernel<const S: [i32; 1]>(output: &mut Tensor<f32, S>) { ... }
+
+#[cutile::entry(dump_mlir_dir = "/tmp/mlir")]
+fn traced_kernel<const S: [i32; 1]>(output: &mut Tensor<f32, S>) { ... }
+```
+
+**Module attributes:**
+
+| Attribute | Type | Description |
+|---|---|---|
+| `core` | bool | Internal: marks the core module (`_core.rs`) that provides built-in DSL functions |
+| `tile_rust_crate = true` | bool | Internal: used when defining kernels inside the cutile crate itself (changes import paths from `cutile::` to `crate::`) |
+
+```rust
+#[cutile::module]                          // standard user module
+mod my_kernels { ... }
+
+#[crate::module(tile_rust_crate = true)]   // internal to cutile crate
+pub mod creation { ... }
+```
+
+### Entry Points vs Device Functions
+
+Functions marked with `#[cutile::entry()]` are compiled as GPU kernel entry points — they can be launched from the host with a grid configuration.
+
+Unmarked functions inside a module are **device functions** — they are inlined at the call site during compilation. They cannot be launched directly but can be called from entry points or other device functions.
+
+```rust
+#[cutile::module]
+mod my_kernels {
+    use cutile::core::*;
+
+    // Device function: inlined into callers
+    fn relu<const S: [i32; 1]>(x: Tile<f32, S>) -> Tile<f32, S> {
+        let zero: Tile<f32, S> = constant(0.0f32, x.shape());
+        select(gt_tile(x, zero), x, zero)
+    }
+
+    #[cutile::entry()]
+    fn apply_relu<const S: [i32; 1]>(
+        output: &mut Tensor<f32, S>,
+        input: &Tensor<f32, { [-1] }>,
+    ) {
+        let pid: (i32, i32, i32) = get_tile_block_id();
+        let tile: Tile<f32, S> = input.load_tile(const_shape!(S), [pid.0]);
+        output.store(relu(tile));  // device function call, inlined
+    }
+}
+```
+
+### Inter-Module Device Function Calls
+
+Device functions defined in one `#[cutile::module]` can be called from
+entry points in another module. When Module B does `use crate::activations::*`,
+two things happen:
+
+1. **Rust's type checker** resolves the function signatures at compile time.
+2. **The macro** records Module A as a dependency of Module B, including
+   Module A's AST in the collected module list for JIT compilation.
+
+At JIT time, the compiler sees all dependent module ASTs and inlines
+device functions from any of them into the entry point.
+
+Each module is identified by its fully-qualified path (via `module_path!()`),
+so shared dependencies like `cutile::core` are automatically deduplicated
+even when imported by multiple modules.
+
+```rust
+/// Module A: reusable activation device functions (no entry points).
+#[cutile::module]
+mod activations {
+    use cutile::core::*;
+
+    pub fn relu<const S: [i32; 1]>(x: Tile<f32, S>) -> Tile<f32, S> {
+        let zero: Tile<f32, S> = constant(0.0f32, x.shape());
+        max_tile(x, zero)
+    }
+
+    pub fn square<const S: [i32; 1]>(x: Tile<f32, S>) -> Tile<f32, S> {
+        x * x
+    }
+}
+
+/// Module B: kernels that call device functions from Module A.
+#[cutile::module]
+mod my_kernels {
+    use cutile::core::*;
+    use crate::activations::{relu, square};  // import from Module A
+
+    #[cutile::entry()]
+    fn apply_relu_square<const S: [i32; 1]>(
+        output: &mut Tensor<f32, S>,
+        input: &Tensor<f32, { [-1] }>,
+    ) {
+        let pid: (i32, i32, i32) = get_tile_block_id();
+        let tile: Tile<f32, S> = input.load_tile(const_shape!(S), [pid.0]);
+        let activated: Tile<f32, S> = relu(tile);   // inlined from Module A
+        output.store(square(activated));             // inlined from Module A
+    }
+}
+```
+
+See `cutile-examples/examples/inter_module.rs` for a runnable version.
+
+### How `cutile::core` Works
+
+`cutile::core` (defined in `_core.rs`) is itself a `#[cutile::module]`
+containing the built-in DSL operations. When you write `use cutile::core::*;`,
+the macro records it as a dependency and includes its AST. The JIT compiler
+then resolves calls to `constant`, `iota`, `mma`, `reduce_sum`, etc. from
+core's AST and inlines them into your entry point — exactly the same
+mechanism as user-defined inter-module calls.
+
+---
+
+## Types
+
+### Tile
+
+`Tile<E: ElementType, const S: [i32; N]>` — A multi-dimensional array of GPU values. This is the fundamental compute type. Tiles are register-resident and processed in parallel by all threads in a warp/block.
+
+```rust
+// Shapes are const generics
+let a: Tile<f32, { [128] }>;          // 1D: 128 f32 elements
+let b: Tile<f32, { [16, 16] }>;       // 2D: 16x16 matrix
+let c: Tile<i32, { [4, 8, 2] }>;      // 3D
+
+// Scalar tile (rank 0)
+let s: Tile<f32, { [] }>;
+```
+
+**Methods:**
+- `tile.shape()` — Returns the tile's `Shape<S>`
+- `tile.broadcast(shape)` — Broadcast to a larger shape
+- `tile.reshape(shape)` — Reshape (must preserve element count)
+
+**Arithmetic operators:** `+`, `-`, `*`, `/` are overloaded for element-wise operations between tiles of the same shape and type.
+
+```rust
+let z: Tile<f32, { [128] }> = a + b;     // element-wise add
+let w: Tile<f32, { [128] }> = a * b - c; // chained arithmetic
+```
+
+### Tensor
+
+`Tensor<E: ElementType, const S: [i32; N]>` — A device-side tensor view. Represents memory that lives in GPU global memory. Unlike `Tile`, tensors must be loaded/stored explicitly.
+
+Static dimensions are known at compile time; dynamic dimensions are marked with `-1`:
+
+```rust
+fn kernel(
+    output: &mut Tensor<f32, { [128, 128] }>,  // static: 128x128
+    input: &Tensor<f32, { [-1, -1] }>,          // dynamic: shape provided at runtime
+)
+```
+
+**Methods:**
+- `tensor.shape()` — Returns the tensor's `Shape<S>`
+- `tensor.load()` — Load the entire tile (only for `&mut Tensor`, loads output tile)
+- `tensor.store(tile)` — Store a tile to the tensor
+- `tensor.load_tile(shape, [indices])` — Load a tile at a specific partition index
+- `tensor.partition(shape)` — Create a `Partition` view for block-indexed loading
+
+### Partition / PartitionMut
+
+`Partition<'a, E, const D: [i32; N]>` — A read-only partitioned view of a tensor, dividing it into tiles indexed by block ID.
+
+`PartitionMut<'a, E, const D: [i32; N]>` — A mutable partitioned view.
+
+```rust
+let part: Partition<f32, { [128, 128] }> = input.partition(const_shape![128, 128]);
+let tile: Tile<f32, { [128, 128] }> = part.load([pid.0, pid.1]);
+```
+
+### Shape / Array
+
+`Shape<const D: [i32; N]>` — A compile-time shape descriptor. Created with `const_shape!`:
+
+```rust
+let shape: Shape<{ [128, 64] }> = const_shape![128, 64];
+let shape: Shape<S> = tensor.shape();
+```
+
+`Array<const D: [i32; N]>` — A compile-time array (used for strides and indices).
+
+#### Const Generic Array (CGA) Syntax
+
+Shapes in the DSL use Rust's const generic arrays (`const S: [i32; N]`). There are two ways to specify them:
+
+**1. Explicit values** — when dimensions are known literals:
+
+```rust
+fn kernel(
+    output: &mut Tensor<f32, { [128, 64] }>,   // fixed 128x64
+    input: &Tensor<f32, { [-1, -1] }>,          // dynamic (runtime) shape
+)
+```
+
+**2. Const generic parameters** — when dimensions are specified at launch time:
+
+```rust
+fn gemm<const BM: i32, const BN: i32, const BK: i32>(
+    output: &mut Tensor<f32, { [BM, BN] }>,    // shape from generics
+    a: &Tensor<f32, { [-1, -1] }>,
+)
+```
+
+**3. Const generic array (CGA)** — when the entire shape is a single generic parameter:
+
+```rust
+fn add<const S: [i32; 1]>(                      // S is the whole shape
+    output: &mut Tensor<f32, S>,
+    input: &Tensor<f32, { [-1] }>,
+)
+```
+
+The CGA form (`const S: [i32; N]`) is concise but has a limitation: **the array length `N` must be fixed at definition time**. You cannot write `const S: [i32; N]` where `N` is itself generic — the rank must be a literal. This means you cannot write a single kernel that works for both 1D and 2D tensors:
+
+```rust
+// NOT supported: generic rank
+fn add<const N: usize, const S: [i32; N]>(output: &mut Tensor<f32, S>) { ... }
+
+// Instead, write separate kernels per rank:
+fn add_1d<const S: [i32; 1]>(output: &mut Tensor<f32, S>) { ... }
+fn add_2d<const S: [i32; 2]>(output: &mut Tensor<f32, S>) { ... }
+```
+
+**When to use which:**
+
+| Pattern | Use when |
+|---|---|
+| `{ [128, 64] }` | Dimensions are fixed literals |
+| `{ [BM, BN] }` | Each dimension is an independent generic (e.g., GEMM tile sizes) |
+| `const S: [i32; 1]` | The whole shape is generic but rank is known |
+| `{ [-1] }` | Dimension is dynamic (provided at runtime by the host) |
+
+Dynamic dimensions (`-1`) are resolved at runtime from the tensor's actual shape. Static dimensions are baked into the compiled kernel. Mixing is allowed: `{ [-1, 128] }` means "dynamic first axis, static second axis."
+
+### PointerTile
+
+`PointerTile<P: Pointer, const D: [i32; N]>` — A tile of device pointers. Used for scatter/gather and atomic operations.
+
+```rust
+let ptr: PointerTile<*mut f32, { [] }> = pointer_to_tile(raw_ptr);
+let offset_ptrs: PointerTile<*mut f32, { [128] }> = ptr.broadcast(const_shape![128]).offset_tile(offsets);
+```
+
+### Token
+
+`Token` — An ordering token for memory operations. Tokens enforce ordering between loads and stores without requiring full barriers.
+
+```rust
+let token: Token = new_token_unordered();
+let joined: Token = join_tokens(&[token_a, token_b]);
+```
+
+### ElementType
+
+Trait implemented by all scalar types usable in tiles:
+
+| Type | Description |
+|------|-------------|
+| `f16` | IEEE 754 half-precision |
+| `bf16` | Brain floating-point |
+| `f32` | Single-precision |
+| `f64` | Double-precision |
+| `i8`, `i16`, `i32`, `i64` | Signed integers |
+| `u8`, `u16`, `u32`, `u64` | Unsigned integers |
+| `bool` | Boolean |
+| `tf32` | TensorFloat-32 (NVIDIA) |
+| `f8e4m3fn`, `f8e5m2` | FP8 (storage only; convert to `f16`/`f32` for compute) |
+
+
+---
+
+## Operations
+
+### Memory: Load and Store
+
+| Function | Signature | Description |
+|---|---|---|
+| `tensor.load()` | `&mut Tensor<E, S> -> Tile<E, S>` | Load the output tile |
+| `tensor.store(tile)` | `(&mut Tensor<E, S>, Tile<E, S>)` | Store a tile to the tensor |
+| `tensor.load_tile(shape, idx)` | `(&Tensor<E, S>, Shape<R>, [i32; N]) -> Tile<E, R>` | Load at a partition index |
+| `load_tile_mut(tensor)` | `(&mut Tensor<E, S>) -> Tile<E, S>` | Load output tile (convenience) |
+| `load_tile_like_1d(src, dst)` | `(&Tensor, &mut Tensor) -> Tile` | Load from src at dst's position (1D) |
+| `load_tile_like_2d(src, dst)` | `(&Tensor, &mut Tensor) -> Tile` | Load from src at dst's position (2D) |
+
+```rust
+// Pattern 1: Direct load/store on mutable tensor
+let tile: Tile<f32, { [128] }> = load_tile_mut(output);
+output.store(tile * scale_tile);
+
+// Pattern 2: Load at block position
+let pid: (i32, i32, i32) = get_tile_block_id();
+let tile: Tile<f32, { [128] }> = input.load_tile(const_shape![128], [pid.0]);
+
+// Pattern 3: Load-like (positional)
+let tile_x: Tile<f32, { [16, 16] }> = load_tile_like_2d(x, output);
+```
+
+### Grid and Block
+
+| Function | Signature | Description |
+|---|---|---|
+| `get_tile_block_id()` | `() -> (i32, i32, i32)` | Current thread block's (x, y, z) index in the grid |
+| `get_num_tile_blocks()` | `() -> (i32, i32, i32)` | Total (x, y, z) dimensions of the grid |
+
+```rust
+let pid: (i32, i32, i32) = get_tile_block_id();
+let grid: (i32, i32, i32) = get_num_tile_blocks();
+// Grid-stride loop
+for i in (pid.0..total).step_by(grid.0 as usize) { ... }
+```
+
+### Arithmetic (Element-wise)
+
+In addition to operator overloading (`+`, `-`, `*`, `/`), these explicit functions are available:
+
+| Function | Signature | Description |
+|---|---|---|
+| `absi(x)` | `Tile<E, S> -> Tile<E, S>` | Absolute value (integer) |
+| `absf(x)` | `Tile<E, S> -> Tile<E, S>` | Absolute value (float) |
+| `negi(x)` | `Tile<E, S> -> Tile<E, S>` | Negation (integer) |
+| `negf(x)` | `Tile<E, S> -> Tile<E, S>` | Negation (float) |
+| `fma(a, b, c)` | `(Tile<E, S>, Tile<E, S>, Tile<E, S>) -> Tile<E, S>` | Fused multiply-add: `a * b + c` |
+| `fma_ftz(a, b, c)` | `(Tile<E, S>, Tile<E, S>, Tile<E, S>) -> Tile<E, S>` | Fused multiply-add (flush-to-zero) |
+| `pow(base, exp)` | `(Tile<E, S>, Tile<E, S>) -> Tile<E, S>` | Power |
+| `ceil_div(a, b)` | `(E, E) -> E` | Ceiling division (scalar) |
+| `true_div(a, b)` | `(Tile<E, S>, Tile<E, S>) -> Tile<E, S>` | True (floating-point) division |
+| `mulhii(a, b)` | `(Tile<E, S>, Tile<E, S>) -> Tile<E, S>` | High bits of integer multiply |
+
+```rust
+// Absolute value
+let abs_x: Tile<f32, S> = absf(x);
+let abs_i: Tile<i32, S> = absi(int_tile);
+
+// Fused multiply-add: a * b + c (single instruction, no intermediate rounding)
+let result: Tile<f32, S> = fma(a, b, c);
+
+// Power
+let squared: Tile<f32, S> = pow(x, broadcast_scalar(2.0f32, x.shape()));
+
+// Negation
+let neg_x: Tile<f32, S> = negf(x);
+let neg_i: Tile<i32, S> = negi(int_tile);
+```
+
+### Math (Floating-Point)
+
+| Function | Signature | Description |
+|---|---|---|
+| `exp(x)` | `Tile<E, S> -> Tile<E, S>` | e^x |
+| `exp2(x, ftz::Disabled)` | `Tile<E, S> -> Tile<E, S>` | 2^x |
+| `exp2_ftz(x)` | `Tile<E, S> -> Tile<E, S>` | 2^x with flush-to-zero |
+| `log(x)` | `Tile<E, S> -> Tile<E, S>` | Natural logarithm |
+| `log2(x)` | `Tile<E, S> -> Tile<E, S>` | Base-2 logarithm |
+| `sqrt(x)` | `Tile<E, S> -> Tile<E, S>` | Square root |
+| `sqrt_ftz(x)` | `Tile<E, S> -> Tile<E, S>` | Square root with flush-to-zero |
+| `rsqrt(x)` | `Tile<E, S> -> Tile<E, S>` | Reciprocal square root (1/sqrt(x)) |
+| `rsqrt_ftz(x)` | `Tile<E, S> -> Tile<E, S>` | Reciprocal square root with flush-to-zero |
+| `sin(x)` | `Tile<E, S> -> Tile<E, S>` | Sine |
+| `cos(x)` | `Tile<E, S> -> Tile<E, S>` | Cosine |
+| `tan(x)` | `Tile<E, S> -> Tile<E, S>` | Tangent |
+| `sinh(x)` | `Tile<E, S> -> Tile<E, S>` | Hyperbolic sine |
+| `cosh(x)` | `Tile<E, S> -> Tile<E, S>` | Hyperbolic cosine |
+| `tanh(x)` | `Tile<E, S> -> Tile<E, S>` | Hyperbolic tangent |
+| `ceil(x)` | `Tile<E, S> -> Tile<E, S>` | Ceiling |
+| `floor(x)` | `Tile<E, S> -> Tile<E, S>` | Floor |
+| `maxf(a, b)` | `(Tile<E, S>, Tile<E, S>) -> Tile<E, S>` | Float max |
+| `minf(a, b)` | `(Tile<E, S>, Tile<E, S>) -> Tile<E, S>` | Float min |
+| `maxf_ftz(a, b)` | `(Tile<E, S>, Tile<E, S>) -> Tile<E, S>` | Float max (flush-to-zero) |
+| `minf_ftz(a, b)` | `(Tile<E, S>, Tile<E, S>) -> Tile<E, S>` | Float min (flush-to-zero) |
+| `addf_ftz(a, b)` | `(Tile<E, S>, Tile<E, S>) -> Tile<E, S>` | Float add (flush-to-zero) |
+| `subf_ftz(a, b)` | `(Tile<E, S>, Tile<E, S>) -> Tile<E, S>` | Float sub (flush-to-zero) |
+| `mulf_ftz(a, b)` | `(Tile<E, S>, Tile<E, S>) -> Tile<E, S>` | Float mul (flush-to-zero) |
+| `divf_ftz(a, b)` | `(Tile<E, S>, Tile<E, S>) -> Tile<E, S>` | Float div (flush-to-zero) |
+
+```rust
+// Softmax numerics: subtract max, exponentiate
+let max_val: Tile<f32, { [1] }> = reduce_max(x, const_shape![1]);
+let shifted: Tile<f32, S> = x - max_val.broadcast(x.shape());
+let softmax_exp: Tile<f32, S> = exp(shifted);
+
+// RMS normalization
+let sq: Tile<f32, S> = x * x;
+let mean_sq: Tile<f32, { [1] }> = reduce_sum(sq, const_shape![1]);
+let rms: Tile<f32, { [1] }> = rsqrt(mean_sq + broadcast_scalar(1e-6f32, const_shape![1]));
+
+// Activation functions
+let gelu_approx: Tile<f32, S> = x * (constant(1.0f32, x.shape()) + tanh(x));
+let swish: Tile<f32, S> = x / (constant(1.0f32, x.shape()) + exp(negf(x)));
+
+// exp2 is faster than exp on GPU — convert: exp(x) = exp2(x * log2(e, ftz::Disabled))
+let log2_e: f32 = 1.4426950408889634f32;
+let fast_exp: Tile<f32, S> = exp2(x * broadcast_scalar(log2_e, x.shape()));
+
+// Flush-to-zero variants: treat denormals as zero (faster on some hardware, f32 only)
+let clamped: Tile<f32, S> = maxf_ftz(x, broadcast_scalar(0.0f32, x.shape()));
+let sum: Tile<f32, S> = addf_ftz(a, b);
+let product: Tile<f32, S> = mulf_ftz(a, b);
+let fma_result: Tile<f32, S> = fma_ftz(a, b, c);
+```
+
+### Comparison
+
+| Function | Signature | Description |
+|---|---|---|
+| `eq_tile(a, b)` | `-> Tile<bool, S>` | Equal |
+| `ne_tile(a, b)` | `-> Tile<bool, S>` | Not equal |
+| `gt_tile(a, b)` | `-> Tile<bool, S>` | Greater than |
+| `ge_tile(a, b)` | `-> Tile<bool, S>` | Greater or equal |
+| `lt_tile(a, b)` | `-> Tile<bool, S>` | Less than |
+| `le_tile(a, b)` | `-> Tile<bool, S>` | Less or equal |
+| `select(cond, a, b)` | `(Tile<bool, S>, Tile<E, S>, Tile<E, S>) -> Tile<E, S>` | Conditional select |
+| `min(a, b)` / `max(a, b)` | Scalar min/max |
+| `min_tile(a, b)` / `max_tile(a, b)` | Element-wise min/max |
+
+```rust
+let mask: Tile<bool, { [128] }> = lt_tile(indices, len_tile);
+let result: Tile<f32, { [128] }> = select(mask, values, zeros);
+```
+
+### Creation
+
+| Function | Signature | Description |
+|---|---|---|
+| `constant(value, shape)` | `(E, Shape<S>) -> Tile<E, S>` | Fill a tile with a constant |
+| `iota(shape)` | `(Shape<S>) -> Tile<E, S>` | Sequential indices `[0, 1, 2, ...]` (1D only) |
+| `broadcast_scalar(val, shape)` | `(E, Shape<S>) -> Tile<E, S>` | Broadcast a scalar to a tile shape |
+
+```rust
+let zeros: Tile<f32, { [128] }> = constant(0.0f32, const_shape![128]);
+let indices: Tile<i32, { [64] }> = iota(const_shape![64]);  // [0, 1, 2, ..., 63]
+let scale: Tile<f32, { [16, 16] }> = broadcast_scalar(2.0f32, const_shape![16, 16]);
+```
+
+### Shape Manipulation
+
+| Function | Signature | Description |
+|---|---|---|
+| `tile.reshape(shape)` | `Tile<E, S> -> Tile<E, R>` | Reshape (preserves element count) |
+| `tile.broadcast(shape)` | `Tile<E, S> -> Tile<E, R>` | Broadcast to a larger shape |
+| `reshape(tile, shape)` | `(Tile<E, S>, Shape<R>) -> Tile<E, R>` | Free function reshape |
+| `broadcast(tile, shape)` | `(Tile<E, S>, Shape<R>) -> Tile<E, R>` | Free function broadcast |
+| `permute(tile, indices, shape)` | `(Tile<E, A>, Array<I>, Shape<R>) -> Tile<E, R>` | Transpose / permute dimensions |
+| `cat(a, b, dim)` | `(Tile<E, SLhs>, Tile<E, SRhs>, i32) -> Tile<E, SOut>` | Concatenate along a dimension |
+| `extract(tile, offsets, shape)` | `(Tile<E, SIn>, [i32; N], Shape<SOut>) -> Tile<E, SOut>` | Extract a sub-tile |
+
+```rust
+let row: Tile<f32, { [128] }> = iota(const_shape![128]);
+let col: Tile<f32, { [128, 1] }> = row.reshape(const_shape![128, 1]);
+let matrix: Tile<f32, { [128, 64] }> = col.broadcast(const_shape![128, 64]);
+```
+
+### Reduction and Scan
+
+| Function | Signature | Description |
+|---|---|---|
+| `reduce_sum(tile, shape)` | `Tile<E, S> -> Tile<E, R>` | Sum reduction along axes |
+| `reduce_max(tile, shape)` | `Tile<E, S> -> Tile<E, R>` | Max reduction |
+| `reduce_min(tile, shape)` | `Tile<E, S> -> Tile<E, R>` | Min reduction |
+| `reduce_prod(tile, shape)` | `Tile<E, S> -> Tile<E, R>` | Product reduction |
+| `reduce(tile, shape, f)` | `Tile<E, S> -> Tile<E, R>` | Custom reduction |
+| `scan_sum(tile, axis)` | `Tile<E, S> -> Tile<E, S>` | Inclusive prefix sum |
+| `scan(tile, axis, f)` | `Tile<E, S> -> Tile<E, S>` | Custom inclusive scan |
+
+```rust
+// Sum a [128, 64] tile to [1, 64] (reduce along axis 0)
+let col_sums: Tile<f32, { [1, 64] }> = reduce_sum(matrix, const_shape![1, 64]);
+
+// Max of a 1D tile to a scalar
+let max_val: Tile<f32, { [1] }> = reduce_max(row, const_shape![1]);
+```
+
+### Matrix Multiply
+
+| Function | Signature | Description |
+|---|---|---|
+| `mma(a, b, c)` | `(Tile<E, {[M,K]}>, Tile<E, {[K,N]}>, Tile<E, {[M,N]}>) -> Tile<E, {[M,N]}>` | Matrix multiply-accumulate |
+
+Maps to hardware tensor cores when available.
+
+```rust
+let mut acc: Tile<f32, { [16, 16] }> = constant(0.0f32, const_shape![16, 16]);
+for k in 0i32..(K/BK) {
+    let a_tile: Tile<f32, { [16, 8] }> = a_part.load([pid.0, k]);
+    let b_tile: Tile<f32, { [8, 16] }> = b_part.load([k, pid.1]);
+    acc = mma(a_tile, b_tile, acc);
+}
+```
+
+### Memory: Pointer-Based
+
+| Function | Signature | Description |
+|---|---|---|
+| `load_ptr_tko(ptrs, ordering, scope, mask, fill, hint)` | `-> (Tile<E, S>, Token)` | Scatter-gather load via pointers |
+| `store_ptr_tko(tile, ptrs, ordering, scope, mask, hint)` | `-> Token` | Scatter-gather store via pointers |
+| `pointer_to_tile(ptr)` | `P -> PointerTile<P, {[]}>` | Convert raw pointer to scalar pointer tile |
+| `tile_to_pointer(ptile)` | `PointerTile<P, {[]}> -> P` | Convert back |
+| `addptr(ptile, offset)` | Offset a pointer tile by a scalar |
+| `addptr_tile(ptile, offsets)` | Offset a pointer tile by an index tile |
+
+```rust
+let base: PointerTile<*mut f32, { [] }> = pointer_to_tile(ptr);
+let ptrs: PointerTile<*mut f32, { [128] }> = base.broadcast(const_shape![128]).offset_tile(offsets);
+let (values, token): (Tile<f32, { [128] }>, Token) = load_ptr_tko(ptrs, "weak", "tl_blk", None, None, None);
+```
+
+### Memory: Atomics
+
+| Function | Signature | Description |
+|---|---|---|
+| `atomic_rmw_tko(ptrs, vals, op, ordering, scope, mask, hint)` | `-> (Tile<E, S>, Token)` | Atomic read-modify-write |
+| `atomic_cas_tko(ptrs, cmp, new, ordering, scope, mask, hint)` | `-> (Tile<E, S>, Token)` | Atomic compare-and-swap |
+
+**RMW operations:** `"add"`, `"addf"`, `"and"`, `"or"`, `"xor"`, `"max"`, `"min"`, `"xchg"`
+
+**Memory orderings:** `"relaxed"`, `"acquire"`, `"release"`, `"acq_rel"`
+
+**Scopes:** `"device"`, `"sys"` (system)
+
+```rust
+atomic_rmw_tko(ptrs, increments, "add", "relaxed", "device", None, None);
+atomic_cas_tko(ptrs, expected, desired, "acq_rel", "sys", None, None);
+```
+
+### Memory: Tokens
+
+Tokens track ordering dependencies between memory operations. A token returned from a load guarantees that the load has completed before any operation that consumes that token. `join_tokens` merges multiple tokens into one, ensuring all joined operations complete before the result token is used.
+
+This enables fine-grained ordering without full barriers: independent loads can execute in parallel, and a store only waits for the specific loads it depends on.
+
+| Function | Signature | Description |
+|---|---|---|
+| `new_token_unordered()` | `() -> Token` | Create a fresh ordering token (no ordering guarantee) |
+| `join_tokens(tokens)` | `(&[Token]) -> Token` | Join multiple tokens: result waits for all inputs |
+
+```rust
+// Thread tokens through a load → compute → store sequence:
+let token: Token = new_token_unordered();
+
+// Load returns a new token guaranteeing the load completed
+let (data, load_token): (Tile<f32, { [128] }>, Token) =
+    load_ptr_tko(src_ptrs, "weak", "tl_blk", None, None, None);
+
+// Compute on the loaded data
+let result: Tile<f32, { [128] }> = data * data;
+
+// Store uses the load token: waits for the load before writing
+let store_token: Token =
+    store_ptr_tko(result, dst_ptrs, "weak", "tl_blk", None, None);
+```
+
+```rust
+// Join tokens from two independent loads before a dependent store:
+let (a_data, a_token): (Tile<f32, { [128] }>, Token) =
+    load_ptr_tko(a_ptrs, "weak", "tl_blk", None, None, None);
+let (b_data, b_token): (Tile<f32, { [128] }>, Token) =
+    load_ptr_tko(b_ptrs, "weak", "tl_blk", None, None, None);
+
+// Both loads must complete before the store
+let combined: Token = join_tokens(&[a_token, b_token]);
+let result: Tile<f32, { [128] }> = a_data + b_data;
+let _: Token = store_ptr_tko(result, out_ptrs, "weak", "tl_blk", None, None);
+```
+
+### Bitwise
+
+| Function | Signature | Description |
+|---|---|---|
+| `andi(a, b)` | `(Tile<E, S>, Tile<E, S>) -> Tile<E, S>` | Bitwise AND |
+| `ori(a, b)` | `(Tile<E, S>, Tile<E, S>) -> Tile<E, S>` | Bitwise OR |
+| `xori(a, b)` | `(Tile<E, S>, Tile<E, S>) -> Tile<E, S>` | Bitwise XOR |
+| `shli(a, b)` | `(Tile<E, S>, Tile<E, S>) -> Tile<E, S>` | Shift left |
+| `shri(a, b)` | `(Tile<E, S>, Tile<E, S>) -> Tile<E, S>` | Shift right |
+
+```rust
+// Mask lower 8 bits
+let mask: Tile<i32, S> = constant(0xFF, x.shape());
+let low_byte: Tile<i32, S> = andi(x, mask);
+
+// Shift left by 2 (multiply by 4)
+let shift: Tile<i32, S> = constant(2, x.shape());
+let shifted: Tile<i32, S> = shli(x, shift);
+
+// Toggle bits with XOR
+let toggled: Tile<i32, S> = xori(x, mask);
+```
+
+### Type Conversion
+
+| Function | Signature | Description |
+|---|---|---|
+| `convert_tile(tile)` | `Tile<FROM, S> -> Tile<TO, S>` | Convert element type |
+| `convert_scalar(x)` | `impl Scalar -> S` | Convert scalar type |
+| `bitcast(tile)` | `Tile<EIn, S> -> Tile<EOut, S>` | Reinterpret bits (no conversion) |
+| `exti(tile)` | `Tile<EIn, S> -> Tile<EOut, S>` | Extend integer (sign/zero) |
+| `trunci(tile)` | `Tile<EIn, S> -> Tile<EOut, S>` | Truncate integer |
+| `int_to_ptr(tile)` | `Tile<SRC_T, S> -> Tile<PTR_T, S>` | Integer to pointer |
+| `ptr_to_int(tile)` | `Tile<E, S> -> Tile<i64, S>` | Pointer to integer |
+| `ptr_to_ptr(tile)` | `Tile<EIn, S> -> Tile<EOut, S>` | Pointer cast |
+
+```rust
+// Float to int conversion
+let indices: Tile<i32, { [128] }> = iota(const_shape![128]);
+let float_indices: Tile<f32, { [128] }> = convert_tile(indices);
+
+// Bitcast: reinterpret f32 bits as u32 (no value conversion)
+let float_tile: Tile<f32, { [128] }> = constant(1.0f32, const_shape![128]);
+let bits: Tile<u32, { [128] }> = bitcast(float_tile);  // 0x3F800000
+
+// Integer extension and truncation
+let small: Tile<i16, { [64] }> = constant(42i16, const_shape![64]);
+let wide: Tile<i32, { [64] }> = exti(small);     // sign-extend i16 -> i32
+let narrow: Tile<i16, { [64] }> = trunci(wide);  // truncate i32 -> i16
+```
+
+### Compiler Hints
+
+| Function | Signature | Description |
+|---|---|---|
+| `assume_div_by::<_, N>(val)` | `T -> T` | Assert value is divisible by N |
+| `assume_bounds_lower::<_, L>(val)` | `T -> T` | Assert value >= L |
+| `assume_bounds_upper::<_, U>(val)` | `T -> T` | Assert value <= U |
+| `assume_bounds::<_, L, U>(val)` | `T -> T` | Assert L <= value <= U |
+
+These are `unsafe` — incorrect assumptions produce undefined behavior. They enable compiler optimizations like vectorized loads and simplified index arithmetic.
+
+```rust
+// Tell the compiler a dimension is a multiple of 16 (enables wider vector loads)
+let dim: i32 = unsafe { assume_div_by::<_, 16>(dim) };
+
+// Bound an index (enables range-based optimizations)
+let idx: i32 = unsafe { assume_bounds::<_, 0, 1024>(idx) };
+
+// Combine: non-negative and aligned
+let stride: i32 = unsafe { assume_bounds_lower::<_, 0>(stride) };
+let stride: i32 = unsafe { assume_div_by::<_, 4>(stride) };
+```
+### Debugging
+
+| Macro | Description |
+|---|---|
+| `cuda_tile_print!(fmt, args...)` | Printf-style GPU print |
+| `cuda_tile_assert!(cond, msg)` | GPU assertion |
+
+```rust
+let pid: (i32, i32, i32) = get_tile_block_id();
+cuda_tile_print!("Block ({}, {}, {})\n", pid.0, pid.1, pid.2);
+
+// Assert a condition — aborts the kernel if false
+cuda_tile_assert!(len > 0, "Length must be positive");
+
+// Print scalars for debugging (runs on every block, so output may interleave)
+cuda_tile_print!("offset = {}\n", pid.0 * 128);
+```
+

--- a/cutile-book/reference/glossary.md
+++ b/cutile-book/reference/glossary.md
@@ -1,0 +1,132 @@
+# Glossary
+
+This glossary defines key terms as they are used throughout the cuTile Rust book.
+
+---
+
+## Tile
+
+A multi-dimensional array fragment that lives in GPU **registers** during kernel execution. Tiles are the fundamental unit of computation in cuTile Rust: you load data from tensors into tiles, compute on tiles, and store the results back. Tiles have compile-time static shapes and are represented by the type `Tile<E, S>`, where `E` is the element type and `S` is the shape (e.g., `Tile<f32, {[16, 16]}>`).
+
+## Tensor
+
+A multi-dimensional array stored in GPU **global memory** (HBM). Tensors are passed as kernel arguments — `&Tensor<E, S>` for read-only inputs and `&mut Tensor<E, S>` for writable outputs. Tensors do not support direct arithmetic; data must first be loaded into tiles.
+
+## Partition
+
+A logical division of a tensor into a grid of equally sized sub-regions, each of which is processed by one tile block. The term "partition" appears on both the host side and the device side, but refers to different things.
+
+**Host-side partition (mutable tensors only).** Calling `.partition([M, N])` on a `Tensor<T>` produces a `Partition<Tensor<T>>`. This is a host-side wrapper that records the `partition_shape` (the tile dimensions) alongside the original tensor. A host-side `Partition<Tensor<T>>` is what you pass to a kernel launcher in the position of a `&mut Tensor<E, S>` parameter. The `partition_shape` stored in the host-side `Partition` determines the static shape `S` that the kernel sees — for example, passing a `Partition` with `partition_shape = [32, 64]` means the kernel receives a `&mut Tensor<T, {[32, 64]}>`.
+
+Only mutable tensors must be partitioned on the host side. This is because each `&mut Tensor` sub-region is written to by exactly one tile block, satisfying Rust's exclusive access requirement for mutable memory: at most one writer may access a given region at a time. By partitioning before launch, the system guarantees that no two tile blocks write to overlapping memory.
+
+**Shared tensor references (no host-side partition required).** Read-only inputs are passed as `Arc<Tensor<T>>` on the host side, corresponding to `&Tensor<E, S>` in the kernel signature. These do *not* need to be partitioned on the host side — multiple tile blocks may safely read from the same tensor or overlapping regions simultaneously, so there is no exclusive-access constraint to enforce. Instead, shared tensors are partitioned on the device side for greater flexibility in how they are accessed.
+
+**Device-side partition.** Inside a kernel, calling `.partition(const_shape![M, N])` on a `&Tensor` creates a read-only `Partition` view that can be indexed to load individual tiles (e.g., `part.load([i, j])`). This is how shared tensor references are divided into tiles for loading. Because the partitioning happens on the device side, the same `&Tensor` can be partitioned in different ways — or accessed with different indexing patterns — within the same kernel. For example, in GEMM the input matrices `x` and `y` are each partitioned with a different shape inside the kernel body (`const_shape![BM, BK]` and `const_shape![BK, BN]` respectively), even though both were passed as plain `Arc<Tensor<T>>` from the host.
+
+The generated launcher code accepts `Partition<Tensor<T>>` for every `&mut Tensor` parameter and `Arc<Tensor<T>>` for every `&Tensor` parameter.
+
+**Grid dimensions.** A host-side partition's grid is computed by dividing the tensor's shape by the partition shape, rounding up: `grid[i] = ceil(tensor_shape[i] / partition_shape[i])`. The result is mapped to a 3D tuple `(x, y, z)`, with trailing dimensions set to 1 for tensors of rank less than 3. For example, a `[128, 256]` tensor partitioned with `[32, 64]` produces a grid of `(4, 4, 1)`.
+
+**Launch grid inference.** At kernel launch time, the launcher calls `.grid()` on each `&mut Tensor` parameter's host-side `Partition` and collects the resulting grids. If no explicit grid is specified via `.grid()` or `.const_grid()`, the launch grid is **inferred** from these partition grids. When multiple `&mut Tensor` parameters are present, all of their inferred grids must match or the launch will fail with an error. This is how partitioning a tensor on the host side determines how many tile blocks the kernel runs.
+
+## Tile Block
+
+A logical tile thread and the basic unit of concurrent execution on the GPU. Each tile block runs the kernel function once as a single logical thread of execution, operating on one partition of the data. A tile block is identified by its coordinates, obtained via `get_tile_block_id()`. The cuTile Rust compiler maps each tile block to one or more underlying CUDA execution units (thread blocks, clusters, or warps) depending on the target architecture — but from the programmer's perspective, a tile block is simply a single-threaded context that processes one tile of data.
+
+## Tile Thread
+
+An alias for [Tile Block](#tile-block), used throughout this book to emphasize the single-threaded programming model. Each tile thread executes the kernel function once as a single logical thread of execution. The terms "tile thread" and "tile block" are interchangeable — the API uses `get_tile_block_id()` and `get_num_tile_blocks()`, while the guides often say "tile thread" for clarity.
+
+## Concurrent Execution
+
+Multiple tile blocks making progress over a period of time by being scheduled onto available Streaming Multiprocessors (SMs). This aligns with Rust's definition of concurrency — different parts of a program executing *independently*, not necessarily at the exact same instant — extended to the GPU context: when a kernel is launched with more tile blocks than there are SMs, the GPU's hardware scheduler assigns tile blocks to SMs as resources become available. Some tile blocks execute in parallel while others are pending, but from the programmer's perspective all tile blocks are logically concurrent — their relative order of execution is unspecified and they are independent of one another.
+
+On the host side, concurrency also arises through CUDA streams and async/await: multiple `DeviceOp`s submitted to different streams can overlap in time, and the async runtime schedules them without requiring the programmer to specify an exact execution order.
+
+## Parallel Execution
+
+Multiple tile blocks executing **at the same time** on different SMs. All NVIDIA GPUs execute tile blocks in parallel — a modern GPU has tens to over a hundred SMs, each capable of running one or more tile blocks simultaneously. The distinction from concurrency is that parallelism refers specifically to simultaneous execution on separate hardware units, whereas concurrency is the broader concept of managing multiple in-progress tasks. In practice, a kernel launch exhibits both: tile blocks that fit on available SMs run in parallel, while the full set of tile blocks runs concurrently (scheduled over time as SMs become free).
+
+This matches Rust's distinction (see [The Rust Programming Language, Ch. 17](https://doc.rust-lang.org/book/ch17-00-async-await.html#parallelism-and-concurrency)): *parallelism* is work happening at the exact same time on different hardware, while *concurrency* is independently executing tasks making progress over time — which may or may not involve parallelism.
+
+## Streaming Multiprocessor (SM)
+
+The primary processing unit on an NVIDIA GPU. Each SM has its own registers, shared memory, and execution pipelines including Tensor Cores. Tile blocks are scheduled onto SMs by the GPU's hardware scheduler. A single SM can run multiple tile blocks concurrently if it has sufficient resources (registers, shared memory, thread slots). For architecture-specific details on SM resources, see the [CUDA C++ Programming Guide](https://docs.nvidia.com/cuda/cuda-c-programming-guide/).
+
+## Tensor Cores
+
+Specialized hardware units (available on Volta architecture and later) that perform small matrix multiply-accumulate operations in a single instruction. The `mma()` intrinsic in cuTile Rust maps to Tensor Core instructions. Tensor Cores impose alignment requirements on tile dimensions (e.g., dimensions must typically be multiples of 8 or 16 depending on the element type).
+
+## Global Memory (HBM)
+
+The GPU's main memory — High Bandwidth Memory. Global memory has the highest capacity but is slower than shared memory and registers. `Tensor` data resides in global memory.
+
+## Registers (RMEM)
+
+The fastest storage on the GPU, private to each thread within a tile block. `Tile` data lives in registers during computation. Each SM has a fixed register file, so larger tiles consume more registers, potentially reducing occupancy.
+
+## Shared Memory (SMEM)
+
+On-chip memory shared among all threads within a tile block. Shared memory is slower than registers but faster than global memory. In the tile programming model, **you never manage shared memory directly** — you simply load from and store to global memory (HBM), and the underlying [Tile IR](https://docs.nvidia.com/cuda/tile-ir/latest/) compiler and runtime handle the mapping onto shared memory, registers, threads, and tensor cores automatically. For capacity and latency details across GPU architectures, see the [CUDA C++ Programming Guide](https://docs.nvidia.com/cuda/cuda-c-programming-guide/).
+
+## Const Generics
+
+Compile-time constant parameters on kernel functions, such as `const BM: i32`. Const generics enable the compiler to optimize register allocation, unroll loops, and generate architecture-specific code. Changing a const generic value triggers JIT recompilation. See also [Const Generic Arrays](#const-generic-arrays).
+
+## Const Generic Arrays
+
+An **extension to the Rust programming language** that allows const generic parameters to have array types — for example, `const S: [i32; 2]`. Standard Rust only supports scalar const generics (integers, `bool`, `char`), so this syntax is not valid in ordinary Rust code. The cuTile Rust compiler recognizes array const generics and uses them to propagate tile shapes through the type system at compile time.
+
+Const generic arrays are the idiomatic way to parameterize a kernel over its tile shape:
+
+```rust
+#[cutile::entry()]
+fn add<const S: [i32; 2]>(
+    z: &mut Tensor<f32, S>,
+    x: &Tensor<f32, {[-1, -1]}>,
+    y: &Tensor<f32, {[-1, -1]}>,
+) { ... }
+```
+
+Here `S` is inferred from the host-side partition shape passed at launch time. Because `S` is a compile-time constant, the compiler can specialize the generated code for each distinct shape. A new value of `S` triggers JIT recompilation, just like scalar const generics.
+
+## Dynamic Dimensions
+
+Tensor shape dimensions specified as `-1` in the kernel signature (e.g., `Tensor<f32, {[-1, -1]}>`). Dynamic dimensions can vary across kernel launches without triggering recompilation. They carry no compile-time optimization benefit but provide flexibility for problem sizes that change often.
+
+## JIT Compilation
+
+cuTile Rust compiles kernels at first invocation through a multi-stage pipeline: Rust AST → MLIR → cubin. The compiled binary is cached in memory (in a thread-local `HashMap`) so subsequent launches with the same generics are instant. A new combination of const generics or type parameters produces a new compilation.
+
+## DeviceOp
+
+A lazy description of GPU work — allocation, kernel launch, or data transfer — that is not executed until either `.sync_on(&stream)`, `.sync()`, or `.await` is invoked. `DeviceOp`s can be composed with `zip!`, `.then()`, `.map()`, `.shared()`, and `.first()`/`.last()` to build dataflow graphs before submitting GPU work. Kernel launchers accept `Tensor<T>`, `Arc<Tensor<T>>`, `&Tensor<T>`, scalars, and `DeviceOp` arguments directly via `IntoDeviceOp` and `KernelInput`. The return type matches the input type — you get back what you put in.
+
+## DeviceFuture
+
+A `DeviceFuture` is a future that has been assigned resources — specifically, a device stream on which to execute — but has not yet started GPU work. A `DeviceFuture` is created when a `DeviceOp` is scheduled (e.g., via `into_future()`), at which point the scheduling policy selects a stream. The actual GPU work is not submitted until the `DeviceFuture` is polled for the first time, which happens when you `.await` it or `tokio::spawn` it.
+
+## Broadcasting
+
+Replicating a smaller tile (or scalar) to match the shape of a larger tile. Broadcasting is a compile-time transformation — no extra memory is allocated. For example, `a.broadcast(y.shape())` expands a scalar into a tile matching `y`'s partition shape.
+
+## Kernel Fusion
+
+Combining multiple logical operations into a single kernel so that intermediate results stay in registers rather than being written to and read back from global memory. Fused softmax is a canonical example: find-max, subtract, exponentiate, sum, and divide are all performed in one kernel launch.
+
+## Arithmetic Intensity
+
+The ratio of compute operations (FLOPs) to memory operations (bytes transferred). Higher arithmetic intensity means better GPU utilization. A kernel with low arithmetic intensity (e.g., element-wise addition) is **memory-bound**; a kernel with high arithmetic intensity (e.g., matrix multiplication) is **compute-bound**.
+
+## CUDA Stream
+
+An ordered queue of GPU operations. Operations on the same stream execute in submission order; operations on different streams may execute concurrently. cuTile Rust's default async scheduling policy distributes work across a pool of four streams in round-robin fashion.
+
+## Occupancy
+
+The ratio of active warps to the maximum number of warps an SM can support. Higher occupancy generally improves the GPU's ability to hide memory latency by switching between warps. Occupancy is affected by register usage, shared memory usage, and thread block size.
+
+## Warp
+
+A group of 32 GPU threads that execute instructions in lockstep. Warps are the smallest scheduling unit on an SM. Tile sizes that are multiples of 32 align well with warp-level execution.

--- a/cutile-book/tutorials/02-vector-addition.md
+++ b/cutile-book/tutorials/02-vector-addition.md
@@ -203,3 +203,11 @@ z.store(tile_x + tile_y + tile_w);
 ### Exercise 3: Non-Square Partitions
 
 Try `partition([4, 8])` — rectangular tiles. Does it still work?
+
+---
+
+## See also
+
+- [Thinking in Tiles](../guide/thinking-in-tiles.md) — tile blocks, partitioning, and the grid
+- [Writing Computations on Tiles](../guide/writing-computations.md) — arithmetic and load/store operations
+- [DSL API Reference](../reference/dsl-api.md) — full signatures for `load_tile_like_2d`, `store`, and the arithmetic operators used here

--- a/cutile-book/tutorials/03-saxpy.md
+++ b/cutile-book/tutorials/03-saxpy.md
@@ -163,3 +163,11 @@ fn saxpy_extended<const S: [i32; 2]>(
 }
 ```
 :::
+
+---
+
+## See also
+
+- [Writing Computations on Tiles](../guide/writing-computations.md) — scalar arithmetic and `broadcast`
+- [Working with Data](../guide/working-with-data.md) — shape broadcasting rules
+- [DSL API Reference](../reference/dsl-api.md) — `broadcast`, `broadcast_scalar`, and arithmetic operator signatures

--- a/cutile-book/tutorials/04-matrix-multiplication.md
+++ b/cutile-book/tutorials/04-matrix-multiplication.md
@@ -392,3 +392,12 @@ Does the code need changes?
 ### Exercise 3: Mixed Precision
 
 Try using `f16` (half precision) for inputs and `f32` for the accumulator. This is common in ML for faster compute.
+
+---
+
+## See also
+
+- [Writing Computations on Tiles](../guide/writing-computations.md#matrix-operations) — `mma` usage and the accumulate pattern
+- [Thinking in Tiles](../guide/thinking-in-tiles.md) — 2D partitioning and grid mapping
+- [Tuning for Performance](../guide/performance-tuning.md) — Tensor Core alignment requirements and tile-size selection
+- [DSL API Reference](../reference/dsl-api.md#matrix-multiply) — `mma` signature and element-type constraints

--- a/cutile-book/tutorials/05-fused-softmax.md
+++ b/cutile-book/tutorials/05-fused-softmax.md
@@ -210,3 +210,11 @@ log_softmax(x)_i = x_i - max(x) - log(Σ exp(x_j - max(x)))
 ```
 You can fuse this too.
 :::
+
+---
+
+## See also
+
+- [Writing Computations on Tiles](../guide/writing-computations.md#reduction-operations) — `reduce_max`, `reduce_sum`, and broadcasting patterns
+- [Tuning for Performance](../guide/performance-tuning.md) — kernel fusion and arithmetic intensity
+- [DSL API Reference](../reference/dsl-api.md#reduction-and-scan) — reduction operator signatures

--- a/cutile-book/tutorials/06-flash-attention.md
+++ b/cutile-book/tutorials/06-flash-attention.md
@@ -302,3 +302,12 @@ How many times less memory does the fused kernel use?
 ### Exercise 2: Add Causal Masking
 
 For autoregressive models (like GPT), we only attend to *previous* positions. Modify the kernel to skip computing attention scores where `key_position > query_position`.
+
+---
+
+## See also
+
+- [Writing Computations on Tiles](../guide/writing-computations.md) — `mma`, reductions, and broadcasting combined
+- [Where Data Lives](../guide/memory-hierarchy.md) — why tiled access matters for bandwidth-bound kernels
+- [Tuning for Performance](../guide/performance-tuning.md) — Tensor Core utilization and tile-size selection
+- [DSL API Reference](../reference/dsl-api.md) — operator reference for the patterns used here

--- a/cutile-book/tutorials/07-intro-to-async.md
+++ b/cutile-book/tutorials/07-intro-to-async.md
@@ -246,3 +246,10 @@ let (a, b, c, d) = zip!(
 ### Exercise 3: Measure the Difference
 
 Time a sync version vs. an async version with overlapped work. Use `std::time::Instant` to measure.
+
+---
+
+## See also
+
+- [Orchestrating Device Operations](../guide/device-operations.md) — full treatment of `DeviceOp`, streams, and scheduling
+- [DeviceOp API Reference](../reference/deviceop-reference.md) — combinator signatures (`.then()`, `.shared()`, `unzip`, `zip!`)

--- a/cutile-book/tutorials/08-data-parallel-mlp.md
+++ b/cutile-book/tutorials/08-data-parallel-mlp.md
@@ -225,3 +225,10 @@ How might we fuse the above kernels into a single kernel? Would this reduce the 
 ### Exercise 2: Overlapping Data Movement with Computation
 
 What would we need to change to construct a pipeline that overlaps data movement with computation?
+
+---
+
+## See also
+
+- [Orchestrating Device Operations](../guide/device-operations.md) — stream scheduling and the `DeviceOp` lifecycle
+- [DeviceOp API Reference](../reference/deviceop-reference.md) — `.schedule()`, scheduling policies, and execution methods

--- a/cutile-book/tutorials/09-pointer-addition.md
+++ b/cutile-book/tutorials/09-pointer-addition.md
@@ -136,6 +136,8 @@ Write a safe Rust wrapper function around the unsafe kernel that validates the p
 
 ---
 
-## See Also
+## See also
 
-For a structured approach to integrating pre-compiled CUDA C++ kernels — using `AsyncKernelLaunch` instead of raw pointers — see the [Interoperability](../guide/interoperability.md) guide.
+- [Integrating with CUDA C++](../guide/interoperability.md) — a structured approach to pre-compiled CUDA C++ kernels using `AsyncKernelLaunch` instead of raw pointers
+- [Working with Data](../guide/working-with-data.md) — `PointerTile` and the safety model for pointer-based kernels
+- [DSL API Reference](../reference/dsl-api.md#memory-pointer-based) — `int_to_ptr`, `ptr_to_int`, `ptr_to_ptr`, and atomic operations

--- a/cutile-book/tutorials/10-cuda-graphs.md
+++ b/cutile-book/tutorials/10-cuda-graphs.md
@@ -426,3 +426,10 @@ The complete working example with benchmarks:
 ```bash
 cargo run -p cutile-examples --example cuda_graphs
 ```
+
+---
+
+## See also
+
+- [Orchestrating Device Operations](../guide/device-operations.md#cuda-graphs-graph_onstream) — where CUDA graphs fit alongside sync and async execution
+- [DeviceOp API Reference: CUDA Graph Integration](../reference/deviceop-reference.md#cuda-graph-integration) — `.graph_on(stream)` and `CudaGraph::scope` signatures


### PR DESCRIPTION
## Summary

Restructure the cuTile Rust Book so concept pages form a teaching sequence and reference material lives in its own top-level section, instead of being interleaved with guide pages.

## Changes

### Structural
- Rename `appendix/` → `reference/`
- Move `dsl-api.md` and `deviceop-reference.md` from `guide/` into `reference/`
- Rename `definitions.md` → `glossary.md` (with matching H1)
- Delete redundant WIP `syntax-reference.md` (content duplicated by `dsl-api.md` and tutorials)

### Guide reorder and retitle

Action-verb / question titles for teaching flow; filename renames where the new name is materially more informative.

| # | Filename | H1 Title |
|---|---|---|
| 1 | `introduction.md` | Introduction |
| 2 | `thinking-in-tiles.md` | Thinking in Tiles |
| 3 | `memory-hierarchy.md` | Where Data Lives: The GPU Memory Hierarchy |
| 4 | `working-with-data.md` | Working with Data: Tensors, Tiles, and Partitions |
| 5 | `writing-computations.md` | Writing Computations on Tiles |
| 6 | `execution-model.md` | How Kernels Run on the GPU |
| 7 | `device-operations.md` | Orchestrating Device Operations |
| 8 | `performance-tuning.md` | Tuning for Performance |
| 9 | `interoperability.md` | Integrating with CUDA C++ |
| 10 | `debugging.md` | Debugging and Profiling |

The new sequence groups device-side concepts (2–6), then host-side orchestration (7), then optimization (8), interop (9), and debug (10).

### Element-type tables

Add FP8 variants (`f8e4m3fn`, `f8e5m2`) and fill missing `bf16`, `i16`, `u8`, `u16` rows across `data-model.md` (now `working-with-data.md`), `dsl-api.md`, and `syntax-reference.md` before its deletion.

### Audit fixes

- `reference/glossary.md`: H1 was `# Definitions`; corrected to `# Glossary`.
- `guide/thinking-in-tiles.md`: removed duplicate `## Thinking in Tiles` H2 left over from the rename.
- `guide/introduction.md`: reworded stale "async execution model" phrasing and the awkward "provides an Interoperability" link.
- `guide/working-with-data.md`: moved "Core Types" to position 2 (after "Tensors vs Tiles") so `Tensor`/`Tile`/`Partition` are introduced before element types and shapes.

### Cross-links

Every guide page's footer updated for the new sequence. Reference pages' backlinks into the guide updated. CSS caption comment updated (Tutorials, User Guide, Reference).