### PR TITLE
docs(book): consolidate guide pages and merge references into host-api

### DIFF
--- a/cutile-book/guide/debugging.md
+++ b/cutile-book/guide/debugging.md
@@ -1,12 +1,12 @@
 # Debugging and Profiling
 
-This guide covers techniques for debugging cuTile Rust programs, organized by the typical debugging workflow: inspect the error, inspect values, verify correctness, then profile performance.
+This guide covers techniques for debugging cuTile Rust programs, organized by the typical workflow: inspect what the code is doing, understand errors, verify correctness, then profile performance.
 
-## Inspecting Values
+---
 
-### Device-Side: `cuda_tile_print!`
+## Inspecting Code and Values
 
-Print from inside a GPU kernel using printf-style formatting:
+**`cuda_tile_print!`** prints from inside a GPU kernel using printf-style formatting:
 
 ```rust
 #[cutile::entry()]
@@ -23,20 +23,16 @@ fn debug_kernel<const S: [i32; 2]>(
 }
 ```
 
-> **Note:** GPU printing is slow and serializes tile block execution. Use only for debugging small grids and remove before production.
+GPU printing is slow and serializes tile block execution — use it only for small-grid debugging and remove before production.
 
-### Device-Side: `cuda_tile_assert!`
-
-Assert conditions inside a GPU kernel:
+**`cuda_tile_assert!`** asserts conditions inside a kernel:
 
 ```rust
 let tile = load_tile_like_2d(input, output);
 cuda_tile_assert!(tile[0] > 0.0, "Value must be positive");
 ```
 
-### Host-Side: Read Back and Inspect
-
-Transfer results to the CPU to inspect them after kernel execution:
+**Read back to the host** to inspect results after kernel execution:
 
 ```rust
 let ctx = CudaContext::new(0)?;
@@ -44,219 +40,92 @@ let stream = ctx.new_stream()?;
 
 let x: Arc<Tensor<f32>> = ones(&[32, 32]).map(Into::into).sync_on(&stream)?;
 let z = zeros(&[32, 32]).sync_on(&stream)?.partition([4, 4]);
-
 let (z, _x) = my_kernel(z, x).sync_on(&stream)?;
 
-// Read output back to host
 let z_host: Vec<f32> = z.unpartition().to_host_vec().sync_on(&stream)?;
-
-// Check for NaN/Inf
 assert!(!z_host.iter().any(|x| x.is_nan()), "Output contains NaN!");
 assert!(!z_host.iter().any(|x| x.is_infinite()), "Output contains Inf!");
-
 println!("First 10 values: {:?}", &z_host[..10]);
 ```
 
----
-
-## Inspecting Generated Code
-
-### Print IR
-
-Use `print_ir = true` to see the generated MLIR during JIT compilation:
-
-```rust
-#[cutile::entry(print_ir = true)]
-fn debug_ir_kernel<const S: [i32; 2]>(
-    output: &mut Tensor<f32, S>,
-    input: &Tensor<f32, {[-1, -1]}>
-) {
-    let tile = load_tile_like_2d(input, output);
-    output.store(tile * 2.0);
-}
-```
-
-This is useful for understanding how your code is compiled, verifying that optimizations are applied, and diagnosing unexpected behavior.
-
-### Dump IR to Files
-
-Save the generated MLIR to a directory for detailed offline analysis:
+**Inspect the generated MLIR** to see how your code is compiled, verify that optimizations are applied, or diagnose unexpected behavior. `print_ir = true` writes the IR to stdout during JIT compilation; `dump_mlir_dir` saves it to files for offline analysis; `use_debug_mlir` loads hand-modified MLIR instead of the compiler's output:
 
 ```rust
 #[cutile::entry(
     print_ir = true,
     dump_mlir_dir = "/tmp/cutile-ir"
 )]
-fn kernel_with_ir_dump<const S: [i32; 2]>(...) { ... }
-```
+fn debug_ir_kernel<const S: [i32; 2]>(...) { ... }
 
-### Load Custom MLIR (Advanced)
-
-For advanced debugging, load hand-modified MLIR instead of the compiler-generated version:
-
-```rust
 #[cutile::entry(use_debug_mlir = "/path/to/custom.mlir")]
 fn kernel_with_custom_mlir<const S: [i32; 2]>(...) { ... }
 ```
 
 ---
 
-## Common Errors and Fixes
+## Errors and Crashes
 
-### Compile-Time Errors
-
-**Shape mismatch** — Tile shapes must be compatible for operations:
+Most cuTile Rust errors surface at compile time. **Shape mismatches**, **type mismatches**, and **invalid reduction axes** are caught by the compiler before any kernel runs:
 
 ```rust
+// Shape mismatch
 let a: Tile<f32, {[64, 64]}> = ...;
 let b: Tile<f32, {[32, 32]}> = ...;
-let c = a + b;  // Compile error: incompatible shapes
-```
+let c = a + b;                       // Error: incompatible shapes
 
-Fix: ensure shapes match, or use `reshape` and `broadcast` to align them.
-
-**Type mismatch** — Element types must match for arithmetic:
-
-```rust
+// Type mismatch
 let float_tile: Tile<f32, S> = ...;
 let int_tile: Tile<i32, S> = ...;
 let result = float_tile + int_tile;  // Error: cannot add f32 and i32
-```
+                                      // Fix: convert_tile()
 
-Fix: use `convert_tile()` for explicit type conversion.
-
-**Invalid reduction axis** — The axis must be in range `0..rank`:
-
-```rust
-let tile: Tile<f32, {[64, 64]}> = ...;  // 2D: axes 0 and 1
-let reduced = reduce_sum(tile, 2i32);    // Error: axis 2 doesn't exist
+// Invalid reduction axis (tile is 2D, axes are 0 and 1 only)
+let reduced = reduce_sum(tile, 2i32);  // Error
 ```
 
 | Error | Cause | Fix |
 |-------|-------|-----|
-| Shape mismatch | Incompatible tile shapes | Fix shapes or add broadcasting |
+| Shape mismatch | Incompatible tile shapes | Align shapes or `reshape`/`broadcast` |
 | Type mismatch | Wrong element types | Add explicit `convert_tile()` |
 | Invalid axis | Reduction axis out of bounds | Use axis in `0..rank` |
-| Not a power of 2 | Tile dimension not 2^n | Use power-of-2 dimensions |
+| Not a power of 2 | Tile dimension isn't 2^n | Use power-of-2 dimensions |
 | Missing entry | No `#[cutile::entry()]` | Add entry attribute |
 
-### Runtime Errors
-
-**Out-of-bounds access** — If a tensor is smaller than the tile size, loads may read out of bounds:
-
-```rust
-fn kernel<const S: [i32; 2]>(
-    output: &mut Tensor<f32, S>,
-    input: &Tensor<f32, {[-1, -1]}>
-) {
-    // If input is smaller than S in any dimension, this may crash
-    let tile = load_tile_like_2d(input, output);
-}
-```
-
-Fix: ensure tensor dimensions are at least as large as the tile dimensions, or that partitioning produces only in-bounds tiles.
-
-**Numeric instability** — Operations like `exp` can overflow; always subtract the maximum before exponentiation:
-
-```rust
-// Unstable:
-let result = exp(large_values);  // May overflow to Inf
-
-// Stable:
-let max_val = reduce_max(tile, 1i32);
-let shifted = tile - max_val.reshape(const_shape![BM, 1]).broadcast(tile.shape());
-let result = exp(shifted);  // Safe: shifted values are <= 0
-```
+Runtime errors typically come from **out-of-bounds accesses** (tensor smaller than expected tile size) or **numeric instability** (`exp` overflow in softmax-style kernels — always subtract the max before exponentiation). The common set:
 
 | Error | Cause | Fix |
 |-------|-------|-----|
 | CUDA error: no kernel image | Wrong GPU architecture | Clear cache, rebuild |
 | Failed to load kernel | CUDA toolkit issue | Check CUDA installation |
-| Out of memory | Tensor too large | Reduce sizes or use streaming |
+| Out of memory | Tensor too large | Reduce sizes or stream |
 | Shape mismatch at runtime | Tensor not divisible by tile | Ensure divisibility |
 
----
+**CPU segfaults** (SIGSEGV in the host process) are a different class — they typically mean something went wrong outside the GPU kernel itself, in the CUDA driver, JIT compilation, or host memory management. GPU kernels that access invalid memory usually surface as CUDA errors, not host segfaults.
 
-## CPU Segfaults
-
-A segfault (signal 11 / SIGSEGV) in the host process typically means something went wrong outside the GPU kernel itself — in the CUDA driver, the JIT compilation pipeline, or host-side memory management. GPU kernels that access invalid memory usually surface as CUDA errors, not host segfaults.
-
-### Getting a Backtrace
-
-The first step is always to capture a backtrace:
+Get a backtrace first:
 
 ```bash
 RUST_BACKTRACE=1 cargo run
-```
+RUST_BACKTRACE=full cargo run   # with all frames, including inlined
 
-For a full backtrace with all frames (including inlined functions):
-
-```bash
-RUST_BACKTRACE=full cargo run
-```
-
-If the segfault occurs inside a native library (CUDA driver, MLIR compiler), the Rust backtrace may be truncated. Use `gdb` to get the full native stack:
-
-```bash
+# If the crash is inside a native library (CUDA driver, MLIR compiler):
 gdb --args ./target/debug/my_program
 (gdb) run
-# ... segfault happens ...
 (gdb) bt
 ```
 
-### Common Causes
+Common causes:
 
-**CUDA toolkit mismatch** — The JIT compilation pipeline calls into CUDA libraries via FFI. If the CUDA toolkit version is incompatible with the installed driver, or if `CUDA_HOME` points to a missing or broken installation, these FFI calls can segfault.
+- **CUDA toolkit mismatch.** The JIT pipeline calls into CUDA libraries via FFI. An incompatible toolkit/driver pair, or a broken `CUDA_HOME`, can segfault in those FFI calls. Verify with `nvidia-smi`, `nvcc --version`, and `echo $CUDA_HOME`.
+- **Use-after-free with raw pointers.** If you extract a raw device pointer via `device_pointer()` and drop the owning tensor before the kernel completes, the kernel operates on freed memory. Ensure all tensors outlive any kernel that uses their pointers.
+- **Async lifetime issues.** With `tokio::spawn`, the kernel runs concurrently; if tensors are dropped before the spawned task completes, the kernel accesses freed memory. Await the spawn handle before tensors go out of scope.
+- **OOM during JIT compilation.** The MLIR compiler allocates host memory during compilation. On RAM-constrained systems this can fail as a segfault rather than a clean error. Monitor host memory during the first kernel launch.
 
-```bash
-# Verify your CUDA installation
-nvidia-smi              # Check driver version
-nvcc --version          # Check toolkit version
-echo $CUDA_HOME         # Check toolkit path
-```
-
-Fix: ensure the CUDA toolkit version is compatible with the installed driver, and that `CUDA_HOME` is set correctly.
-
-**Use-after-free with raw pointers** — If you extract a raw device pointer via `device_pointer()` and then drop the owning tensor before the kernel completes, the kernel operates on freed memory. This can corrupt host-side state and cause a segfault when the results are read back.
-
-```rust
-// WRONG: tensor dropped while kernel is still running
-let z: Tensor<f32> = zeros(&[len]).await?;
-let z_ptr = z.device_pointer();
-drop(z);  // Frees GPU memory!
-unsafe { add_ptr(z_ptr, ...) }.sync_on(&stream)?;  // Segfault or corruption
-```
-
-Fix: ensure all tensors outlive any kernel that uses their pointers. The `await` or `.sync_on()` call must complete before the tensor is dropped.
-
-**Async lifetime issues** — With `tokio::spawn`, the kernel runs concurrently. If tensors are moved or dropped before the spawned task completes, the kernel may access freed memory.
-
-```rust
-// WRONG: tensor may be dropped before kernel finishes
-let handle = tokio::spawn(kernel_op.into_future());
-// ... tensor goes out of scope here ...
-
-// Fix: await the handle before tensors are dropped
-let result = handle.await?;
-```
-
-**Out-of-memory during JIT compilation** — The MLIR compiler allocates host memory during compilation. On systems with limited RAM, this can fail and manifest as a segfault rather than a clean error.
-
-Fix: monitor host memory usage during the first kernel launch (when JIT compilation occurs). If memory is the issue, reduce the number of concurrent compilations or increase system RAM.
-
-### Diagnostic Checklist
-
-- [ ] Does `nvidia-smi` report a healthy driver?
-- [ ] Does `CUDA_HOME` point to a valid toolkit installation?
-- [ ] Are all tensors alive for the duration of any kernel that uses their pointers?
-- [ ] If using `tokio::spawn`, are all handles awaited before tensors are dropped?
-- [ ] Does the backtrace point into CUDA/MLIR libraries (toolkit issue) or your code (lifetime issue)?
+Diagnostic checklist for segfaults: Is `nvidia-smi` reporting a healthy driver? Does `CUDA_HOME` point to a valid toolkit? Are all tensors alive for the duration of any kernel that uses their pointers? If using `tokio::spawn`, are all handles awaited before tensors are dropped? Does the backtrace point into CUDA/MLIR libraries (toolkit issue) or your own code (lifetime issue)?
 
 ---
 
 ## Verifying Correctness
-
-### Small Test Cases
 
 Start with minimal, manually verifiable inputs:
 
@@ -265,7 +134,6 @@ Start with minimal, manually verifiable inputs:
 mod tests {
     #[test]
     fn test_small_add() {
-        // Use small sizes where you can verify by hand
         let a = vec![1.0, 2.0, 3.0, 4.0];
         let b = vec![10.0, 20.0, 30.0, 40.0];
         let expected = vec![11.0, 22.0, 33.0, 44.0];
@@ -276,9 +144,7 @@ mod tests {
 }
 ```
 
-### Reference Implementation
-
-Compare GPU results against a known-correct CPU implementation:
+Then compare GPU results against a known-correct CPU implementation:
 
 ```rust
 fn cpu_softmax(input: &[f32]) -> Vec<f32> {
@@ -299,58 +165,31 @@ fn test_softmax_correctness() {
 }
 ```
 
-### Decompose Complex Kernels
-
-If a fused kernel produces wrong results, split it into separate kernels to isolate the bug:
-
-```rust
-// Instead of one complex kernel, run each step separately:
-fn debug_step1<const S: [i32; 2]>(out: &mut Tensor<f32, S>, input: &Tensor<f32, {[-1, -1]}>) {
-    out.store(step1(input));
-}
-fn debug_step2<const S: [i32; 2]>(out: &mut Tensor<f32, S>, input: &Tensor<f32, {[-1, -1]}>) {
-    out.store(step2(input));
-}
-
-// Run each step and inspect intermediate results on the host
-```
+If a fused kernel produces wrong results, split it into separate kernels and inspect intermediate results on the host. Each stage becomes its own testable unit.
 
 ---
 
 ## Profiling
 
-### Nsight Compute
-
-Profile individual kernel performance:
+**Nsight Compute** profiles individual kernel performance:
 
 ```bash
 ncu --target-processes all ./my_cutile_program
 ncu --set full -o profile_report ./my_cutile_program
 ```
 
-Key metrics:
-- **Memory Throughput** — Should be close to theoretical peak for memory-bound kernels.
-- **Compute Throughput** — Percentage of peak ALU/Tensor Core utilization.
-- **Occupancy** — Percentage of maximum warps active on each SM.
-- **Stall Reasons** — Why warps are waiting (memory, execution, synchronization).
+Focus on memory throughput (close to peak for memory-bound kernels), compute throughput (percentage of peak ALU/Tensor Core utilization), occupancy (percentage of maximum warps active per SM), and stall reasons (why warps are waiting — memory, execution, synchronization).
 
-### Nsight Systems
-
-Profile system-wide behavior across CPU and GPU:
+**Nsight Systems** profiles system-wide behavior across CPU and GPU:
 
 ```bash
 nsys profile ./my_cutile_program
 nsys-ui report.nsys-rep
 ```
 
-Look for:
-- **Kernel launch overhead** — Time between consecutive launches.
-- **Memory transfer overlap** — Whether computation hides data transfers.
-- **CPU/GPU sync points** — Unnecessary blocking waits.
+Look for kernel launch overhead (time between consecutive launches), memory transfer overlap (whether computation hides data transfers), and unnecessary CPU/GPU sync points.
 
----
-
-## Environment Variables
+A few environment variables help during debugging:
 
 | Variable | Description | Default |
 |----------|-------------|---------|
@@ -358,29 +197,10 @@ Look for:
 | `CUDA_VISIBLE_DEVICES` | Select GPU device | All GPUs |
 | `CUDA_HOME` | Path to CUDA toolkit | `/usr/local/cuda` |
 
-```bash
-CUTILE_DEBUG=1 cargo run              # Debug kernel compilation
-CUDA_VISIBLE_DEVICES=0 cargo run      # Select specific GPU
-```
+The JIT kernel cache is in-memory per process — restart the process to force recompilation.
 
-The JIT kernel cache is in-memory per process. Restart the process to force recompilation.
+Pre-ship debugging checklist: shapes compatible (tile shapes match for operations; tensors divisible by tile size); types match (element types agree or are explicitly converted); algorithm correct (CPU reference produces expected results); numerically stable (no NaN/Inf in outputs; max subtracted before `exp`); small case passes (manually verifiable input produces correct output); IR looks right (`print_ir = true` shows expected operations).
 
 ---
 
-## Debugging Checklist
-
-- [ ] **Shapes compatible?** — Tile shapes match for operations; tensors divisible by tile size.
-- [ ] **Types match?** — Element types agree or are explicitly converted.
-- [ ] **Algorithm correct?** — CPU reference implementation produces expected results.
-- [ ] **Numerically stable?** — No NaN/Inf in outputs; max subtracted before `exp`.
-- [ ] **Small case passes?** — Manually verifiable test case produces correct output.
-- [ ] **IR looks right?** — `print_ir = true` shows expected operations.
-
----
-
-## Next Steps
-
-- Review [Tuning for Performance](performance-tuning.md) for optimization techniques
-- Review [Integrating with CUDA C++](interoperability.md) for integrating custom CUDA kernels
-- Look up APIs in the [DSL API Reference](../reference/dsl-api.md) and [DeviceOp API Reference](../reference/deviceop-reference.md)
-- Try the [Tutorials](../tutorials/01-hello-world.md) for working examples
+Review [Tuning for Performance](performance-tuning.md) for optimization techniques, [Integrating with CUDA C++](interoperability.md) for custom CUDA kernels, the [DSL API](../reference/dsl-api.md) and [Host API](../reference/host-api.md) for API lookups, or the [Tutorials](../tutorials/01-hello-world.md) for worked examples.

--- a/cutile-book/guide/device-operations.md
+++ b/cutile-book/guide/device-operations.md
@@ -2,72 +2,31 @@
 
 A `DeviceOp` is the host-side handle for GPU work: it describes a computation lazily, composes with other `DeviceOp`s on the host, and then runs when you choose how. Every host-side API that returns a future (`api::zeros`, kernel launchers, `.then()` / `.shared()` / `unzip`) produces a `DeviceOp`.
 
-This chapter covers three things in sequence:
+This chapter covers the `DeviceOp` model and the three ways to execute one, how to compose `DeviceOp`s into larger computation graphs, the stream scheduling rules that determine ordering and overlap, and practical patterns for tensor ownership and synchronization.
 
-1. **Constructing** operations: what a `DeviceOp` is, how to compose them into lazy computation graphs before any GPU work starts.
-2. **Executing** them: `.sync()` blocks the thread, `.await` runs under an async runtime, and `.graph_on(&stream)` records the operation into a CUDA graph for replay.
-3. **Scheduling** them: how the default round-robin stream pool distributes work across streams, and how `.sync_on(&stream)` / `.then()` let you enforce ordering when data dependencies require it.
+---
 
-## Two Worlds: Host and Device
+## The DeviceOp Model
 
-GPU programming involves two processors working together:
-
-- **Host (CPU)** — Constructs and schedules operations, launches kernels, manages memory
-- **Device (GPU)** — Executes kernels in massively parallel fashion
+Your Rust code runs on the CPU (the *host*) and schedules work on the GPU (the *device*). A `DeviceOp` is how you express that scheduling: the host constructs and composes operations, the device executes them in parallel when the runtime asks it to.
 
 ![Host-device execution: how kernel calls flow from the host to the GPU](../_static/images/async-host-device.svg)
 
-This separation is fundamental: your Rust code runs on the CPU and schedules work on the GPU.
-
----
-
-## Streams: Queues for GPU Work
-
-A **stream** is a sequence of operations that execute in order on the GPU:
+A `DeviceOp` is a lazy description of GPU work — nothing runs until you say so:
 
 ```rust
-let ctx = CudaContext::new(0)?;      // Connect to GPU device 0
-let stream = ctx.new_stream()?;       // Create a work queue
+let z = api::zeros(&[64, 64]);  // DeviceOp<Output=Tensor<f32>>. No GPU work yet.
+let result = z.await?;          // NOW it executes.
 ```
 
-Key properties of streams:
-- Operations on the **same stream** execute in order
-- Operations on **different streams** may execute concurrently
-- Synchronization points wait for stream completion
-
----
-
-## DeviceOps: Lazy Computation Graphs
-
-The core abstraction is `DeviceOp` — a lazy operation that describes GPU work without executing it.
-
-### What's a DeviceOp?
-
-Think of it as a recipe that hasn't been cooked yet:
-
-```rust
-let z = api::zeros(&[64, 64]);  // DeviceOp<Output=Tensor<f32>>
-// Nothing happened yet! Just built a description of what to do.
-
-let result = z.await;  // NOW it executes: allocates GPU memory, fills with zeros
-```
-
-### The Key Trait
+Every `DeviceOp` implements `IntoFuture`, so every operation is awaitable:
 
 ```rust
 pub trait DeviceOp: Send + Sized + IntoFuture
-where Self::Output: Send {
-    // ...
-}
+where Self::Output: Send { /* ... */ }
 ```
 
-Every `DeviceOp` implements `IntoFuture`, which means every operation is awaitable.
-
----
-
-## The Execution Flow
-
-When you `.await` a DeviceOp, here's what happens:
+When you `.await`, the conversion goes through `into_future()` → `schedule()` → `DeviceFuture` → first poll → `execute()` → GPU work. The full sequence:
 
 ```{raw} html
 <style>
@@ -131,55 +90,9 @@ When you `.await` a DeviceOp, here's what happens:
 </div>
 ```
 
-**Step-by-step:**
+GPU work starts at `execute()`, which fires during the *first poll* — not at `.await` itself. `.await` is cheap; the DeviceFuture is built immediately at `into_future()`, and actual submission to the GPU happens when the runtime polls.
 
-1. **`.await`** converts to `IntoFuture::into_future()`
-2. **`into_future()`** immediately calls `DevicePolicy::schedule()` and returns a `DeviceFuture`
-3. **Tokio's first poll** calls `DeviceFuture::poll()` → this triggers `execute()`
-4. **`execute()`** submits work to the GPU (kernel launch, memory copy, etc.)
-5. **Subsequent polls** check if GPU work is complete
-6. When done, returns `Poll::Ready(result)`
-
----
-
-## When Does GPU Work Actually Happen?
-
-Consider the following snippet:
-
-```rust
-let x: Tensor<f32> = api::randn(0.0f32, 1.0f32, &[m, k]).await?;
-```
-
-This is what each method does:
-
-| Step | Code | GPU Work? |
-|------|------|-----------|
-| 1 | `api::randn(...)` | ❌ Creates lazy DeviceOp |
-| 2 | `.await` | ❌ Creates DeviceFuture |
-| 3 | First poll | ✅ **NOW** allocates GPU memory, generates random values |
-| 4 | Completion | Returns tensor |
-
-GPU work happens during the **first poll**, not when you call `.await`!
-
----
-
-## Starting with `.sync()`
-
-The simplest way to run a kernel is `.sync()`:
-
-```rust
-let x = api::ones::<f32>(&[1024]).sync()?;
-let y = api::ones::<f32>(&[1024]).sync()?;
-let mut z = api::zeros::<f32>(&[1024]).sync()?;
-
-add((&mut z).partition([128]), &x, &y).sync()?;
-```
-
-This is the right choice for scripts, debugging, and learning. Each `.sync()` call launches work on the GPU and blocks the CPU until it finishes.
-
-### Why sync-per-op is expensive
-
-In a multi-layer model, calling `.sync()` after every kernel creates a gap where *both* the CPU and GPU are idle — the CPU is waiting for the GPU, and the GPU has nothing queued:
+This laziness is the whole point. Calling `.sync()` after every kernel forces the CPU to wait for the GPU and the GPU to idle between kernels:
 
 ```text
 CPU:  [launch] [wait......] [launch] [wait......] [launch] [wait......]
@@ -188,14 +101,9 @@ GPU:           [kernel████]          [kernel████]          [kern
                      idle gap                idle gap
 ```
 
-For inference, this overhead dominates — kernels are fast (microseconds), but sync round-trips are not. A 22-layer transformer with 6 kernels per layer means 132 sync gaps per token.
-
-### The fix: compose first, sync once
-
-Build the entire operation graph lazily, then execute in one shot:
+For inference-style workloads — kernels take microseconds; sync round-trips don't — these gaps dominate. A 22-layer transformer with 6 kernels per layer hits 132 sync gaps per token. Composing lazily and synchronizing once eliminates them:
 
 ```rust
-// No GPU work yet — just building the graph.
 let result = rms_norm(out1, hidden.clone(), weight.clone(), eps)
     .first()
     .unpartition()
@@ -206,7 +114,6 @@ let q = matvec(out2, result.clone(), wq.clone())
     .unpartition()
     .shared();
 
-// NOW execute everything on one stream, no gaps.
 let output = q.sync_on(&stream)?;
 ```
 
@@ -216,94 +123,56 @@ GPU:                    [norm████][mv████][add████]
                          no gaps — work is pipelined
 ```
 
-The rest of this guide explains the tools for building these graphs:
-`.then()`, `zip!`, `.shared()`, `.await`, and stream scheduling.
+cuTile offers three peer execution modes for running a constructed `DeviceOp`:
 
-### Synchronous: `.sync()` / `.sync_on()`
+**Synchronous** — `.sync()` and `.sync_on(&stream)` block the thread until the result is ready. Best for scripts, debugging, and learning.
 
 ```rust
-kernel(args...).sync()?;          // default device, default stream policy
-kernel(args...).sync_on(&stream)?; // explicit stream
+kernel(args...).sync()?;            // default device, default stream policy
+kernel(args...).sync_on(&stream)?;  // explicit stream
 ```
 
-### Asynchronous: `.await`
+**Asynchronous** — `.await` is non-blocking in an async context. Composes lazily for overlap.
 
 ```rust
-let result = kernel(args...).await?;  // non-blocking in async context
-```
+let result = kernel(args...).await?;
 
-Or compose lazily and await the final result:
-
-```rust
 let result = step1(args)
     .then(|out| step2(out))
     .then(|out| step3(out))
     .await?;
 ```
 
-### CUDA Graphs: `.graph_on(&stream)`
-
-For repetitive workloads — the same `DeviceOp` chain run many times — record it as a CUDA graph once and replay with minimal launch overhead. This is how you get the lowest possible per-invocation cost for hot paths (e.g., inference loops where the same pipeline runs per token).
+**CUDA graph** — `.graph_on(&stream)` records a `DeviceOp` chain as a CUDA graph once and replays with minimal launch overhead. For hot paths like per-token inference loops that run the same pipeline many times.
 
 ```rust
-let stream = ctx.new_stream()?;
 let graph = pipeline(input).graph_on(&stream)?;
-
 for _ in 0..iterations {
     graph.launch(&stream)?;  // replay — no per-op dispatch
 }
 ```
 
-Graph recording captures exact kernel launches and memory operations at build time; subsequent launches skip CPU-side dispatch. See [CUDA Graph Integration in the DeviceOp API Reference](../reference/deviceop-reference.md#cuda-graph-integration) for the combinator (`.graph_on`) and scope-based (`CudaGraph::scope`) approaches, and [Tutorial 10](../tutorials/10-cuda-graphs.md) for a worked example.
+See [CUDA Graph Integration in the Host API](../reference/host-api.md#cuda-graph-integration) and [Tutorial 10](../tutorials/10-cuda-graphs.md) for the graph API in detail.
 
 ---
 
-## Building Computation Graphs
+## Composing DeviceOps
 
-DeviceOps compose into computation graphs:
+`DeviceOp`s compose into computation graphs using four combinators: `.then()`, `zip!`, `unzip`, and `.shared()`. Graphs are constructed lazily and evaluated as a unit, which lets the scheduler fuse kernels, reuse memory, and overlap independent work.
+
+![Lazy computation graph showing how DeviceOps compose](../_static/images/computation-graph.svg)
+
+**`.then()`** chains operations sequentially — the output of one feeds the next. Chained ops share a stream, so ordering is strict.
 
 ```rust
-// Build lazy computation graph — no GPU work yet
-let z = api::zeros(&[m, n]).partition([bm, bn]);
-let x = api::randn(0.0, 1.0, &[m, k]);
-let y = api::randn(0.0, 1.0, &[k, n]);
-
-// Chain kernel invocations — output-first convention, direct calls
 let result = matmul(z, x, y)
     .then(|(z, _x, _y)| activation(z))
     .then(|(z,)| normalize(z));
 
-// Execute entire graph in one shot
 let output = result.await?;
 ```
 
-![Lazy computation graph showing how DeviceOps compose](../_static/images/computation-graph.svg)
-
-**Benefits:**
-- Operations can be fused
-- Memory can be reused
-- Scheduling can be optimized
-
----
-
-## Splitting and Sharing Operations
-
-`zip!` combines multiple `DeviceOp`s into one. But what about the reverse — taking a single operation's output and feeding it into multiple downstream branches? That's what `unzip` and `.shared()` are for.
-
-### unzip: Fan-Out from a Tuple
-
-`unzip` takes an operation that produces a tuple and splits it into independent operations, one per element:
-
-```rust
-// A kernel returns (output, weight, bias) as a 3-tuple.
-let (output, weight, bias) = kernel(args).unzip();
-
-// Each is now an independent DeviceOp.
-let result = output.unpartition().await?;
-let w = weight.await?;
-```
-
-`unzip` is the inverse of `zip!`:
+**`zip!`** combines multiple independent `DeviceOp`s into a single tuple-valued one (fan-in). **`unzip`** is the inverse: splits a tuple-producing op into independent branches (fan-out).
 
 ```text
   zip! (fan-in)                     unzip (fan-out)
@@ -313,51 +182,27 @@ let w = weight.await?;
     op_b ─┘                           └── branch_b
 ```
 
-### The Execute-Once Guarantee
-
-When you `unzip`, the ancestor operation that produces the tuple is **executed at most once**, regardless of how many branches consume it. Internally, `unzip` uses a shared gate (`Select`) that runs the ancestor on the first branch to execute and caches the results for the remaining branches:
-
-```text
-                                      ┌── SelectLeft ── .sync()  ─── runs ancestor,
-  ancestor_op ────── Select (shared) ─┤                               caches both results
-                                      └── SelectRight ── .sync() ─── finds cached result,
-                                                                      no re-execution
-```
-
-This means fan-out patterns like "compute once, use in two places" are safe and efficient:
+When you `unzip`, the upstream operation runs **at most once** regardless of how many branches consume it. An internal shared gate executes it on the first branch to poll and caches the results for the rest:
 
 ```rust
 let (z, x, y) = zip!(z_op, x_op, y_op)
     .then(my_kernel)
     .unzip();
 
-// The kernel runs once. z, x, and y each take their portion of the result.
-let output = z.unpartition().to_host_vec().sync()?;
+let output = z.unpartition().to_host_vec().sync()?;  // kernel runs once
 ```
 
-### .shared(): Cloneable, Execute-Once Operations
-
-`.shared()` converts any `DeviceOp` into a `SharedDeviceOp<T>` that implements `Clone`. The underlying operation executes at most once — every clone gets `Arc::clone()` of the cached result. This follows the `FutureExt::shared()` convention from the `futures` crate.
+**`.shared()`** converts any `DeviceOp` into a `Clone`-able `SharedDeviceOp<T>`. All clones share one `Arc` of the result; the underlying op executes once. Use it when many downstream kernels need the same input.
 
 ```rust
-// Create a shared operation — cloneable, execute-once.
 let x = api::ones(&[32, 32]).shared();
 
-// Pass to multiple consumers without consuming the original.
 let a = kernel_a(x.clone()).sync()?;  // x executes here (once)
-let b = kernel_b(x.clone()).sync()?;  // Uses the cached Arc — no re-execution
+let b = kernel_b(x.clone()).sync()?;  // Uses the cached Arc
 let c = kernel_c(x).sync()?;          // Also uses the cached result
 ```
 
-Unlike `unzip` (which splits a fixed tuple), `.shared()` supports unlimited consumers. The result is always `Arc<T>`, so shared reads are cheap.
-
-For pre-computed values (e.g., weight tensors already in `Arc`), use the `shared()` constructor:
-
-```rust
-let w: SharedDeviceOp<Tensor<f32>> = cuda_async::device_operation::shared(weight_arc);
-```
-
-### Common Patterns
+Diamond (fan-out then fan-in) and broadcast are two common composition patterns:
 
 ```text
 Diamond (fan-out then fan-in):
@@ -374,94 +219,15 @@ Broadcast (.shared() into parallel kernels):
                      └── kernel_c ── result_c
 ```
 
-### Limitations
-
-The execute-once mechanism relies on **sequential execution** — the normal mode for `cuda-async`, where operations are `.sync()`'d or `.await`'d one at a time from a single thread. Under this model, the shared gate is guaranteed to see only one caller at a time.
-
-If two branches of an `unzip` were somehow executed **concurrently on different OS threads** (e.g., via `tokio::spawn` on a multi-threaded runtime), the gate is not safe — it uses a non-atomic check-then-act pattern internally. In practice, this is not triggerable because device contexts are thread-local, so scheduling an operation from a thread that hasn't initialized its device context will fail before reaching the gate. However, avoid designs that would poll both sides of an `unzip` from different threads.
-
----
-
-## Sync Points and Memory Management
-
-### When to Sync
-
-You need synchronization when:
-1. Reading results back to CPU
-2. Before modifying data that's still being read
-3. At computation boundaries
-
-```rust
-// Bad: No sync before reading
-let z = kernel(x, y).sync_on(&stream);
-let data = z.to_host_vec();  // ❌ May read incomplete data!
-
-// Good: Sync before reading
-let z = kernel(x, y).sync_on(&stream);
-let data = z.to_host_vec().sync_on(&stream);  // ✅ Waits for completion
-```
-
-### Passing Tensors to Kernels
-
-Kernel `&Tensor` params accept three input forms, and `&mut Tensor` params
-accept two partition forms. You get back the same type you put in.
-
-**Inputs (`&Tensor`):**
-
-```rust
-// Owned — single use, no Arc overhead.
-let x: Tensor<f32> = ones(&[32, 32]).sync_on(&stream)?;
-let (_, x) = kernel(out, x).sync_on(&stream)?;  // x is Tensor<f32>
-
-// Shared — use the same tensor in multiple kernels.
-let x: Arc<Tensor<f32>> = ones(&[32, 32]).sync_on(&stream)?.into();
-let z1 = kernel1(out1, x.clone()).sync_on(&stream)?;
-let z2 = kernel2(out2, x.clone()).sync_on(&stream)?;
-
-// Borrowed — no allocation, borrow checker enforces lifetime.
-let x: Tensor<f32> = ones(&[32, 32]).sync_on(&stream)?;
-let _ = kernel(out, &x).sync_on(&stream)?;  // x still available
-```
-
-**Outputs (`&mut Tensor`):**
-
-```rust
-// Owned partition — must unpartition() to get the tensor back.
-let z = zeros(&[32, 32]).sync_on(&stream)?.partition([4, 4]);
-let (z, ..) = kernel(z, &x).sync_on(&stream)?;
-let tensor = z.unpartition();
-
-// Borrowed partition — writes in place, no unpartition() needed.
-let mut z = zeros(&[32, 32]).sync_on(&stream)?;
-let _ = kernel((&mut z).partition([4, 4]), &x).sync_on(&stream)?;
-// z already has the result.
-```
-
-Borrowed inputs (`&Tensor<T>`) and borrowed partitions (`Partition<&mut Tensor<T>>`)
-are not `'static`, so `tokio::spawn` rejects them at compile time — use `Arc`
-and owned partitions for spawned tasks.
-
-See the [DeviceOp API Reference](../reference/deviceop-reference.md#ownership-model)
-for the full ownership model.
+The execute-once mechanism assumes sequential polling from a single thread, which is the normal mode for `cuda-async`. Polling both sides of an `unzip` from different OS threads is unsafe (the gate uses a non-atomic check-then-act). Device contexts are thread-local, so the common triggering patterns fail earlier; still, avoid designs that fan out across threads.
 
 ---
 
 ## Streams and Scheduling
 
-This section explains **when GPU operations run in order** and **when they can overlap**. Understanding this is critical for both correctness and performance.
+A CUDA stream is an ordered queue of GPU work. The foundational rule: operations on the **same stream** execute in submission order; operations on **different streams** may execute concurrently.
 
-### The One Rule of CUDA Streams
-
-A CUDA **stream** is an ordered queue of GPU work. The rule is simple:
-
-> Operations on the **same stream** always execute in submission order.
-> Operations on **different streams** may execute concurrently — the GPU is free to overlap them.
-
-This means the stream an operation lands on determines its ordering guarantees with respect to other operations.
-
-### Default Behavior: Round-Robin Stream Pool
-
-When you call `.await` or `.sync()`, cutile does **not** put every operation on a single stream. Instead, it uses a **round-robin scheduling policy** that rotates through a pool of streams:
+By default, cuTile distributes operations across a pool of 4 streams using a round-robin policy, so independent operations land on different streams and can overlap:
 
 ```text
                          ┌─────────────────────────────────────────┐
@@ -476,127 +242,44 @@ When you call `.await` or `.sync()`, cutile does **not** put every operation on 
                          └─────────────────────────────────────────┘
 ```
 
-The default pool has **4 streams**. Each new operation goes to the next stream in rotation (0 → 1 → 2 → 3 → 0 → …). Because they land on different streams, **independent operations can overlap** — the GPU can work on multiple kernels or memory transfers simultaneously.
+Operations serialize in four cases: wrap-around onto the same stream (every 4th op in the default pool); chained with `.then()` (same stream); pinned to a single stream via `.sync_on(&stream)`; or awaited sequentially (the host blocks between awaits, so the next op is submitted only after the previous completes).
 
-### When Operations Serialize
+Operations overlap when they land on different streams **and** are submitted before the host waits for either — typically via `zip!`, `tokio::join!`, or direct lazy composition that the async runtime polls concurrently.
 
-Even with the round-robin pool, operations **will** run in order in these cases:
-
-**1. Same stream (wrap-around)**
-
-Every 4th operation lands on the same stream. If `op_a` and `op_e` are both on Stream 0, `op_e` waits for `op_a` to finish:
-
-```text
-Stream 0: ████████ (op_a)         ████████ (op_e waits for op_a)
-Stream 1:    ████████ (op_b)
-Stream 2:       ████████ (op_c)
-Stream 3:          ████████ (op_d)
-```
-
-**2. Chained with `.then()`**
-
-Operations composed with `.then()` share a single stream, so the second operation always sees the first one's output:
+Data dependencies are your responsibility. The round-robin policy does not track them. If operation B reads A's output, you must force ordering:
 
 ```rust
-let result = allocate_tensor()
-    .then(|tensor| fill_with_ones(tensor))  // same stream → ordered
-    .then(|tensor| run_kernel(tensor))       // same stream → ordered
-    .await;
-```
+// Chain with .then() — same stream, automatic ordering
+let result = create_tensor().then(|t| process(t)).await;
 
-**3. Explicit stream with `.sync_on()`**
-
-When you pass the same stream to multiple `.sync_on()` calls, all operations serialize on that stream:
-
-```rust
-let stream = ctx.new_stream()?;
-
-let a = op_a.sync_on(&stream);  // Stream X: runs first
-let b = op_b.sync_on(&stream);  // Stream X: waits for op_a
-let c = op_c.sync_on(&stream);  // Stream X: waits for op_b
-```
-
-**4. Awaiting sequentially**
-
-Each `.await` blocks the host until its GPU work completes (the `DeviceFuture` polls until the stream callback fires). So even though `op_a` and `op_b` may be on different streams, awaiting them one-by-one means `op_b` is not submitted until `op_a`'s result is ready on the host:
-
-```rust
-let a = op_a.await;  // Host waits for GPU to finish op_a
-let b = op_b.await;  // op_b submitted after op_a is confirmed done
-// These effectively serialize, even on different streams.
-```
-
-### When Operations Can Overlap
-
-Overlap requires two things: (1) operations land on different streams, and (2) they are submitted to the GPU before waiting for each other.
-
-**Building a lazy graph — direct kernel call:**
-
-```rust
-// The unified launcher accepts both DeviceOps and plain values.
-// No need for zip! or value() wrapping.
-let result = my_kernel(
-    zeros(&[1024, 1024]).partition([64, 64]),
-    x,
-    y,
-)
-.first()
-.unpartition()
-.await?;
-```
-
-**Using `tokio::join!` for independent work:**
-
-```rust
-// Both futures are polled concurrently by the async runtime.
-// They will likely land on different streams and overlap on the GPU.
-let (result_a, result_b) = tokio::join!(
-    kernel_a(x.clone()),
-    kernel_b(y.clone()),
-);
-```
-
-### Data Dependencies: Your Responsibility
-
-The round-robin policy does **not** track data dependencies. If operation B reads the output of operation A, you must ensure A finishes before B starts. Otherwise B may read stale or partially-written data.
-
-**Safe patterns for dependent operations:**
-
-```rust
-// Pattern 1: Chain with .then() — same stream, automatic ordering
-let result = create_tensor()
-    .then(|t| process(t))
-    .await;
-
-// Pattern 2: Await sequentially — host ensures ordering
+// Await sequentially — host ensures ordering
 let tensor = create_tensor().await;
 let result = process(tensor).await;
 
-// Pattern 3: Pin to the same stream — CUDA guarantees ordering
+// Pin to the same stream — CUDA guarantees ordering
 let stream = ctx.new_stream()?;
 let tensor = create_tensor().sync_on(&stream);
 let result = process(tensor).sync_on(&stream);
 ```
 
-**Unsafe pattern to avoid:**
+The unsafe pattern — feeding A's output to B but submitting them as independent futures that land on different streams — can produce stale or partial reads:
 
 ```rust
 // ⚠️ DANGER: op_b may start before op_a finishes if they land on different streams!
-let future_a = op_a.into_future();  // Submitted to Stream 0
-let future_b = op_b_reads_a_output.into_future();  // Submitted to Stream 1
+let future_a = op_a.into_future();                    // Submitted to Stream 0
+let future_b = op_b_reads_a_output.into_future();     // Submitted to Stream 1
 let (a, b) = tokio::join!(future_a, future_b);
-// op_b might read incomplete data from op_a.
 ```
 
-### Choosing the Right Execution Method
+### Execution method comparison
 
-| Method               | Stream assignment           | Ordering guarantee          | Best for                           |
-|----------------------|-----------------------------|-----------------------------|------------------------------------|
-| `.then()`        | Shares parent's stream      | **Strict** — same stream    | Dependent operations               |
-| `.sync_on(&stream)`  | Your explicit stream        | **Strict** — if same stream | Debugging, deterministic pipelines |
-| `.sync()`            | Policy picks (round-robin)  | **None** between calls      | Quick scripts                      |
-| `.await`             | Policy picks (round-robin)  | **None** between awaits     | Async code (see note below)        |
-| `zip!` + `.then()`  | Single stream for the graph | **Strict** within the graph | Kernel launch patterns             |
+| Method                | Stream assignment           | Ordering guarantee          | Best for                           |
+|-----------------------|-----------------------------|-----------------------------|------------------------------------|
+| `.then()`             | Shares parent's stream      | Strict: same stream         | Dependent operations               |
+| `.sync_on(&stream)`   | Your explicit stream        | Strict if same stream       | Debugging, deterministic pipelines |
+| `.sync()`             | Policy picks (round-robin)  | None between calls          | Quick scripts                      |
+| `.await`              | Policy picks (round-robin)  | None between awaits         | Async code                         |
+| `zip!` + `.then()`    | Single stream for the graph | Strict within the graph     | Kernel launch patterns             |
 
 :::{tip}
 Sequential `.await` calls *appear* ordered from the host's perspective (each waits before the next starts), but the GPU work for each `.await` runs on whichever stream the policy assigns. For truly independent operations you want to overlap, use `zip!` or `tokio::join!`.
@@ -604,80 +287,56 @@ Sequential `.await` calls *appear* ordered from the host's perspective (each wai
 
 ---
 
-## Performance Tips
+## Practical Patterns
 
-### 1. Batch Operations
+Kernel `&Tensor` params accept three input forms, and `&mut Tensor` params accept two partition forms. You get back the same type you put in.
 
-```rust
-// Bad: Many small syncs
-for i in 0..1000 {
-    let result = kernel(data[i]).sync_on(&stream);
-}
-
-// Good: Build graph, sync once
-let ops: Vec<_> = (0..1000).map(|i| kernel(data[i])).collect();
-let results = join_all(ops).await;
-```
-
-### 2. Overlap Computation and Memory Transfers
-
-The default round-robin policy already enables this — consecutive operations land on different streams, so a kernel on Stream 0 can overlap with a memory transfer on Stream 1:
+Read-only inputs (`&Tensor`):
 
 ```rust
-// These naturally overlap with the default 4-stream pool:
-let compute_op = heavy_kernel(input.clone());
-let transfer_op = api::zeros(&[next_batch_size, dim]);
+// Owned — single use, no Arc overhead.
+let x: Tensor<f32> = ones(&[32, 32]).sync_on(&stream)?;
+let (_, x) = kernel(out, x).sync_on(&stream)?;
 
-// Submit both before waiting for either:
-let (result, next_buffer) = tokio::join!(compute_op, transfer_op);
+// Shared — use the same tensor in multiple kernels.
+let x: Arc<Tensor<f32>> = ones(&[32, 32]).sync_on(&stream)?.into();
+let z1 = kernel1(out1, x.clone()).sync_on(&stream)?;
+let z2 = kernel2(out2, x.clone()).sync_on(&stream)?;
+
+// Borrowed — no allocation, borrow checker enforces lifetime.
+let x: Tensor<f32> = ones(&[32, 32]).sync_on(&stream)?;
+let _ = kernel(out, &x).sync_on(&stream)?;
 ```
 
-For explicit control, create dedicated streams:
+Mutable outputs (`&mut Tensor`):
 
 ```rust
-let compute_stream = ctx.new_stream()?;
-let transfer_stream = ctx.new_stream()?;
+// Owned partition — must unpartition() to get the tensor back.
+let z = zeros(&[32, 32]).sync_on(&stream)?.partition([4, 4]);
+let (z, ..) = kernel(z, &x).sync_on(&stream)?;
+let tensor = z.unpartition();
 
-let result = heavy_kernel(input).sync_on(&compute_stream);
-let next_batch = load_data().sync_on(&transfer_stream); // overlaps!
+// Borrowed partition — writes in place, no unpartition() needed.
+let mut z = zeros(&[32, 32]).sync_on(&stream)?;
+let _ = kernel((&mut z).partition([4, 4]), &x).sync_on(&stream)?;
 ```
 
-### 3. Use Appropriate Grid Sizes
+Borrowed inputs and borrowed partitions aren't `'static`, so `tokio::spawn` rejects them at compile time — use `Arc` and owned partitions for spawned tasks. See the [Host API: Ownership Model](../reference/host-api.md#ownership-model) for the full ownership model.
+
+Synchronize before reading results back to the host or before modifying data that's still being read. `to_host_vec` always needs a sync:
 
 ```rust
-// Match grid to your data size
-let num_tiles = data.len() / tile_size;
-launcher.grid((num_tiles as u32, 1, 1)).sync_on(&stream);
+// Bad: No sync before reading
+let z = kernel(x, y).sync_on(&stream);
+let data = z.to_host_vec();  // ❌ May read incomplete data!
+
+// Good: Sync before reading
+let z = kernel(x, y).sync_on(&stream);
+let data = z.to_host_vec().sync_on(&stream);  // ✅ Waits for completion
 ```
+
+Common pitfalls: syncing per operation in hot paths (build a graph and sync once instead); forgetting to compose for overlap (use `zip!` or `tokio::join!` for independent work); calling `.await` sequentially when operations are actually independent (this effectively serializes them across streams).
 
 ---
 
-## Summary
-
-| Concept                   | What it is                                                  |
-|---------------------------|-------------------------------------------------------------|
-| **DeviceOp**       | Lazy computation description                                |
-| **Stream**                | Ordered queue of GPU work                                   |
-| **SchedulingPolicy**      | Decides which stream each operation uses                    |
-| **Round-Robin (default)** | Rotates across 4 streams — enables overlap                  |
-| **SingleStream**          | All ops on one stream — strict ordering                     |
-| **sync_on()**             | Execute on an explicit stream and wait                      |
-| **await**                 | Execute via the default device's scheduling policy (async)  |
-| **.then()**           | Chain operations on the same stream                         |
-| **zip!**                  | Combine multiple operations into one (fan-in)               |
-| **unzip**                 | Split a tuple operation into independent branches (fan-out) |
-| **.shared()**             | Cloneable, execute-once operation — share data across N branches |
-| **.map(f)**               | Transform output without new GPU work                       |
-| **.first()** / **.last()**| Extract first/last element from tuple output                |
-| **.boxed()**              | Type-erase an operation for heterogeneous collections       |
-
-**Key takeaways:**
-
-1. The default policy distributes work across **4 streams** — consecutive operations can overlap.
-2. Operations on the **same stream** are always ordered; operations on **different streams** are not.
-3. Use `.then()`, sequential `.await`, or `.sync_on()` with a shared stream to enforce ordering between dependent operations.
-4. Use `zip!`, `.then()`, or `tokio::join!` to enable overlap for independent operations.
-
----
-
-Continue to [Tuning for Performance](performance-tuning.md) for optimization techniques. For the full `DeviceOp` API, see the [DeviceOp API Reference](../reference/deviceop-reference.md).
+Continue to [Tuning for Performance](performance-tuning.md) for optimization techniques. For the full `DeviceOp` API, see the [Host API](../reference/host-api.md).

--- a/cutile-book/guide/execution-model.md
+++ b/cutile-book/guide/execution-model.md
@@ -1,12 +1,14 @@
-# How Kernels Run on the GPU
+# The Execution Model
 
-This page describes how cuTile Rust programs execute on NVIDIA GPUs.
+This page describes how cuTile Rust programs execute on NVIDIA GPUs — the abstract machine the compiler targets, how entry points are declared, how tile blocks run concurrently, and which values are compile-time constants vs. runtime inputs.
 
-## Abstract Machine
+---
 
-cuTile Rust is built on [Tile IR](https://docs.nvidia.com/cuda/tile-ir/latest/) — a tile virtual machine and instruction set that models the GPU as a tile-based processor. Unlike the traditional SIMT (Single Instruction Multiple Thread) model, Tile IR enables programming in terms of tiles (multi-dimensional array fragments) rather than individual threads.
+## The Abstract Machine
 
-cuTile Rust targets an **abstract machine** that maps to CUDA:
+cuTile Rust is built on [Tile IR](https://docs.nvidia.com/cuda/tile-ir/latest/): a tile virtual machine and instruction set that models the GPU as a tile-based processor. Unlike the traditional SIMT (Single Instruction Multiple Thread) model, Tile IR lets you program in terms of tiles (multi-dimensional array fragments) rather than individual threads.
+
+The abstract machine maps to CUDA like this:
 
 | Abstract Concept | What It Represents | CUDA Mapping |
 |------------------|--------------------|------------------|
@@ -14,60 +16,11 @@ cuTile Rust targets an **abstract machine** that maps to CUDA:
 | **Tile** | An immutable multi-dimensional array fragment with compile-time static shape | Data in registers |
 | **Tensor** | A multi-dimensional array in global memory, accessed via structured views | Data in HBM, accessed through typed pointers with shape and stride metadata |
 
-The mapping of both the grid and individual tile blocks to the underlying hardware threads is abstracted away and handled entirely by the compiler. This includes:
-- Thread block and cluster configuration.
-- Register allocation.
-- Shared memory staging.
-- Memory coalescing.
-- Tensor Core utilization.
+The mapping of the grid and individual tile blocks to underlying hardware threads is abstracted away and handled by the compiler: thread block and cluster configuration, register allocation, shared memory staging, memory coalescing, and Tensor Core utilization.
 
-## Execution Spaces
+Execution happens across two spaces: the **host side** (CPU) allocates GPU memory, launches kernels, manages data transfers, and coordinates async operations; the **device side** (GPU) concurrently runs kernel code on tile blocks, operating on tiles in registers and accessing global memory through tensors. See [Orchestrating Device Operations](device-operations.md) for the host-side execution story.
 
-cuTile Rust operates across two execution spaces, more commonly referred to as the host-side and device-side:
-
-### Host Side (CPU)
-
-- Allocates GPU memory.
-- Launches kernels.
-- Manages data transfers.
-- Coordinates async operations.
-
-```rust
-// Host code: sets up data and launches the kernel
-fn main() -> Result<(), Error> {
-    let ctx = CudaContext::new(0)?;
-    let stream = ctx.new_stream()?;
-
-    let x: Arc<Tensor<f32>> = ones(&[1024, 1024]).map(Into::into).sync_on(&stream)?;
-    let y: Arc<Tensor<f32>> = ones(&[1024, 1024]).map(Into::into).sync_on(&stream)?;
-    let z = zeros(&[1024, 1024]).sync_on(&stream)?.partition([64, 64]);
-
-    let (z, _x, _y) = add(z, x, y).sync_on(&stream)?;
-    Ok(())
-}
-```
-
-### Device Side (GPU)
-
-- Concurrently executes kernel code on tile threads.
-- Operates on tiles in registers.
-- Accesses global memory through tensors.
-
-```rust
-// Device code: runs on GPU
-#[cutile::entry()]
-fn add<const S: [i32; 2]>(
-    c: &mut Tensor<f32, S>,
-    a: &Tensor<f32, {[-1, -1]}>,
-    b: &Tensor<f32, {[-1, -1]}>
-) {
-    // The compiler performs automatic parallelization, 
-    // executing the following code on hundreds of GPU threads in parallel
-    let tile_a = load_tile_like_2d(a, c);
-    let tile_b = load_tile_like_2d(b, c);
-    c.store(tile_a + tile_b);
-}
-```
+---
 
 ## Kernel Entry Points
 
@@ -88,28 +41,23 @@ mod my_kernels {
 }
 ```
 
-### Entry Point Rules
+Entry points have four rules:
 
 1. **Must be in a module** — Entry points must be inside a `#[cutile::module]` block.
 2. **Const generics for tile size** — An output tensor's shape must be static. It determines the output tensor's tile size.
 3. **Tensor parameters** — All data passes through `Tensor` references.
 4. **No return values** — Results are written to output tensors.
 
+---
+
 ## Tile Concurrency
 
-When a kernel launches, the runtime creates a **grid of tile blocks**:
+When a kernel launches, the runtime creates a **grid of tile blocks**. Each tile block runs the same kernel function independently, processing one sub-tensor of the data:
 
 ```{figure} ../_static/images/tile-parallelism.svg
 :width: 100%
 :alt: Tile concurrency showing how tensors are partitioned into sub-tensors
 ```
-
-Each tile thread:
-- Processes one sub-tensor of data.
-- Runs independently of other tile threads.
-- Executes the same kernel function.
-
-### Tile Block Identification
 
 Within a kernel, each tile block can query its coordinates in the grid and the total grid dimensions:
 
@@ -129,43 +77,30 @@ fn kernel<const S: [i32; 2]>(
 }
 ```
 
-## Constantness
+Tile blocks that fit on available SMs run in parallel; the full set of tile blocks runs concurrently, with unspecified relative order. See [Thinking in Tiles](thinking-in-tiles.md) for the partitioning rules that drive the grid geometry.
 
-cuTile Rust enforces **compile-time constantness** for key values:
+---
 
-### Compile-Time Constants
+## Compile-Time vs Runtime Values
 
-These must be known at compile time. Some compile-time constants include:
-- **Tile dimensions** — Shape of tiles in registers.
-- **Dtype** — Element data types.
-- **Reduction axes** — Which dimensions to reduce.
+cuTile Rust enforces compile-time constantness for values the compiler needs to reason about. **Compile-time constants** include tile dimensions (shape of tiles in registers), element dtypes, and reduction axes. **Runtime values** include tensor dimensions (size of input tensors), tensor data, and grid size (number of tile blocks to launch).
 
 ```rust
-// Tile shape is a compile-time constant, specified via const generics
 #[cutile::entry()]
 fn kernel<const TILE_SIZE: [i32; 2]>(
-    output: &mut Tensor<f32, TILE_SIZE>,  // [64, 64] known at compile time
-    input: &Tensor<f32, {[-1, -1]}>       // Dynamic size
+    output: &mut Tensor<f32, TILE_SIZE>,  // Tile shape: compile-time constant
+    input: &Tensor<f32, {[-1, -1]}>       // Tensor shape: runtime
 ) {
     let tile = load_tile_like_2d(input, output);
-    
-    // Reduction axis is a compile-time constant
-    let max_vals = reduce_max(tile, 1i32);  // Reduce along axis 1
+
+    let max_vals = reduce_max(tile, 1i32);  // Reduction axis: compile-time constant
 
     output.store(tile);
 }
 ```
 
-### Runtime Values
+Compile-time constants drive specialization: each unique combination of const generic values triggers its own compilation. Keeping the set of distinct specializations small matters for compile time and binary size.
 
-These can vary at runtime:
-- **Tensor dimensions** — Size of input tensors.
-- **Tensor data** — Actual element values.
-- **Grid size** — Number of tile blocks to launch.
+---
 
-## Next Steps
-
-- Continue to [Orchestrating Device Operations](device-operations.md) for the host-side execution story
-- Review [Working with Data](working-with-data.md) for details on types and shapes
-- Review [Where Data Lives](memory-hierarchy.md) for memory layout details
-- See [Integrating with CUDA C++](interoperability.md) for combining custom CUDA kernels with the `DeviceOp` model
+Continue to [Orchestrating Device Operations](device-operations.md) for the host-side execution story. For tuning tile sizes and architecture-specific hints, see [Tuning for Performance](performance-tuning.md).

--- a/cutile-book/guide/interoperability.md
+++ b/cutile-book/guide/interoperability.md
@@ -1,10 +1,10 @@
 # Integrating with CUDA C++
 
-The tile model handles dense tensor algebra well — GEMM, element-wise operations, reductions, convolutions — but some algorithms depend on **warp-level primitives** (`__shfl_sync`, `__ballot_sync`, `__reduce_sync`) for things like custom scan/prefix-sum, cooperative groups, or irregular data access patterns. For these, write the kernel in CUDA C++ and integrate it using the approach below.
+The tile model handles dense tensor algebra well — GEMM, element-wise operations, reductions, convolutions — but some algorithms depend on **warp-level primitives** (`__shfl_sync`, `__ballot_sync`, `__reduce_sync`) for things like custom scan/prefix-sum, cooperative groups, or irregular data access patterns. For these, write the kernel in CUDA C++ and integrate it using the approach below. A custom CUDA kernel can participate in the same `DeviceOp` execution model as your tile kernels — sharing streams, chaining with `.then()`, and avoiding unnecessary synchronization.
 
-A custom CUDA kernel can participate in the same `DeviceOp` execution model as your tile kernels — sharing streams, chaining with `.then()`, and avoiding unnecessary synchronization.
+---
 
-## Step 1: Compile Your CUDA Kernel
+## Integrating a CUDA C++ Kernel
 
 Compile your CUDA C++ kernel to PTX (portable) or a `.cubin` (architecture-specific):
 
@@ -16,32 +16,24 @@ nvcc -ptx -arch=compute_80 my_kernel.cu -o my_kernel.ptx
 nvcc -cubin -arch=sm_80 my_kernel.cu -o my_kernel.cubin
 ```
 
-> **Architecture portability:** A `.cubin` file only runs on the exact SM architecture it was compiled for. Code compiled with `-arch=sm_80` will not load on an `sm_100` GPU. PTX avoids this problem — the CUDA driver JIT-compiles it for the target GPU at load time, at the cost of a one-time compilation delay. Prefer PTX unless you need to eliminate JIT overhead. If you must ship `.cubin` files, compile for each target architecture.
+> **Architecture portability:** A `.cubin` file only runs on the exact SM architecture it was compiled for. Code compiled with `-arch=sm_80` will not load on an `sm_100` GPU. PTX avoids this problem — the CUDA driver JIT-compiles it for the target GPU at load time, at the cost of a one-time compilation delay. Prefer PTX unless you need to eliminate JIT overhead.
 
-## Step 2: Load the Module and Function
-
-Use `cuda-async`'s module loading functions to load the compiled kernel:
+Load the compiled module and get a handle to the entry function:
 
 ```rust
-use cuda_async::device_context::load_module_from_file;
+use cuda_async::device_context::{load_module_from_file, load_module_from_ptx};
 
+// From cubin:
 let module = load_module_from_file("my_kernel.cubin", device_id)?;
-let function = Arc::new(module.load_function("my_kernel_entry")?);
-```
 
-For PTX (JIT-compiled at runtime):
-
-```rust
-use cuda_async::device_context::load_module_from_ptx;
-
+// Or from PTX (JIT-compiled at load time):
 let ptx_src = include_str!("my_kernel.ptx");
 let module = load_module_from_ptx(ptx_src, device_id)?;
+
 let function = Arc::new(module.load_function("my_kernel_entry")?);
 ```
 
-## Step 3: Launch via AsyncKernelLaunch
-
-`AsyncKernelLaunch` is a `DeviceOp` that wraps the CUDA driver's kernel launch API:
+Launch the kernel via `AsyncKernelLaunch`, which is a `DeviceOp` wrapping the CUDA driver's kernel launch API:
 
 ```rust
 use cuda_async::launch::AsyncKernelLaunch;
@@ -68,26 +60,17 @@ launcher.set_launch_config(LaunchConfig {
 launcher.await?;
 ```
 
-Scalar arguments (types implementing `DType`) can be pushed safely with `push_arg`. Device pointers must use `unsafe { push_device_ptr() }` — see [Safety: Device Pointer Arguments](#safety-device-pointer-arguments) below.
-
-## Safety: Device Pointer Arguments
-
-`push_device_ptr` passes a raw address to the CUDA driver. The Rust compiler has no visibility into GPU kernel code and cannot verify that:
-
-- The pointer refers to a valid device memory allocation on the correct GPU.
-- The allocation is large enough for the kernel's access pattern.
-- No other operation is concurrently reading or writing the same memory.
-- The argument order and types match the kernel's parameter signature.
-
-Neither the Rust compiler nor the CUDA driver validates these invariants — mistakes result in silent undefined behavior or hard-to-diagnose GPU faults. You must verify them manually.
-
-Scalar arguments (like `num_elements as u32`) are copied into the kernel's parameter space — the kernel reads the value, not an address. Any type implementing `DType` can be pushed safely with `push_arg`.
+Scalar arguments (types implementing `DType`) push safely with `push_arg`. Device pointers require `unsafe { push_device_ptr() }`: the Rust compiler has no visibility into GPU kernel code and cannot verify that the pointer refers to a valid allocation on the correct GPU, that the allocation is large enough for the kernel's access pattern, that no other operation is concurrently touching the same memory, or that the argument order and types match the kernel's signature. Neither the Rust compiler nor the CUDA driver validates these invariants — mistakes result in silent undefined behavior or hard-to-diagnose GPU faults, so you must verify them manually.
 
 To prevent data races, use stream ordering: operations chained with `.then()` on the same stream execute in order and see each other's writes. Operations on different streams require explicit synchronization.
 
-> **Why generated cuTile Rust kernels don't require `unsafe`:** When you write a tile kernel with `#[cutile::entry]`, the generated launcher uses the `KernelArgument` and `ArcKernelArgument` implementations for `Tensor<T>` and `Partition<Tensor<T>>`. These implementations call `push_device_ptr` internally, but can do so safely because the framework controls both sides: device pointers come from framework-managed allocations (guaranteed valid), and the ownership model — `Partition` for exclusive access, `Arc<Tensor>` for shared reads — prevents aliasing at the type level. Custom kernels bypass this: you are pushing pointers that the framework didn't allocate and can't track, so the safety burden falls on you.
+> **Why generated cuTile kernels don't require `unsafe`:** the `#[cutile::entry]` macro generates launchers that call `push_device_ptr` internally, but they do so safely because the framework controls both sides — device pointers come from framework-managed allocations, and the ownership model (`Partition` for exclusive access, `Arc<Tensor>` for shared reads) prevents aliasing at the type level. Custom kernels bypass this: you are pushing pointers the framework didn't allocate and can't track, so the safety burden falls on you.
 
-You can wrap a custom kernel launch in a struct that implements `DeviceOp`. The struct's typed fields enforce the correct argument signature, and `unsafe` is confined to `execute`:
+---
+
+## Wrapping as a Safe DeviceOp
+
+Wrap a custom kernel launch in a struct that implements `DeviceOp`. The struct's typed fields enforce the correct argument signature; `unsafe` is confined to `execute`:
 
 ```rust
 use cuda_async::device_context::with_default_device_policy;
@@ -112,8 +95,6 @@ impl DeviceOp for ScaleKernel {
 
     // execute is unsafe because it enqueues async GPU work without
     // synchronizing — the returned tensors may still be in-flight.
-    // Callers must synchronize (e.g. via DeviceFuture) before accessing
-    // the output.
     unsafe fn execute(
         self,
         ctx: &ExecutionContext,
@@ -152,19 +133,13 @@ impl IntoFuture for ScaleKernel {
 }
 ```
 
-This is the same pattern the `#[cutile::entry]` macro uses to generate safe launchers for tile kernels. No `unsafe` at the call site.
-
-## Step 4: Compose with Tile Kernels
-
-`AsyncKernelLaunch` implements `DeviceOp`, so it chains with tile kernels. This pipeline runs a tile add (`z = x + y`), then the custom scale wrapper (`w = scale * z`):
+This is the same pattern the `#[cutile::entry]` macro uses to generate safe launchers for tile kernels — no `unsafe` at the call site. Once wrapped, the custom kernel composes with tile kernels through the usual `DeviceOp` combinators. This pipeline runs a tile add (`z = x + y`), then the wrapped scale kernel (`w = scale * z`):
 
 ```rust
-// Run the tile add kernel — z = x + y.
 let (z_part, _x, _y) =
     tile_add::add(z.partition([tile_size]), x.clone(), y.clone()).await?;
 let z: Tensor<f32> = z_part.unpartition();
 
-// Run the custom scale kernel — w = scale * z.
 let w: Tensor<f32> = zeros(&[num_elements]).await?;
 let (_z, w) = ScaleKernel {
     function: scale_function,
@@ -180,7 +155,7 @@ See [`interop.rs`](https://github.com/NVlabs/cutile-rs/blob/main/cutile-examples
 
 ---
 
-## Using `with_context` for Low-Level Control
+## Low-Level Driver Access
 
 For more direct control, use `with_context` to access the CUDA stream and issue driver API calls directly:
 
@@ -207,7 +182,6 @@ let op = with_context(|ctx: &ExecutionContext| {
 });
 
 let dptr = op.await?;
-// host_data is safe to drop now — the await synchronized the stream.
 
 // Clean up: free the device memory on a stream.
 with_context(move |ctx: &ExecutionContext| {
@@ -221,30 +195,26 @@ This gives you full access to the CUDA driver API while participating in the `De
 
 ---
 
-## Coming from Triton
+## Migrating from Other DSLs
 
-[Triton](https://triton-lang.org/) and cuTile Rust both let you write kernels in terms of tile-level operations. Many patterns that require explicit warp specialization in Triton (e.g., `warp_specialize` in `tl.range`) are handled implicitly by the cuTile Rust compiler:
+**From Triton.** [Triton](https://triton-lang.org/) and cuTile Rust both let you write kernels in terms of tile-level operations. Many patterns that require explicit warp specialization in Triton are handled implicitly by the cuTile Rust compiler:
 
 | Triton (manual) | cuTile Rust (automatic) |
 |-----------------|------------------------|
 | Assign producer warps to prefetch tiles from global → shared memory | Compiler generates shared memory staging for `load_tile` operations |
 | Assign consumer warps to compute on shared memory tiles | Compiler maps tile arithmetic to Tensor Cores and registers |
-| Software pipeline with `warp_specialize` in `tl.range` to overlap loads and compute | Compiler uses TMA for hardware-assisted pipelining on supported architectures |
+| Software pipeline with `warp_specialize` in `tl.range` | Compiler uses TMA for hardware-assisted pipelining on supported architectures |
 | Manual `tl.dot` placement across warps | `mma()` maps directly to Tensor Core instructions; thread/warp assignment is compiler-managed |
 | Tune `num_warps` and `num_stages` for occupancy | `occupancy` and `num_cta_in_cga` optimization hints guide the compiler |
 
-For patterns that don't map to the tile model, compile the kernel with Triton (or write it in CUDA C++) and integrate it via `AsyncKernelLaunch` as described above. Since Triton outputs PTX, you can load it directly:
+For patterns that don't map to the tile model, compile the kernel with Triton and integrate it via `AsyncKernelLaunch` as described above. Since Triton outputs PTX, load it directly:
 
 ```rust
 let module = load_module_from_ptx(triton_generated_ptx, device_id)?;
 let function = Arc::new(module.load_function("gemm_kernel")?);
 ```
 
----
-
-## Coming from cuTile Python
-
-If you're familiar with [cuTile Python](https://docs.nvidia.com/cuda/cutile-python/), here's how the kernel-side concepts map to cuTile Rust:
+**From cuTile Python.** If you're familiar with [cuTile Python](https://docs.nvidia.com/cuda/cutile-python/), the kernel-side concepts map directly:
 
 | cuTile Python | cuTile Rust |
 |---------------|-------------|

--- a/cutile-book/guide/introduction.md
+++ b/cutile-book/guide/introduction.md
@@ -1,13 +1,12 @@
 # Introduction
 
-## What is cuTile Rust?
+**cuTile Rust** is a safe tile-based parallel programming model for Rust. It automatically leverages advanced hardware capabilities — Tensor Cores, Tensor Memory Accelerators — while providing portability across NVIDIA GPU architectures, without requiring code changes. On the host side, it provides a safe API for allocating device tensors, partitioning mutable tensors for safe parallel access, wrapping shared immutable tensors in `Arc`, constructing kernel launchers, and JIT-compiling and asynchronously executing tile kernels on the GPU.
 
-**cuTile Rust** is a safe tile-based parallel programming model for Rust. It automatically leverages advanced hardware capabilities, such as Tensor Cores and Tensor Memory Accelerators, while providing portability across different NVIDIA GPU architectures. cuTile Rust enables the latest hardware features without requiring code changes. On the host side, it provides a safe API for allocating device tensors, partitioning mutable tensors for safe parallel access, wrapping shared immutable tensors in `Arc`, constructing kernel launchers, and JIT-compiling and asynchronously executing tile kernels on the GPU.
+---
 
-## Your First cuTile Rust Kernel
+## A First Kernel
 
-cuTile Rust kernels are GPU programs that execute concurrently across a logical grid of tile blocks.
-The `#[cutile::entry()]` attribute marks a Rust function as an *entry point*: a function you can call from your Rust program that executes on the GPU.
+cuTile Rust kernels are GPU programs that execute concurrently across a logical grid of tile blocks. The `#[cutile::entry()]` attribute marks a Rust function as an *entry point*: a function you can call from your Rust program that executes on the GPU.
 
 ```rust
 use cutile::prelude::*;
@@ -44,15 +43,13 @@ fn main() -> Result<(), cuda_async::error::DeviceError> {
 
 Here, `main` is host Rust code: it runs on the CPU, allocates tensors, and launches work. The `add` function is device Rust code because it is marked with `#[cutile::entry()]`; when `main` first calls `add(...)`, cuTile Rust JIT-compiles that function into optimized GPU code. The `#[cutile::module]` macro makes `my_module` expose the generated host-side APIs for launching `add`.
 
----
-
-## The Compilation Pipeline
-
 ![The cuTile Rust compilation pipeline from Rust to GPU execution](../_static/images/compilation-pipeline.svg)
 
+At first call, the pipeline transforms the entry function through Rust AST → MLIR → cubin. Subsequent calls reuse the cached binary, so JIT overhead is paid once per unique specialization.
+
 ---
 
-## How Kernel Arguments Map
+## Kernel Arguments and Launching
 
 On the host side, the generated launcher accepts several forms for each kernel parameter:
 
@@ -66,11 +63,7 @@ Partitioning splits a tensor into disjoint regions with a fixed tile shape, such
 
 The borrow-based form (`&Tensor`, `Partition<&mut Tensor>`) lets you pass tensors without moving them. The kernel writes through the borrow — no `unpartition()` or return capture needed.
 
----
-
-## Launching Kernels
-
-The simplest pattern borrows everything:
+The simplest launch pattern borrows everything:
 
 ```rust
 let x = api::ones::<f32>(&[32, 32]).sync_on(&stream)?;
@@ -104,7 +97,7 @@ let result = allocate()
 
 ## Tensors and Tiles
 
-Kernels move data between **Tensors** and **Tiles** using operations like `load_tile` and `store`. Both are tensor-like data structures: each has a specific **shape** (the number of elements along each axis) and a **dtype** (the data type of elements). However, there are important differences:
+Kernels move data between **Tensors** and **Tiles** using operations like `load_tile` and `store`. Both are tensor-like data structures: each has a specific **shape** (the number of elements along each axis) and a **dtype** (the data type of elements). The difference is where they live and what you can do with them.
 
 ### Tensors (Global Memory)
 
@@ -142,7 +135,7 @@ output.store(result_tile);                     // Store tile to tensor
 
 ### The Load → Compute → Store Pattern
 
-Every cuTile Rust kernel follows this fundamental pattern:
+Every cuTile Rust kernel follows the same fundamental pattern:
 
 ![Data flow: Load from Tensor to Tile, Compute in registers, Store back to Tensor](../_static/images/data-flow.svg)
 
@@ -150,17 +143,17 @@ Every cuTile Rust kernel follows this fundamental pattern:
 2. **Compute**: Perform operations on tiles
 3. **Store**: Write results from tiles back to global memory (Tensor)
 
-This pattern is key to performance: global memory is slow compared to on-chip resources. By loading once, computing many operations, and storing once, we maximize the compute-to-memory ratio.
+This is key to performance: global memory is slow compared to on-chip resources. By loading once, computing many operations, and storing once, we maximize the compute-to-memory ratio.
 
 ---
 
-## When to Use cuTile Rust
+## Use cases
 
 **Use cuTile Rust when:**
 - You need custom GPU kernels not available in libraries
-- You want to fuse multiple operations for performance  
-- You need Rust's safety guarantees on GPU code
+- You want to fuse multiple operations for performance
 - You're building performance-critical ML infrastructure
+- You need Rust's safety guarantees on GPU code
 
 **Don't use cuTile Rust when:**
 - Standard library operations (cuBLAS, cuDNN) suffice
@@ -170,7 +163,5 @@ This pattern is key to performance: global memory is slow compared to on-chip re
 > **Note**: For algorithms requiring warp-level primitives or custom CUDA C++ kernels, see [Integrating with CUDA C++](interoperability.md); custom kernels can participate in the same `DeviceOp` execution model as your tile kernels.
 
 ---
-
-## Next Steps
 
 Continue to [Thinking in Tiles](thinking-in-tiles.md), or jump straight to the [Tutorials](../tutorials/01-hello-world.md).

--- a/cutile-book/guide/memory-hierarchy.md
+++ b/cutile-book/guide/memory-hierarchy.md
@@ -1,14 +1,12 @@
-# Where Data Lives: The GPU Memory Hierarchy
+# Where Data Lives
 
-Understanding GPU memory is essential for writing fast kernels. The key insight: **data locality determines performance**.
-
-## The Memory Pyramid
-
-Modern NVIDIA GPUs (H100 shown) have a multi-level memory hierarchy:
+Understanding GPU memory is essential for writing fast kernels. The key insight: **data locality determines performance**. Modern NVIDIA GPUs have a multi-level memory hierarchy — faster memory is smaller; larger memory is slower. Writing a fast kernel means keeping the working set high in the pyramid.
 
 ![GPU Memory Hierarchy showing registers at top (fastest) down to HBM at bottom (largest)](../_static/images/memory-hierarchy.svg)
 
-## Memory Types in Detail
+---
+
+## The Memory Hierarchy
 
 ### Global Memory (HBM)
 
@@ -23,10 +21,7 @@ Modern NVIDIA GPUs (H100 shown) have a multi-level memory hierarchy:
 let x: Arc<Tensor<f32>> = ones(&[1024, 1024]).map(Into::into).sync_on(&stream)?;
 ```
 
-**Best practices:**
-- Coalesce memory accesses (adjacent threads access adjacent memory)
-- Minimize global memory round-trips
-- Load once, use many times
+Coalesce memory accesses, minimize round-trips, and load once to use many times.
 
 ### L2 Cache
 
@@ -35,10 +30,7 @@ let x: Arc<Tensor<f32>> = ones(&[1024, 1024]).map(Into::into).sync_on(&stream)?;
 - **Bandwidth**: Several times faster than HBM
 - **Latency**: ~200 cycles
 
-**cuTile Rust automatically benefits from L2** when you:
-- Reuse data across tiles
-- Access memory in predictable patterns
-- Keep working sets small
+cuTile Rust automatically benefits from L2 when you reuse data across tiles, access memory in predictable patterns, and keep working sets small.
 
 ### Shared Memory (SMEM)
 
@@ -49,7 +41,7 @@ let x: Arc<Tensor<f32>> = ones(&[1024, 1024]).map(Into::into).sync_on(&stream)?;
 - **Scope**: Shared within a tile block
 
 :::{note}
-In the tile programming model, **you never manage shared memory directly**. You simply load from and store to global memory (HBM) using tensors, and the underlying [Tile IR](https://docs.nvidia.com/cuda/tile-ir/latest/) compiler and runtime handle the mapping onto hardware resources — including shared memory, threads, and Tensor Cores — automatically. This is a key advantage of the tile-based abstraction over traditional CUDA programming, where shared memory management is a significant source of complexity and bugs.
+In the tile programming model, **you never manage shared memory directly**. You load from and store to global memory (HBM), and the underlying [Tile IR](https://docs.nvidia.com/cuda/tile-ir/latest/) compiler and runtime handle the mapping onto hardware resources — including shared memory, threads, and Tensor Cores — automatically. This is a key advantage over traditional CUDA programming, where shared memory management is a significant source of complexity and bugs.
 :::
 
 ### Registers (RMEM)
@@ -60,43 +52,47 @@ In the tile programming model, **you never manage shared memory directly**. You 
 - **Latency**: ~1 cycle
 - **Scope**: Private to each thread within a tile block
 
-**In cuTile Rust, `Tile<E, S>` data lives in registers during computation.** You load data from global memory (HBM) into tiles, compute on tiles, and store results back:
+In cuTile Rust, `Tile<E, S>` data lives in registers during computation. You load data from global memory (HBM) into tiles, compute on tiles, and store results back:
 
 ```rust
 let tile: Tile<f32, {[16, 16]}> = load_tile_like_2d(input, output);
 // 'tile' lives in registers — loaded from HBM, computed on in registers
 ```
 
+| Memory Level | Size          | Latency      | Use For             |
+|--------------|---------------|--------------|---------------------|
+| Registers    | 256KB/SM      | ~1 cycle     | Active computation  |
+| Shared Mem   | 228KB/SM      | ~20 cycles   | Block-level sharing |
+| L2 Cache     | ~50 MB        | ~200 cycles  | Automatic caching   |
+| HBM          | Varies by GPU | ~400 cycles  | Large data storage  |
+
 ---
 
-## Data Movement in cuTile Rust
+## Data Movement and Access Patterns
 
-### The Load/Store Pattern
+The fundamental pattern is Load → Compute → Store:
 
-The fundamental pattern is:
 1. **Load** from global memory (HBM) into tiles
 2. **Compute** on tiles
 3. **Store** results back to global memory (HBM)
 
-You only interact with global memory (HBM) — the [Tile IR](https://docs.nvidia.com/cuda/tile-ir/latest/) runtime decides how to map your tiles onto the hardware memory hierarchy (registers, shared memory, caches) for optimal performance.
+You only interact with global memory — the [Tile IR](https://docs.nvidia.com/cuda/tile-ir/latest/) runtime decides how to map your tiles onto the hardware memory hierarchy (registers, shared memory, caches) for optimal performance.
 
 ```rust
 #[cutile::entry()]
 fn kernel(output: &mut Tensor<f32, S>, input: &Tensor<f32, {[-1, -1]}>) {
     // 1. Load: HBM → Tile
     let tile = load_tile_like_2d(input, output);
-    
+
     // 2. Compute on tile
     let result = tile * 2.0 + 1.0;
-    
+
     // 3. Store: Tile → HBM
     output.store(result);
 }
 ```
 
 ![Load-Compute-Store data flow between global memory and tiles](../_static/images/data-flow.svg)
-
-### Partitioning for Tiled Access
 
 Partitioning logically divides a tensor into a grid of equally sized sub-regions, each processed by one tile block:
 
@@ -109,13 +105,7 @@ let output = zeros(&[1024, 1024])
 // Tile (i, j) processes output[i*16:(i+1)*16, j*16:(j+1)*16]
 ```
 
----
-
-## Memory Access Patterns
-
-### Coalesced Access (Good)
-
-When the underlying threads within a tile block access adjacent memory locations, the hardware can combine these into a single wide memory transaction:
+When the underlying threads within a tile block access adjacent memory locations, the hardware combines them into a single wide memory transaction — this is **coalesced access**:
 
 ```text
 Thread 0: memory[0]
@@ -127,11 +117,9 @@ Thread 31: memory[31]
 → Single 128-byte transaction! Efficient!
 ```
 
-cuTile Rust's tile load operations automatically generate coalesced access patterns — the compiler maps tile elements to threads in a way that maximizes memory throughput. This is one of the key advantages of the tile programming model: you choose tile shapes and access patterns, and the compiler handles the thread-level memory coalescing.
+cuTile Rust's tile load operations automatically generate coalesced access patterns: the compiler maps tile elements to threads in a way that maximizes memory throughput. This is a key advantage of the tile programming model — you choose tile shapes and access patterns, and the compiler handles thread-level coalescing.
 
-### Strided Access (Avoid)
-
-When threads access memory with large gaps between addresses, each access becomes a separate transaction:
+When threads access memory with large gaps between addresses, each access becomes a separate transaction — **strided access**:
 
 ```text
 Thread 0: memory[0]
@@ -148,62 +136,11 @@ Strided access can reduce effective bandwidth by 32x or more. Use tile operation
 
 ---
 
-## Data Reuse Strategies
+## Arithmetic Intensity
 
-### Strategy 1: Tile Reuse
+**Arithmetic intensity** is operations per byte of memory access. Higher is better — it means more compute per memory transaction, which is how you stay ahead of bandwidth limits.
 
-Load data once, use multiple times:
-
-```rust
-fn gemm_tile<const BM: i32, const BN: i32, const BK: i32, const K: i32>(
-    z: &mut Tensor<f32, {[BM, BN]}>,
-    x: &Tensor<f32, {[-1, K]}>,
-    y: &Tensor<f32, {[K, -1]}>,
-) {
-    let mut acc = load_tile_mut(z);
-    
-    for i in 0..(K / BK) {
-        let tile_x = x.partition(const_shape![BM, BK]).load([pid.0, i]);
-        let tile_y = y.partition(const_shape![BK, BN]).load([i, pid.1]);
-        
-        // tile_x and tile_y are loaded once, used for BM×BN×BK operations
-        acc = mma(tile_x, tile_y, acc);
-    }
-    
-    z.store(acc);
-}
-```
-
-**Arithmetic intensity** = Operations / Memory Access
-
-Higher is better! The tiled GEMM above achieves ~O(BK) reuse per loaded element.
-
-### Strategy 2: Partition Wisely
-
-Choose partition sizes that:
-1. Are not too large (the runtime needs to map tiles onto finite hardware resources)
-2. Maximize reuse (not too small)
-3. Are powers of 2 or multiples of common hardware widths
-
-```rust
-// Good: Powers of 2, reasonable size
-.partition([64, 64])   // 4096 elements per tile
-.partition([128, 32])  // 4096 elements per tile
-
-// Bad: Too small (overhead dominates)
-.partition([4, 4])     // Only 16 elements per tile
-
-// Bad: Too large (may spill to slower memory)
-.partition([512, 512]) // 262144 elements per tile
-```
-
----
-
-## Memory-Bound vs Compute-Bound
-
-### Memory-Bound Kernels
-
-Limited by memory bandwidth, not compute:
+A kernel is **memory-bound** when bandwidth limits throughput (low arithmetic intensity):
 
 ```rust
 // Element-wise add: 3 memory ops, 1 compute op
@@ -219,12 +156,9 @@ fn add<const S: [i32; 2]>(
 // Arithmetic intensity: 1 FLOP / 12 bytes = 0.08 FLOPS/byte
 ```
 
-### Compute-Bound Kernels
-
-Limited by compute throughput:
+A kernel is **compute-bound** when compute throughput limits it (high arithmetic intensity). Matrix multiply is the canonical example — O(N³) compute on O(N²) memory:
 
 ```rust
-// Matrix multiply: O(N³) compute, O(N²) memory
 fn gemm<E: ElementType, const BM: i32, const BN: i32, const BK: i32, const K: i32>(
     z: &mut Tensor<E, { [BM, BN] }>,
     x: &Tensor<E, { [-1, K] }>,
@@ -235,24 +169,43 @@ fn gemm<E: ElementType, const BM: i32, const BN: i32, const BK: i32, const K: i3
 // Arithmetic intensity: O(N) FLOPS/byte for large N
 ```
 
-**Goal**: Make kernels compute-bound by maximizing data reuse.
+Raising arithmetic intensity is a matter of data reuse. The main technique is tiled reuse — load a tile once and use it many times:
 
----
+```rust
+fn gemm_tile<const BM: i32, const BN: i32, const BK: i32, const K: i32>(
+    z: &mut Tensor<f32, {[BM, BN]}>,
+    x: &Tensor<f32, {[-1, K]}>,
+    y: &Tensor<f32, {[K, -1]}>,
+) {
+    let mut acc = load_tile_mut(z);
 
-## Summary
+    for i in 0..(K / BK) {
+        let tile_x = x.partition(const_shape![BM, BK]).load([pid.0, i]);
+        let tile_y = y.partition(const_shape![BK, BN]).load([i, pid.1]);
 
-| Memory Level | Size | Latency | Use For |
-|-------------|------|---------|---------|
-| Registers | 256KB/SM | ~1 cycle | Active computation |
-| Shared Mem | 228KB/SM | ~20 cycles | Block-level sharing |
-| L2 Cache | ~50 MB | ~200 cycles | Automatic caching |
-| HBM | Varies by GPU | ~400 cycles | Large data storage |
+        // tile_x and tile_y are loaded once, used for BM×BN×BK operations
+        acc = mma(tile_x, tile_y, acc);
+    }
 
-**Key takeaways:**
-1. You only load from and store to HBM — the [Tile IR](https://docs.nvidia.com/cuda/tile-ir/latest/) runtime manages the rest of the memory hierarchy for you
-2. Load once, use many times (maximize arithmetic intensity)
-3. Access memory in coalesced patterns (tile operations do this automatically)
-4. Choose partition sizes wisely
+    z.store(acc);
+}
+```
+
+Each loaded element drives ~O(BK) operations. The other lever is partition size. Partitions that are too small waste reuse opportunities and drown in overhead; partitions that are too large overflow register capacity and spill to slower memory. Aim for powers of two or multiples of common hardware widths:
+
+```rust
+// Good: Powers of 2, reasonable size
+.partition([64, 64])   // 4096 elements per tile
+.partition([128, 32])  // 4096 elements per tile
+
+// Bad: Too small (overhead dominates)
+.partition([4, 4])     // Only 16 elements per tile
+
+// Bad: Too large (may spill to slower memory)
+.partition([512, 512]) // 262144 elements per tile
+```
+
+The goal is to make kernels compute-bound by maximizing data reuse.
 
 ---
 

--- a/cutile-book/guide/performance-tuning.md
+++ b/cutile-book/guide/performance-tuning.md
@@ -1,49 +1,38 @@
 # Tuning for Performance
 
-This guide covers techniques for optimizing cuTile Rust kernel performance. For algorithms where peak performance requires warp-level control or integration with hand-tuned CUDA C++ kernels, see [Interoperability](interoperability.md).
-
-## The Performance Mindset
-
-GPU performance optimization focuses on three key areas:
-
-1. **Memory bandwidth** — Moving data efficiently
-2. **Compute utilization** — Keeping ALUs busy
-3. **Occupancy** — Maximizing parallel execution
+GPU performance optimization balances three concerns: memory bandwidth (moving data efficiently), compute utilization (keeping ALUs busy), and occupancy (maximizing parallel execution). Good kernels are well-balanced across all three; poor kernels are bottlenecked on one.
 
 ```{figure} ../_static/images/performance-triangle.svg
 :width: 100%
 :alt: The GPU performance triangle showing memory bandwidth, compute utilization, and occupancy
 ```
 
-## Architecture-Specific Configuration
+For algorithms where peak performance requires warp-level control or integration with hand-tuned CUDA C++ kernels, see [Integrating with CUDA C++](interoperability.md).
 
-### Optimization Hints
+---
+
+## Compiler Hints and Specialization
 
 cuTile Rust provides `optimization_hints` at two levels: **entry-level** (kernel-wide) and **per-op** (on individual load/store operations).
 
-#### Entry-Level Hints
-
-Set `occupancy` and `num_cta_in_cga` in the entry annotation. These can also be overridden at runtime via `CompileOptions`:
+Entry-level hints go on the entry annotation. They can also be overridden at runtime via `CompileOptions` for autotuning — different values trigger separate JIT compilations and are part of the kernel cache key:
 
 ```rust
 #[cutile::entry(
     optimization_hints = (
-        sm_120 = (                         // Blackwell-specific hints
-            num_cta_in_cga = 2,           // CTAs per Cooperative Group
-            occupancy = 2,                 // Target occupancy
-            max_divisibility = 16,         // Cap auto-inferred alignment
+        sm_120 = (                       // Blackwell-specific hints
+            num_cta_in_cga = 2,
+            occupancy = 2,
+            max_divisibility = 16,
         ),
-        sm_90 = (                          // Ampere-specific hints
+        sm_90 = (                        // Hopper-specific hints
             num_cta_in_cga = 1,
         ),
     )
 )]
 fn optimized_kernel<const S: [i32; 2]>(...) { ... }
-```
 
-To override entry-level hints at runtime (e.g. for autotuning):
-
-```rust
+// Runtime override for autotuning:
 use cutile::tile_kernel::CompileOptions;
 
 let result = my_kernel(input)
@@ -52,79 +41,37 @@ let result = my_kernel(input)
     .await;
 ```
 
-Different `CompileOptions` values trigger separate JIT compilations and are part of the kernel cache key.
-
-#### Per-Op Hints
-
-`latency` and `disallow_tma` are set directly on individual load/store operations:
+Per-op hints (`latency`, `disallow_tma`) apply to individual load/store operations:
 
 ```rust
-// Per-op latency hint on a view load
 let tile: Tile<f32, S> = load_from_view(&partition, idx, Some(4), false);
-
-// Disable TMA on a specific store
 unsafe { store_to_view_mut(&mut partition, tile, idx, None, true); }
-
-// Per-op latency on a pointer load
 let (values, token) = load_ptr_tko(ptrs, "weak", "tl_blk", None, None, None, Some(4));
 ```
 
-### Hint Reference
+| Level | Hint | Description | Default |
+|---|---|---|---|
+| Entry | `max_divisibility` | Cap on auto-inferred alignment divisor | 16 |
+| Entry | `num_cta_in_cga` | CTAs in Cooperative Group Array | 1 |
+| Entry | `occupancy` | Target occupancy level | Auto |
+| Per-op | `latency` | Latency optimization hint (`Option<i32>`) | `None` (compiler decides) |
+| Per-op | `disallow_tma` | Disable Tensor Memory Accelerator for this op | `false` (TMA allowed) |
 
-#### Entry-Level Hints
-
-| Hint | Description | Default |
-|------|-------------|---------|
-| `max_divisibility` | Cap on auto-inferred alignment divisor | 16 |
-| `num_cta_in_cga` | CTAs in Cooperative Group Array | 1 |
-| `occupancy` | Target occupancy level | Auto |
-
-#### Per-Op Hints (on load/store operations)
-
-| Parameter | Description | Default |
-|-----------|-------------|---------|
-| `latency` | Latency optimization hint (`Option<i32>`) | `None` (compiler decides) |
-| `disallow_tma` | Disable Tensor Memory Accelerator for this op (`bool`) | `false` (TMA allowed) |
-
-### Tile Size Selection
-
-Tile sizes significantly impact performance. General guidelines:
+**Tile size** significantly impacts performance. Larger tiles mean fewer memory transactions but more registers per block, reducing occupancy. General guidelines:
 
 | GPU Architecture | Recommended Tile Sizes |
-|------------------|----------------------|
+|------------------|------------------------|
 | Ampere (A100) | `[128, 128]`, `[64, 64]`, `[256, 64]` |
 | Hopper (H100) | `[128, 128]`, `[64, 128]`, `[128, 256]` |
 | Ada (RTX 4090) | `[64, 64]`, `[128, 64]` |
 
-```rust
-// Choose tile size based on workload characteristics
-#[cutile::entry(
-    optimization_hints = (sm_120 = (max_divisibility = 16,),)
-)]
-fn matmul<const TILE_M: i32, const TILE_N: i32, const TILE_K: i32>(
-    c: &mut Tensor<f32, {[TILE_M, TILE_N]}>,
-    a: &Tensor<f32, {[-1, -1]}>,
-    b: &Tensor<f32, {[-1, -1]}>
-) {
-    // TILE_M=128, TILE_N=128, TILE_K=32 is often a good starting point
-}
-```
+| Tile Size     | Registers (approx) | Max Occupancy |
+|---------------|--------------------|---------------|
+| `[32, 32]`    | ~32                | High          |
+| `[64, 64]`    | ~64-128            | Medium-High   |
+| `[128, 128]`  | ~256+              | Medium        |
 
-### Register Pressure
-
-Larger tiles use more registers, potentially reducing occupancy:
-
-| Tile Size | Registers (approx) | Max Occupancy |
-|-----------|-------------------|---------------|
-| `[32, 32]` | ~32 | High |
-| `[64, 64]` | ~64-128 | Medium-High |
-| `[128, 128]` | ~256+ | Medium |
-
-**Trade-off:** Larger tiles = fewer memory transactions, but lower occupancy.
-
-### Unchecked Accesses
-
-For maximum performance, disable bounds checking (use with caution):
+Two strategies remove bounds checks on tile loads and stores, depending on how stable your problem sizes are. **`unchecked_accesses = true`** (with `unsafe`) removes all runtime bounds checks from tile loads and stores. Compile-time shape and MMA-dimension checks still apply. Use when problem sizes vary widely and compilation overhead matters more than the safety net:
 
 ```rust
 #[cutile::entry(unchecked_accesses = true)]
@@ -133,11 +80,7 @@ unsafe fn fast_kernel<const S: [i32; 2]>(...) {
 }
 ```
 
-Setting `unchecked_accesses = true` removes all runtime bounds checks on `load` and `store` operations. The entry point must be marked `unsafe`, and the call site must use an `unsafe` block. Even with bounds checks disabled, cuTile Rust's compile-time checks still apply: tile shapes, `mma` dimensions, and element types are still validated.
-
-### Eliminating Bounds Checks with Static Shapes
-
-An alternative to `unchecked_accesses` is to make all tensor dimensions static const generics and provide the launch grid via `.const_grid()`. When the JIT compiler knows every dimension at compile time, it can prove that all partition accesses are in bounds and optimize the bounds checks away entirely — no `unsafe` required.
+**`.const_grid()` with fully static tensor shapes** keeps the safety net. When every dimension is a compile-time const and the grid is passed via `.const_grid()`, the JIT compiler can prove all partition accesses are in bounds and optimize the checks away — no `unsafe` needed:
 
 ```rust
 #[cutile::entry()]
@@ -147,8 +90,8 @@ fn gemm<
     const M: i32, const N: i32, const K: i32,
 >(
     z: &mut Tensor<E, { [BM, BN] }>,
-    x: &Tensor<E, { [M, K] }>,    // Fully static — no dynamic dimensions
-    y: &Tensor<E, { [K, N] }>,    // Fully static — no dynamic dimensions
+    x: &Tensor<E, { [M, K] }>,    // Fully static
+    y: &Tensor<E, { [K, N] }>,    // Fully static
 ) {
     let part_x = x.partition(const_shape![BM, BK]);
     let part_y = y.partition(const_shape![BK, BN]);
@@ -156,20 +99,14 @@ fn gemm<
 
     let mut acc = load_tile_mut(z);
     for i in 0i32..(K / BK) {
-        // The compiler knows K, BK, M, N, BM, BN at JIT time.
-        // It can prove pid.0 < M/BM, i < K/BK, pid.1 < N/BN,
-        // so these loads are guaranteed in bounds — checks eliminated.
         let tile_x = part_x.load([pid.0, i]);
         let tile_y = part_y.load([i, pid.1]);
         acc = mma(tile_x, tile_y, acc);
     }
     z.store(acc);
 }
-```
 
-On the host side, pass the grid as a compile-time constant via `.const_grid()`:
-
-```rust
+// On the host side:
 let grid = z.grid()?;
 let (z, _x, _y) = gemm(z, x, y)
     .const_grid(grid)
@@ -177,49 +114,24 @@ let (z, _x, _y) = gemm(z, x, y)
     .sync_on(&stream)?;
 ```
 
-`.const_grid()` passes the grid dimensions as compile-time constants to the JIT compiler, which enables it to reason about the range of `get_tile_block_id()` values and prove that all partition accesses derived from them are within bounds.
+The tradeoff: every new combination of const values triggers a JIT recompilation. Use this when problem sizes come from a small, known set — the JIT cache makes repeated sizes free.
 
-**Tradeoff:** Every new combination of `M`, `N`, `K`, `BM`, `BN`, `BK` triggers a JIT recompilation. Use this approach when problem sizes come from a small, known set (the JIT cache makes repeated sizes free). Use `unchecked_accesses` when problem sizes vary widely and compilation overhead matters more than safety.
+---
 
 ## Memory Optimization
 
-### Coalesced Memory Access
+**Coalesced access** — adjacent threads reading adjacent memory locations — is how the GPU memory system is designed to be used. cuTile Rust's tile load operations automatically generate coalesced access patterns, so you get this for free from `load_tile_like_2d`, `Partition::load`, and the standard loading APIs.
 
-The GPU memory system is optimized for **coalesced access** — adjacent threads accessing adjacent memory:
+**Keep data in registers.** Load once from global memory, compute many times in registers:
 
-```rust
-// GOOD: Coalesced access pattern
-// Threads in a warp access consecutive elements
-let tile = load_tile_like_2d(input, output);  // Automatic coalescing
-
-// The load operation automatically generates coalesced memory transactions
-```
-
-### Load/Store Hints
-
-Use load hints to optimize memory access patterns:
+| Memory Level | Latency | Strategy |
+|--------------|---------|----------|
+| Registers | ~0 cycles | Keep data in tiles |
+| Shared Memory | ~20 cycles | Reuse across iterations |
+| L2 Cache | ~200 cycles | Temporal locality |
+| Global Memory | ~400 cycles | Minimize accesses |
 
 ```rust
-// Standard load
-let tile = load_tile_like_2d(input, output);
-
-// Load with cache hints (when available)
-// The compiler may generate different PTX based on access patterns
-```
-
-### Memory Hierarchy Utilization
-
-Maximize use of faster memory levels:
-
-| Memory Level | Relative Speed | Latency | Strategy |
-|--------------|----------------|---------|----------|
-| Registers | Fastest | ~0 cycles | Keep data in tiles |
-| Shared Memory | Very fast | ~20 cycles | Reuse across iterations |
-| L2 Cache | Fast | ~200 cycles | Temporal locality |
-| Global Memory | Slowest | ~400 cycles | Minimize accesses |
-
-```rust
-// Pattern: Load once, compute many
 #[cutile::entry()]
 fn fused_ops<const S: [i32; 2]>(
     output: &mut Tensor<f32, S>,
@@ -227,94 +139,23 @@ fn fused_ops<const S: [i32; 2]>(
 ) {
     // Single load from global memory
     let tile = load_tile_like_2d(input, output);
-    
+
     // Multiple operations in registers (free!)
     let normalized = tile - reduce_max(tile, 1i32);
     let exp_vals = exp(normalized);
     let softmax = true_div(exp_vals, reduce_sum(exp_vals, 1));
-    
+
     // Single store to global memory
     output.store(softmax);
 }
 ```
 
-## Compute Optimization
-
-### Tensor Core Utilization
-
-cuTile Rust automatically uses Tensor Cores for matrix operations when shapes align:
+**Kernel fusion** is the register strategy scaled up — combining multiple logical operations into a single kernel. A pipeline of 3 kernels might read and write intermediate results to global memory 6 times; fusing into one kernel eliminates most of those round-trips:
 
 ```rust
-// Tensor Core requirements:
-// - Matrix dimensions divisible by 16 (f16) or 8 (tf32)
-// - Appropriate data types (f16, bf16, tf32)
+// UNFUSED: 3 kernels, 6 loads + 3 stores total.
 
-#[cutile::entry()]
-fn tensor_core_matmul<const M: i32, const N: i32>(
-    c: &mut Tensor<f16, {[M, N]}>,  // f16 enables Tensor Cores
-    a: &Tensor<f16, {[-1, -1]}>,
-    b: &Tensor<f16, {[-1, -1]}>
-) {
-    let tile_a = load_tile_like_2d(a, c);
-    let tile_b = load_tile_like_2d(b, c);
-    
-    // MMA automatically uses Tensor Cores
-    let acc = constant(0.0f32, c.shape());
-    let result = mma(tile_a, tile_b, acc);
-    c.store(result);
-}
-```
-
-### Arithmetic Intensity
-
-**Arithmetic intensity** = FLOPs / Bytes transferred
-
-Higher arithmetic intensity = better GPU utilization.
-
-| Operation | Arithmetic Intensity | Bound |
-|-----------|---------------------|-------|
-| Vector Add | 0.125 | Memory |
-| Matrix-Vector | 1-2 | Memory |
-| Matrix-Matrix | O(N) | Compute |
-| Fused Softmax | ~10+ | Compute |
-
-```rust
-// Low arithmetic intensity: simple elementwise
-let c = a + b;  // 1 FLOP per 12 bytes (3 f32s)
-
-// High arithmetic intensity: matrix multiply
-let c = mma(a, b, acc);  // O(N) FLOPs per element
-
-// Very high: fused operations
-let result = softmax(matmul(a, b));  // Many FLOPs, few memory ops
-```
-
-### Instruction-Level Parallelism
-
-The compiler automatically exploits ILP, but you can help:
-
-```rust
-// Independent operations can execute in parallel
-let sum1 = reduce_sum(tile1, 1i32);
-let sum2 = reduce_sum(tile2, 1i32);  // Can overlap with sum1
-
-// Dependent operations serialize
-let step1 = tile * 2.0;
-let step2 = step1 + 1.0;  // Must wait for step1
-```
-
-## Kernel Fusion
-
-Fusing multiple operations into one kernel reduces memory traffic:
-
-```rust
-// UNFUSED: Multiple kernels, multiple memory round-trips
-// kernel1: y = a + b  (load a, b; store y)
-// kernel2: z = y * c  (load y, c; store z)
-// kernel3: w = exp(z) (load z; store w)
-// Total: 6 loads + 3 stores
-
-// FUSED: Single kernel, single memory round-trip
+// FUSED: 1 kernel, 3 loads + 1 store (3× memory reduction).
 #[cutile::entry()]
 fn fused<const S: [i32; 2]>(
     w: &mut Tensor<f32, S>,
@@ -325,107 +166,90 @@ fn fused<const S: [i32; 2]>(
     let tile_a = load_tile_like_2d(a, w);
     let tile_b = load_tile_like_2d(b, w);
     let tile_c = load_tile_like_2d(c, w);
-    
-    // All in registers - no intermediate memory traffic
+
+    // All in registers — no intermediate memory traffic
     let y = tile_a + tile_b;
     let z = y * tile_c;
     let result = exp(z);
-    
+
     w.store(result);
 }
-// Total: 3 loads + 1 store (3x memory reduction!)
 ```
 
-## Profiling
-
-### Key Metrics
-
-When profiling cuTile Rust kernels, focus on:
-
-| Metric | Target | Tool |
-|--------|--------|------|
-| Memory Throughput | >80% of peak | Nsight Compute |
-| Compute Throughput | >70% for compute-bound | Nsight Compute |
-| Occupancy | >50% | Nsight Compute |
-| Register Spills | 0 | Nsight Compute |
-
-### Identifying Bottlenecks
-
-```
-Memory Bound:
-- Low compute throughput
-- High memory throughput (near peak)
-- Solution: Increase arithmetic intensity, fuse kernels
-
-Compute Bound:
-- High compute throughput
-- Low memory throughput
-- Solution: Already optimal for this algorithm
-
-Latency Bound:
-- Low both compute and memory
-- High stall cycles
-- Solution: Increase parallelism, overlap operations
-```
-
-## Common Pitfalls
-
-### 1. Uncoalesced Memory Access
-
-```rust
-// AVOID: Strided access patterns when possible
-// The compiler handles this, but algorithm design matters
-```
-
-### 2. Excessive Synchronization
-
-```rust
-// Tile operations are designed to minimize sync points
-// Trust the compiler to handle thread synchronization
-```
-
-### 3. Wrong Tile Size
-
-```rust
-// Too small: High overhead, poor utilization
-const TILE_SIZE: [i32; 2] = [8, 8];  // Usually too small
-
-// Too large: Register spills, low occupancy
-const TILE_SIZE: [i32; 2] = [512, 512];  // Probably too large
-
-// Just right: Balance of efficiency and occupancy
-const TILE_SIZE: [i32; 2] = [64, 64];  // Good starting point
-```
-
-### 4. Ignoring Data Types
-
-```rust
-// f16/bf16 can double throughput on Tensor Cores
-// Use when precision allows
-
-#[cutile::entry()]
-fn fast_matmul<const S: [i32; 2]>(
-    c: &mut Tensor<f16, S>,  // Half precision = 2x throughput
-    a: &Tensor<f16, {[-1, -1]}>,
-    b: &Tensor<f16, {[-1, -1]}>
-) { ... }
-```
-
-## Performance Checklist
-
-- [ ] **Tile size** appropriate for workload and GPU architecture
-- [ ] **Memory access** patterns are coalesced
-- [ ] **Kernel fusion** applied where possible
-- [ ] **Data types** optimized (f16/bf16 for Tensor Cores)
-- [ ] **Arithmetic intensity** maximized
-- [ ] **Occupancy** balanced with tile size
-- [ ] **Profiled** with Nsight Compute
+For the full memory hierarchy model and arithmetic intensity analysis, see [Where Data Lives](memory-hierarchy.md).
 
 ---
 
-## Next Steps
+## Compute Optimization
 
-- Continue to [Integrating with CUDA C++](interoperability.md) for the escape hatch when tile programming isn't enough
-- Review [Where Data Lives](memory-hierarchy.md) for memory-layout optimization
-- Review [Orchestrating Device Operations](device-operations.md) for overlapping operations across kernels
-- Check [Debugging and Profiling](debugging.md) for troubleshooting performance issues
+**Tensor Cores** deliver massive throughput for matrix operations when shapes align. cuTile Rust automatically uses them when matrix dimensions are divisible by 16 (for `f16`/`bf16`) or 8 (for `tf32`), and element types are `f16`, `bf16`, or `tf32`:
+
+```rust
+#[cutile::entry()]
+fn tensor_core_matmul<const M: i32, const N: i32>(
+    c: &mut Tensor<f16, {[M, N]}>,  // f16 enables Tensor Cores
+    a: &Tensor<f16, {[-1, -1]}>,
+    b: &Tensor<f16, {[-1, -1]}>
+) {
+    let tile_a = load_tile_like_2d(a, c);
+    let tile_b = load_tile_like_2d(b, c);
+
+    // MMA automatically uses Tensor Cores
+    let acc = constant(0.0f32, c.shape());
+    let result = mma(tile_a, tile_b, acc);
+    c.store(result);
+}
+```
+
+**Arithmetic intensity** is FLOPs per byte transferred. Higher is better: high-intensity kernels are compute-bound rather than memory-bound.
+
+| Operation | Arithmetic Intensity | Bound |
+|-----------|----------------------|-------|
+| Vector Add | ~0.1 | Memory |
+| Matrix-Vector | 1-2 | Memory |
+| Matrix-Matrix | O(N) | Compute |
+| Fused Softmax | ~10+ | Compute |
+
+See [Where Data Lives: Arithmetic Intensity](memory-hierarchy.md#arithmetic-intensity) for the full treatment.
+
+**Instruction-level parallelism** (ILP) lets the compiler overlap independent operations. Write independent branches explicitly so the compiler can schedule them in parallel:
+
+```rust
+// Independent operations — compiler can overlap them
+let sum1 = reduce_sum(tile1, 1i32);
+let sum2 = reduce_sum(tile2, 1i32);  // Can execute concurrently
+
+// Dependent operations — serialize
+let step1 = tile * 2.0;
+let step2 = step1 + 1.0;  // Must wait for step1
+```
+
+---
+
+## Profiling and Pitfalls
+
+Focus on four metrics when profiling with Nsight Compute:
+
+| Metric | Target |
+|---|---|
+| Memory Throughput | >80% of peak for memory-bound kernels |
+| Compute Throughput | >70% for compute-bound kernels |
+| Occupancy | >50% |
+| Register Spills | 0 |
+
+Identify the bottleneck from the profile:
+- **High memory throughput, low compute** → memory-bound; increase arithmetic intensity, fuse kernels.
+- **Low memory throughput, high compute** → compute-bound; already near-optimal for this algorithm.
+- **Low on both, high stall cycles** → latency-bound; increase parallelism, overlap independent operations.
+
+Common pitfalls:
+- **Wrong tile size.** `[8, 8]` is usually too small (overhead dominates); `[512, 512]` is usually too large (register spills, low occupancy). Start with `[64, 64]` or `[128, 128]`.
+- **Wrong dtype.** Using `f32` when `f16`/`bf16` would suffice leaves 2× Tensor Core throughput on the table.
+- **Excessive synchronization.** Let the compiler handle thread synchronization; avoid introducing extra sync points.
+- **Algorithmic stride.** Tile operations coalesce automatically, but strided access patterns in your algorithm logic defeat this.
+
+Pre-ship checklist: tile size appropriate for workload and architecture; memory access coalesced; kernel fusion applied where possible; data types optimized (`f16`/`bf16` for Tensor Cores); arithmetic intensity maximized; occupancy balanced against tile size; profiled with Nsight Compute.
+
+---
+
+Continue to [Integrating with CUDA C++](interoperability.md) for the escape hatch when tile programming isn't enough, or [Debugging and Profiling](debugging.md) for deeper troubleshooting.

--- a/cutile-book/guide/thinking-in-tiles.md
+++ b/cutile-book/guide/thinking-in-tiles.md
@@ -4,6 +4,8 @@ The fundamental unit of computation in cuTile Rust is the **tile** — an immuta
 
 ![Thread-centric vs Tile-centric programming mental model](../_static/images/mental-model-shift.svg)
 
+---
+
 ## Tile-Based vs Thread-Based Programming
 
 Traditional CUDA programming asks you to think in terms of individual threads and explicit thread indices:
@@ -34,7 +36,9 @@ fn add<const S: [i32; 2]>(
 
 Instead of managing thread indices directly, you describe what should happen to one tile-shaped region of the data. The compiler and runtime handle how that work is mapped onto the underlying GPU execution model.
 
-## Tile Blocks and Tile Threads
+---
+
+## Tile Blocks
 
 A **tile block** is a logical thread and the basic unit of concurrent execution on the GPU. Each tile block runs the kernel function once, operating on one partition of the data. A tile block is identified by its coordinates, obtained via `get_tile_block_id()`:
 
@@ -43,9 +47,11 @@ let pid: (i32, i32, i32) = get_tile_block_id();    // This block's (x, y, z) coo
 let npids: (i32, i32, i32) = get_num_tile_blocks(); // Total grid dimensions
 ```
 
-The cuTile Rust compiler maps each tile block to one or more underlying CUDA execution units (thread blocks, clusters, or warps) depending on the target architecture — but from the programmer's perspective, a tile block is simply a single-threaded context that processes one tile of data.
+The cuTile Rust compiler maps each tile block to one or more underlying CUDA execution units (thread blocks, clusters, or warps) depending on the target architecture — but from the programmer's perspective, a tile block is simply a single-threaded context that processes one tile of data. The terms **tile block** and **tile thread** are interchangeable: the API uses `get_tile_block_id()` and `get_num_tile_blocks()`, while the guides often say "tile thread" to emphasize the single-threaded programming model.
 
-The terms **tile block** and **tile thread** are interchangeable. The API uses `get_tile_block_id()` and `get_num_tile_blocks()`, while the guides often say "tile thread" to emphasize the single-threaded programming model.
+When a kernel launches, the GPU's hardware scheduler assigns tile blocks to Streaming Multiprocessors (SMs) as resources become available. Tile blocks that fit on available SMs run **in parallel** — simultaneously on separate hardware units. The full set of tile blocks runs **concurrently** — their relative order of execution is unspecified and they are independent of one another. This matches Rust's distinction between concurrency and parallelism: parallelism is work happening at the exact same time on different hardware, while concurrency is independently executing tasks making progress over time.
+
+---
 
 ## Partitioning
 
@@ -81,11 +87,11 @@ let tile = part_x.load([pid.0, i]);
 
 Because the partitioning happens on the device side, the same `&Tensor` can be partitioned in different ways within the same kernel. For example, in GEMM the input matrices `x` and `y` are each partitioned with a different shape inside the kernel body (`const_shape![BM, BK]` and `const_shape![BK, BN]` respectively), even though both were passed as plain `Arc<Tensor<T>>` from the host.
 
+---
+
 ## The Grid
 
 The **grid** determines how many tile blocks run. It can be specified explicitly or inferred from the partitioned tensors passed to the kernel.
-
-### Grid Inference
 
 A host-side partition's grid is computed by dividing the tensor's shape by the partition shape, rounding up:
 
@@ -93,9 +99,7 @@ A host-side partition's grid is computed by dividing the tensor's shape by the p
 grid[i] = ceil(tensor_shape[i] / partition_shape[i])
 ```
 
-The result is mapped to a 3D tuple `(x, y, z)`, with trailing dimensions set to 1 for tensors of rank less than 3. The mapping is direct and order-preserving: tensor dimension 0 maps to grid `x`, dimension 1 to `y`, and dimension 2 to `z`.
-
-For example, a `[128, 256]` tensor partitioned with `[32, 64]` produces a grid of `(4, 4, 1)`:
+The result is mapped to a 3D tuple `(x, y, z)`, with trailing dimensions set to 1 for tensors of rank less than 3. The mapping is direct and order-preserving: tensor dimension 0 maps to grid `x`, dimension 1 to `y`, and dimension 2 to `z`. For example, a `[128, 256]` tensor partitioned with `[32, 64]` produces a grid of `(4, 4, 1)`:
 
 ```text
 Tensor shape:    [128, 256]
@@ -103,11 +107,9 @@ Partition shape: [ 32,  64]
 Grid:            (ceil(128/32), ceil(256/64), 1) = (4, 4, 1)
 ```
 
-### From Grid Coordinates to Sub-Tensors
-
 Inside the kernel, `get_tile_block_id()` returns the tile block's `(x, y, z)` coordinates in the grid. These coordinates correspond directly to the sub-tensor indices in the partition. For the example above, tile block `(2, 1, 0)` processes the sub-tensor at rows `2×32..3×32` and columns `1×64..2×64` — that is, the region `[64:96, 64:128]` of the original tensor.
 
-For a `&mut Tensor`, this mapping is implicit — the kernel receives the sub-tensor directly, and loads and stores operate within the sub-tensor's bounds. For a `&Tensor` partitioned on the device side, you use the tile block ID to index into the partition explicitly:
+For a `&mut Tensor`, this mapping is implicit: the kernel receives the sub-tensor directly, and loads and stores operate within the sub-tensor's bounds. For a `&Tensor` partitioned on the device side, you use the tile block ID to index into the partition explicitly:
 
 ```rust
 let pid: (i32, i32, i32) = get_tile_block_id();
@@ -120,8 +122,6 @@ let part_x = x.partition(const_shape![BM, BK]);
 let tile_x = part_x.load([pid.0, i]);  // Loads tile at row pid.0, column i
 ```
 
-### Launch Grid Inference
-
 At kernel launch time, the launcher calls `.grid()` on each `&mut Tensor` parameter's host-side `Partition` and collects the resulting grids. If no explicit grid is specified via `.grid()` or `.const_grid()`, the launch grid is **inferred** from these partition grids:
 
 ```rust
@@ -130,25 +130,15 @@ let z = zeros(&[1024, 1024]).sync_on(&stream)?.partition([64, 64]);
 let (z, _x, _y) = add(z, x, y).sync_on(&stream)?;
 ```
 
-When multiple `&mut Tensor` parameters are present, all of their inferred grids must match or the launch will fail with an error.
-
-### Explicit Grid
-
-You can also set the grid manually, which overrides inference:
+When multiple `&mut Tensor` parameters are present, all of their inferred grids must match or the launch will fail with an error. You can also set the grid manually, which overrides inference:
 
 ```rust
 launcher.grid((16, 16, 1)).sync_on(&stream)?;
 ```
 
-Each tile block receives unique 3-dimensional coordinates within the grid via `get_tile_block_id()`.
+---
 
-## Concurrent and Parallel Execution
-
-When a kernel launches, the GPU's hardware scheduler assigns tile blocks to Streaming Multiprocessors (SMs) as resources become available. Tile blocks that fit on available SMs run **in parallel** — simultaneously on separate hardware units. The full set of tile blocks runs **concurrently** — their relative order of execution is unspecified and they are independent of one another.
-
-This matches Rust's distinction between concurrency and parallelism: parallelism is work happening at the exact same time on different hardware, while concurrency is independently executing tasks making progress over time.
-
-## Tile Types
+To recap, the three core types in a kernel's data flow are:
 
 | Type | Description | Lives In |
 |------|-------------|----------|
@@ -156,10 +146,6 @@ This matches Rust's distinction between concurrency and parallelism: parallelism
 | `Partition<E, S>` | Logical division of a tensor into sub-regions | Metadata only |
 | `Tile<E, S>` | Immutable data fragment for computation; compile-time static shapes | GPU registers |
 
-The flow is always: **Tensor → Partition → Tile → Compute → Store**
-
-You only load from and store to HBM (global memory). The underlying [Tile IR](https://docs.nvidia.com/cuda/tile-ir/latest/) runtime handles mapping your tiles onto the hardware memory hierarchy — including shared memory, caches, and registers — so you never need to manage these resources yourself.
-
----
+The flow is always: **Tensor → Partition → Tile → Compute → Store**. You only load from and store to HBM; the underlying [Tile IR](https://docs.nvidia.com/cuda/tile-ir/latest/) runtime maps tiles onto the hardware memory hierarchy (shared memory, caches, registers) so you never manage those resources yourself.
 
 Continue to [Where Data Lives](memory-hierarchy.md) to understand the GPU memory model that tiles map onto.

--- a/cutile-book/guide/working-with-data.md
+++ b/cutile-book/guide/working-with-data.md
@@ -1,6 +1,8 @@
-# Working with Data: Tensors, Tiles, and Partitions
+# Working with Data
 
 cuTile Rust leverages Rust's type system to catch errors at compile time. Shape mismatches, type errors, and many common GPU programming bugs are caught before your code even runs.
+
+---
 
 ## Tensors vs Tiles
 
@@ -30,61 +32,9 @@ fn kernel(
 
 ---
 
-## Core Types
+## Host-side and Device-side Types
 
-The `Tensor` and `Partition` types exist on both the host side (CPU) and the device side (GPU kernel), but they are different Rust types with similar semantics. Host-side types are parameterized by element type only; device-side types carry shape information in the type system for compile-time optimization.
-
-### Tensor Creation
-
-The `api` module provides functions for creating tensors on the GPU:
-
-```rust
-use cutile::api;
-
-// Constant-filled tensors
-let z = api::zeros::<f32>(&[1024]).sync_on(&stream)?;     // all zeros
-let o = api::ones::<f32>(&[256, 256]).sync_on(&stream)?;  // all ones
-let f = api::full(3.14f32, &[512]).sync_on(&stream)?;     // fill with value
-
-// Sequential and evenly spaced values
-let r = api::arange::<i32>(1024).sync_on(&stream)?;       // [0, 1, 2, ..., 1023]
-let l = api::linspace(0.0, 1.0, 256).sync_on(&stream)?;   // 256 values from 0 to 1
-
-// Identity matrices
-let I = api::eye(64).sync_on(&stream)?;                    // 64x64 identity
-let R = api::eye_rect(32, 64).sync_on(&stream)?;           // 32x64, ones on diagonal
-
-// Random tensors
-let u = api::rand::<f32, 1>(&[1024]).sync_on(&stream)?;   // uniform [0, 1)
-let n = api::randn::<f32, 1>(&[1024]).sync_on(&stream)?;  // normal (0, 1)
-```
-
-### Views and Slices
-
-`TensorView` provides zero-copy borrowed views of tensors with different
-shape or offset. Views borrow the underlying tensor — the tensor cannot be
-mutated while a view exists.
-
-```rust
-let tensor = api::arange::<f32>(1024).sync_on(&stream)?;
-
-// Reshape without copying
-let matrix = tensor.view(&[32, 32])?;
-
-// Slice: borrow a subregion (numpy-style ranges)
-let first_half = tensor.slice(&[0..512])?;           // elements 0-511
-let row_slice = matrix.slice(&[1..3])?;              // rows 1-2, all columns
-let block = matrix.slice(&[1..3, 2..6])?;            // rows 1-2, cols 2-5
-
-// Chained slices accumulate offsets
-let inner = tensor.slice(&[100..200])?.slice(&[10..20])?;  // = tensor[110..120]
-```
-
-Views and slices can be passed to kernels as `&Tensor` parameters. The
-offset is applied host-side — the kernel receives a pointer to the correct
-starting address.
-
-### Host-Side Types
+The `Tensor` and `Partition` types exist on both the host side (CPU) and the device side (GPU kernel), but they are different Rust types with similar semantics. Host-side types are parameterized by element type only; device-side types additionally carry shape information in the type system for compile-time optimization.
 
 On the host, you allocate tensors, partition them, and pass them to kernel launchers:
 
@@ -99,20 +49,39 @@ let partitioned: Partition<Tensor<f32>> = tensor.partition([16, 16]);
 let partitioned_ref = (&mut tensor).partition([16, 16]);
 
 // Read-only inputs: borrow, Arc, or owned
-let input: &Tensor<f32> = &tensor;           // borrow
-let shared: Arc<Tensor<f32>> = Arc::new(tensor);  // shared ownership
+let input: &Tensor<f32> = &tensor;
+let shared: Arc<Tensor<f32>> = Arc::new(tensor);
 ```
 
-The generated launcher accepts multiple forms for each parameter type.
-`&Tensor` params accept `&Tensor<T>`, `Arc<Tensor<T>>`, or `Tensor<T>`.
-`&mut Tensor` params accept `Partition<Tensor<T>>` or `Partition<&mut Tensor<T>>`.
+The generated launcher accepts multiple forms for each parameter type. `&Tensor` params accept `&Tensor<T>`, `Arc<Tensor<T>>`, or `Tensor<T>`. `&mut Tensor` params accept `Partition<Tensor<T>>` or `Partition<&mut Tensor<T>>`.
 
-### Device-Side Types
-
-Inside a kernel, tensors and tiles carry their shape as a type parameter. This enables compile-time shape checking and optimization:
+The `api::*` module constructs tensors on the device. Each constructor returns a `DeviceOp`, so allocation and initialization are lazy until `.sync()` or `.await`:
 
 ```rust
-// Device-side Tensor<E, S> — element type + shape
+use cutile::api;
+
+// 3D tensor of random values from a standard normal distribution.
+let weights: Tensor<f32> = api::randn(0.0f32, 1.0, [32, 64, 128], None).sync_on(&stream)?;
+
+// Other common constructors: zeros, ones, full, arange, linspace, eye, rand, randn.
+// Note: zeros/ones/full take &[usize] slices; rand/randn take [usize; RANK] arrays + Option<u64> seed.
+```
+
+**`TensorView`** provides zero-copy views and slices of an existing tensor, which matters for performance: when you want to process a subregion, views avoid the allocation and copy you'd otherwise need. The offset is applied host-side, so passing a view to a kernel hands it a pointer to the correct starting address with no data movement.
+
+```rust
+let tensor = api::arange::<f32>(1024).sync_on(&stream)?;
+
+let matrix = tensor.view(&[32, 32])?;           // Reshape without copying
+let row_slice = matrix.slice(&[1..3])?;         // Rows 1-2, all columns
+let block = matrix.slice(&[1..3, 2..6])?;       // Rows 1-2, cols 2-5
+```
+
+Views and slices pass to kernels as `&Tensor` parameters. Use them for attention over a sub-sequence, GEMM over a sub-matrix, and similar sub-region patterns — no allocation, no copy. See the [Host API](../reference/host-api.md#tensor-creation-and-views) for the full list of constructors and `TensorView` methods.
+
+Inside a kernel, tensors and tiles carry their shape as a type parameter, enabling compile-time shape checking and optimization:
+
+```rust
 fn kernel(
     output: &mut Tensor<f32, { [BM, BN] }>,  // Static shape from partition
     input: &Tensor<f32, { [-1, -1] }>,       // Dynamic shape
@@ -123,13 +92,13 @@ fn kernel(
 
     // Tile<E, S> — immutable data fragment in registers
     let tile_a: Tile<f32, { [BM, BN] }> = load_tile_like_2d(input, output);
-    let result = tile_a * 2.0;       // Operations create new tiles
+    let result = tile_a * 2.0;
     output.store(result);
 }
 ```
 
 | Type | Side | Parameterized By | Description |
-|------|------|-----------------|-------------|
+|------|------|------------------|-------------|
 | `Tensor<T>` | Host | Element type | Tensor in global memory; allocated and managed on the CPU |
 | `Partition<Tensor<T>>` | Host | Element type | Host-side wrapper recording a tensor and its partition shape |
 | `Arc<Tensor<T>>` | Host | Element type | Shared reference for read-only kernel inputs |
@@ -137,105 +106,31 @@ fn kernel(
 | `Partition<E, S>` | Device | Element type + shape | Read-only view of a `&Tensor` divided into tiles inside a kernel |
 | `Tile<E, S>` | Device | Element type + shape (always static) | Immutable data fragment in GPU registers |
 
----
-
-## Element Types
-
-cuTile Rust supports various numeric types for GPU computation:
-
-### Floating Point Types
-
-| Type | Size | Description | Use Case |
-|------|------|-------------|----------|
-| `f16` | 16-bit | Half precision | Training, inference (2× Tensor Core throughput) |
-| `bf16` | 16-bit | Brain float (FP16 range, less precision) | Training (better range than `f16`) |
-| `f32` | 32-bit | Single precision | General purpose, debugging |
-| `f64` | 64-bit | Double precision | Scientific computing |
-| `tf32` | 19-bit | TensorFloat-32 | Tensor Core operations |
-| `f8e4m3fn` | 8-bit | FP8 E4M3FN (no infinity) | Quantized storage; convert to `f16`/`f32` for compute |
-| `f8e5m2` | 8-bit | FP8 E5M2 | Quantized storage; convert to `f16`/`f32` for compute |
-
-### Integer Types
-
-| Type | Size | Description |
-|------|------|-------------|
-| `i8` / `u8` | 8-bit | Signed/unsigned byte |
-| `i16` / `u16` | 16-bit | Signed/unsigned short |
-| `i32` / `u32` | 32-bit | Signed/unsigned int |
-| `i64` / `u64` | 64-bit | Signed/unsigned long |
-
-### Boolean Type
-
-| Type | Description |
-|------|-------------|
-| `bool` | Boolean (true/false), maps to `i1` |
-
-### Choosing Element Types
-
-| Type | Performance | Precision | Recommendation |
-|------|-------------|-----------|----------------|
-| `f32` | Baseline | High | Development, debugging |
-| `f16` | 2× on Tensor Cores | Medium | Inference |
-| `bf16` | 2× on Tensor Cores | Medium (better range) | Training |
-| `i32` | Native integer ops | Exact | Indexing, control flow |
+For the full list of supported element types (`f16`, `bf16`, `f32`, `f64`, `tf32`, `f8e4m3fn`, `f8e5m2`, integer types, `bool`), see the [DSL API: ElementType](../reference/dsl-api.md#elementtype). For the `api::*` module and `TensorView`, see [Host API: Tensor Creation and Views](../reference/host-api.md#tensor-creation-and-views).
 
 ---
 
-## Shapes
+## Shapes and Broadcasting
 
-Shapes define the dimensions of tensors and tiles.
-
-### Static Shapes (Compile-Time)
-
-When you know the shape at compile time, use const generics:
+**Static shapes** are compile-time constants. **Dynamic shapes** (written as `-1`) are determined at runtime.
 
 ```rust
-fn kernel<const BM: i32, const BN: i32>(
-    output: &mut Tensor<f32, { [BM, BN] }>,  // Static shape
+// Static: known at compile time, fully optimized
+fn kernel_static<const BM: i32, const BN: i32>(
+    output: &mut Tensor<f32, { [BM, BN] }>,
+) { /* BM and BN known; compiler can optimize layout and access patterns */ }
+
+// Dynamic: -1 means "determined at runtime"
+fn kernel_dynamic(
+    input: &Tensor<f32, { [-1, -1] }>,
 ) {
-    // BM and BN are known at compile time
-    // Compiler can optimize layout and access patterns
+    let shape = input.shape();  // Query actual dimensions at runtime
 }
 ```
 
-**Benefits:**
-- Compiler can optimize layout and access patterns
-- Shape errors caught at compile time
-- Zero runtime overhead for shape checks
+Static shapes let the compiler optimize layout and access patterns and catch shape errors at compile time, at the cost of re-compilation whenever a type or const generic changes. Dynamic shape dimensions that vary across launches do not trigger re-compilation.
 
-**Drawbacks:**
-- Kernels are re-compiled whenever their type or const generics change. 
-- Too many consts which change across kernel launches will trigger excessive re-compilation, 
-  which may not be desirable/optimal for all applications.
-
-### Dynamic Shapes (Runtime)
-
-When the shape is only known at runtime:
-
-```rust
-fn kernel(
-    input: &Tensor<f32, { [-1, -1] }>,  // Dynamic shape
-) {
-    // -1 means "determined at runtime"
-    let shape = input.shape();  // Query actual dimensions
-}
-```
-
-Dynamic shape dimensions which vary across kernel launches do not trigger re-compilation.
-
-### Common Tile Sizes
-
-For optimal performance, tile dimensions are typically powers of two:
-
-| Shape | Total Elements | Use Case |
-|-------|----------------|----------|
-| `[64, 64]` | 4,096 | General matrix ops |
-| `[128, 128]` | 16,384 | Large matrix ops |
-| `[256, 64]` | 16,384 | Tall tiles |
-| `[64, 256]` | 16,384 | Wide tiles |
-| `[1024]` | 1,024 | 1D vectors |
-
-### The Common Pattern: Static Output, Dynamic Input
+The common pattern is **static output, dynamic input**: the tile size is a const generic, while the full tensor dimensions are runtime values:
 
 ```rust
 #[cutile::entry()]
@@ -250,145 +145,48 @@ fn add<const S: [i32; 2]>(
 }
 ```
 
----
-
-## Shape Broadcasting
-
-When operating on tiles of different shapes, cuTile Rust uses **broadcasting** rules similar to NumPy:
-
-### Broadcasting Rules
-
-1. **Align dimensions from the right**
-2. **Dimensions are compatible if they're equal or one is 1**
-3. **The result shape is the maximum along each dimension**
+**Broadcasting** expands a tile of one shape to operate against a tile of another, following NumPy rules: align dimensions from the right; two dimensions are compatible if they are equal or one of them is 1; the result shape is the maximum along each dimension.
 
 ```rust
-// Example: [64, 64] + [1, 64] -> [64, 64]
-let tile_a: Tile<f32, [64, 64]> = ...;
-let tile_b: Tile<f32, [1, 64]> = ...;
-let result = tile_a + tile_b.broadcast(const_shape![64, 64]);  // Result is [64, 64], B broadcast along dim 0
+// [64, 64] + [1, 64] -> [64, 64]  (broadcast B along dim 0)
+let tile_a: Tile<f32, {[64, 64]}> = ...;
+let tile_b: Tile<f32, {[1, 64]}> = ...;
+let result = tile_a + tile_b.broadcast(const_shape![64, 64]);
 ```
-
-<!--
-### Broadcasting Examples
-
-```
-Shape A      Shape B      Result
-[64, 64]  +  [64, 64]  -> [64, 64]   (exact match)
-[64, 64]  +  [1, 64]   -> [64, 64]   (broadcast B along dim 0)
-[64, 64]  +  [64, 1]   -> [64, 64]   (broadcast B along dim 1)
-[64, 64]  +  [1, 1]    -> [64, 64]   (broadcast B along both dims)
-[64, 1]   +  [1, 64]   -> [64, 64]   (broadcast both)
-```
--->
-
-<!--
-### Arithmetic Promotion
-
-When operating on tiles with different dtypes, automatic promotion occurs:
-
-```rust
-// f16 + f32 -> f32
-let a: Tile<f16, S> = ...;
-let b: Tile<f32, S> = ...;
-let c = a + b;  // c is Tile<f32, S>
-```
-
-**Promotion Hierarchy:**
-```
-f16 < bf16 < f32 < f64
-i8 < i16 < i32 < i64
-```
--->
 
 ---
 
-## Type Safety
+## Type Safety and Generics
 
-### Compile-Time Shape Checking
-
-The compiler catches shape mismatches:
+The compiler catches shape mismatches, element-type mismatches, and matrix-multiply dimension errors before code runs:
 
 ```rust
-// ❌ Won't compile: shapes don't match
+// ❌ Shape mismatch
 let a: Tile<f32, {[4, 4]}> = ...;
 let b: Tile<f32, {[8, 8]}> = ...;
 let c = a + b;  // Error: cannot add [4,4] and [8,8]
 
-// ✅ Correct: same shapes
-let a: Tile<f32, {[4, 4]}> = ...;
-let b: Tile<f32, {[4, 4]}> = ...;
-let c = a + b;  // OK: both [4,4]
-```
-
-### Element Type Checking
-
-```rust
-// ❌ Won't compile: type mismatch without conversion
+// ❌ Element-type mismatch without conversion
 let x: Tile<f32, {[4, 4]}> = ...;
 let y: Tile<i32, {[4, 4]}> = ...;
 let z = x + y;  // Error: cannot add f32 and i32
 
-// ✅ Correct: explicit conversion
+// ✅ Explicit conversion
 let y_float: Tile<f32, {[4, 4]}> = convert_tile(y);
-let z = x + y_float;  // OK
+let z = x + y_float;
+
+// ❌ MMA inner dimensions don't match: [M=16, K=8] × [K=16, N=32]
+let a: Tile<f32, {[16, 8]}>;
+let b: Tile<f32, {[16, 32]}>;
+let c = mma(a, b, zeros);  // Error!
+
+// ✅ MMA inner dims match: [M=16, K=8] × [K=8, N=32] -> [16, 32]
+let a: Tile<f32, {[16, 8]}>;
+let b: Tile<f32, {[8, 32]}>;
+let c = mma(a, b, zeros);
 ```
 
-### Matrix Multiplication Shape Rules
-
-For `C = A @ B`:
-- A shape: `[M, K]`
-- B shape: `[K, N]`
-- C shape: `[M, N]`
-
-The inner dimension K must match:
-
-```rust
-// ❌ Won't compile: inner dimensions don't match
-let a: Tile<f32, {[16, 8]}>;   // [M=16, K=8]
-let b: Tile<f32, {[16, 32]}>;  // [K=16, N=32]  K mismatch!
-let c = mma(a, b, zeros);      // Error!
-
-// ✅ Correct: K dimensions match
-let a: Tile<f32, {[16, 8]}>;   // [M=16, K=8]
-let b: Tile<f32, {[8, 32]}>;   // [K=8, N=32]   K matches!
-let c = mma(a, b, zeros);      // OK: result is [16, 32]
-```
-
----
-
-## Type Conversions
-
-### Explicit Casting
-
-Convert between types explicitly:
-
-```rust
-let float_tile: Tile<f32, S> = ...;
-
-// Float to integer
-let int_tile: Tile<i32, S> = convert_tile(float_tile);
-
-// Integer extension
-let i8_tile: Tile<i8, S> = ...;
-let i32_tile: Tile<i32, S> = convert_tile(i8_tile);
-```
-
-<!--
-### Conversion Operations
-
-| Operation | Description |
-|-----------|-------------|
-| `trunci::<T>()` | Truncate to smaller integer type |
-| `exti::<T>()` | Sign-extend to larger integer type |
-| `cast::<T>()` | General type conversion |
--->
-
----
-
-## Generic Kernels
-
-Use generics to specify flexible, reusable kernels:
+**Generic kernels** let a single function handle multiple element types and shapes:
 
 ```rust
 #[cutile::entry()]
@@ -405,11 +203,7 @@ fn flexible_gemm<
 ) {
     // Works for any element type and tile sizes!
 }
-```
 
-Launch with specific types:
-
-```rust
 let generics = vec![
     "f32".to_string(),  // E
     "16".to_string(),   // BM
@@ -420,92 +214,8 @@ let generics = vec![
 gemm(z, x, y).generics(generics).sync_on(&stream);
 ```
 
-### The ElementType Trait
-
-Custom element types must implement `ElementType`:
-
-```rust
-pub trait ElementType: Copy + Clone {}
-
-// Built-in implementations:
-impl ElementType for f32 { ... }
-impl ElementType for f16 { ... }
-impl ElementType for i32 { ... }
-// etc.
-```
+Custom element types implement the [`ElementType`](../reference/dsl-api.md#elementtype) trait. The built-in numeric types all implement it.
 
 ---
 
-## Memory Layout
-
-### Tensor Memory Layout
-
-Tensors in global memory use row-major (C-style) layout:
-
-```{figure} ../_static/images/tensor-memory-layout.svg
-:width: 100%
-:alt: Tensor memory layout showing row-major ordering
-```
-
-**Key insight:** Consecutive elements in a row are adjacent in memory, enabling coalesced memory access when threads read along rows.
-
-### Tile Register Layout
-
-Tiles exist in registers without a specific addressable layout. The compiler optimizes register usage automatically.
-
----
-
-## Shape Utilities
-
-### const_shape! Macro
-
-Create compile-time shapes:
-
-```rust
-use cutile::core::const_shape;
-
-let shape = const_shape![64, 64];       // [64, 64]
-let shape_3d = const_shape![8, 16, 32]; // [8, 16, 32]
-```
-
-### Shape Operations
-
-```rust
-// Get shape at runtime
-let dims = tensor.shape();  // Returns shape info
-
-// Reshape (total elements must match)
-let reshaped = tile.reshape(const_shape![8, 8]);
-
-// Broadcast (expand dimensions)
-let scalar: Tile<f32, {[]}> = constant(2.0f32, const_shape![]);
-let expanded = scalar.broadcast(const_shape![64, 64]);
-```
-
----
-
-## Summary
-
-| Concept | Purpose |
-|---------|---------|
-| **Static shapes** `{[M, N]}` | Compile-time known, fully optimized |
-| **Dynamic shapes** `{[-1, -1]}` | Runtime determined |
-| **Tensor\<T\>** (host) | Tensor in global memory, allocated and managed on the CPU |
-| **Tensor\<E, S\>** (device) | Kernel parameter with element type and shape |
-| **Partition\<Tensor\<T\>\>** (host) | Wrapper recording a tensor and its partition shape |
-| **Partition\<E, S\>** (device) | Read-only view of a tensor divided into tiles inside a kernel |
-| **Tile\<E, S\>** (device only) | Immutable data fragment in GPU registers |
-| **Const generics** | Flexible, type-safe kernels |
-| **Broadcasting** | Automatic shape expansion |
-
-**Key benefits:**
-- Catch shape mismatches at compile time
-- Zero runtime overhead for static shapes
-- Generic kernels work with any valid configuration
-
----
-
-## Next Steps
-
-- Continue to [Writing Computations on Tiles](writing-computations.md) for the operations you can apply
-- Look up individual operations in the [DSL API Reference](../reference/dsl-api.md)
+Continue to [Writing Computations](writing-computations.md) for the operations you can apply on tiles. For type signatures, operator catalogs, and `const_shape!` / shape utilities, see the [DSL API reference](../reference/dsl-api.md).

--- a/cutile-book/guide/writing-computations.md
+++ b/cutile-book/guide/writing-computations.md
@@ -1,326 +1,35 @@
-# Writing Computations on Tiles
+# Writing Computations
 
-cuTile Rust provides a rich set of operations for GPU computation. All operations work on tiles and leverage GPU parallelism.
-
-## Loading and Storing
-
-### Basic Load/Store
-
-```rust
-// Load entire output tile
-let tile = load_tile_mut(tensor);
-
-// Store result
-tensor.store(tile);
-```
-
-### Load Like (Positional Loading)
-
-Load from a dynamic tensor at the position matching another tile:
-
-```rust
-// Load from x at the same position as output tile z
-let tile_x = load_tile_like_2d(x, z);
-let tile_y = load_tile_like_2d(y, z);
-```
-
-This is the most common pattern for element-wise operations.
-
-### Partitioned Loading
-
-For explicit control over which tile to load:
-
-```rust
-let part = tensor.partition(const_shape![16, 16]);
-let tile = part.load([row_idx, col_idx]);
-```
+cuTile Rust provides a rich set of operations that work on tiles and leverage GPU parallelism. The [DSL API reference](../reference/dsl-api.md) has the complete catalog with full signatures; this page focuses on how these building blocks compose into complete algorithms.
 
 ---
 
-## Elementwise Operations
+## Operations at a Glance
 
-Standard math operations work element-by-element on tiles:
+Everything you express inside a kernel boils down to a small set of operation categories:
 
-### Arithmetic
+| Category | Representative operations | Reference |
+|---|---|---|
+| Load and store | `load_tile_mut`, `load_tile_like_2d`, `Partition::load`, `Tensor::store` | [Memory: Load and Store](../reference/dsl-api.md#memory-load-and-store) |
+| Arithmetic | `+`, `-`, `*`, `/`, `fma`, `true_div` | [Arithmetic (Element-wise)](../reference/dsl-api.md#arithmetic-element-wise) |
+| Math | `exp`, `log`, `sqrt`, `rsqrt`, `sin`, `cos`, `tanh` | [Math (Floating-Point)](../reference/dsl-api.md#math-floating-point) |
+| Reduction / scan | `reduce_max`, `reduce_sum`, `reduce_min`, `reduce_prod`, `scan` | [Reduction and Scan](../reference/dsl-api.md#reduction-and-scan) |
+| Matrix multiply | `mma`, `permute` | [Matrix Multiply](../reference/dsl-api.md#matrix-multiply) |
+| Shape manipulation | `reshape`, `broadcast`, `const_shape!` | [Shape Manipulation](../reference/dsl-api.md#shape-manipulation) |
+| Comparison | `gt_tile`, `ge_tile`, `lt_tile`, `le_tile`, `eq_tile`, `select` | [Comparison](../reference/dsl-api.md#comparison) |
+| Creation | `constant`, `iota`, `convert_tile` | [Creation](../reference/dsl-api.md#creation) |
 
-```rust
-let c = a + b;    // Addition
-let c = a - b;    // Subtraction
-let c = a * b;    // Multiplication
-let c = a / b;    // Division
-```
-
-### With Scalars
-
-```rust
-let scale = 2.0f32;
-let scaled = tile * scale;           // Multiply by scalar
-let shifted = tile + 1.0f32;         // Add scalar
-```
-
-### Compound Operations
-
-```rust
-// SAXPY: y = a*x + y
-let result = a * x + y;
-
-// Fused multiply-add (more accurate)
-let result = fma(a, x, y);
-
-// Fused multiply-add with rounding mode
-let result = fma(a, x, y, rounding_mode);
-```
+Arithmetic operators apply element-wise to tiles of compatible shapes (broadcasting fills mismatched dimensions where one side is 1). Scalars can be combined with tiles directly or promoted to a tile with `broadcast`. Math functions, reductions, and shape operations compose freely with arithmetic to express most numerical algorithms.
 
 ---
 
-## Mathematical Functions
+## Composition Patterns
 
-### Exponential and Logarithmic
+The real value of the tile model shows up when you combine operations into full algorithms. Three representative patterns.
 
-```rust
-let y = exp(x);              // e^x
-let y = exp2(x, ftz::Disabled);             // 2^x (faster on GPU)
-let y = log(x);              // Natural log (ln)
-let y = log2(x);             // Log base 2
-let y = sqrt(x, "rn");       // Square root (requires rounding mode)
-let y = rsqrt(x);            // 1/sqrt(x) (fast reciprocal sqrt)
-```
+### Scale and shift
 
-### Trigonometric
-
-```rust
-let y = sin(x);      // Sine
-let y = cos(x);      // Cosine
-let y = tanh(x);     // Hyperbolic tangent
-```
-
-### Other
-
-```rust
-let y = absf(x);             // Absolute value (float)
-let y = absi(x);             // Absolute value (integer)
-let y = negf(x);             // Negation (float)
-let y = negi(x);             // Negation (integer)
-let y = ceil(x, "rn");       // Ceiling (requires rounding mode)
-let y = floor(x);            // Floor
-```
-
----
-
-## Reduction Operations
-
-Reduce along an axis to produce a smaller tile:
-
-### Max and Sum
-
-```rust
-// Input: Tile<f32, {[BM, BN]}>
-
-// Reduce across columns (axis=1) → Tile<f32, {[BM]}>
-let row_max = reduce_max(tile, 1i32);
-let row_sum = reduce_sum(tile, 1);
-
-// Reduce across rows (axis=0) → Tile<f32, {[BN]}>
-let col_max = reduce_max(tile, 0i32);
-let col_sum = reduce_sum(tile, 0);
-```
-
-![Reduction operations along axis 0 (columns) and axis 1 (rows)](../_static/images/reduction-axes.svg)
-
-### Min
-
-```rust
-let row_min = reduce_min(tile, 1);
-let col_min = reduce_min(tile, 0);
-```
-
-### Prod
-
-```rust
-let row_prod = reduce_prod(tile, 1);
-let col_prod = reduce_prod(tile, 0);
-```
-
----
-
-## Matrix Operations
-
-### Matrix Multiply-Accumulate (MMA)
-
-The workhorse of GPU computing:
-
-```rust
-// C = A @ B + C
-let c = mma(a, b, c);
-
-// For accumulation loop:
-let mut acc = constant(0.0f32, const_shape![BM, BN]);
-for i in 0..K {
-    let a_tile = load_a(i);
-    let b_tile = load_b(i);
-    acc = mma(a_tile, b_tile, acc);
-}
-```
-
-**Shape requirements:**
-- A: `[M, K]`
-- B: `[K, N]`
-- C: `[M, N]`
-- Result: `[M, N]`
-
-### Transpose / Permute
-
-```rust
-// Define permutation
-let transpose: Array<{[1, 0]}> = Array::<{[1, 0]}> {
-    dims: &[1i32, 0i32],
-};
-
-// Apply transpose
-let transposed = permute(tile, transpose);
-// [M, N] → [N, M]
-```
-
----
-
-## Broadcasting
-
-Expand a smaller tile to match a larger shape:
-
-### Scalar Broadcasting
-
-```rust
-// Broadcast scalar to tile
-let scalar = 2.0f32;
-let tile = scalar.broadcast(const_shape![64, 64]);
-// Creates 64×64 tile filled with 2.0
-```
-
-### Dimension Broadcasting
-
-```rust
-// Broadcast [BM] to [BM, BN]
-let row_values: Tile<f32, {[BM]}> = ...;
-let expanded = row_values
-    .reshape(const_shape![BM, 1])
-    .broadcast(const_shape![BM, BN]);
-```
-
-### Common Pattern: Softmax Normalization
-
-```rust
-// Get max per row: [BM, BN] → [BM]
-let row_max = reduce_max(tile, 1);
-
-// Broadcast back: [BM] → [BM, BN]
-let max_broadcast = row_max
-    .reshape(const_shape![BM, 1])
-    .broadcast(tile.shape());
-
-// Subtract max from each element
-let normalized = tile - max_broadcast;
-```
-
----
-
-## Shape Operations
-
-### Reshape
-
-Change shape without changing data (total elements must match):
-
-```rust
-// Flatten 2D to 1D
-let flat = tile.reshape(const_shape![BM * BN]);
-
-// Reshape for broadcasting
-let col_vector = row.reshape(const_shape![BM, 1]);
-```
-
-### Get Shape
-
-```rust
-let shape = tensor.shape();
-let dim_0 = get_shape_dim(tensor.shape(), 0i32);
-```
-
----
-
-## Comparison Operations
-
-```rust
-// Element-wise comparisons return bool tiles
-let mask = gt_tile(a, b);    // a > b
-let mask = ge_tile(a, b);    // a >= b
-let mask = lt_tile(a, b);    // a < b
-let mask = le_tile(a, b);    // a <= b
-let mask = eq_tile(a, b);    // a == b
-```
-
-### Select (Conditional)
-
-```rust
-// Select elements based on mask
-let result = select(mask, if_true, if_false);
-```
-
----
-
-## Control Flow Operations
-
-### Tile-Level Max/Min
-
-```rust
-// Element-wise max/min of two tiles
-let result = max_tile(a, b);
-let result = min_tile(a, b);
-```
-
----
-
-## Constants
-
-```rust
-// Create constant tile
-let zeros = constant(0.0f32, const_shape![64, 64]);
-let ones = constant(1.0f32, const_shape![64, 64]);
-let neg_inf = constant(f32::NEG_INFINITY, const_shape![BM, 1]);
-```
-
-### Iota (Index Generation)
-
-```rust
-// Create [0, 1, 2, 3, ...] tile
-let indices: Tile<i32, {[64]}> = iota(const_shape![64]);
-```
-
----
-
-## Utility Operations
-
-### Print (Debugging)
-
-```rust
-cuda_tile_print!("Value at tile ({}, {}): {}\n", 
-    pid.0, pid.1, some_value);
-```
-
-:::{warning}
-GPU printing is slow and should only be used for debugging small grids.
-:::
-
-### Type Conversion
-
-```rust
-let float_tile: Tile<f32, S> = convert_tile(int_tile);
-let half_tile: Tile<f16, S> = convert_tile(float_tile);
-```
-
----
-
-## Common Operation Patterns
-
-### Element-wise with Broadcast
+Multiply a tile by a scale and add a bias — elementwise combined with broadcast:
 
 ```rust
 fn scale_and_shift<const S: [i32; 2]>(
@@ -332,19 +41,19 @@ fn scale_and_shift<const S: [i32; 2]>(
 }
 ```
 
-### Numerically Stable Softmax
+### Numerically stable softmax
+
+Reductions combine with broadcasting to produce normalization. Subtracting the per-row max before `exp` prevents overflow on large inputs:
 
 ```rust
 fn softmax<const BM: i32, const BN: i32>(
     x: Tile<f32, { [BM, BN] }>
 ) -> Tile<f32, { [BM, BN] }> {
-    // Subtract max for numerical stability
     let max: Tile<f32, { [BM, BN] }> = reduce_max(x, 1i32)
         .reshape(const_shape![BM, 1])
         .broadcast(const_shape![BM, BN]);
     let stable = x - max;
 
-    // Compute softmax
     let exp_x = exp(stable);
     let sum: Tile<f32, { [BM, BN] }> = reduce_sum(exp_x, 1)
         .reshape(const_shape![BM, 1])
@@ -354,7 +63,13 @@ fn softmax<const BM: i32, const BN: i32>(
 }
 ```
 
-### Tiled Matrix Multiply
+The `reshape(const_shape![BM, 1])` converts the reduced `[BM]` back to a column vector, then `broadcast` expands it across the column dimension to match the original `[BM, BN]` shape.
+
+![Reduction operations along axis 0 (columns) and axis 1 (rows)](../_static/images/reduction-axes.svg)
+
+### Tiled matrix multiply
+
+Repeated `mma` calls accumulate into a destination tile across a K loop. Each iteration loads a `[BM, BK]` tile from `x` and a `[BK, BN]` tile from `y`, multiplies them, and accumulates into `acc`. The accumulator lives in registers throughout the loop:
 
 ```rust
 fn tiled_gemm<E: ElementType, const BM: i32, const BN: i32, const BK: i32, const K: i32>(
@@ -379,20 +94,21 @@ fn tiled_gemm<E: ElementType, const BM: i32, const BN: i32, const BK: i32, const
 
 ---
 
-## Summary
+## Debugging Computations
 
-| Category | Key Operations |
-|----------|---------------|
-| **Load/Store** | `load_tile_mut`, `load_tile_like_2d`, `partition().load()`, `store` |
-| **Arithmetic** | `+`, `-`, `*`, `/`, `fma`, `true_div` |
-| **Math** | `exp`, `exp2`, `log`, `log2`, `sqrt`, `rsqrt`, `sin`, `cos`, `tanh` |
-| **Reduction** | `reduce_max`, `reduce_sum`, `reduce_min`, `reduce_prod` |
-| **Matrix** | `mma`, `permute` |
-| **Shape** | `reshape`, `broadcast`, `const_shape!` |
-| **Compare** | `gt_tile`, `ge_tile`, `lt_tile`, `le_tile`, `eq_tile`, `select` |
-| **Element-wise** | `max_tile`, `min_tile`, `absf`, `negf`, `floor`, `ceil` |
-| **Constants** | `constant`, `iota`, `convert_tile` |
+`cuda_tile_print!` prints from within a kernel:
+
+```rust
+cuda_tile_print!("Value at tile ({}, {}): {}\n",
+    pid.0, pid.1, some_value);
+```
+
+:::{warning}
+GPU printing is slow and serializes execution. Use it only for debugging small grids.
+:::
+
+For more techniques — type conversion sanity checks, assertions, IR dumping, and profiler integration — see [Debugging and Profiling](debugging.md).
 
 ---
 
-Continue to [How Kernels Run on the GPU](execution-model.md) to see how these operations map onto the hardware. For the full catalog of operations with signatures, see the [DSL API Reference](../reference/dsl-api.md).
+Continue to [The Execution Model](execution-model.md) to see how these operations map onto the hardware. For the full catalog of operations with signatures, see the [DSL API](../reference/dsl-api.md).

--- a/cutile-book/index.md
+++ b/cutile-book/index.md
@@ -108,6 +108,6 @@ guide/debugging
 :caption: Reference
 
 reference/dsl-api
-reference/deviceop-reference
+reference/host-api
 reference/glossary
 ```

--- a/cutile-book/reference/dsl-api.md
+++ b/cutile-book/reference/dsl-api.md
@@ -1,4 +1,4 @@
-# DSL API Reference
+# DSL API
 
 > **Status**: This API is under active development. Expect changes.
 
@@ -162,7 +162,7 @@ mod my_kernels {
 
 See `cutile-examples/examples/inter_module.rs` for a runnable version.
 
-### How `cutile::core` Works
+### `cutile::core` internals
 
 `cutile::core` (defined in `_core.rs`) is itself a `#[cutile::module]`
 containing the built-in DSL operations. When you write `use cutile::core::*;`,

--- a/cutile-book/reference/host-api.md
+++ b/cutile-book/reference/host-api.md
@@ -1,0 +1,598 @@
+# Host API
+
+Reference for everything host-side: creating and transferring tensors, managing contexts and streams, configuring kernel launches, the `DeviceOp` trait and its combinators, and CUDA graph integration. For tutorial-style introductions, see [Orchestrating Device Operations](../guide/device-operations.md) and [Working with Data](../guide/working-with-data.md).
+
+---
+
+## Tensor Creation and Views
+
+### `api::*` constructors
+
+All creation functions return a `DeviceOp` — allocation and initialization happen when the operation runs, not when it is constructed.
+
+| Function | Output | Description |
+|---|---|---|
+| `api::zeros::<T>(shape: &[usize])` | `DeviceOp<Output = Tensor<T>>` | All zeros |
+| `api::ones::<T>(shape: &[usize])` | `DeviceOp<Output = Tensor<T>>` | All ones |
+| `api::full::<T>(val, shape: &[usize])` | `DeviceOp<Output = Tensor<T>>` | Fill with scalar value |
+| `api::arange::<T>(len: usize)` | `DeviceOp<Output = Tensor<T>>` | `[0, 1, 2, ..., len-1]` (1D) |
+| `api::linspace(start: f32, stop: f32, n: usize)` | `DeviceOp<Output = Tensor<f32>>` | `n` values evenly spaced from `start` to `stop` |
+| `api::eye(n: usize)` | `DeviceOp<Output = Tensor<f32>>` | `n × n` identity matrix |
+| `api::eye_rect(rows: usize, cols: usize)` | `DeviceOp<Output = Tensor<f32>>` | `rows × cols`, ones on main diagonal |
+| `api::rand::<T, RANK>(shape: [usize; RANK], seed: Option<u64>)` | `DeviceOp<Output = Tensor<T>>` | Uniform `[0, 1)` from cuRAND (`T: RandUniform`) |
+| `api::randn::<T, RANK>(mean: T, std: T, shape: [usize; RANK], seed: Option<u64>)` | `DeviceOp<Output = Tensor<T>>` | Normal `N(mean, std²)` from cuRAND (`T: RandNormal`) |
+| `api::randn_f16(mean: f16, std: f16, shape: [usize; RANK], seed: Option<u64>)` | `DeviceOp<Output = Tensor<f16>>` | Normal for `f16` (generates `f32` and converts; cuRAND has no native `f16`) |
+
+Shape conventions vary across the module: `zeros`/`ones`/`full` take `&[usize]` slices of arbitrary length; `rand`/`randn` take `[usize; RANK]` arrays (rank is a const generic). The `RANK` parameter is usually inferred from the array literal.
+
+```rust
+use cutile::api;
+
+let z = api::zeros::<f32>(&[1024]).sync_on(&stream)?;
+let m = api::ones::<f32>(&[256, 256]).sync_on(&stream)?;
+let r = api::randn(0.0f32, 1.0, [32, 64, 128], None).sync_on(&stream)?;   // 3D N(0, 1)
+let u = api::rand::<f32, 1>([1024], Some(42)).sync_on(&stream)?;          // Uniform with fixed seed
+let idx = api::arange::<i32>(1024).sync_on(&stream)?;
+let I = api::eye(64).sync_on(&stream)?;
+```
+
+### `TensorView`: zero-copy views and slices
+
+`TensorView` provides zero-copy borrowed views of a tensor with a different shape or offset. Views borrow the underlying tensor — the tensor cannot be mutated while a view exists. The offset is applied host-side, so passing a view to a kernel hands the kernel a pointer to the correct starting address without any data movement.
+
+| Method | Description |
+|---|---|
+| `tensor.view(&shape)` | Reshape to the given shape without copying. Total element count must match. |
+| `tensor.slice(&ranges)` | Borrow a rectangular sub-region (one numpy-style range per dimension). |
+| `view.slice(&ranges)` | Chain-slice further; offsets accumulate. |
+
+```rust
+let tensor = api::arange::<f32>(1024).sync_on(&stream)?;
+
+// Reshape without copying.
+let matrix = tensor.view(&[32, 32])?;
+
+// Slice: borrow a subregion (numpy-style ranges).
+let first_half = tensor.slice(&[0..512])?;       // elements 0-511
+let row_slice = matrix.slice(&[1..3])?;          // rows 1-2, all columns
+let block = matrix.slice(&[1..3, 2..6])?;        // rows 1-2, cols 2-5
+
+// Chained slices accumulate offsets.
+let inner = tensor.slice(&[100..200])?.slice(&[10..20])?;  // = tensor[110..120]
+```
+
+Views and slices are passed to kernels as `&Tensor` parameters. They're the right tool when you want to process a subregion of an existing tensor — an attention kernel over a sub-sequence, a GEMM over a sub-matrix, a scan over a contiguous slice — without allocation or copying.
+
+---
+
+## Host-Device Transfers
+
+Moving data between CPU and GPU uses three APIs, all of which return `DeviceOp`s — the copy is scheduled when the op runs, not constructed:
+
+| API | Returns | Description |
+|---|---|---|
+| `api::copy_host_vec_to_device::<T>(vec: &Arc<Vec<T>>)` | `DeviceOp<Output = Tensor<T>>` | Copy host `Vec<T>` to a new device `Tensor<T>` |
+| `api::copy_device_to_host_vec::<T>(tensor: &Tensor<T>)` | `DeviceOp<Output = Vec<T>>` | Copy a device `Tensor<T>` to a host `Vec<T>` |
+| `tensor.to_host_vec()` | `DeviceOp<Output = Vec<T>>` | Method form of `copy_device_to_host_vec` (preferred) |
+
+```rust
+// Host -> device
+let data: Arc<Vec<f32>> = Arc::new(vec![1.0; 1024]);
+let tensor: Tensor<f32> = api::copy_host_vec_to_device(&data).sync_on(&stream)?;
+
+// Device -> host
+let result: Vec<f32> = tensor.to_host_vec().sync_on(&stream)?;
+```
+
+The host-side `Vec` must remain alive until the op completes — the async copy reads from it until the stream synchronizes. `Arc<Vec<T>>` makes this straightforward for shared access. `to_host_vec` is available on `Tensor<T>`, `Arc<Tensor<T>>`, and `&Tensor<T>`; each returns the same `DeviceOp<Output = Vec<T>>`.
+
+---
+
+## Context and Streams
+
+Every host program starts with a `CudaContext` bound to a GPU device, plus one or more `CudaStream`s for scheduling GPU work:
+
+```rust
+use cuda_core::CudaContext;
+
+let ctx = CudaContext::new(0)?;              // Device ordinal 0
+let stream = ctx.new_stream()?;              // A new stream owned by this context
+```
+
+| Method | Returns | Description |
+|---|---|---|
+| `CudaContext::new(ordinal: usize)` | `Result<Arc<CudaContext>, DriverError>` | Create a context bound to a device ordinal |
+| `CudaContext::device_count()` | `Result<i32, DriverError>` | Number of CUDA-capable devices |
+| `ctx.ordinal()` | `usize` | Device ordinal this context binds |
+| `ctx.new_stream()` | `Result<Arc<CudaStream>, DriverError>` | Create a new stream on this context |
+
+Contexts are `Arc`-wrapped for sharing across threads; streams are also `Arc`-wrapped and can be passed to `.sync_on(&stream)` for explicit stream scheduling.
+
+The default round-robin scheduling policy handles stream assignment automatically for most workloads — these APIs are for when you need explicit stream control (debugging, deterministic ordering, paired with `AsyncKernelLaunch`, or overlapping compute with transfers on dedicated streams).
+
+---
+
+## Kernel Launch Configuration
+
+Several types configure how kernels compile and launch.
+
+**`CompileOptions`** — runtime overrides for entry-level `optimization_hints`, typically used for autotuning:
+
+```rust
+use cutile::tile_kernel::CompileOptions;
+
+let opts = CompileOptions::default()
+    .occupancy(4)
+    .num_cta_in_cga(2)
+    .max_divisibility(16);
+
+let result = my_kernel(args).compile_options(opts).grid(grid).await?;
+```
+
+Different `CompileOptions` values trigger separate JIT compilations and are part of the kernel cache key.
+
+**`LaunchConfig`** — grid/block/shared-memory specification for `AsyncKernelLaunch` (raw CUDA kernels launched outside the `#[cutile::entry]` path):
+
+```rust
+use cuda_core::LaunchConfig;
+
+LaunchConfig {
+    grid_dim: ((n + 255) / 256, 1, 1),    // 3D grid of thread blocks
+    block_dim: (256, 1, 1),                // 3D block of threads
+    shared_mem_bytes: 0,                   // Dynamic shared memory per block
+}
+```
+
+**`AsyncKernelLaunch`** — wraps a CUDA driver kernel launch as a `DeviceOp`. Build the argument list with `push_arg` (safe, for `DType` scalars) or `push_device_ptr` (`unsafe`, for raw device pointers), set the launch config, then `.await` or `.sync_on()`:
+
+```rust
+use cuda_async::launch::AsyncKernelLaunch;
+
+let mut launcher = AsyncKernelLaunch::new(function.clone());
+launcher.push_arg(num_elements as u32);
+launcher.push_arg(scale);
+unsafe {
+    launcher
+        .push_device_ptr(input.cu_deviceptr())
+        .push_device_ptr(output.cu_deviceptr());
+}
+launcher.set_launch_config(LaunchConfig {
+    grid_dim: ((num_elements as u32 + 255) / 256, 1, 1),
+    block_dim: (256, 1, 1),
+    shared_mem_bytes: 0,
+});
+launcher.await?;  // Executes as a DeviceOp
+```
+
+See [Integrating with CUDA C++](../guide/interoperability.md) for the full walkthrough and the wrapper pattern that hides `unsafe` at the call site.
+
+**`.generics(Vec<String>)`** — `#[cutile::entry]`-generated launchers accept this method to bind const generics and type parameters at runtime:
+
+```rust
+let generics = vec![
+    "f32".to_string(),  // E
+    "16".to_string(),   // BM
+    "16".to_string(),   // BN
+    "8".to_string(),    // BK
+    "128".to_string(),  // K
+];
+gemm(z, x, y).generics(generics).sync_on(&stream)?;
+```
+
+Generic values are part of the kernel cache key: each unique combination triggers its own JIT compilation.
+
+---
+
+## The Futures Analogy
+
+`DeviceOp` is to GPU work what `Future` is to async I/O. Both are lazy
+descriptions of work that don't execute until driven:
+
+| Concept | `std::future::Future` | `DeviceOp` |
+|---|---|---|
+| What it represents | Async computation | GPU computation |
+| When it runs | On `.await` or `poll()` | On `.sync()`, `.sync_on()`, or `.await` |
+| Chaining | `.then()`, `.map()` via `FutureExt` | `.then()`, `.map()` on `DeviceOp` |
+| Fan-in | `join!` | `zip!` |
+| Fan-out | N/A (single consumer) | `.unzip()` |
+| Shared access | `FutureExt::shared()` | `.shared()` |
+| Type erasure | `BoxFuture` | `.boxed()` → `BoxedDeviceOp` |
+| Output wrapper | `Poll<T>` | `Result<T, DeviceError>` |
+
+The key difference: a `Future` is pulled by an async runtime via `poll()`,
+while a `DeviceOp` is pushed to the GPU via `execute()`. When you convert
+a `DeviceOp` to a `Future` (via `.await` or `.into_future()`), cuTile bridges
+the two models — the runtime polls a `DeviceFuture` that checks whether the
+GPU has finished.
+
+---
+
+## Combinator Reference
+
+All combinators follow established Rust conventions. The "Precedent" column
+shows which standard library or `futures` crate method inspired the design.
+
+### Composition
+
+| Combinator | Signature | Precedent | What it does |
+|---|---|---|---|
+| `zip!(a, b, …)` | `(impl DeviceOp, …) → impl DeviceOp<Output=(A, B, …)>` | `Iterator::zip` | Combine N operations into a single tuple-producing operation |
+| `.unzip()` | `impl DeviceOp<Output=(A, B, …)> → (impl DeviceOp<Output=A>, …)` | `Iterator::unzip` | Split a tuple operation into independent per-element operations |
+| `.then(f)` | `self → f(Self::Output) → impl DeviceOp<Output=O>` | `FutureExt::then` | Chain follow-up GPU work **on the same stream** |
+| `.map(f)` | `self → f(Self::Output) → O` (no GPU work) | `FutureExt::map` | Transform output without issuing GPU work |
+| `.inspect(f)` | `self → f(&Self::Output)` (passthrough) | `FutureExt::inspect` | Peek at output for debugging; returns it unchanged |
+
+### Selection
+
+| Combinator | Signature | Precedent | What it does |
+|---|---|---|---|
+| `.first()` | `impl DeviceOp<Output=(A, B, …)> → impl DeviceOp<Output=A>` | `slice::first` | Extract the first element of a tuple output |
+| `.last()` | `impl DeviceOp<Output=(A, B, …)> → impl DeviceOp<Output=Z>` | `slice::last` | Extract the last element of a tuple output |
+
+### Sharing and Erasure
+
+| Combinator | Signature | Precedent | What it does |
+|---|---|---|---|
+| `.shared()` | `self → SharedDeviceOp<Self::Output>` | `FutureExt::shared` | Cloneable, execute-once; output is `Arc<T>` |
+| `shared(arc)` | `Arc<T> → SharedDeviceOp<T>` | — | Wrap an existing `Arc` as a pre-computed `SharedDeviceOp` |
+| `.boxed()` | `self → BoxedDeviceOp<Self::Output>` | `FutureExt::boxed` | Type-erase for heterogeneous collections |
+
+### Execution
+
+| Method | Stream chosen by | Blocks? | Use case |
+|---|---|---|---|
+| `.sync()` | Default policy (round-robin) | Yes | Quick scripts |
+| `.sync_on(&stream)` | The explicit stream | Yes | Deterministic ordering, debugging |
+| `.await` | Default policy (round-robin) | No (suspends task) | Async production code |
+| `.into_future()` | Default policy | No (returns `DeviceFuture`) | Manual future handling |
+| `.schedule(policy)` | The policy you provide | No (returns `DeviceFuture`) | Multi-device dispatch |
+| `.graph()` | Default policy (round-robin) | Yes (captures + syncs) | CUDA graph capture |
+| `.graph_on(stream)` | The explicit stream | Yes (captures + syncs) | CUDA graph capture on specific stream |
+
+:::{note}
+If any kernel input is `&Tensor<T>` (borrowed), the operation is not
+`'static` and cannot be used with `tokio::spawn`. Use `.sync_on()` or
+`.await` in the same scope, or switch to `Arc<Tensor<T>>` for spawned tasks.
+:::
+
+---
+
+## Supported Kernel Parameter Types
+
+| Kernel param | Host type | Return type |
+|---|---|---|
+| `&Tensor<T, S>` | `Tensor<T>`, `Arc<Tensor<T>>`, or `&Tensor<T>` | Same as input |
+| `&mut Tensor<T, S>` | `Partition<Tensor<T>>` or `Partition<&mut Tensor<T>>` | Same as input |
+| Scalar (`f32`, `i32`, etc.) | Same scalar | Same scalar |
+| `*mut T` (unsafe only) | `DevicePointer<T>` | `DevicePointer<T>` |
+
+The borrowed partition form (`Partition<&mut Tensor<T>>`) writes in place — no
+`unpartition()` needed. Create it with `(&mut tensor).partition(shape)`.
+
+---
+
+## Ownership Model
+
+The core invariant: **you get back what you put in**.
+
+### Read-only inputs (`&Tensor` params)
+
+| Input | Returned | `tokio::spawn`? |
+|---|---|---|
+| `Tensor<T>` | `Tensor<T>` | Yes |
+| `Arc<Tensor<T>>` | `Arc<Tensor<T>>` | Yes |
+| `&'a Tensor<T>` | `&'a Tensor<T>` | No (not `'static`) |
+
+### Mutable outputs (`&mut Tensor` params)
+
+| Input | Returned | `unpartition()` needed? |
+|---|---|---|
+| `Partition<Tensor<T>>` (owned) | `Partition<Tensor<T>>` | Yes |
+| `Partition<&'a mut Tensor<T>>` (borrowed) | `Partition<&'a mut Tensor<T>>` | No — tensor is written in place |
+
+The borrowed form is created with `(&mut tensor).partition(shape)`:
+
+### Owned: `Tensor<T>`
+
+Pass a tensor directly — the launcher wraps it in `Arc` internally for the
+kernel, then unwraps it back afterward (safe because refcount is 1):
+
+```rust
+let output = my_kernel(
+    api::zeros(&[1024]).partition([128]),
+    api::ones::<f32>(&[1024]),  // DeviceOp<Output=Tensor<f32>>
+)
+.first()
+.unpartition()
+.sync_on(&stream)?;
+```
+
+Use this for single-use tensors where you don't need shared access.
+
+### Shared: `Arc<Tensor<T>>`
+
+Wrap in `Arc` when the same tensor is passed to multiple kernels:
+
+```rust
+let x: Arc<Tensor<f32>> = api::ones(&[1024]).sync_on(&stream)?.into();
+
+let a = kernel_a(out_a, x.clone()).sync_on(&stream)?;
+let b = kernel_b(out_b, x.clone()).sync_on(&stream)?;
+```
+
+This is the most common pattern in existing code.
+
+### Borrowed: `&Tensor<T>`
+
+Pass a reference when you want to retain ownership and avoid `Arc` overhead.
+The borrow checker ensures the tensor outlives the kernel:
+
+```rust
+let weights: Tensor<f32> = api::ones(&[1024]).sync_on(&stream)?;
+
+// Borrow — no Arc allocation, no refcount.
+let result = my_kernel(out_partition, &weights).sync_on(&stream)?;
+
+// weights is still available here.
+```
+
+**Key safety property**: because `&Tensor<T>` is not `'static`,
+`tokio::spawn` rejects operations that borrow tensors:
+
+```rust
+let op = my_kernel(out, &weights);  // borrows weights
+tokio::spawn(op);                    // ← compile error: not 'static
+```
+
+This is enforced at compile time by Rust's lifetime system — no runtime
+checks needed.
+
+### `.shared()`: Clone + Execute-Once
+
+`.shared()` converts a `DeviceOp` into a `SharedDeviceOp<T>` that is
+`Clone`. The underlying operation runs **at most once**; every clone
+receives `Arc::clone()` of the cached result:
+
+```rust
+let x = api::ones::<f32>(&[32, 32]).shared();
+
+let a = kernel_a(x.clone()).sync()?;  // x executes here (first clone to run)
+let b = kernel_b(x.clone()).sync()?;  // uses cached Arc<Tensor<f32>>
+```
+
+Output type changes: `DeviceOp<Output=T>` becomes
+`SharedDeviceOp` with `Output=Arc<T>`.
+
+For pre-computed values (e.g., weight tensors), use the
+`shared()` free function to wrap an `Arc<T>` directly:
+
+```rust
+use cuda_async::device_operation::shared;
+
+let w: Arc<Tensor<f32>> = /* loaded weights */;
+let w_op: SharedDeviceOp<Tensor<f32>> = shared(w);
+```
+
+### `.unwrap_arc()`
+
+`.shared()` and `unzip` produce `Arc<T>` outputs. When you need owned `T`
+back (e.g., to partition a tensor), use `.unwrap_arc()`:
+
+```rust
+let x: Arc<Tensor<f32>> = api::ones(&[1024]).shared().sync()?;
+
+let owned: Tensor<f32> = value(x).unwrap_arc().sync()?;
+let partitioned = owned.partition([128]);
+```
+
+Panics if the Arc has multiple owners.
+
+### IntoDeviceOp: Automatic Wrapping
+
+The `IntoDeviceOp` trait lets kernel launchers accept both `DeviceOp`s and
+plain values:
+
+| Type | Wraps as |
+|---|---|
+| Any `impl DeviceOp<Output=T>` | Pass-through |
+| `Tensor<T>` | `Value<Tensor<T>>` |
+| `Arc<T>` | `Value<Arc<T>>` |
+| `&'a Tensor<T>` | `Value<&'a Tensor<T>>` |
+| `&Arc<T>` | `Value<Arc<T>>` (clones the Arc) |
+| `f32`, `f64`, `i32`, `i64`, `u32`, `u64`, `usize` | `Value<T>` |
+| `Partition<Tensor<T>>` | `Value<Partition<Tensor<T>>>` |
+
+```rust
+// All of these work as inputs to a &Tensor kernel param:
+my_kernel(out, tensor);              // Tensor<T>
+my_kernel(out, arc_tensor);          // Arc<Tensor<T>>
+my_kernel(out, &tensor);             // &Tensor<T>
+my_kernel(out, api::ones(&[1024]));  // DeviceOp<Output=Tensor<T>>
+```
+
+---
+
+## Scheduling Model
+
+### Stream assignment
+
+When you call `.sync()` or `.await`, the operation asks the **default
+device's scheduling policy** for a stream. The default policy is
+`StreamPoolRoundRobin` with 4 streams:
+
+```text
+op_a.sync()  →  Stream 0
+op_b.sync()  →  Stream 1
+op_c.sync()  →  Stream 2
+op_d.sync()  →  Stream 3
+op_e.sync()  →  Stream 0  (wraps around)
+```
+
+Consecutive independent operations land on different streams, enabling GPU
+overlap. Operations chained with `.then()` share the parent's stream,
+preserving data-dependency ordering.
+
+### Explicit Stream: `.sync_on()`
+
+Bypasses the policy entirely. All operations given the same stream execute
+in call order:
+
+```rust
+let stream = ctx.new_stream()?;
+let a = op_a.sync_on(&stream)?;  // Stream X
+let b = op_b.sync_on(&stream)?;  // Stream X — guaranteed after op_a
+```
+
+### Available Policies
+
+| Policy | Behavior |
+|---|---|
+| `StreamPoolRoundRobin` (default) | Rotates through N streams (default 4) |
+| `SingleStream` | All operations on one stream — strict ordering |
+| Custom `impl SchedulingPolicy` | Implement `fn next_stream()` for your own strategy |
+
+### `.then()` Guarantees
+
+`.then()` is the recommended way to express data dependencies. Both
+operations share a single stream, so the second is guaranteed to see the
+first's output fully written — no manual synchronization needed:
+
+```rust
+let result = allocate_buffer()
+    .then(|buf| fill_kernel(buf))      // same stream
+    .then(|buf| process_kernel(buf))   // same stream
+    .sync()?;
+```
+
+**Non-reentrancy:** On any given thread, only one DeviceOp may be
+executing at a time. Calling `sync_on`, `sync`, or `.await` inside a
+`then` closure will return a runtime error. This prevents CUDA data
+races from cross-stream access to in-flight tensors. If you need
+nested execution and have verified there are no cross-stream data
+races, use `unsafe then_unchecked`.
+
+---
+
+## Error Propagation
+
+All execution methods return `Result<T, DeviceError>`. Errors propagate
+through combinators: if any operation in a `.then()` chain fails, the
+error short-circuits to the caller.
+
+### DeviceError Variants
+
+| Variant | When it occurs |
+|---|---|
+| `Driver(DriverError)` | CUDA driver call failed (OOM, invalid argument, etc.) |
+| `Context { device_id, message }` | Device context assertion failed |
+| `KernelCache(String)` | Kernel compilation or cache lookup failed |
+| `Scheduling(String)` | No stream available or policy misconfigured |
+| `Launch(String)` | Kernel launch precondition violated |
+| `Internal(String)` | Bug in cuda-async internals |
+| `Anyhow(String)` | Converted from `anyhow::Error` |
+
+### Error Handling Patterns
+
+```rust
+// Pattern 1: Propagate with ?
+let x = api::zeros(&[1024]).sync_on(&stream)?;
+
+// Pattern 2: Match specific errors
+match my_kernel(args).sync_on(&stream) {
+    Ok(result) => { /* use result */ }
+    Err(DeviceError::Launch(msg)) => {
+        eprintln!("kernel launch failed: {msg}");
+    }
+    Err(e) => return Err(e.into()),
+}
+```
+
+### cutile::error::Error vs DeviceError
+
+`cutile::error::Error` is the top-level error type that wraps
+`DeviceError` alongside other error categories (I/O, shape mismatches,
+etc.). Functions that only do GPU work return `DeviceError`; functions
+that mix host and device work (like the examples) return
+`cutile::error::Error`.
+
+---
+
+## CUDA Graph Integration
+
+### Combinator approach: `.graph_on(stream)`
+
+Any `DeviceOp` can be captured into a replayable CUDA graph:
+
+```rust
+let forward_op = build_forward(&cfg, &weights, input, buffers);
+let mut graph = forward_op.graph_on(stream.clone())?;
+let output = graph.take_output().unwrap();
+
+// Replay loop — no graph rebuilding, no kernel re-compilation.
+for token in tokens {
+    graph.update(api::memcpy(&mut input_buf, &token))?;
+    graph.launch().sync_on(&stream)?;
+}
+```
+
+This requires `Arc<Tensor<T>>` + `try_partition` for shared buffers.
+
+### Scope approach: `CudaGraph::scope`
+
+`CudaGraph::scope` provides an imperative alternative using `&mut` borrows
+instead of `Arc`. Each `s.record(op)` records a graph node and releases
+borrows immediately. A buffer written by one `record` call can be read
+by the next:
+
+```rust
+let mut output = api::zeros::<f32>(&[d]).sync_on(&stream)?;
+let weights = api::ones::<f32>(&[d]).sync_on(&stream)?;
+
+let graph = CudaGraph::scope(&stream, |s| {
+    s.record(kernel1((&mut output).partition([128]), &weights))?;
+    s.record(kernel2((&mut output).partition([64]), &weights))?;
+    Ok(())
+})?;
+
+graph.launch().sync_on(&stream)?;
+```
+
+`record` only accepts operations that implement `GraphNode` — kernel
+launches and `memcpy`. Allocation ops (`zeros`, `ones`, `dup`) are
+rejected at compile time because their addresses may change on replay.
+
+### `GraphNode` trait
+
+`GraphNode` is a marker trait for operations safe to record in a CUDA
+graph. Only operations that do not allocate or free device memory
+implement it:
+
+| Implements `GraphNode` | Why safe |
+|---|---|
+| Macro-generated kernel launchers | Kernel launch only — no alloc/free |
+| `Memcpy` (`api::memcpy`) | Copy between pre-allocated buffers |
+| `Value<T>` (`value(x)`) | No GPU work |
+
+### CudaGraph methods
+
+| Method | What it does |
+|---|---|
+| `.graph()` / `.graph_on(stream)` | Capture a `DeviceOp` into a `CudaGraph<T>` |
+| `CudaGraph::scope(&stream, \|s\| { … })` | Scoped capture with `&mut` borrows |
+| `s.record(op: impl GraphNode)` | Record a graph node inside a scope |
+| `graph.take_output()` | Retrieve the output from the capture execution |
+| `graph.update(op)` | Run a `DeviceOp` on the graph's stream (e.g., copy new input) |
+| `graph.launch()` | Returns a `DeviceOp` that replays the captured graph |
+
+All device pointers are baked in at capture time. To vary inputs, pre-allocate
+a buffer, pass it into the operation, and `memcpy` new data before each
+launch. See [Tutorial 10](../tutorials/10-cuda-graphs.md) for a
+complete walkthrough.
+
+---
+
+## See Also
+
+- [Orchestrating Device Operations](../guide/device-operations.md) — tutorial-style guide to streams, scheduling, and composition patterns
+- [Tutorial 10](../tutorials/10-cuda-graphs.md) — end-to-end CUDA graph example
+- [Integrating with CUDA C++](../guide/interoperability.md) — integrating custom CUDA C++ kernels into the DeviceOp model

--- a/cutile-book/tutorials/01-hello-world.md
+++ b/cutile-book/tutorials/01-hello-world.md
@@ -1,4 +1,4 @@
-# Tutorial 1: Hello World
+# 1. Hello World
 
 Tile kernels are functions which run as `N` copies concurrently and in parallel when invoked. The primary difference between tile-based kernels and CUDA C++ kernels is the basic unit of execution: a *tile-block*, which expresses the computation performed by a single logical *tile thread* operating over a multi-dimensional *tile of data*.
 
@@ -97,7 +97,7 @@ Host-side code sets up the GPU, specifies the kernel launch grid, and launches t
 
 ---
 
-## How Tiles Identify Themselves
+## Tile IDs
 
 Each tile is assigned an ID corresponding to a coordinate within the 3-dimensional launch grid:
 
@@ -112,7 +112,7 @@ Each tile runs the same code but with different coordinates. This is how tiles d
 
 ---
 
-## What Happens Under the Hood
+## Under the hood
 
 1. **At compile time:** `#[cutile::module]` captures your Rust code as an AST.
 2. **At first kernel launch:** The AST is compiled to MLIR → cubin (GPU binary).

--- a/cutile-book/tutorials/02-vector-addition.md
+++ b/cutile-book/tutorials/02-vector-addition.md
@@ -1,4 +1,4 @@
-# Tutorial 2: Vector Addition
+# 2. Vector Addition
 
 In cutile, tile threads run concurrently and each tile knows its coordinates via `get_tile_block_id()`. To make tiles process different pieces of data, we use **partitioning** — dividing the output tensor into sub-tensors so that each tile thread reads from and writes to a distinct region.
 
@@ -209,5 +209,5 @@ Try `partition([4, 8])` — rectangular tiles. Does it still work?
 ## See also
 
 - [Thinking in Tiles](../guide/thinking-in-tiles.md) — tile blocks, partitioning, and the grid
-- [Writing Computations on Tiles](../guide/writing-computations.md) — arithmetic and load/store operations
-- [DSL API Reference](../reference/dsl-api.md) — full signatures for `load_tile_like_2d`, `store`, and the arithmetic operators used here
+- [Writing Computations](../guide/writing-computations.md) — arithmetic and load/store operations
+- [DSL API](../reference/dsl-api.md) — full signatures for `load_tile_like_2d`, `store`, and the arithmetic operators used here

--- a/cutile-book/tutorials/03-saxpy.md
+++ b/cutile-book/tutorials/03-saxpy.md
@@ -1,4 +1,4 @@
-# Tutorial 3: SAXPY
+# 3. SAXPY
 
 SAXPY stands for **S**ingle-precision **A**·**X** **P**lus **Y** — a classic numerical computing operation where a scalar multiplies a vector and the result is added to another vector:
 
@@ -168,6 +168,6 @@ fn saxpy_extended<const S: [i32; 2]>(
 
 ## See also
 
-- [Writing Computations on Tiles](../guide/writing-computations.md) — scalar arithmetic and `broadcast`
+- [Writing Computations](../guide/writing-computations.md) — scalar arithmetic and `broadcast`
 - [Working with Data](../guide/working-with-data.md) — shape broadcasting rules
-- [DSL API Reference](../reference/dsl-api.md) — `broadcast`, `broadcast_scalar`, and arithmetic operator signatures
+- [DSL API](../reference/dsl-api.md) — `broadcast`, `broadcast_scalar`, and arithmetic operator signatures

--- a/cutile-book/tutorials/04-matrix-multiplication.md
+++ b/cutile-book/tutorials/04-matrix-multiplication.md
@@ -1,4 +1,4 @@
-# Tutorial 4: Matrix Multiplication
+# 4. Matrix Multiplication
 
 Matrix multiplication (GEMM = General Matrix Multiply) is everywhere in modern computing:
 
@@ -397,7 +397,7 @@ Try using `f16` (half precision) for inputs and `f32` for the accumulator. This 
 
 ## See also
 
-- [Writing Computations on Tiles](../guide/writing-computations.md#matrix-operations) — `mma` usage and the accumulate pattern
+- [Writing Computations](../guide/writing-computations.md#tiled-matrix-multiply) — `mma` usage and the accumulate pattern
 - [Thinking in Tiles](../guide/thinking-in-tiles.md) — 2D partitioning and grid mapping
 - [Tuning for Performance](../guide/performance-tuning.md) — Tensor Core alignment requirements and tile-size selection
-- [DSL API Reference](../reference/dsl-api.md#matrix-multiply) — `mma` signature and element-type constraints
+- [DSL API](../reference/dsl-api.md#matrix-multiply) — `mma` signature and element-type constraints

--- a/cutile-book/tutorials/05-fused-softmax.md
+++ b/cutile-book/tutorials/05-fused-softmax.md
@@ -1,4 +1,4 @@
-# Tutorial 5: Fused Softmax
+# 5. Fused Softmax
 
 Softmax is a multi-step operation:
 
@@ -12,7 +12,7 @@ A naive implementation would use separate kernels for each step. **Kernel fusion
 
 ---
 
-## Why Subtract the Max?
+## Numerical stability
 
 Subtracting the row maximum before calling `exp` prevents overflow:
 
@@ -215,6 +215,6 @@ You can fuse this too.
 
 ## See also
 
-- [Writing Computations on Tiles](../guide/writing-computations.md#reduction-operations) — `reduce_max`, `reduce_sum`, and broadcasting patterns
+- [Writing Computations](../guide/writing-computations.md#numerically-stable-softmax) — `reduce_max`, `reduce_sum`, and broadcasting patterns
 - [Tuning for Performance](../guide/performance-tuning.md) — kernel fusion and arithmetic intensity
-- [DSL API Reference](../reference/dsl-api.md#reduction-and-scan) — reduction operator signatures
+- [DSL API](../reference/dsl-api.md#reduction-and-scan) — reduction operator signatures

--- a/cutile-book/tutorials/06-flash-attention.md
+++ b/cutile-book/tutorials/06-flash-attention.md
@@ -1,4 +1,4 @@
-# Tutorial 6: Fused Multihead Attention
+# 6. Fused Multihead Attention
 
 Attention is a performance-critical operation at the heart of transformer models (BERT, GPT, etc.). It computes a weighted combination of values, where the weights reflect the relevance of each position in the sequence. Given parameters Q, K, and V constructed from an input sequence, attention is computed as:
 
@@ -307,7 +307,7 @@ For autoregressive models (like GPT), we only attend to *previous* positions. Mo
 
 ## See also
 
-- [Writing Computations on Tiles](../guide/writing-computations.md) — `mma`, reductions, and broadcasting combined
+- [Writing Computations](../guide/writing-computations.md) — `mma`, reductions, and broadcasting combined
 - [Where Data Lives](../guide/memory-hierarchy.md) — why tiled access matters for bandwidth-bound kernels
 - [Tuning for Performance](../guide/performance-tuning.md) — Tensor Core utilization and tile-size selection
-- [DSL API Reference](../reference/dsl-api.md) — operator reference for the patterns used here
+- [DSL API](../reference/dsl-api.md) — operator reference for the patterns used here

--- a/cutile-book/tutorials/07-intro-to-async.md
+++ b/cutile-book/tutorials/07-intro-to-async.md
@@ -1,4 +1,4 @@
-# Tutorial 7: Intro to Async Execution
+# 7. Intro to Async Execution
 
 > Note: While async concepts are taught using the `tokio` runtime, any async runtime can be used.
 
@@ -166,7 +166,7 @@ let (a, b, c) = combined.await?;
 
 ---
 
-## When to Use Async
+## Choosing between sync and async
 
 | Scenario | Use Sync | Use Async |
 |----------|----------|-----------|
@@ -252,4 +252,4 @@ Time a sync version vs. an async version with overlapped work. Use `std::time::I
 ## See also
 
 - [Orchestrating Device Operations](../guide/device-operations.md) — full treatment of `DeviceOp`, streams, and scheduling
-- [DeviceOp API Reference](../reference/deviceop-reference.md) — combinator signatures (`.then()`, `.shared()`, `unzip`, `zip!`)
+- [Host API](../reference/host-api.md) — combinator signatures (`.then()`, `.shared()`, `unzip`, `zip!`) and the full host-side API

--- a/cutile-book/tutorials/08-data-parallel-mlp.md
+++ b/cutile-book/tutorials/08-data-parallel-mlp.md
@@ -1,4 +1,4 @@
-# Tutorial 8: Data Parallel MLP
+# 8. Data Parallel MLP
 
 > Note: While async concepts are taught using the `tokio` runtime, any async runtime can be used.
 
@@ -231,4 +231,4 @@ What would we need to change to construct a pipeline that overlaps data movement
 ## See also
 
 - [Orchestrating Device Operations](../guide/device-operations.md) — stream scheduling and the `DeviceOp` lifecycle
-- [DeviceOp API Reference](../reference/deviceop-reference.md) — `.schedule()`, scheduling policies, and execution methods
+- [Host API](../reference/host-api.md) — `.schedule()`, scheduling policies, and execution methods

--- a/cutile-book/tutorials/09-pointer-addition.md
+++ b/cutile-book/tutorials/09-pointer-addition.md
@@ -1,4 +1,4 @@
-# Tutorial 9: Pointer Addition
+# 9. Pointer Addition
 
 Sometimes the abstractions provided by cutile are not enough — you need direct control over memory. In this tutorial, we implement vector addition using raw device pointers, and use async to illustrate how things could go wrong.
 
@@ -95,7 +95,7 @@ async fn async_main() -> Result<(), cutile::error::Error> {
 
 ---
 
-## How It Works
+## Kernel walkthrough
 
 The helper function `get_tensor` constructs a `Tensor` view from a raw device pointer, a length, and a stride. Because the compiler has no way to verify that the pointer is valid or that the memory it references outlives the kernel, the function — and the kernel entry point — must be marked `unsafe`.
 
@@ -140,4 +140,4 @@ Write a safe Rust wrapper function around the unsafe kernel that validates the p
 
 - [Integrating with CUDA C++](../guide/interoperability.md) — a structured approach to pre-compiled CUDA C++ kernels using `AsyncKernelLaunch` instead of raw pointers
 - [Working with Data](../guide/working-with-data.md) — `PointerTile` and the safety model for pointer-based kernels
-- [DSL API Reference](../reference/dsl-api.md#memory-pointer-based) — `int_to_ptr`, `ptr_to_int`, `ptr_to_ptr`, and atomic operations
+- [DSL API](../reference/dsl-api.md#memory-pointer-based) — `int_to_ptr`, `ptr_to_int`, `ptr_to_ptr`, and atomic operations

--- a/cutile-book/tutorials/10-cuda-graphs.md
+++ b/cutile-book/tutorials/10-cuda-graphs.md
@@ -1,4 +1,4 @@
-# Tutorial 10: CUDA Graphs
+# 10. CUDA Graphs
 
 CUDA graphs let you capture an entire GPU workload once and replay it
 many times, eliminating per-launch overhead. This tutorial builds a
@@ -7,7 +7,7 @@ a CUDA graph, and replays it in a token loop.
 
 ---
 
-## Why CUDA Graphs?
+## Motivation
 
 Every kernel launch involves CPU-side work: selecting a stream, setting up
 arguments, invoking the driver. For workloads that repeat the same graph of
@@ -365,7 +365,7 @@ at compile time because their addresses may change on graph replay.
 
 ---
 
-## When to Use CUDA Graphs
+## Use cases
 
 | Scenario | Use CUDA graphs? | Why |
 |---|---|---|
@@ -431,5 +431,5 @@ cargo run -p cutile-examples --example cuda_graphs
 
 ## See also
 
-- [Orchestrating Device Operations](../guide/device-operations.md#cuda-graphs-graph_onstream) — where CUDA graphs fit alongside sync and async execution
-- [DeviceOp API Reference: CUDA Graph Integration](../reference/deviceop-reference.md#cuda-graph-integration) — `.graph_on(stream)` and `CudaGraph::scope` signatures
+- [Orchestrating Device Operations](../guide/device-operations.md) — where CUDA graphs fit alongside sync and async execution
+- [Host API: CUDA Graph Integration](../reference/host-api.md#cuda-graph-integration) — `.graph_on(stream)` and `CudaGraph::scope` signatures


### PR DESCRIPTION
Second pass on the book reorganization.

- `appendix/` renamed to `reference/`; `deviceop-reference.md` renamed to `host-api.md` and expanded with host-side infra sections (tensor creation, transfers, context/streams, launch config).
- All 10 guide pages consolidated to ~4 H2s with declarative titles and prose-led structure; catalog content moved to reference with cross-links.
- `device-operations.md` restructured around the `DeviceOp` model with three peer execution modes (sync, async, CUDA graph).
- FP8 and missing numeric types (bf16/i16/u8/u16) added to element-type tables; "See also" footers added to tutorials 02-10.