### PR TITLE
cuda-core: rename Cuda* types and add borrow_raw for external handles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - **Prelude**: `use cutile::prelude::*` for common imports.
 - **New examples**: `cuda_graphs.rs` (scope-based), `cuda_graphs_deviceop.rs` (combinator-based), `add_refs.rs` (borrow pattern).
 - **cutile-book**: DeviceOp API reference, CUDA Graphs tutorial, tutorials 6-9 in book_examples.rs.
+- **`borrow_raw` on `Device` / `Stream` / `Module` / `Function`**: wrap externally-owned CUDA handles (from cudarc, Candle, or any other CUDA binding crate) without taking ownership. Accepts `*mut c_void` / `c_int` primitives so no `cuda_bindings` typedef is required at the call site; borrowed wrappers skip release/destroy/unload on drop.
 
 ### Changed
 - **`DeviceOperation` renamed to `DeviceOp`**: Shorter, consistent with `DeviceOp` combinators.
@@ -36,6 +37,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - **Output-first convention**: `&mut Tensor` is always the first kernel parameter.
 - **Extension trait renames**: `IntoDeviceOperationPartition` → `PartitionOp`, `TensorDeviceOpToHostVec` → `ToHostVecOp`.
 - **`.graph()` / `.graph_on(stream)`**: Follows `sync` / `sync_on` convention.
+- **Renamed types in `cuda_core`**: `CudaContext` → `Device`, `CudaStream` → `Stream`, `CudaModule` → `Module`, `CudaFunction` → `Function`. The `Cuda` prefix was redundant inside the `cuda_core` module path. Variables of type `Arc<Device>` are now named `device` throughout the codebase (previously `ctx` / `cuda_context`).
+- **Renamed methods**: `Stream::context()` → `Stream::device()`, `ExecutionContext::get_cuda_context()` → `ExecutionContext::device()`, `with_cuda_context()` → `with_device()`.
 
 ### Added (cont.)
 - **`api::linspace(start, stop, n)`**: Evenly spaced f32 values between two endpoints.
@@ -46,14 +49,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Fixed
 - **`arange` multi-block correctness**: `arange` used `get_tile_block_id()` where it needed the partition dimension (`S[0]`), producing wrong values at block boundaries. Hidden by uniform-data tests.
 - **`sync_on` error propagation**: `stream.synchronize()` errors are now returned instead of panicking.
-- **Concurrent stream capture**: Removed `cuCtxSynchronize` call in `CudaContext::new_stream` that caused `DriverError(900)` when creating streams while another thread was capturing a CUDA graph.
+- **Concurrent stream capture**: Removed `cuCtxSynchronize` call in `Device::new_stream` that caused `DriverError(900)` when creating streams while another thread was capturing a CUDA graph.
 
 ### Removed
 - `DeviceOperationArc`, `UnwrapArc` struct, `GlobalSchedulingPolicy` enum, `WithDeviceId` trait.
 - `_op()` generated launcher variant (unified launcher replaces it).
 - `num_mb()`, `num_gb()`, `copy_sync()` on Tensor.
 - `DeviceOperationReshape`, `DeviceOperationDynamicReshape`, `DeviceOperationCopyFrom` traits.
-- cudarc event-tracking infrastructure (`num_streams`, `event_tracking` on `CudaContext`). Unused; caused interference with concurrent captures.
+- cudarc event-tracking infrastructure (`num_streams`, `event_tracking` on `Device`). Unused; caused interference with concurrent captures.
 
 ## [0.0.1] - 2026-04-07
 

--- a/cuda-async/README.md
+++ b/cuda-async/README.md
@@ -17,8 +17,8 @@ until `.sync()`, `.sync_on()`, or `.await` is called.
 use cutile::prelude::*;
 
 fn main() -> Result<(), DeviceError> {
-    let ctx = cuda_core::CudaContext::new(0)?;
-    let stream = ctx.new_stream()?;
+    let device = cuda_core::Device::new(0)?;
+    let stream = device.new_stream()?;
 
     let mut z = api::zeros::<f32>(&[16, 16]).sync_on(&stream)?;
     let x = api::ones::<f32>(&[16, 16]).sync_on(&stream)?;

--- a/cuda-async/src/cuda_graph.rs
+++ b/cuda-async/src/cuda_graph.rs
@@ -7,7 +7,7 @@ use crate::device_context::with_default_device_policy;
 use crate::device_future::DeviceFuture;
 use crate::device_operation::{DeviceOp, ExecutionContext, GraphNode};
 use crate::error::DeviceError;
-use cuda_core::{stream, sys, CudaStream, IntoResult};
+use cuda_core::{sys, IntoResult, Stream};
 use std::future::IntoFuture;
 use std::mem::MaybeUninit;
 use std::sync::Arc;
@@ -43,7 +43,7 @@ const CU_STREAM_CAPTURE_MODE_RELAXED: sys::CUstreamCaptureMode = 2;
 /// }
 /// ```
 pub struct CudaGraph<T> {
-    stream: Arc<CudaStream>,
+    stream: Arc<Stream>,
     cu_graph: sys::CUgraph,
     cu_graph_exec: sys::CUgraphExec,
     output: Option<T>,
@@ -59,15 +59,15 @@ impl<T: Send> CudaGraph<T> {
     ///
     /// Retrieve the output via [`take_output`](CudaGraph::take_output).
     pub fn capture(
-        stream: Arc<CudaStream>,
+        stream: Arc<Stream>,
         op: impl DeviceOp<Output = T>,
     ) -> Result<Self, DeviceError> {
-        let ctx = stream.context().clone();
-        ctx.bind_to_thread()?;
+        let device = stream.device().clone();
+        device.bind_to_thread()?;
 
         // Begin capture.
         unsafe {
-            stream::begin_capture(stream.cu_stream(), CU_STREAM_CAPTURE_MODE_RELAXED)?;
+            stream.begin_capture(CU_STREAM_CAPTURE_MODE_RELAXED)?;
         }
 
         // Execute the operation on the capture stream.
@@ -75,7 +75,7 @@ impl<T: Send> CudaGraph<T> {
         let op_result = unsafe { op.execute(&exec_ctx) };
 
         // End capture — must happen regardless of op success.
-        let end_result = unsafe { stream::end_capture(stream.cu_stream()) };
+        let end_result = unsafe { stream.end_capture() };
 
         // Handle the (op_result, end_result) matrix, cleaning up on failure.
         let (output, cu_graph) = match (op_result, end_result) {
@@ -126,7 +126,7 @@ impl<T: Send> CudaGraph<T> {
         }
 
         // Synchronize so the output is safe to read.
-        stream.synchronize()?;
+        unsafe { stream.synchronize() }?;
 
         Ok(Self {
             stream,
@@ -183,7 +183,7 @@ impl<T: Send> CudaGraph<T> {
     }
 
     /// Returns a reference to the stream this graph was captured on.
-    pub fn stream(&self) -> &Arc<CudaStream> {
+    pub fn stream(&self) -> &Arc<Stream> {
         &self.stream
     }
 }
@@ -228,17 +228,17 @@ impl IntoFuture for GraphLaunch {
 
 impl<T> Drop for CudaGraph<T> {
     fn drop(&mut self) {
-        let ctx = self.stream.context();
-        ctx.record_err(ctx.bind_to_thread());
+        let device = self.stream.device();
+        let _ = device.bind_to_thread();
 
         let cu_graph_exec = std::mem::replace(&mut self.cu_graph_exec, std::ptr::null_mut());
         if !cu_graph_exec.is_null() {
-            ctx.record_err(unsafe { sys::cuGraphExecDestroy(cu_graph_exec).result() });
+            let _ = unsafe { sys::cuGraphExecDestroy(cu_graph_exec).result() };
         }
 
         let cu_graph = std::mem::replace(&mut self.cu_graph, std::ptr::null_mut());
         if !cu_graph.is_null() {
-            ctx.record_err(unsafe { sys::cuGraphDestroy(cu_graph).result() });
+            let _ = unsafe { sys::cuGraphDestroy(cu_graph).result() };
         }
     }
 }
@@ -400,7 +400,7 @@ impl CudaGraph<()> {
     /// ```
     ///
     /// See [`Scope`] for the safety proof and edge-case behavior.
-    pub fn scope<F>(stream: &Arc<CudaStream>, f: F) -> Result<Self, DeviceError>
+    pub fn scope<F>(stream: &Arc<Stream>, f: F) -> Result<Self, DeviceError>
     where
         F: FnOnce(&Scope) -> Result<(), DeviceError>,
     {
@@ -418,16 +418,16 @@ impl CudaGraph<()> {
         }
     }
 
-    fn scope_inner<F>(stream: &Arc<CudaStream>, f: F) -> Result<Self, DeviceError>
+    fn scope_inner<F>(stream: &Arc<Stream>, f: F) -> Result<Self, DeviceError>
     where
         F: FnOnce(&Scope) -> Result<(), DeviceError>,
     {
-        let ctx = stream.context().clone();
-        ctx.bind_to_thread()?;
+        let device = stream.device().clone();
+        device.bind_to_thread()?;
 
         // Begin capture.
         unsafe {
-            stream::begin_capture(stream.cu_stream(), CU_STREAM_CAPTURE_MODE_RELAXED)?;
+            stream.begin_capture(CU_STREAM_CAPTURE_MODE_RELAXED)?;
         }
 
         let scope = Scope {
@@ -440,13 +440,13 @@ impl CudaGraph<()> {
             match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| f(&scope))) {
                 Ok(result) => result,
                 Err(panic_payload) => {
-                    let _ = unsafe { stream::end_capture(stream.cu_stream()) };
+                    let _ = unsafe { stream.end_capture() };
                     std::panic::resume_unwind(panic_payload);
                 }
             };
 
         // End capture.
-        let end_result = unsafe { stream::end_capture(stream.cu_stream()) };
+        let end_result = unsafe { stream.end_capture() };
 
         let cu_graph = match (scope_result, end_result) {
             (Err(scope_err), Ok(cu_graph)) => {
@@ -496,7 +496,7 @@ impl CudaGraph<()> {
         }
 
         // Synchronize.
-        stream.synchronize()?;
+        unsafe { stream.synchronize() }?;
 
         Ok(CudaGraph {
             stream: stream.clone(),
@@ -528,7 +528,7 @@ impl CudaGraph<()> {
 /// }
 ///
 /// impl MyModel {
-///     fn new(stream: Arc<CudaStream>) -> Result<Self, DeviceError> {
+///     fn new(stream: Arc<Stream>) -> Result<Self, DeviceError> {
 ///         let h_input = api::zeros(&[d]).sync_on(&stream)?;
 ///         let forward_op = build_forward(h_input.clone().into());
 ///         let mut graph = forward_op.graph_on(stream)?;

--- a/cuda-async/src/device_context.rs
+++ b/cuda-async/src/device_context.rs
@@ -7,7 +7,7 @@
 
 use crate::error::{device_assert, device_error, DeviceError};
 use crate::scheduling_policies::{SchedulingPolicy, StreamPoolRoundRobin};
-use cuda_core::{CudaContext, CudaFunction, CudaModule, CudaStream};
+use cuda_core::{Device, Function, Module, Stream};
 use std::cell::Cell;
 use std::collections::HashMap;
 use std::hash::{DefaultHasher, Hash, Hasher};
@@ -66,14 +66,14 @@ pub struct Validator {
     pub params: Vec<ValidParamType>,
 }
 
-type DeviceFunctions = HashMap<String, (Arc<CudaModule>, Arc<CudaFunction>)>;
+type DeviceFunctions = HashMap<String, (Arc<Module>, Arc<Function>)>;
 type DeviceFunctionValidators = HashMap<String, Arc<Validator>>;
 
-/// Per-device state: CUDA context, scheduling policy, and compiled kernel cache.
+/// Per-device state: GPU device, scheduling policy, and compiled kernel cache.
 ///
 /// Each GPU device has one `AsyncDeviceContext` stored in a thread-local map. It holds:
 ///
-/// - A [`CudaContext`] for driver API calls.
+/// - A [`Device`] for driver API calls.
 /// - A [`SchedulingPolicy`] that decides which stream each operation runs on.
 /// - A cache of already-compiled kernel functions (keyed by [`FunctionKey::get_hash_string()`]).
 ///
@@ -85,8 +85,8 @@ pub struct AsyncDeviceContext {
     #[expect(dead_code, reason = "will be used when multi-device is implemented")]
     device_id: usize,
     // TODO: (hme): This will hurt perf due to contention. This should at least be static (OnceLock?).
-    context: Arc<CudaContext>,
-    deallocator_stream: Arc<CudaStream>,
+    device: Arc<Device>,
+    deallocator_stream: Arc<Stream>,
     policy: Arc<dyn SchedulingPolicy>,
     functions: DeviceFunctions,
     validators: DeviceFunctionValidators,
@@ -156,11 +156,11 @@ pub fn new_device_context(
     device_id: usize,
     policy: Arc<dyn SchedulingPolicy>,
 ) -> Result<AsyncDeviceContext, DeviceError> {
-    let context = CudaContext::new(device_id)?;
-    let deallocator_stream = context.new_stream()?;
+    let device = Device::new(device_id)?;
+    let deallocator_stream = device.new_stream()?;
     Ok(AsyncDeviceContext {
         device_id,
-        context,
+        device,
         deallocator_stream,
         policy,
         functions: HashMap::new(),
@@ -196,12 +196,12 @@ pub fn init_with_default_policy(
     hashmap: &mut HashMap<usize, AsyncDeviceContext>,
     device_id: usize,
 ) -> Result<(), DeviceError> {
-    let context = CudaContext::new(device_id)?;
-    let policy = StreamPoolRoundRobin::new(&context, DEFAULT_ROUND_ROBIN_STREAM_POOL_SIZE)?;
-    let deallocator_stream = context.new_stream()?;
+    let device = Device::new(device_id)?;
+    let policy = StreamPoolRoundRobin::new(&device, DEFAULT_ROUND_ROBIN_STREAM_POOL_SIZE)?;
+    let deallocator_stream = device.new_stream()?;
     let device_context = AsyncDeviceContext {
         device_id,
-        context,
+        device,
         deallocator_stream,
         policy: Arc::new(policy),
         functions: HashMap::new(),
@@ -281,18 +281,19 @@ pub fn global_policy(device_id: usize) -> Result<Arc<dyn SchedulingPolicy>, Devi
 
 pub unsafe fn with_deallocator_stream<F, R>(device_id: usize, f: F) -> Result<R, DeviceError>
 where
-    F: FnOnce(&Arc<CudaStream>) -> R,
+    F: FnOnce(&Arc<Stream>) -> R,
 {
     with_global_device_context(device_id, |device_context| {
         f(&device_context.deallocator_stream)
     })
 }
 
-pub fn with_cuda_context<F, R>(device_id: usize, f: F) -> Result<R, DeviceError>
+/// Run a closure with a reference to the [`Device`] for `device_id`.
+pub fn with_device<F, R>(device_id: usize, f: F) -> Result<R, DeviceError>
 where
-    F: FnOnce(&Arc<CudaContext>) -> R,
+    F: FnOnce(&Arc<Device>) -> R,
 {
-    with_global_device_context(device_id, |device_context| f(&device_context.context))
+    with_global_device_context(device_id, |device_context| f(&device_context.device))
 }
 
 // Default device policy.
@@ -331,23 +332,17 @@ where
 // Kernel operations — compile, cache, and retrieve GPU kernels.
 
 /// Load a compiled CUDA module from a `.cubin` file.
-pub fn load_module_from_file(
-    filename: &str,
-    device_id: usize,
-) -> Result<Arc<CudaModule>, DeviceError> {
-    with_cuda_context(device_id, |cuda_ctx| {
-        let module = cuda_ctx.load_module_from_file(filename)?;
+pub fn load_module_from_file(filename: &str, device_id: usize) -> Result<Arc<Module>, DeviceError> {
+    with_device(device_id, |device| {
+        let module = device.load_module_from_file(filename)?;
         Ok(module)
     })?
 }
 
 /// JIT-compile a PTX string into a CUDA module for the given device.
-pub fn load_module_from_ptx(
-    ptx_src: &str,
-    device_id: usize,
-) -> Result<Arc<CudaModule>, DeviceError> {
-    with_cuda_context(device_id, |cuda_ctx| {
-        let module = cuda_ctx.load_module_from_ptx_src(ptx_src)?;
+pub fn load_module_from_ptx(ptx_src: &str, device_id: usize) -> Result<Arc<Module>, DeviceError> {
+    with_device(device_id, |device| {
+        let module = device.load_module_from_ptx_src(ptx_src)?;
         Ok(module)
     })?
 }
@@ -357,7 +352,7 @@ pub fn load_module_from_ptx(
 pub fn insert_cuda_function(
     device_id: usize,
     func_key: &impl FunctionKey,
-    value: (Arc<CudaModule>, Arc<CudaFunction>),
+    value: (Arc<Module>, Arc<Function>),
 ) -> Result<(), DeviceError> {
     with_global_device_context_mut(device_id, |device_context| {
         let key = func_key.get_hash_string();
@@ -384,7 +379,7 @@ pub fn contains_cuda_function(device_id: usize, func_key: &impl FunctionKey) -> 
 pub fn get_cuda_function(
     device_id: usize,
     func_key: &impl FunctionKey,
-) -> Result<Arc<CudaFunction>, DeviceError> {
+) -> Result<Arc<Function>, DeviceError> {
     with_global_device_context(device_id, |device_context| {
         let key = func_key.get_hash_string();
         let entry = device_context

--- a/cuda-async/src/device_operation.rs
+++ b/cuda-async/src/device_operation.rs
@@ -9,7 +9,7 @@ use crate::device_context::with_default_device_policy;
 use crate::device_future::DeviceFuture;
 use crate::error::{device_error, DeviceError};
 use crate::scheduling_policies::SchedulingPolicy;
-use cuda_core::{CudaContext, CudaStream};
+use cuda_core::{Device, Stream};
 use std::cell::{Cell, UnsafeCell};
 use std::fmt::Debug;
 use std::future::IntoFuture;
@@ -54,33 +54,33 @@ pub(crate) fn release_execution_lock() {
     });
 }
 
-pub type Device = usize;
+pub type DeviceOrdinal = usize;
 
 #[derive(Debug, Clone)]
 pub struct ExecutionContext {
-    device: Device,
-    cuda_stream: Arc<CudaStream>,
-    cuda_context: Arc<CudaContext>,
+    ordinal: DeviceOrdinal,
+    cuda_stream: Arc<Stream>,
+    device: Arc<Device>,
 }
 
 impl ExecutionContext {
-    pub fn new(cuda_stream: Arc<CudaStream>) -> Self {
-        let cuda_context = cuda_stream.context().clone();
-        let device = cuda_context.ordinal();
+    pub fn new(cuda_stream: Arc<Stream>) -> Self {
+        let device = cuda_stream.device().clone();
+        let ordinal = device.ordinal();
         Self {
             cuda_stream,
-            cuda_context,
             device,
+            ordinal,
         }
     }
-    pub fn get_cuda_stream(&self) -> &Arc<CudaStream> {
+    pub fn get_cuda_stream(&self) -> &Arc<Stream> {
         &self.cuda_stream
     }
-    pub fn get_cuda_context(&self) -> &Arc<CudaContext> {
-        &self.cuda_context
+    pub fn device(&self) -> &Arc<Device> {
+        &self.device
     }
-    pub fn get_device_id(&self) -> Device {
-        self.device
+    pub fn get_device_id(&self) -> DeviceOrdinal {
+        self.ordinal
     }
     #[expect(
         dead_code,
@@ -328,7 +328,7 @@ pub trait DeviceOp:
     /// replayable graph and the initial output.
     fn graph_on(
         self,
-        stream: Arc<CudaStream>,
+        stream: Arc<Stream>,
     ) -> Result<crate::cuda_graph::CudaGraph<<Self as DeviceOp>::Output>, DeviceError> {
         crate::cuda_graph::CudaGraph::capture(stream, self)
     }
@@ -351,7 +351,7 @@ pub trait DeviceOp:
     /// GPU data from the output.
     unsafe fn async_on(
         self,
-        stream: &Arc<CudaStream>,
+        stream: &Arc<Stream>,
     ) -> Result<<Self as DeviceOp>::Output, DeviceError> {
         let ctx = ExecutionContext::new(stream.clone());
         unsafe { self.execute(&ctx) }
@@ -361,11 +361,11 @@ pub trait DeviceOp:
     /// This bypasses the scheduling policy entirely. All operations `sync_on` the same
     /// stream are guaranteed to execute in call order. Use this when you need deterministic
     /// ordering or are debugging concurrency issues.
-    fn sync_on(self, stream: &Arc<CudaStream>) -> Result<<Self as DeviceOp>::Output, DeviceError> {
+    fn sync_on(self, stream: &Arc<Stream>) -> Result<<Self as DeviceOp>::Output, DeviceError> {
         acquire_execution_lock()?;
         let ctx = ExecutionContext::new(stream.clone());
         let res = unsafe { self.execute(&ctx) };
-        let sync_res = stream.synchronize();
+        let sync_res = unsafe { stream.synchronize() };
         release_execution_lock();
         sync_res?;
         res

--- a/cuda-async/src/launch.rs
+++ b/cuda-async/src/launch.rs
@@ -11,7 +11,7 @@ use crate::device_operation::{DeviceOp, ExecutionContext};
 use crate::error::DeviceError;
 use anyhow::{Context, Result};
 use cuda_core::sys::CUdeviceptr;
-use cuda_core::{launch_kernel, CudaFunction, CudaStream, DType, LaunchConfig};
+use cuda_core::{launch_kernel, DType, Function, LaunchConfig, Stream};
 use std::ffi::c_void;
 use std::fmt::Debug;
 use std::future::IntoFuture;
@@ -21,7 +21,7 @@ use std::vec::Vec;
 /// A builder for asynchronously launching a CUDA kernel on a stream.
 #[derive(Debug)]
 pub struct AsyncKernelLaunch {
-    pub func: Arc<CudaFunction>,
+    pub func: Arc<Function>,
     pub args: Vec<*mut c_void>,
     cfg: Option<LaunchConfig>,
 }
@@ -43,7 +43,7 @@ impl Drop for AsyncKernelLaunch {
 
 impl AsyncKernelLaunch {
     /// Creates a new kernel launch builder for the given CUDA function.
-    pub fn new(func: Arc<CudaFunction>) -> AsyncKernelLaunch {
+    pub fn new(func: Arc<Function>) -> AsyncKernelLaunch {
         AsyncKernelLaunch {
             func,
             args: Vec::new(),
@@ -88,7 +88,7 @@ impl AsyncKernelLaunch {
     ///
     /// # Safety
     /// The caller must ensure the kernel arguments and launch config are valid.
-    unsafe fn launch(mut self, stream: &Arc<CudaStream>) -> Result<(), DeviceError> {
+    unsafe fn launch(mut self, stream: &Arc<Stream>) -> Result<(), DeviceError> {
         let cfg = self.cfg.ok_or(DeviceError::Launch(
             "Await called before launching the kernel.".to_string(),
         ))?;

--- a/cuda-async/src/scheduling_policies.rs
+++ b/cuda-async/src/scheduling_policies.rs
@@ -6,7 +6,7 @@
 //! Stream scheduling policies that control how operations are assigned to CUDA streams.
 
 use crate::error::DeviceError;
-use cuda_core::{CudaContext, CudaStream};
+use cuda_core::{Device, Stream};
 use std::sync::atomic::AtomicUsize;
 use std::sync::Arc;
 
@@ -24,7 +24,7 @@ use std::sync::Arc;
 /// Work on **different streams** has no ordering guarantee.
 pub trait SchedulingPolicy: Send + Sync {
     /// Select the next CUDA stream for an operation.
-    fn next_stream(&self) -> Result<Arc<CudaStream>, DeviceError>;
+    fn next_stream(&self) -> Result<Arc<Stream>, DeviceError>;
 }
 
 /// Distributes operations across a fixed-size pool of CUDA streams using round-robin assignment.
@@ -34,15 +34,15 @@ pub trait SchedulingPolicy: Send + Sync {
 /// on **different streams** and may run concurrently on the GPU.
 pub struct StreamPoolRoundRobin {
     next_stream_idx: AtomicUsize,
-    stream_pool: Vec<Arc<CudaStream>>,
+    stream_pool: Vec<Arc<Stream>>,
 }
 
 impl StreamPoolRoundRobin {
-    /// Creates a round-robin pool with `num_streams` streams on the given context.
-    pub fn new(ctx: &Arc<CudaContext>, num_streams: usize) -> Result<Self, DeviceError> {
+    /// Creates a round-robin pool with `num_streams` streams on the given device.
+    pub fn new(device: &Arc<Device>, num_streams: usize) -> Result<Self, DeviceError> {
         let mut stream_pool = Vec::with_capacity(num_streams);
         for _ in 0..num_streams {
-            stream_pool.push(ctx.new_stream()?);
+            stream_pool.push(device.new_stream()?);
         }
         Ok(Self {
             stream_pool,
@@ -52,7 +52,7 @@ impl StreamPoolRoundRobin {
 }
 
 impl SchedulingPolicy for StreamPoolRoundRobin {
-    fn next_stream(&self) -> Result<Arc<CudaStream>, DeviceError> {
+    fn next_stream(&self) -> Result<Arc<Stream>, DeviceError> {
         let idx = self
             .next_stream_idx
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
@@ -63,25 +63,25 @@ impl SchedulingPolicy for StreamPoolRoundRobin {
 
 /// Routes every operation to a single CUDA stream, guaranteeing strict sequential execution.
 pub struct SingleStream {
-    stream: Arc<CudaStream>,
+    stream: Arc<Stream>,
 }
 
 impl SingleStream {
-    /// Creates a single-stream policy on the given context.
-    pub fn new(ctx: &Arc<CudaContext>) -> Result<Self, DeviceError> {
+    /// Creates a single-stream policy on the given device.
+    pub fn new(device: &Arc<Device>) -> Result<Self, DeviceError> {
         Ok(Self {
-            stream: ctx.new_stream()?,
+            stream: device.new_stream()?,
         })
     }
 
     /// Returns a reference to the underlying stream.
-    pub fn stream(&self) -> &Arc<CudaStream> {
+    pub fn stream(&self) -> &Arc<Stream> {
         &self.stream
     }
 }
 
 impl SchedulingPolicy for SingleStream {
-    fn next_stream(&self) -> Result<Arc<CudaStream>, DeviceError> {
+    fn next_stream(&self) -> Result<Arc<Stream>, DeviceError> {
         Ok(Arc::clone(&self.stream))
     }
 }

--- a/cuda-async/tests/concurrent_capture.rs
+++ b/cuda-async/tests/concurrent_capture.rs
@@ -10,7 +10,7 @@ use cuda_async::device_operation::value;
 use cuda_async::error::DeviceError;
 
 fn has_gpu() -> bool {
-    cuda_core::CudaContext::device_count()
+    cuda_core::Device::device_count()
         .map(|n| n > 0)
         .unwrap_or(false)
 }
@@ -23,9 +23,9 @@ fn concurrent_capture_same_context() {
         return;
     }
 
-    let ctx = cuda_core::CudaContext::new(0).unwrap();
-    let stream_a = ctx.new_stream().unwrap();
-    let stream_b = ctx.new_stream().unwrap();
+    let device = cuda_core::Device::new(0).unwrap();
+    let stream_a = device.new_stream().unwrap();
+    let stream_b = device.new_stream().unwrap();
 
     let handle_a = std::thread::spawn(move || -> Result<(), DeviceError> {
         CudaGraph::scope(&stream_a, |s| {
@@ -57,7 +57,7 @@ fn concurrent_capture_same_context() {
 }
 
 /// Thread A captures while thread B creates a new stream from a
-/// fresh CudaContext::new(0). Previously this failed because
+/// fresh Device::new(0). Previously this failed because
 /// new_stream called cuCtxSynchronize (for event tracking init),
 /// which conflicted with A's active capture.
 #[test]
@@ -66,8 +66,8 @@ fn new_stream_during_capture_on_another_thread() {
         return;
     }
 
-    let ctx_a = cuda_core::CudaContext::new(0).unwrap();
-    let stream_a = ctx_a.new_stream().unwrap();
+    let device_a = cuda_core::Device::new(0).unwrap();
+    let stream_a = device_a.new_stream().unwrap();
 
     let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
     let barrier_a = barrier.clone();
@@ -86,8 +86,8 @@ fn new_stream_during_capture_on_another_thread() {
 
     let handle_b = std::thread::spawn(move || -> Result<(), DeviceError> {
         barrier_b.wait();
-        let ctx_b = cuda_core::CudaContext::new(0).unwrap();
-        let _stream = ctx_b.new_stream()?;
+        let device_b = cuda_core::Device::new(0).unwrap();
+        let _stream = device_b.new_stream()?;
         Ok(())
     });
 

--- a/cuda-async/tests/cuda_graph.rs
+++ b/cuda-async/tests/cuda_graph.rs
@@ -10,7 +10,7 @@ use cuda_async::device_operation::{value, DeviceOp};
 use cuda_async::error::DeviceError;
 
 fn has_gpu() -> bool {
-    cuda_core::CudaContext::device_count()
+    cuda_core::Device::device_count()
         .map(|n| n > 0)
         .unwrap_or(false)
 }
@@ -25,8 +25,8 @@ fn scope_empty_closure() {
         return;
     }
     on_fresh_thread(|| {
-        let ctx = cuda_core::CudaContext::new(0).unwrap();
-        let stream = ctx.new_stream().unwrap();
+        let device = cuda_core::Device::new(0).unwrap();
+        let stream = device.new_stream().unwrap();
 
         let graph = CudaGraph::scope(&stream, |_s| Ok(())).unwrap();
         graph.launch().sync_on(&stream).unwrap();
@@ -39,8 +39,8 @@ fn scope_records_value_ops() {
         return;
     }
     on_fresh_thread(|| {
-        let ctx = cuda_core::CudaContext::new(0).unwrap();
-        let stream = ctx.new_stream().unwrap();
+        let device = cuda_core::Device::new(0).unwrap();
+        let stream = device.new_stream().unwrap();
 
         let mut recorded = Vec::new();
         let graph = CudaGraph::scope(&stream, |s| {
@@ -63,8 +63,8 @@ fn scope_error_propagation() {
         return;
     }
     on_fresh_thread(|| {
-        let ctx = cuda_core::CudaContext::new(0).unwrap();
-        let stream = ctx.new_stream().unwrap();
+        let device = cuda_core::Device::new(0).unwrap();
+        let stream = device.new_stream().unwrap();
 
         let result = CudaGraph::scope(&stream, |_s| {
             Err(DeviceError::Internal("test error".into()))
@@ -90,8 +90,8 @@ fn scope_panic_safety() {
         return;
     }
     let result = std::thread::spawn(|| {
-        let ctx = cuda_core::CudaContext::new(0).unwrap();
-        let stream = ctx.new_stream().unwrap();
+        let device = cuda_core::Device::new(0).unwrap();
+        let stream = device.new_stream().unwrap();
 
         let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             CudaGraph::scope(&stream, |_s| {
@@ -100,7 +100,7 @@ fn scope_panic_safety() {
         }));
 
         // Stream should still be usable after the panic.
-        stream.synchronize().unwrap();
+        unsafe { stream.synchronize() }.unwrap();
     })
     .join();
 
@@ -116,8 +116,8 @@ fn scope_multiple_launches() {
         return;
     }
     on_fresh_thread(|| {
-        let ctx = cuda_core::CudaContext::new(0).unwrap();
-        let stream = ctx.new_stream().unwrap();
+        let device = cuda_core::Device::new(0).unwrap();
+        let stream = device.new_stream().unwrap();
 
         let graph = CudaGraph::scope(&stream, |_s| Ok(())).unwrap();
 
@@ -137,9 +137,9 @@ fn scope_nested_execution_rejected() {
         return;
     }
     on_fresh_thread(|| {
-        let ctx = cuda_core::CudaContext::new(0).unwrap();
-        let stream = ctx.new_stream().unwrap();
-        let other_stream = ctx.new_stream().unwrap();
+        let device = cuda_core::Device::new(0).unwrap();
+        let stream = device.new_stream().unwrap();
+        let other_stream = device.new_stream().unwrap();
 
         // sync_on capture stream — rejected by execution lock.
         let result = CudaGraph::scope(&stream, |_s| {

--- a/cuda-async/tests/error_handling.rs
+++ b/cuda-async/tests/error_handling.rs
@@ -174,9 +174,9 @@ fn set_default_device_changes_value() {
 #[test]
 fn new_device_context_with_invalid_device_returns_driver_error() {
     // Device ordinal 9999 should not exist on any reasonable system.
-    // CudaContext::new(9999) will fail with a driver error, which propagates
+    // Device::new(9999) will fail with a driver error, which propagates
     // through new_device_context.
-    let result = cuda_core::CudaContext::new(9999);
+    let result = cuda_core::Device::new(9999);
     let result = result.map_err(DeviceError::Driver);
     match result {
         Err(DeviceError::Driver(_)) => { /* expected */ }

--- a/cuda-core/src/api.rs
+++ b/cuda-core/src/api.rs
@@ -14,14 +14,13 @@ use cuda_bindings::{
     CUdevice_attribute_enum_CU_DEVICE_ATTRIBUTE_CLOCK_RATE,
     CUdevice_attribute_enum_CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR,
     CUdevice_attribute_enum_CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR,
-    CUdevice_attribute_enum_CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT,
 };
 use std::ffi::{c_int, c_uint, c_void};
 use std::mem::{self, MaybeUninit};
 use std::sync::Arc;
 
 use crate::error::*;
-use crate::CudaStream;
+use crate::runtime::Stream;
 
 /// Initializes the CUDA driver API. Must be called before any other driver call.
 ///
@@ -74,16 +73,17 @@ pub unsafe fn launch_kernel(
 ///
 /// # Safety
 /// `stream` must be a valid, non-destroyed CUDA stream.
-pub unsafe fn malloc_async(num_bytes: usize, stream: &Arc<CudaStream>) -> sys::CUdeviceptr {
-    crate::memory::malloc_async(stream.cu_stream(), num_bytes).expect("Malloc async failed.")
+pub unsafe fn malloc_async(num_bytes: usize, stream: &Arc<Stream>) -> sys::CUdeviceptr {
+    crate::cudarc_shim::memory::malloc_async(stream.cu_stream(), num_bytes)
+        .expect("Malloc async failed.")
 }
 
 /// Asynchronously frees device memory on the given stream.
 ///
 /// # Safety
 /// `dptr` must have been allocated with `malloc_async` and must not be used after this call.
-pub unsafe fn free_async(dptr: sys::CUdeviceptr, stream: &Arc<CudaStream>) {
-    crate::memory::free_async(dptr, stream.cu_stream()).expect("Free async failed.")
+pub unsafe fn free_async(dptr: sys::CUdeviceptr, stream: &Arc<Stream>) {
+    crate::cudarc_shim::memory::free_async(dptr, stream.cu_stream()).expect("Free async failed.")
 }
 
 /// Asynchronously copies `num_elements` of type `T` from host to device memory.
@@ -94,11 +94,13 @@ pub unsafe fn memcpy_htod_async<T>(
     dst: sys::CUdeviceptr,
     src: *const T,
     num_elements: usize,
-    stream: &Arc<CudaStream>,
+    stream: &Arc<Stream>,
 ) {
     let num_bytes = num_elements * mem::size_of::<T>();
-    unsafe { crate::memory::memcpy_htod_async(dst, src, num_bytes, stream.cu_stream()) }
-        .expect("memcpy_htod_async failed.")
+    unsafe {
+        crate::cudarc_shim::memory::memcpy_htod_async(dst, src, num_bytes, stream.cu_stream())
+    }
+    .expect("memcpy_htod_async failed.")
 }
 
 /// Asynchronously copies `num_elements` of type `T` from device to host memory.
@@ -109,11 +111,13 @@ pub unsafe fn memcpy_dtoh_async<T>(
     dst: *mut T,
     src: sys::CUdeviceptr,
     num_elements: usize,
-    stream: &Arc<CudaStream>,
+    stream: &Arc<Stream>,
 ) {
     let num_bytes = num_elements * mem::size_of::<T>();
-    unsafe { crate::memory::memcpy_dtoh_async(dst, src, num_bytes, stream.cu_stream()) }
-        .expect("memcpy_dtoh_async failed.")
+    unsafe {
+        crate::cudarc_shim::memory::memcpy_dtoh_async(dst, src, num_bytes, stream.cu_stream())
+    }
+    .expect("memcpy_dtoh_async failed.")
 }
 
 /// Asynchronously copies `num_elements` of type `T` between device memory regions.
@@ -124,11 +128,13 @@ pub unsafe fn memcpy_dtod_async<T>(
     dst: sys::CUdeviceptr,
     src: sys::CUdeviceptr,
     num_elements: usize,
-    stream: &Arc<CudaStream>,
+    stream: &Arc<Stream>,
 ) {
     let num_bytes = num_elements * mem::size_of::<T>();
-    unsafe { crate::memory::memcpy_dtod_async(dst, src, num_bytes, stream.cu_stream()) }
-        .expect("memcpy_dtod_async failed.")
+    unsafe {
+        crate::cudarc_shim::memory::memcpy_dtod_async(dst, src, num_bytes, stream.cu_stream())
+    }
+    .expect("memcpy_dtod_async failed.")
 }
 
 /// Wrappers around the cuRAND random number generation library.
@@ -302,29 +308,13 @@ pub mod curand {
     }
 }
 
-/// Queries a device attribute value for the given device.
-///
-/// # Safety
-/// `device` must be a valid CUDA device handle.
-pub unsafe fn get_device_attribute(
+unsafe fn get_device_attribute(
     device: CUdevice,
     device_attr: CUdevice_attribute,
 ) -> Result<i32, DriverError> {
     let mut result: MaybeUninit<c_int> = MaybeUninit::uninit();
     assert!(cuDeviceGetAttribute(result.as_mut_ptr(), device_attr, device) == 0);
     Ok(result.assume_init())
-}
-
-/// Returns the device clock rate in MHz.
-///
-/// # Safety
-/// `device` must be a valid CUDA device handle.
-pub unsafe fn get_device_clock_rate_mhz(device: CUdevice) -> Result<f64, DriverError> {
-    let result = get_device_attribute(
-        device,
-        CUdevice_attribute_enum_CU_DEVICE_ATTRIBUTE_CLOCK_RATE,
-    )?;
-    Ok(f64::from(result) * 1e-3)
 }
 
 /// Returns the device clock rate in kHz.
@@ -335,17 +325,6 @@ pub unsafe fn get_device_clock_rate(device: CUdevice) -> Result<i32, DriverError
     get_device_attribute(
         device,
         CUdevice_attribute_enum_CU_DEVICE_ATTRIBUTE_CLOCK_RATE,
-    )
-}
-
-/// Returns the number of multiprocessors on the device.
-///
-/// # Safety
-/// `device` must be a valid CUDA device handle.
-pub unsafe fn get_device_multiprocessor_count(device: CUdevice) -> Result<i32, DriverError> {
-    get_device_attribute(
-        device,
-        CUdevice_attribute_enum_CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT,
     )
 }
 

--- a/cuda-core/src/cudarc_shim.rs
+++ b/cuda-core/src/cudarc_shim.rs
@@ -4,617 +4,16 @@
  * Portions of this file are copyright per https://github.com/chelsea0x3b/cudarc
  */
 
-//! CUDA context, stream, event, module, and function wrappers.
-//!
-//! Provides RAII types that manage CUDA driver object lifetimes and expose
-//! safe(r) methods for common operations.
-
-use std::ffi::{c_int, c_uint, c_void, CString};
-use std::sync::{
-    atomic::{AtomicU32, Ordering},
-    Arc,
-};
+//\! Low-level CUDA driver API wrappers.
+//\!
+//\! Thin `pub(crate)` modules around `cuda_bindings` calls. The public API
+//\! lives in [`crate::runtime`].
 
 use crate::error::*;
-use crate::init;
-
-/// Kernel launch configuration specifying grid, block, and shared memory sizes.
-#[derive(Clone, Copy, Debug)]
-pub struct LaunchConfig {
-    /// Grid dimensions `(x, y, z)` in thread blocks.
-    pub grid_dim: (u32, u32, u32),
-    /// Block dimensions `(x, y, z)` in threads.
-    pub block_dim: (u32, u32, u32),
-    /// Bytes of dynamic shared memory per block.
-    pub shared_mem_bytes: u32,
-}
-
-/// Owns a CUDA primary context and tracks stream/event/error state.
-#[derive(Debug)]
-pub struct CudaContext {
-    pub(crate) cu_device: cuda_bindings::CUdevice,
-    pub(crate) cu_ctx: cuda_bindings::CUcontext,
-    pub(crate) ordinal: usize,
-    #[expect(
-        dead_code,
-        reason = "cached device capability for future async memory pool decisions"
-    )]
-    pub(crate) has_async_alloc: bool,
-    pub(crate) error_state: AtomicU32,
-}
-
-unsafe impl Send for CudaContext {}
-unsafe impl Sync for CudaContext {}
-
-impl Drop for CudaContext {
-    fn drop(&mut self) {
-        self.record_err(self.bind_to_thread());
-        let ctx = std::mem::replace(&mut self.cu_ctx, std::ptr::null_mut());
-        if !ctx.is_null() {
-            self.record_err(unsafe { primary_ctx::release(self.cu_device) });
-        }
-    }
-}
-
-impl PartialEq for CudaContext {
-    fn eq(&self, other: &Self) -> bool {
-        self.cu_device == other.cu_device
-            && self.cu_ctx == other.cu_ctx
-            && self.ordinal == other.ordinal
-    }
-}
-impl Eq for CudaContext {}
-
-impl CudaContext {
-    /// Creates a new context on the specified device ordinal.
-    pub fn new(ordinal: usize) -> Result<Arc<Self>, DriverError> {
-        unsafe { init(0)? };
-        let cu_device = device::get(ordinal as c_int)?;
-        let cu_ctx = unsafe { primary_ctx::retain(cu_device) }?;
-        let has_async_alloc = unsafe {
-            let memory_pools_supported = device::get_attribute(
-                cu_device,
-                cuda_bindings::CUdevice_attribute_enum_CU_DEVICE_ATTRIBUTE_MEMORY_POOLS_SUPPORTED,
-            )?;
-            memory_pools_supported > 0
-        };
-        let ctx = Arc::new(CudaContext {
-            cu_device,
-            cu_ctx,
-            ordinal,
-            has_async_alloc,
-            error_state: AtomicU32::new(0),
-        });
-        ctx.bind_to_thread()?;
-        Ok(ctx)
-    }
-
-    /// Returns the number of CUDA-capable devices available.
-    pub fn device_count() -> Result<i32, DriverError> {
-        unsafe { init(0)? };
-        device::get_count()
-    }
-
-    /// Get the `ordinal` index of the device this is on.
-    pub fn ordinal(&self) -> usize {
-        self.ordinal
-    }
-
-    /// Get the name of this device.
-    pub fn name(&self) -> Result<String, DriverError> {
-        self.check_err()?;
-        device::get_name(self.cu_device)
-    }
-
-    /// Get the UUID of this device.
-    pub fn uuid(&self) -> Result<cuda_bindings::CUuuid, DriverError> {
-        self.check_err()?;
-        device::get_uuid(self.cu_device)
-    }
-
-    /// Returns the raw `CUdevice` handle.
-    pub fn cu_device(&self) -> cuda_bindings::CUdevice {
-        self.cu_device
-    }
-
-    /// Returns the raw `CUcontext` handle.
-    pub fn cu_ctx(&self) -> cuda_bindings::CUcontext {
-        self.cu_ctx
-    }
-
-    /// Binds this context to the calling thread if not already current.
-    pub fn bind_to_thread(&self) -> Result<(), DriverError> {
-        self.check_err()?;
-        if match ctx::get_current()? {
-            Some(curr_ctx) => curr_ctx != self.cu_ctx,
-            None => true,
-        } {
-            unsafe { ctx::set_current(self.cu_ctx) }?;
-        }
-        Ok(())
-    }
-
-    /// Queries a device attribute for the underlying device.
-    pub fn attribute(&self, attrib: cuda_bindings::CUdevice_attribute) -> Result<i32, DriverError> {
-        self.check_err()?;
-        unsafe { device::get_attribute(self.cu_device, attrib) }
-    }
-
-    /// Blocks until all work on this context's device is complete.
-    pub fn synchronize(&self) -> Result<(), DriverError> {
-        self.bind_to_thread()?;
-        ctx::synchronize()
-    }
-
-    /// Configures the context to use blocking synchronization.
-    pub fn set_blocking_synchronize(&self) -> Result<(), DriverError> {
-        self.set_flags(cuda_bindings::CUctx_flags_enum_CU_CTX_SCHED_BLOCKING_SYNC)
-    }
-
-    /// Sets context flags (e.g. scheduling policy).
-    pub fn set_flags(&self, flags: cuda_bindings::CUctx_flags) -> Result<(), DriverError> {
-        self.bind_to_thread()?;
-        ctx::set_flags(flags)
-    }
-
-    /// Checks and clears the context's recorded error state.
-    pub fn check_err(&self) -> Result<(), DriverError> {
-        let error_state = self.error_state.swap(0, Ordering::Relaxed);
-        if error_state == 0 {
-            Ok(())
-        } else {
-            Err(DriverError(unsafe {
-                std::mem::transmute::<u32, cuda_bindings::cudaError_enum>(error_state)
-            }))
-        }
-    }
-
-    /// Records an error into the context's error state if the result is `Err`.
-    pub fn record_err<T>(&self, result: Result<T, DriverError>) {
-        if let Err(err) = result {
-            self.error_state.store(err.0, Ordering::Relaxed)
-        }
-    }
-}
-
-/// Owns a CUDA stream and its parent context reference.
-#[derive(Debug, PartialEq, Eq)]
-pub struct CudaStream {
-    pub(crate) cu_stream: cuda_bindings::CUstream,
-    pub(crate) ctx: Arc<CudaContext>,
-}
-
-unsafe impl Send for CudaStream {}
-unsafe impl Sync for CudaStream {}
-
-impl Drop for CudaStream {
-    fn drop(&mut self) {
-        self.ctx.record_err(self.ctx.bind_to_thread());
-        if !self.cu_stream.is_null() {
-            self.ctx
-                .record_err(unsafe { stream::destroy(self.cu_stream) });
-        }
-    }
-}
-
-impl CudaContext {
-    /// Returns the default (null) CUDA stream for this context.
-    pub fn default_stream(self: &Arc<Self>) -> Arc<CudaStream> {
-        Arc::new(CudaStream {
-            cu_stream: std::ptr::null_mut(),
-            ctx: self.clone(),
-        })
-    }
-    /// Creates a new non-blocking CUDA stream on this context.
-    pub fn new_stream(self: &Arc<Self>) -> Result<Arc<CudaStream>, DriverError> {
-        self.bind_to_thread()?;
-        let cu_stream = stream::create(stream::StreamKind::NonBlocking)?;
-        Ok(Arc::new(CudaStream {
-            cu_stream,
-            ctx: self.clone(),
-        }))
-    }
-}
-
-impl CudaStream {
-    /// Creates a new stream that waits on this stream's current work before proceeding.
-    pub fn fork(&self) -> Result<Arc<Self>, DriverError> {
-        self.ctx.bind_to_thread()?;
-        let cu_stream = stream::create(stream::StreamKind::NonBlocking)?;
-        let stream = Arc::new(CudaStream {
-            cu_stream,
-            ctx: self.ctx.clone(),
-        });
-        stream.join(self)?;
-        Ok(stream)
-    }
-
-    /// Returns the raw `CUstream` handle.
-    pub fn cu_stream(&self) -> cuda_bindings::CUstream {
-        self.cu_stream
-    }
-
-    /// Returns a reference to the parent context.
-    pub fn context(&self) -> &Arc<CudaContext> {
-        &self.ctx
-    }
-
-    /// Blocks until all work on this stream is complete.
-    pub fn synchronize(&self) -> Result<(), DriverError> {
-        self.ctx.bind_to_thread()?;
-        unsafe { stream::synchronize(self.cu_stream) }
-    }
-
-    /// Records a new event on this stream and returns it.
-    pub fn record_event(
-        &self,
-        flags: Option<cuda_bindings::CUevent_flags>,
-    ) -> Result<CudaEvent, DriverError> {
-        let event = self.ctx.new_event(flags)?;
-        event.record(self)?;
-        Ok(event)
-    }
-
-    /// Makes this stream wait until the given event has been recorded.
-    pub fn wait(&self, event: &CudaEvent) -> Result<(), DriverError> {
-        if self.ctx != event.ctx {
-            return Err(DriverError(
-                cuda_bindings::cudaError_enum_CUDA_ERROR_INVALID_CONTEXT,
-            ));
-        }
-        self.ctx.bind_to_thread()?;
-        unsafe {
-            stream::wait_event(
-                self.cu_stream,
-                event.cu_event,
-                cuda_bindings::CUevent_wait_flags_enum_CU_EVENT_WAIT_DEFAULT,
-            )
-        }
-    }
-    /// Makes this stream wait until all prior work on `other` is complete.
-    pub fn join(&self, other: &CudaStream) -> Result<(), DriverError> {
-        self.wait(&other.record_event(None)?)
-    }
-    /// Enqueues a host-side callback to execute after all prior stream work completes.
-    pub fn launch_host_function<F: FnOnce() + Send>(
-        &self,
-        host_func: F,
-    ) -> Result<(), DriverError> {
-        let boxed_host_func = Box::new(host_func);
-        unsafe {
-            stream::launch_host_function(
-                self.cu_stream,
-                CudaStream::callback_wrapper::<F>,
-                // Memory allocated for the callback is wrapped in a ManuallyDrop.
-                Box::into_raw(boxed_host_func) as *mut c_void,
-            )
-        }
-    }
-    unsafe extern "C" fn callback_wrapper<F: FnOnce() + Send>(callback: *mut c_void) {
-        // Stop panics from unwinding across the FFI.
-        let _ = std::panic::catch_unwind(|| {
-            // Any memory allocated for the callback is freed when this Box goes out of scope.
-            let callback: Box<F> = Box::from_raw(callback as *mut F);
-            callback();
-        });
-    }
-}
-
-/// Owns a CUDA event and its parent context reference.
-#[derive(Debug)]
-pub struct CudaEvent {
-    pub(crate) cu_event: cuda_bindings::CUevent,
-    pub(crate) ctx: Arc<CudaContext>,
-}
-
-unsafe impl Send for CudaEvent {}
-unsafe impl Sync for CudaEvent {}
-
-impl Drop for CudaEvent {
-    fn drop(&mut self) {
-        self.ctx.record_err(self.ctx.bind_to_thread());
-        self.ctx
-            .record_err(unsafe { event::destroy(self.cu_event) });
-    }
-}
-
-impl CudaContext {
-    /// Creates a new CUDA event with the given flags (defaults to disable-timing).
-    pub fn new_event(
-        self: &Arc<Self>,
-        flags: Option<cuda_bindings::CUevent_flags>,
-    ) -> Result<CudaEvent, DriverError> {
-        let flags = flags.unwrap_or(cuda_bindings::CUevent_flags_enum_CU_EVENT_DISABLE_TIMING);
-        self.bind_to_thread()?;
-        let cu_event = event::create(flags)?;
-        Ok(CudaEvent {
-            cu_event,
-            ctx: self.clone(),
-        })
-    }
-}
-
-impl CudaEvent {
-    /// Returns the raw `CUevent` handle.
-    pub fn cu_event(&self) -> cuda_bindings::CUevent {
-        self.cu_event
-    }
-
-    /// Returns a reference to the parent context.
-    pub fn context(&self) -> &Arc<CudaContext> {
-        &self.ctx
-    }
-
-    /// Records this event on the given stream.
-    pub fn record(&self, stream: &CudaStream) -> Result<(), DriverError> {
-        if self.ctx != stream.ctx {
-            return Err(DriverError(
-                cuda_bindings::cudaError_enum_CUDA_ERROR_INVALID_CONTEXT,
-            ));
-        }
-        self.ctx.bind_to_thread()?;
-        unsafe { event::record(self.cu_event, stream.cu_stream) }
-    }
-
-    /// Blocks until this event has been recorded.
-    pub fn synchronize(&self) -> Result<(), DriverError> {
-        self.ctx.bind_to_thread()?;
-        unsafe { event::synchronize(self.cu_event) }
-    }
-
-    /// Returns elapsed time in milliseconds between `self` (start) and `end`.
-    pub fn elapsed_ms(&self, end: &Self) -> Result<f32, DriverError> {
-        if self.ctx != end.ctx {
-            return Err(DriverError(
-                cuda_bindings::cudaError_enum_CUDA_ERROR_INVALID_CONTEXT,
-            ));
-        }
-        self.ctx.bind_to_thread()?;
-        self.synchronize()?;
-        end.synchronize()?;
-        unsafe { event::elapsed(self.cu_event, end.cu_event) }
-    }
-
-    /// Returns `true` if all work preceding this event has completed.
-    pub fn is_complete(&self) -> bool {
-        unsafe { event::query(self.cu_event) }.is_ok()
-    }
-}
-
-/// Owns a loaded CUDA module (PTX/cubin) and its parent context reference.
-#[derive(Debug)]
-pub struct CudaModule {
-    pub(crate) cu_module: cuda_bindings::CUmodule,
-    pub(crate) ctx: Arc<CudaContext>,
-}
-
-unsafe impl Send for CudaModule {}
-unsafe impl Sync for CudaModule {}
-
-impl Drop for CudaModule {
-    fn drop(&mut self) {
-        self.ctx.record_err(self.ctx.bind_to_thread());
-        self.ctx
-            .record_err(unsafe { module::unload(self.cu_module) });
-    }
-}
-
-impl CudaContext {
-    /// Loads a CUDA module from a PTX source string.
-    pub fn load_module_from_ptx_src(
-        self: &Arc<Self>,
-        ptx_src: &str,
-    ) -> Result<Arc<CudaModule>, DriverError> {
-        self.bind_to_thread()?;
-        let cu_module = {
-            let c_src = CString::new(ptx_src).unwrap();
-            unsafe { module::load_data(c_src.as_ptr() as *const _) }
-        }?;
-        Ok(Arc::new(CudaModule {
-            cu_module,
-            ctx: self.clone(),
-        }))
-    }
-    /// Loads a CUDA module from a file path (PTX or cubin).
-    pub fn load_module_from_file(
-        self: &Arc<Self>,
-        filename: &str,
-    ) -> Result<Arc<CudaModule>, DriverError> {
-        self.bind_to_thread()?;
-        let cu_module = { module::load(filename) }?;
-        Ok(Arc::new(CudaModule {
-            cu_module,
-            ctx: self.clone(),
-        }))
-    }
-}
-
-/// Handle to a device function loaded from a [`CudaModule`].
-#[derive(Debug, Clone)]
-pub struct CudaFunction {
-    pub(crate) cu_function: cuda_bindings::CUfunction,
-    #[allow(unused)]
-    pub(crate) module: Arc<CudaModule>,
-}
-
-unsafe impl Send for CudaFunction {}
-unsafe impl Sync for CudaFunction {}
-
-impl CudaModule {
-    /// Looks up a device function by name within this module.
-    pub fn load_function(self: &Arc<Self>, fn_name: &str) -> Result<CudaFunction, DriverError> {
-        let cu_function = unsafe { module::get_function(self.cu_module, fn_name) }?;
-        Ok(CudaFunction {
-            cu_function,
-            module: self.clone(),
-        })
-    }
-}
-
-impl CudaFunction {
-    /// Returns the raw `CUfunction` handle.
-    ///
-    /// # Safety
-    /// The caller must not use the handle after the parent module is dropped.
-    pub unsafe fn cu_function(&self) -> cuda_bindings::CUfunction {
-        self.cu_function
-    }
-
-    /// Returns the available dynamic shared memory per block for the given configuration.
-    pub fn occupancy_available_dynamic_smem_per_block(
-        &self,
-        num_blocks: u32,
-        block_size: u32,
-    ) -> Result<usize, DriverError> {
-        let mut dynamic_smem_size: usize = 0;
-
-        unsafe {
-            cuda_bindings::cuOccupancyAvailableDynamicSMemPerBlock(
-                &mut dynamic_smem_size,
-                self.cu_function,
-                num_blocks as c_int,
-                block_size as c_int,
-            )
-            .result()?
-        };
-
-        Ok(dynamic_smem_size)
-    }
-
-    /// Returns the maximum number of active blocks per SM for the given block size.
-    pub fn occupancy_max_active_blocks_per_multiprocessor(
-        &self,
-        block_size: u32,
-        dynamic_smem_size: usize,
-        flags: Option<cuda_bindings::CUoccupancy_flags_enum>,
-    ) -> Result<u32, DriverError> {
-        let mut num_blocks: c_int = 0;
-        let flags = flags.unwrap_or(cuda_bindings::CUoccupancy_flags_enum_CU_OCCUPANCY_DEFAULT);
-
-        unsafe {
-            cuda_bindings::cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags(
-                &mut num_blocks,
-                self.cu_function,
-                block_size as c_int,
-                dynamic_smem_size,
-                flags as c_uint,
-            )
-            .result()?
-        };
-
-        Ok(num_blocks as u32)
-    }
-
-    /// Returns the maximum number of active clusters for the given launch configuration.
-    pub fn occupancy_max_active_clusters(
-        &self,
-        config: LaunchConfig,
-        stream: &CudaStream,
-    ) -> Result<u32, DriverError> {
-        let mut num_clusters: c_int = 0;
-
-        let cfg = cuda_bindings::CUlaunchConfig {
-            gridDimX: config.grid_dim.0,
-            gridDimY: config.grid_dim.1,
-            gridDimZ: config.grid_dim.2,
-            blockDimX: config.block_dim.0,
-            blockDimY: config.block_dim.1,
-            blockDimZ: config.block_dim.2,
-            sharedMemBytes: config.shared_mem_bytes,
-            hStream: stream.cu_stream,
-            attrs: std::ptr::null_mut(),
-            numAttrs: 0,
-        };
-
-        unsafe {
-            cuda_bindings::cuOccupancyMaxActiveClusters(&mut num_clusters, self.cu_function, &cfg)
-                .result()?
-        };
-
-        Ok(num_clusters as u32)
-    }
-
-    /// Returns `(min_grid_size, block_size)` that achieves maximum occupancy.
-    pub fn occupancy_max_potential_block_size(
-        &self,
-        block_size_to_dynamic_smem_size: extern "C" fn(block_size: c_int) -> usize,
-        dynamic_smem_size: usize,
-        block_size_limit: u32,
-        flags: Option<cuda_bindings::CUoccupancy_flags_enum>,
-    ) -> Result<(u32, u32), DriverError> {
-        let mut min_grid_size: c_int = 0;
-        let mut block_size: c_int = 0;
-        let flags = flags.unwrap_or(cuda_bindings::CUoccupancy_flags_enum_CU_OCCUPANCY_DEFAULT);
-
-        unsafe {
-            cuda_bindings::cuOccupancyMaxPotentialBlockSizeWithFlags(
-                &mut min_grid_size,
-                &mut block_size,
-                self.cu_function,
-                Some(block_size_to_dynamic_smem_size),
-                dynamic_smem_size,
-                block_size_limit as c_int,
-                flags as c_uint,
-            )
-            .result()?
-        };
-
-        Ok((min_grid_size as u32, block_size as u32))
-    }
-
-    /// Returns the maximum potential cluster size for the given launch configuration.
-    pub fn occupancy_max_potential_cluster_size(
-        &self,
-        config: LaunchConfig,
-        stream: &CudaStream,
-    ) -> Result<u32, DriverError> {
-        let mut cluster_size: c_int = 0;
-
-        let cfg = cuda_bindings::CUlaunchConfig {
-            gridDimX: config.grid_dim.0,
-            gridDimY: config.grid_dim.1,
-            gridDimZ: config.grid_dim.2,
-            blockDimX: config.block_dim.0,
-            blockDimY: config.block_dim.1,
-            blockDimZ: config.block_dim.2,
-            sharedMemBytes: config.shared_mem_bytes,
-            hStream: stream.cu_stream,
-            attrs: std::ptr::null_mut(),
-            numAttrs: 0,
-        };
-
-        unsafe {
-            cuda_bindings::cuOccupancyMaxPotentialClusterSize(
-                &mut cluster_size,
-                self.cu_function,
-                &cfg,
-            )
-            .result()?
-        };
-
-        Ok(cluster_size as u32)
-    }
-
-    /// Sets a function attribute (e.g. max dynamic shared memory).
-    pub fn set_attribute(
-        &self,
-        attribute: cuda_bindings::CUfunction_attribute_enum,
-        value: i32,
-    ) -> Result<(), DriverError> {
-        unsafe { function::set_function_attribute(self.cu_function, attribute, value) }
-    }
-
-    /// Sets the preferred cache configuration for this function.
-    pub fn set_function_cache_config(
-        &self,
-        attribute: cuda_bindings::CUfunc_cache_enum,
-    ) -> Result<(), DriverError> {
-        unsafe { function::set_function_cache_config(self.cu_function, attribute) }
-    }
-}
 
 /// Low-level primary context retain/release operations.
-pub mod primary_ctx {
+#[allow(dead_code)]
+pub(crate) mod primary_ctx {
 
     use super::{DriverError, IntoResult};
     use std::mem::MaybeUninit;
@@ -641,7 +40,9 @@ pub mod primary_ctx {
 }
 
 /// Low-level device query operations.
-pub mod device {
+
+#[allow(dead_code)]
+pub(crate) mod device {
 
     use super::{DriverError, IntoResult};
     use std::{
@@ -715,7 +116,8 @@ pub mod device {
 }
 
 /// Low-level function attribute operations.
-pub mod function {
+#[allow(dead_code)]
+pub(crate) mod function {
 
     use super::{DriverError, IntoResult};
 
@@ -750,7 +152,8 @@ pub mod function {
 }
 
 /// Low-level CUDA context management operations.
-pub mod ctx {
+#[allow(dead_code)]
+pub(crate) mod ctx {
     use super::{DriverError, IntoResult};
     use std::mem::MaybeUninit;
 
@@ -788,7 +191,9 @@ pub mod ctx {
 }
 
 /// Low-level CUDA stream operations.
-pub mod stream {
+
+#[allow(dead_code)]
+pub(crate) mod stream {
     use super::{DriverError, IntoResult};
     use std::ffi::c_void;
     use std::mem::MaybeUninit;
@@ -918,7 +323,8 @@ pub mod stream {
 }
 
 /// Low-level CUDA module load/unload and function lookup operations.
-pub mod module {
+#[allow(dead_code)]
+pub(crate) mod module {
     use super::{DriverError, IntoResult};
     use core::ffi::c_void;
     use std::ffi::CString;
@@ -982,7 +388,8 @@ pub mod module {
 }
 
 /// Low-level CUDA event operations.
-pub mod event {
+#[allow(dead_code)]
+pub(crate) mod event {
     use super::{DriverError, IntoResult};
     use std::mem::MaybeUninit;
 
@@ -1049,7 +456,8 @@ pub mod event {
 }
 
 /// Low-level CUDA memory allocation, transfer, and management operations.
-pub mod memory {
+#[allow(dead_code)]
+pub(crate) mod memory {
 
     use crate::sys::{self};
     use std::ffi::{c_uchar, c_uint, c_void};

--- a/cuda-core/src/lib.rs
+++ b/cuda-core/src/lib.rs
@@ -6,12 +6,13 @@
 //! Low-level CUDA driver API bindings and safe wrappers.
 
 mod api;
-mod cudarc_shim;
+pub(crate) mod cudarc_shim;
 mod dtype;
 mod error;
+mod runtime;
 
 pub use api::*;
 pub use cuda_bindings as sys;
-pub use cudarc_shim::*;
 pub use dtype::*;
 pub use error::*;
+pub use runtime::*;

--- a/cuda-core/src/runtime.rs
+++ b/cuda-core/src/runtime.rs
@@ -1,0 +1,413 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! CUDA runtime types: Device, Stream, Module, Function, LaunchConfig.
+//!
+//! These are the public API of `cuda-core`. They wrap raw CUDA driver
+//! handles with RAII lifetimes and provide `borrow_raw` constructors
+//! for interop with external frameworks (cudarc, etc.).
+
+use std::ffi::{c_int, c_void, CString};
+use std::sync::Arc;
+
+use crate::cudarc_shim::{ctx, device, module, primary_ctx, stream};
+use crate::error::*;
+use crate::init;
+
+/// Kernel launch configuration specifying grid, block, and shared memory sizes.
+#[derive(Clone, Copy, Debug)]
+pub struct LaunchConfig {
+    /// Grid dimensions `(x, y, z)` in thread blocks.
+    pub grid_dim: (u32, u32, u32),
+    /// Block dimensions `(x, y, z)` in threads.
+    pub block_dim: (u32, u32, u32),
+    /// Bytes of dynamic shared memory per block.
+    pub shared_mem_bytes: u32,
+}
+
+/// A GPU device handle wrapping a CUDA primary context.
+///
+/// Can be either **owned** (created via [`Device::new`], releases the
+/// primary context on drop) or **borrowed** (created via
+/// [`Device::borrow_raw`], does NOT release on drop).
+#[derive(Debug)]
+pub struct Device {
+    pub(crate) cu_device: cuda_bindings::CUdevice,
+    pub(crate) cu_ctx: cuda_bindings::CUcontext,
+    pub(crate) ordinal: usize,
+    owned: bool,
+}
+
+unsafe impl Send for Device {}
+unsafe impl Sync for Device {}
+
+impl Drop for Device {
+    fn drop(&mut self) {
+        if !self.owned {
+            return;
+        }
+        let _ = self.bind_to_thread();
+        let ctx = std::mem::replace(&mut self.cu_ctx, std::ptr::null_mut());
+        if !ctx.is_null() {
+            let _ = unsafe { primary_ctx::release(self.cu_device) };
+        }
+    }
+}
+
+impl PartialEq for Device {
+    fn eq(&self, other: &Self) -> bool {
+        self.cu_device == other.cu_device
+            && self.cu_ctx == other.cu_ctx
+            && self.ordinal == other.ordinal
+    }
+}
+impl Eq for Device {}
+
+impl Device {
+    /// Creates a new owned device on the specified ordinal.
+    pub fn new(ordinal: usize) -> Result<Arc<Self>, DriverError> {
+        unsafe { init(0)? };
+        let cu_device = device::get(ordinal as c_int)?;
+        let cu_ctx = unsafe { primary_ctx::retain(cu_device) }?;
+        let device = Arc::new(Device {
+            cu_device,
+            cu_ctx,
+            ordinal,
+            owned: true,
+        });
+        device.bind_to_thread()?;
+        Ok(device)
+    }
+
+    /// Wraps externally-owned CUDA handles without taking ownership.
+    ///
+    /// Inputs are the raw C primitives (`CUcontext` is an opaque pointer,
+    /// `CUdevice` is `int` in the driver API). Accepting primitives rather
+    /// than `cuda_bindings::CU*` typedefs keeps this API agnostic to which
+    /// binding crate the caller uses — a cudarc `CUcontext`, a fresh
+    /// `bindgen` wrapper, or a hand-rolled FFI type all cast in the same way.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure:
+    /// - `cu_ctx` points to a valid retained `CUcontext` for `cu_device`
+    /// - The handles outlive the returned `Device`
+    /// - No concurrent destruction of the handles
+    pub unsafe fn borrow_raw(cu_ctx: *mut c_void, cu_device: c_int, ordinal: usize) -> Arc<Self> {
+        Arc::new(Device {
+            cu_device: cu_device as cuda_bindings::CUdevice,
+            cu_ctx: cu_ctx as cuda_bindings::CUcontext,
+            ordinal,
+            owned: false,
+        })
+    }
+
+    /// Returns the number of CUDA-capable devices available.
+    pub fn device_count() -> Result<i32, DriverError> {
+        unsafe { init(0)? };
+        device::get_count()
+    }
+
+    /// Returns the raw `CUdevice` handle for a given ordinal without
+    /// creating a full `Device` (no context retained).
+    pub fn raw_device(ordinal: usize) -> Result<cuda_bindings::CUdevice, DriverError> {
+        unsafe { init(0)? };
+        device::get(ordinal as c_int)
+    }
+
+    /// Get the `ordinal` index of the device this is on.
+    pub fn ordinal(&self) -> usize {
+        self.ordinal
+    }
+
+    /// Get the name of this device.
+    pub fn name(&self) -> Result<String, DriverError> {
+        device::get_name(self.cu_device)
+    }
+
+    /// Returns the raw `CUdevice` handle.
+    pub fn cu_device(&self) -> cuda_bindings::CUdevice {
+        self.cu_device
+    }
+
+    /// Returns the raw `CUcontext` handle.
+    pub fn cu_ctx(&self) -> cuda_bindings::CUcontext {
+        self.cu_ctx
+    }
+
+    /// Binds this context to the calling thread if not already current.
+    pub fn bind_to_thread(&self) -> Result<(), DriverError> {
+        if match ctx::get_current()? {
+            Some(curr_ctx) => curr_ctx != self.cu_ctx,
+            None => true,
+        } {
+            unsafe { ctx::set_current(self.cu_ctx) }?;
+        }
+        Ok(())
+    }
+
+    /// Blocks until all work on this device's context is complete.
+    ///
+    /// # Safety
+    /// The caller must ensure this device's context is current on the
+    /// calling thread (via [`bind_to_thread`](Device::bind_to_thread)).
+    pub unsafe fn synchronize(&self) -> Result<(), DriverError> {
+        ctx::synchronize()
+    }
+
+    /// Creates a new non-blocking CUDA stream on this device.
+    pub fn new_stream(self: &Arc<Self>) -> Result<Arc<Stream>, DriverError> {
+        self.bind_to_thread()?;
+        let cu_stream = stream::create(stream::StreamKind::NonBlocking)?;
+        Ok(Arc::new(Stream {
+            cu_stream,
+            device: self.clone(),
+            owned: true,
+        }))
+    }
+
+    /// Loads a CUDA module from a PTX source string.
+    pub fn load_module_from_ptx_src(
+        self: &Arc<Self>,
+        ptx_src: &str,
+    ) -> Result<Arc<Module>, DriverError> {
+        self.bind_to_thread()?;
+        let cu_module = {
+            let c_src = CString::new(ptx_src).unwrap();
+            unsafe { module::load_data(c_src.as_ptr() as *const _) }
+        }?;
+        Ok(Arc::new(Module {
+            cu_module,
+            device: self.clone(),
+            owned: true,
+        }))
+    }
+
+    /// Loads a CUDA module from a file path (PTX or cubin).
+    pub fn load_module_from_file(
+        self: &Arc<Self>,
+        filename: &str,
+    ) -> Result<Arc<Module>, DriverError> {
+        self.bind_to_thread()?;
+        let cu_module = { module::load(filename) }?;
+        Ok(Arc::new(Module {
+            cu_module,
+            device: self.clone(),
+            owned: true,
+        }))
+    }
+}
+
+/// A CUDA stream handle.
+///
+/// Can be either **owned** (created via [`Device::new_stream`], destroyed
+/// on drop) or **borrowed** (created via [`Stream::borrow_raw`], does
+/// NOT destroy on drop).
+#[derive(Debug, PartialEq, Eq)]
+pub struct Stream {
+    pub(crate) cu_stream: cuda_bindings::CUstream,
+    pub(crate) device: Arc<Device>,
+    owned: bool,
+}
+
+unsafe impl Send for Stream {}
+unsafe impl Sync for Stream {}
+
+impl Drop for Stream {
+    fn drop(&mut self) {
+        if !self.owned {
+            return;
+        }
+        let _ = self.device.bind_to_thread();
+        if !self.cu_stream.is_null() {
+            let _ = unsafe { stream::destroy(self.cu_stream) };
+        }
+    }
+}
+
+impl Stream {
+    /// Wraps an externally-owned CUDA stream without taking ownership.
+    ///
+    /// `cu_stream` is the raw `CUstream` opaque pointer. See
+    /// [`Device::borrow_raw`] for why this is a `*mut c_void` rather than a
+    /// `cuda_bindings::CUstream` typedef.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure:
+    /// - `cu_stream` points to a valid CUDA stream on `device`
+    /// - The stream outlives the returned `Stream`
+    /// - No concurrent destruction of the stream
+    pub unsafe fn borrow_raw(cu_stream: *mut c_void, device: &Arc<Device>) -> Arc<Self> {
+        Arc::new(Stream {
+            cu_stream: cu_stream as cuda_bindings::CUstream,
+            device: device.clone(),
+            owned: false,
+        })
+    }
+
+    /// Returns the raw `CUstream` handle.
+    pub fn cu_stream(&self) -> cuda_bindings::CUstream {
+        self.cu_stream
+    }
+
+    /// Returns a reference to the parent device.
+    pub fn device(&self) -> &Arc<Device> {
+        &self.device
+    }
+
+    /// Blocks until all work on this stream is complete.
+    ///
+    /// # Safety
+    /// The caller must ensure the parent device's context is current on
+    /// the calling thread.
+    pub unsafe fn synchronize(&self) -> Result<(), DriverError> {
+        stream::synchronize(self.cu_stream)
+    }
+
+    /// Enqueues a host-side callback to execute after all prior stream work completes.
+    ///
+    /// # Safety
+    /// The caller must ensure the parent device's context is current on
+    /// the calling thread.
+    pub unsafe fn launch_host_function<F: FnOnce() + Send>(
+        &self,
+        host_func: F,
+    ) -> Result<(), DriverError> {
+        let boxed_host_func = Box::new(host_func);
+        stream::launch_host_function(
+            self.cu_stream,
+            Self::callback_wrapper::<F>,
+            Box::into_raw(boxed_host_func) as *mut c_void,
+        )
+    }
+
+    unsafe extern "C" fn callback_wrapper<F: FnOnce() + Send>(callback: *mut c_void) {
+        let _ = std::panic::catch_unwind(|| {
+            let callback: Box<F> = Box::from_raw(callback as *mut F);
+            callback();
+        });
+    }
+
+    /// Begins stream capture for CUDA graph construction.
+    ///
+    /// # Safety
+    /// The caller must ensure the context is current and the stream is not
+    /// already being captured.
+    pub unsafe fn begin_capture(
+        &self,
+        mode: cuda_bindings::CUstreamCaptureMode,
+    ) -> Result<(), DriverError> {
+        stream::begin_capture(self.cu_stream, mode)
+    }
+
+    /// Ends stream capture and returns the captured CUDA graph.
+    ///
+    /// # Safety
+    /// The caller must ensure `begin_capture` was previously called on this stream.
+    pub unsafe fn end_capture(&self) -> Result<cuda_bindings::CUgraph, DriverError> {
+        stream::end_capture(self.cu_stream)
+    }
+}
+
+/// A loaded CUDA module (PTX/cubin).
+///
+/// Can be either **owned** (created via [`Device::load_module_from_ptx_src`]
+/// / [`Device::load_module_from_file`], unloads on drop) or **borrowed**
+/// (created via [`Module::borrow_raw`], does NOT unload on drop).
+#[derive(Debug)]
+pub struct Module {
+    pub(crate) cu_module: cuda_bindings::CUmodule,
+    pub(crate) device: Arc<Device>,
+    owned: bool,
+}
+
+unsafe impl Send for Module {}
+unsafe impl Sync for Module {}
+
+impl Drop for Module {
+    fn drop(&mut self) {
+        if !self.owned {
+            return;
+        }
+        let _ = self.device.bind_to_thread();
+        let _ = unsafe { module::unload(self.cu_module) };
+    }
+}
+
+impl Module {
+    /// Wraps an externally-owned CUDA module without taking ownership.
+    ///
+    /// `cu_module` is the raw `CUmodule` opaque pointer. See
+    /// [`Device::borrow_raw`] for why this is a `*mut c_void`.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure:
+    /// - `cu_module` points to a valid module loaded on `device`
+    /// - The module outlives the returned `Module`
+    /// - No concurrent unload of the module
+    pub unsafe fn borrow_raw(cu_module: *mut c_void, device: &Arc<Device>) -> Arc<Self> {
+        Arc::new(Module {
+            cu_module: cu_module as cuda_bindings::CUmodule,
+            device: device.clone(),
+            owned: false,
+        })
+    }
+
+    /// Returns the raw `CUmodule` handle.
+    pub fn cu_module(&self) -> cuda_bindings::CUmodule {
+        self.cu_module
+    }
+
+    /// Looks up a device function by name within this module.
+    pub fn load_function(self: &Arc<Self>, fn_name: &str) -> Result<Function, DriverError> {
+        let cu_function = unsafe { module::get_function(self.cu_module, fn_name) }?;
+        Ok(Function {
+            cu_function,
+            module: self.clone(),
+        })
+    }
+}
+
+/// Handle to a device function loaded from a [`Module`].
+#[derive(Debug, Clone)]
+pub struct Function {
+    pub(crate) cu_function: cuda_bindings::CUfunction,
+    #[allow(unused)]
+    pub(crate) module: Arc<Module>,
+}
+
+unsafe impl Send for Function {}
+unsafe impl Sync for Function {}
+
+impl Function {
+    /// Wraps an externally-owned CUDA function without taking ownership.
+    ///
+    /// `cu_function` is the raw `CUfunction` opaque pointer. The returned
+    /// `Function` holds a clone of `module` to keep the parent alive;
+    /// there is no `owned` flag because `Function` has no `Drop` (functions
+    /// are not freed independently — they live as long as their module).
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure:
+    /// - `cu_function` points to a valid function within `module`
+    /// - `module` is the module that `cu_function` was obtained from
+    pub unsafe fn borrow_raw(cu_function: *mut c_void, module: &Arc<Module>) -> Function {
+        Function {
+            cu_function: cu_function as cuda_bindings::CUfunction,
+            module: module.clone(),
+        }
+    }
+
+    /// Returns the raw `CUfunction` handle.
+    ///
+    /// # Safety
+    /// The caller must not use the handle after the parent module is dropped.
+    pub unsafe fn cu_function(&self) -> cuda_bindings::CUfunction {
+        self.cu_function
+    }
+}

--- a/cuda-core/tests/borrow_raw.rs
+++ b/cuda-core/tests/borrow_raw.rs
@@ -1,0 +1,130 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Verifies the ownership contract of `Device::borrow_raw` and
+//! `Stream::borrow_raw`: dropping a borrowed wrapper must not release the
+//! primary context or destroy the stream, so the source handles keep
+//! working afterward.
+
+use core::ffi::{c_int, c_void};
+use cuda_core::{Device, Function, Module, Stream};
+
+const NOOP_PTX: &str = "\
+.version 7.0
+.target sm_52
+.address_size 64
+
+.visible .entry noop()
+{
+    ret;
+}
+";
+
+fn has_gpu() -> bool {
+    Device::device_count().map(|n| n > 0).unwrap_or(false)
+}
+
+fn borrow_device(src: &Device) -> std::sync::Arc<Device> {
+    unsafe {
+        Device::borrow_raw(
+            src.cu_ctx() as *mut c_void,
+            src.cu_device() as c_int,
+            src.ordinal(),
+        )
+    }
+}
+
+fn borrow_stream(src: &Stream, dev: &std::sync::Arc<Device>) -> std::sync::Arc<Stream> {
+    unsafe { Stream::borrow_raw(src.cu_stream() as *mut c_void, dev) }
+}
+
+#[test]
+fn borrowed_drop_leaves_source_device_usable() {
+    if !has_gpu() {
+        return;
+    }
+    let source = Device::new(0).unwrap();
+
+    {
+        let borrowed = borrow_device(&source);
+        borrowed.bind_to_thread().unwrap();
+        unsafe { borrowed.synchronize() }.unwrap();
+    }
+
+    source.bind_to_thread().unwrap();
+    unsafe { source.synchronize() }.unwrap();
+    let _stream = source.new_stream().unwrap();
+}
+
+#[test]
+fn borrowed_drop_leaves_source_stream_usable() {
+    if !has_gpu() {
+        return;
+    }
+    let source_dev = Device::new(0).unwrap();
+    let source_stream = source_dev.new_stream().unwrap();
+
+    {
+        let borrowed_dev = borrow_device(&source_dev);
+        let borrowed_stream = borrow_stream(&source_stream, &borrowed_dev);
+        unsafe { borrowed_stream.synchronize() }.unwrap();
+    }
+
+    unsafe { source_stream.synchronize() }.unwrap();
+}
+
+#[test]
+fn borrowed_module_drop_does_not_unload() {
+    if !has_gpu() {
+        return;
+    }
+    let source_dev = Device::new(0).unwrap();
+    let source_module = source_dev.load_module_from_ptx_src(NOOP_PTX).unwrap();
+
+    {
+        let borrowed =
+            unsafe { Module::borrow_raw(source_module.cu_module() as *mut c_void, &source_dev) };
+        // Looking up a function through the borrowed wrapper exercises the
+        // raw CUmodule handle.
+        let _f = borrowed.load_function("noop").unwrap();
+    }
+
+    // If the borrowed drop had unloaded the module, this lookup would fail.
+    let _f = source_module.load_function("noop").unwrap();
+}
+
+#[test]
+fn borrowed_function_uses_parent_module() {
+    if !has_gpu() {
+        return;
+    }
+    let source_dev = Device::new(0).unwrap();
+    let source_module = source_dev.load_module_from_ptx_src(NOOP_PTX).unwrap();
+    let source_fn = source_module.load_function("noop").unwrap();
+
+    let raw_fn = unsafe { source_fn.cu_function() } as *mut c_void;
+    let borrowed_fn = unsafe { Function::borrow_raw(raw_fn, &source_module) };
+    assert_eq!(unsafe { borrowed_fn.cu_function() }, unsafe {
+        source_fn.cu_function()
+    });
+}
+
+#[test]
+fn many_borrowed_drops_do_not_invalidate_source() {
+    if !has_gpu() {
+        return;
+    }
+    let source_dev = Device::new(0).unwrap();
+    let source_stream = source_dev.new_stream().unwrap();
+
+    for _ in 0..8 {
+        let borrowed_dev = borrow_device(&source_dev);
+        let borrowed_stream = borrow_stream(&source_stream, &borrowed_dev);
+        unsafe { borrowed_stream.synchronize() }.unwrap();
+    }
+
+    unsafe { source_stream.synchronize() }.unwrap();
+    let _another = source_dev.new_stream().unwrap();
+}

--- a/cutile-benchmarks/benches/execution_lock.rs
+++ b/cutile-benchmarks/benches/execution_lock.rs
@@ -14,7 +14,7 @@ use cuda_async::device_operation::{value, DeviceOp};
 use std::time::Duration;
 
 fn has_gpu() -> bool {
-    cuda_core::CudaContext::device_count()
+    cuda_core::Device::device_count()
         .map(|n| n > 0)
         .unwrap_or(false)
 }
@@ -27,8 +27,8 @@ fn bench_execution_lock(c: &mut Criterion) {
 
     // Run on a fresh thread to get a clean CUDA context.
     let (stream,) = std::thread::spawn(|| {
-        let ctx = cuda_core::CudaContext::new(0).unwrap();
-        let stream = ctx.new_stream().unwrap();
+        let device = cuda_core::Device::new(0).unwrap();
+        let stream = device.new_stream().unwrap();
         (stream,)
     })
     .join()
@@ -55,7 +55,7 @@ fn bench_execution_lock(c: &mut Criterion) {
     group.bench_function("async_on_no_lock", |b| {
         b.iter(|| {
             unsafe { value(42).async_on(&stream).unwrap() };
-            stream.synchronize().unwrap();
+            unsafe { stream.synchronize() }.unwrap();
         });
     });
 

--- a/cutile-benchmarks/benches/fmha.rs
+++ b/cutile-benchmarks/benches/fmha.rs
@@ -4,7 +4,7 @@
  */
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use cuda_async::device_operation::DeviceOp;
-use cuda_core::CudaContext;
+use cuda_core::Device;
 use cutile::api::{randn_f16, zeros};
 use cutile::core::f16;
 use cutile::tensor::{IntoPartition, Partition, Tensor};
@@ -153,8 +153,8 @@ fn ocean_fmha(c: &mut Criterion) {
             .measurement_time(Duration::from_millis(2000));
     }
 
-    let ctx = CudaContext::new(0).expect("Failed to get context.");
-    let stream = ctx.new_stream().expect("Failed to get stream.");
+    let device = Device::new(0).expect("Failed to get device.");
+    let stream = device.new_stream().expect("Failed to get stream.");
 
     // This is what the ocean benchmark uses.
     let context_lengths = (0..6).map(|i| (2usize.pow(10 + i),)).collect::<Vec<_>>();
@@ -232,7 +232,7 @@ fn ocean_fmha(c: &mut Criterion) {
                         out.grid().expect("Invalid grid."),
                         ((b * h) as u32, (m / bm) as u32, 1)
                     );
-                    stream.synchronize().expect("Failed to synchronize.");
+                    unsafe { stream.synchronize() }.expect("Failed to synchronize.");
                     let start = Instant::now();
                     for _i in 0..iters {
                         let (_, _, _, out_local, _, _) = unsafe {
@@ -250,7 +250,7 @@ fn ocean_fmha(c: &mut Criterion) {
                         };
                         out = out_local;
                     }
-                    stream.synchronize().expect("Failed to synchronize.");
+                    unsafe { stream.synchronize() }.expect("Failed to synchronize.");
                     start.elapsed()
                 });
             },

--- a/cutile-benchmarks/benches/fmha_causal.rs
+++ b/cutile-benchmarks/benches/fmha_causal.rs
@@ -4,7 +4,7 @@
  */
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use cuda_async::device_operation::DeviceOp;
-use cuda_core::CudaContext;
+use cuda_core::Device;
 use cutile::api::{randn_f16, zeros};
 use cutile::core::f16;
 use cutile::tensor::{IntoPartition, Partition, Tensor};
@@ -152,8 +152,8 @@ fn ocean_fmha_causal(c: &mut Criterion) {
             .measurement_time(Duration::from_millis(2000));
     }
 
-    let ctx = CudaContext::new(0).expect("Failed to get context.");
-    let stream = ctx.new_stream().expect("Failed to get stream.");
+    let device = Device::new(0).expect("Failed to get device.");
+    let stream = device.new_stream().expect("Failed to get stream.");
 
     // This is what the ocean benchmark uses.
     let context_lengths = (0..6).map(|i| (2usize.pow(10 + i),)).collect::<Vec<_>>();
@@ -242,7 +242,7 @@ fn ocean_fmha_causal(c: &mut Criterion) {
                         out.grid().expect("Invalid grid."),
                         ((b * h) as u32, (m / bm) as u32, 1)
                     );
-                    stream.synchronize().expect("Failed to synchronize.");
+                    unsafe { stream.synchronize() }.expect("Failed to synchronize.");
                     let start = Instant::now();
                     for _i in 0..iters {
                         let (_, _, _, out_local, _, _, _) = unsafe {
@@ -261,7 +261,7 @@ fn ocean_fmha_causal(c: &mut Criterion) {
                         };
                         out = out_local;
                     }
-                    stream.synchronize().expect("Failed to synchronize.");
+                    unsafe { stream.synchronize() }.expect("Failed to synchronize.");
                     start.elapsed()
                 });
             },

--- a/cutile-benchmarks/benches/gemm.rs
+++ b/cutile-benchmarks/benches/gemm.rs
@@ -4,7 +4,7 @@
  */
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use cuda_async::device_operation::{value, DeviceOp};
-use cuda_core::CudaContext;
+use cuda_core::Device;
 use cutile::api;
 use cutile::core::f16;
 use cutile::tile_kernel::{PartitionOp, TileKernel};
@@ -91,8 +91,8 @@ fn ocean_gemm(c: &mut Criterion) {
             .measurement_time(Duration::from_millis(2000));
     }
 
-    let ctx = CudaContext::new(0).expect("Failed to get context.");
-    let stream = ctx.new_stream().expect("Failed to get stream.");
+    let device = Device::new(0).expect("Failed to get device.");
+    let stream = device.new_stream().expect("Failed to get stream.");
 
     // This is what the ocean benchmark uses.
     let shapes = (0..6)
@@ -135,7 +135,7 @@ fn ocean_gemm(c: &mut Criterion) {
                     .partition([bm, bn])
                     .sync_on(&stream)
                     .expect("Failed.");
-                stream.synchronize().expect("Failed to synchronize.");
+                unsafe { stream.synchronize() }.expect("Failed to synchronize.");
                 let start = Instant::now();
                 for _i in 0..iters {
                     unsafe {
@@ -146,7 +146,7 @@ fn ocean_gemm(c: &mut Criterion) {
                         z = local_z;
                     }
                 }
-                stream.synchronize().expect("Failed to synchronize.");
+                unsafe { stream.synchronize() }.expect("Failed to synchronize.");
                 start.elapsed()
             });
         });

--- a/cutile-benchmarks/benches/launch_overhead.rs
+++ b/cutile-benchmarks/benches/launch_overhead.rs
@@ -15,7 +15,7 @@
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use cuda_async::device_operation::DeviceOp;
-use cuda_core::CudaContext;
+use cuda_core::Device;
 use cutile::api;
 use cutile::core::f16;
 use cutile::tensor::{IntoPartition, Partition, Tensor};
@@ -63,8 +63,8 @@ fn launch_overhead(c: &mut Criterion) {
             .measurement_time(Duration::from_millis(2000));
     }
 
-    let ctx = CudaContext::new(0).expect("Failed to get context.");
-    let stream = ctx.new_stream().expect("Failed to get stream.");
+    let device = Device::new(0).expect("Failed to get device.");
+    let stream = device.new_stream().expect("Failed to get stream.");
 
     let n: usize = 1024;
     let (bm, bn, bk) = (128, 128, 64);
@@ -100,17 +100,17 @@ fn launch_overhead(c: &mut Criterion) {
             z = local_z;
         }
     }
-    stream.synchronize().expect("Failed.");
+    unsafe { stream.synchronize() }.expect("Failed.");
     std::thread::sleep(Duration::from_millis(200));
 
-    // 1. sync_on: execute + stream.synchronize(), no callbacks.
+    // 1. sync_on: execute + unsafe { stream.synchronize() }, no callbacks.
     group.bench_function(BenchmarkId::new("mode", "sync_on"), |b| {
         b.iter_custom(|iters| {
             let mut z: Partition<Tensor<f16>> = api::zeros::<f16>(&[n, n])
                 .sync_on(&stream)
                 .expect("Failed.")
                 .partition([bm, bn]);
-            stream.synchronize().expect("Failed.");
+            unsafe { stream.synchronize() }.expect("Failed.");
             let start = Instant::now();
             for _ in 0..iters {
                 let (local_z, _, _, _) = unsafe {
@@ -146,7 +146,7 @@ fn launch_overhead(c: &mut Criterion) {
             }
         });
     }
-    stream.synchronize().expect("Failed.");
+    unsafe { stream.synchronize() }.expect("Failed.");
     std::thread::sleep(Duration::from_millis(200));
 
     // 2. await: execute on first poll + cuLaunchHostFunc callback.
@@ -157,7 +157,7 @@ fn launch_overhead(c: &mut Criterion) {
                     .sync_on(&stream)
                     .expect("Failed.")
                     .partition([bm, bn]);
-                stream.synchronize().expect("Failed.");
+                unsafe { stream.synchronize() }.expect("Failed.");
                 let start = Instant::now();
                 for _ in 0..iters {
                     let (local_z, _, _, _) = unsafe {
@@ -188,7 +188,7 @@ fn launch_overhead(c: &mut Criterion) {
             }
         }
     }
-    stream.synchronize().expect("Failed.");
+    unsafe { stream.synchronize() }.expect("Failed.");
     std::thread::sleep(Duration::from_millis(200));
 
     // 3. async_on: execute only, single synchronize at end.
@@ -198,7 +198,7 @@ fn launch_overhead(c: &mut Criterion) {
                 .sync_on(&stream)
                 .expect("Failed.")
                 .partition([bm, bn]);
-            stream.synchronize().expect("Failed.");
+            unsafe { stream.synchronize() }.expect("Failed.");
             let start = Instant::now();
             for _ in 0..iters {
                 unsafe {
@@ -209,7 +209,7 @@ fn launch_overhead(c: &mut Criterion) {
                     z = local_z;
                 }
             }
-            stream.synchronize().expect("Failed.");
+            unsafe { stream.synchronize() }.expect("Failed.");
             start.elapsed()
         });
     });

--- a/cutile-benchmarks/benches/rmsnorm.rs
+++ b/cutile-benchmarks/benches/rmsnorm.rs
@@ -4,7 +4,7 @@
  */
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use cuda_async::device_operation::DeviceOp;
-use cuda_core::CudaContext;
+use cuda_core::Device;
 use cutile::api::{randn_f16, zeros};
 use cutile::core::f16;
 use cutile::tensor::{IntoPartition, Partition, Tensor};
@@ -80,8 +80,8 @@ fn ocean_rmsnorm(c: &mut Criterion) {
             .measurement_time(Duration::from_millis(2000));
     }
 
-    let ctx = CudaContext::new(0).expect("Failed to get context.");
-    let stream = ctx.new_stream().expect("Failed to get stream.");
+    let device = Device::new(0).expect("Failed to get device.");
+    let stream = device.new_stream().expect("Failed to get stream.");
 
     let shapes = (0..6)
         .map(|i| (4096, 2usize.pow(10 + i)))
@@ -111,7 +111,7 @@ fn ocean_rmsnorm(c: &mut Criterion) {
                     .sync_on(&stream)
                     .expect("Failed.")
                     .partition([1, n]);
-                stream.synchronize().expect("Failed to synchronize.");
+                unsafe { stream.synchronize() }.expect("Failed to synchronize.");
                 let start = Instant::now();
                 for _i in 0..iters {
                     unsafe {
@@ -122,7 +122,7 @@ fn ocean_rmsnorm(c: &mut Criterion) {
                         out = local_out;
                     }
                 }
-                stream.synchronize().expect("Failed to synchronize.");
+                unsafe { stream.synchronize() }.expect("Failed to synchronize.");
                 start.elapsed()
             });
         });

--- a/cutile-benchmarks/benches/softmax.rs
+++ b/cutile-benchmarks/benches/softmax.rs
@@ -4,7 +4,7 @@
  */
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use cuda_async::device_operation::DeviceOp;
-use cuda_core::CudaContext;
+use cuda_core::Device;
 use cutile::api::{randn_f16, zeros};
 use cutile::core::f16;
 use cutile::tensor::{IntoPartition, Partition, Tensor};
@@ -49,8 +49,8 @@ fn softmax(c: &mut Criterion) {
             .measurement_time(Duration::from_millis(2000));
     }
 
-    let ctx = CudaContext::new(0).expect("Failed to get context.");
-    let stream = ctx.new_stream().expect("Failed to get stream.");
+    let device = Device::new(0).expect("Failed to get device.");
+    let stream = device.new_stream().expect("Failed to get stream.");
 
     let shapes = (0..6)
         .map(|i| (4096, 2usize.pow(10 + i)))
@@ -82,7 +82,7 @@ fn softmax(c: &mut Criterion) {
                         .sync_on(&stream)
                         .expect("Failed.")
                         .partition([bm, bn]);
-                    stream.synchronize().expect("Failed to synchronize.");
+                    unsafe { stream.synchronize() }.expect("Failed to synchronize.");
                     let start = Instant::now();
                     for _i in 0..iters {
                         unsafe {
@@ -93,7 +93,7 @@ fn softmax(c: &mut Criterion) {
                             out = local_out;
                         }
                     }
-                    stream.synchronize().expect("Failed to synchronize.");
+                    unsafe { stream.synchronize() }.expect("Failed to synchronize.");
                     start.elapsed()
                 });
             },

--- a/cutile-book/README.md
+++ b/cutile-book/README.md
@@ -1,3 +1,7 @@
+---
+orphan: true
+---
+
 # The cuTile Rust Book
 
 This directory contains the source for the cuTile Rust Book. To build the book:

--- a/cutile-book/_static/images/compilation-pipeline.svg
+++ b/cutile-book/_static/images/compilation-pipeline.svg
@@ -164,11 +164,11 @@
     
     <g transform="translate(14, 44)" font-family="'RobotoMono', monospace" font-size="10" fill="#374151">
       <text fill="#dc2626">let</text>
-      <text x="22">ctx =</text>
-      <text x="52" fill="#2563eb">CudaContext</text>
-      <text x="118">::new(0)?;</text>
+      <text x="22">device =</text>
+      <text x="76" fill="#2563eb">Device</text>
+      <text x="112">::new(0)?;</text>
       <text y="18" fill="#dc2626">let</text>
-      <text x="22" y="18">stream = ctx.new_stream()?;</text>
+      <text x="22" y="18">stream = device.new_stream()?;</text>
       <text y="38" fill="#dc2626">let</text>
       <text x="22" y="38">launcher =</text>
       <text x="90" y="38" fill="#7c3aed">compute</text>

--- a/cutile-book/conf.py
+++ b/cutile-book/conf.py
@@ -22,6 +22,9 @@ myst_enable_extensions = [
     "attrs_inline",
 ]
 
+# Auto-generate anchors for H1–H3 so inline `#slug` links resolve.
+myst_heading_anchors = 3
+
 # Source files can be .rst or .md
 source_suffix = {
     '.rst': 'restructuredtext',

--- a/cutile-book/guide/async-execution.md
+++ b/cutile-book/guide/async-execution.md
@@ -1,3 +1,7 @@
+---
+orphan: true
+---
+
 # Async Execution
 
 Understanding cuTile Rust's async execution model is essential for writing efficient GPU programs.
@@ -20,8 +24,8 @@ This separation is fundamental: your Rust code runs on the CPU and schedules wor
 A **stream** is a sequence of operations that execute in order on the GPU:
 
 ```rust
-let ctx = CudaContext::new(0)?;      // Connect to GPU device 0
-let stream = ctx.new_stream()?;       // Create a work queue
+let device = Device::new(0)?;      // Connect to GPU device 0
+let stream = device.new_stream()?;       // Create a work queue
 ```
 
 Key properties of streams:
@@ -488,7 +492,7 @@ let result = allocate_tensor()
 When you pass the same stream to multiple `.sync_on()` calls, all operations serialize on that stream:
 
 ```rust
-let stream = ctx.new_stream()?;
+let stream = device.new_stream()?;
 
 let a = op_a.sync_on(&stream);  // Stream X: runs first
 let b = op_b.sync_on(&stream);  // Stream X: waits for op_a
@@ -552,7 +556,7 @@ let tensor = create_tensor().await;
 let result = process(tensor).await;
 
 // Pattern 3: Pin to the same stream — CUDA guarantees ordering
-let stream = ctx.new_stream()?;
+let stream = device.new_stream()?;
 let tensor = create_tensor().sync_on(&stream);
 let result = process(tensor).sync_on(&stream);
 ```
@@ -614,8 +618,8 @@ let (result, next_buffer) = tokio::join!(compute_op, transfer_op);
 For explicit control, create dedicated streams:
 
 ```rust
-let compute_stream = ctx.new_stream()?;
-let transfer_stream = ctx.new_stream()?;
+let compute_stream = device.new_stream()?;
+let transfer_stream = device.new_stream()?;
 
 let result = heavy_kernel(input).sync_on(&compute_stream);
 let next_batch = load_data().sync_on(&transfer_stream); // overlaps!

--- a/cutile-book/guide/data-model.md
+++ b/cutile-book/guide/data-model.md
@@ -1,3 +1,7 @@
+---
+orphan: true
+---
+
 # Data Model & Types
 
 cuTile Rust leverages Rust's type system to catch errors at compile time. Shape mismatches, type errors, and many common GPU programming bugs are caught before your code even runs.
@@ -505,4 +509,4 @@ let expanded = scalar.broadcast(const_shape![64, 64]);
 
 - See [Operations](operations.md) for available tile operations
 - Learn about [Memory Hierarchy](memory-hierarchy.md) for performance
-- Explore the [Syntax Reference](../appendix/syntax-reference.md) for complete API
+- Explore the [Syntax Reference](../reference/syntax-reference.md) for complete API

--- a/cutile-book/guide/debugging.md
+++ b/cutile-book/guide/debugging.md
@@ -35,8 +35,8 @@ cuda_tile_assert!(tile[0] > 0.0, "Value must be positive");
 **Read back to the host** to inspect results after kernel execution:
 
 ```rust
-let ctx = CudaContext::new(0)?;
-let stream = ctx.new_stream()?;
+let device = Device::new(0)?;
+let stream = device.new_stream()?;
 
 let x: Arc<Tensor<f32>> = ones(&[32, 32]).map(Into::into).sync_on(&stream)?;
 let z = zeros(&[32, 32]).sync_on(&stream)?.partition([4, 4]);
@@ -203,4 +203,4 @@ Pre-ship debugging checklist: shapes compatible (tile shapes match for operation
 
 ---
 
-Review [Tuning for Performance](performance-tuning.md) for optimization techniques, [Integrating with CUDA C++](interoperability.md) for custom CUDA kernels, the [DSL API](../reference/dsl-api.md) and [Host API](../reference/host-api.md) for API lookups, or the [Tutorials](../tutorials/01-hello-world.md) for worked examples.
+Review [Tuning for Performance](performance-tuning.md) for optimization techniques, [Interoperability](interoperability.md) for custom CUDA kernels, the [DSL API](../reference/dsl-api.md) and [Host API](../reference/host-api.md) for API lookups, or the [Tutorials](../tutorials/01-hello-world.md) for worked examples.

--- a/cutile-book/guide/device-operations.md
+++ b/cutile-book/guide/device-operations.md
@@ -1,8 +1,8 @@
-# Orchestrating Device Operations
+# Device Operations
 
-A `DeviceOp` is the host-side handle for GPU work: it describes a computation lazily, composes with other `DeviceOp`s on the host, and then runs when you choose how. Every host-side API that returns a future (`api::zeros`, kernel launchers, `.then()` / `.shared()` / `unzip`) produces a `DeviceOp`.
+`DeviceOp` is how you describe and compose GPU work on the host. Every host-side API that returns a future — `api::zeros`, kernel launchers, and the `.then()` / `.shared()` / `zip!` / `unzip` combinators — produces one. Composition is decoupled from execution: you build the operation graph with combinators, then run it in one of three peer modes — `.sync()` (blocking), `.await` (async), or `.graph()` (capture once, launch many).
 
-This chapter covers the `DeviceOp` model and the three ways to execute one, how to compose `DeviceOp`s into larger computation graphs, the stream scheduling rules that determine ordering and overlap, and practical patterns for tensor ownership and synchronization.
+This chapter covers the `DeviceOp` model, composition, stream scheduling, CUDA graph capture, and the runtime state worth knowing about.
 
 ---
 
@@ -143,16 +143,7 @@ let result = step1(args)
     .await?;
 ```
 
-**CUDA graph** — `.graph_on(&stream)` records a `DeviceOp` chain as a CUDA graph once and replays with minimal launch overhead. For hot paths like per-token inference loops that run the same pipeline many times.
-
-```rust
-let graph = pipeline(input).graph_on(&stream)?;
-for _ in 0..iterations {
-    graph.launch(&stream)?;  // replay — no per-op dispatch
-}
-```
-
-See [CUDA Graph Integration in the Host API](../reference/host-api.md#cuda-graph-integration) and [Tutorial 10](../tutorials/10-cuda-graphs.md) for the graph API in detail.
+**CUDA graph** — `.graph()` / `.graph_on(&stream)` captures a composed `DeviceOp` into a reusable `CudaGraph<T>`. Best for hot paths that run the same pipeline many times. See [CUDA Graphs](#cuda-graphs) below for the capture/replay pattern.
 
 ---
 
@@ -257,7 +248,7 @@ let tensor = create_tensor().await;
 let result = process(tensor).await;
 
 // Pin to the same stream — CUDA guarantees ordering
-let stream = ctx.new_stream()?;
+let stream = device.new_stream()?;
 let tensor = create_tensor().sync_on(&stream);
 let result = process(tensor).sync_on(&stream);
 ```
@@ -284,6 +275,39 @@ let (a, b) = tokio::join!(future_a, future_b);
 :::{tip}
 Sequential `.await` calls *appear* ordered from the host's perspective (each waits before the next starts), but the GPU work for each `.await` runs on whichever stream the policy assigns. For truly independent operations you want to overlap, use `zip!` or `tokio::join!`.
 :::
+
+---
+
+## CUDA Graphs
+
+A CUDA graph captures a composed `DeviceOp` into a pre-compiled executable. Launching the executable submits the entire graph in a single driver call — no per-op dispatch overhead — and the same graph can be replayed many times. This matters for hot paths like per-token inference loops, where individual kernels run in microseconds and launch overhead dominates.
+
+Two capture APIs, depending on how you want to express the pipeline:
+
+```rust
+// Combinator form — capture what a DeviceOp chain produces.
+let graph = pipeline(input).graph_on(&stream)?;
+
+// Scope form — imperative capture when you need &mut between steps.
+let graph = CudaGraph::scope(&stream, |s| {
+    s.record(kernel_a((&mut out_a).partition([32]), x.clone()))?;
+    s.record(kernel_b((&mut out_b).partition([32]), x))?;
+    Ok(())
+})?;
+```
+
+Once captured, replay with `graph.launch()`, which returns a `DeviceOp` you can sync, await, or compose further. For parameterized replay — the common "change one input per step" case — `graph.update(new_op)` rewrites the graph's inputs in place without re-instantiating:
+
+```rust
+for token in tokens {
+    graph.update(api::memcpy(&mut model.input, &token))?;
+    graph.launch().sync_on(&stream)?;  // no per-op dispatch
+}
+```
+
+Only operations that implement the `GraphNode` trait can be recorded: kernel launches and `memcpy`. Allocation operations (`api::zeros`, `api::ones`, etc.) are not graph-safe — allocate outside the capture closure and pass the tensors in. Inside a `scope` body, calling `.sync_on(...)`, `.sync()`, or `.await` on any `DeviceOp` returns a `DeviceError`: the execution lock rejects nested execution during capture.
+
+See [Tutorial 10: CUDA Graphs](../tutorials/10-cuda-graphs.md) for a walkthrough and [Host API: CUDA Graph Integration](../reference/host-api.md#cuda-graph-integration) for the full API reference.
 
 ---
 
@@ -336,6 +360,16 @@ let data = z.to_host_vec().sync_on(&stream);  // ✅ Waits for completion
 ```
 
 Common pitfalls: syncing per operation in hot paths (build a graph and sync once instead); forgetting to compose for overlap (use `zip!` or `tokio::join!` for independent work); calling `.await` sequentially when operations are actually independent (this effectively serializes them across streams).
+
+---
+
+## Runtime Notes
+
+**Execution lock.** cuTile enforces "only one `DeviceOp` executes per thread at a time." Nesting `.sync_on(...)`, `.sync()`, or `.await` inside a `.then(...)` closure or a `CudaGraph::scope` body returns a `DeviceError`. The lock exists to prevent cross-stream data races: a nested `sync_on(&other_stream)` inside a `.then()` handler would submit work to a second stream without ordering it against the first. For the rare legitimate case, use `unsafe fn then_unchecked`.
+
+**Default device.** The device each `DeviceOp` lands on is thread-local. `set_default_device(id)` changes it for the current thread — the common pattern for one-thread-per-GPU worker pools. For per-op routing without touching the thread default, `with_device(id, |device| …)` runs a closure against a specific device's scheduling policy.
+
+Handles from other frameworks (cudarc, Candle, hand-rolled FFI) can be wrapped into a cuTile `Device` or `Stream` without transferring ownership via `Device::borrow_raw` / `Stream::borrow_raw` — see [Interoperability](interoperability.md).
 
 ---
 

--- a/cutile-book/guide/deviceop-reference.md
+++ b/cutile-book/guide/deviceop-reference.md
@@ -1,3 +1,7 @@
+---
+orphan: true
+---
+
 # DeviceOp API Reference
 
 Quick-reference for the `DeviceOp` trait and its combinators. For a
@@ -260,7 +264,7 @@ Bypasses the policy entirely. All operations given the same stream execute
 in call order:
 
 ```rust
-let stream = ctx.new_stream()?;
+let stream = device.new_stream()?;
 let a = op_a.sync_on(&stream)?;  // Stream X
 let b = op_b.sync_on(&stream)?;  // Stream X — guaranteed after op_a
 ```

--- a/cutile-book/guide/dsl-api.md
+++ b/cutile-book/guide/dsl-api.md
@@ -1,3 +1,7 @@
+---
+orphan: true
+---
+
 # DSL API Reference
 
 > **Status**: This API is under active development. Expect changes.

--- a/cutile-book/guide/execution-model.md
+++ b/cutile-book/guide/execution-model.md
@@ -18,7 +18,7 @@ The abstract machine maps to CUDA like this:
 
 The mapping of the grid and individual tile blocks to underlying hardware threads is abstracted away and handled by the compiler: thread block and cluster configuration, register allocation, shared memory staging, memory coalescing, and Tensor Core utilization.
 
-Execution happens across two spaces: the **host side** (CPU) allocates GPU memory, launches kernels, manages data transfers, and coordinates async operations; the **device side** (GPU) concurrently runs kernel code on tile blocks, operating on tiles in registers and accessing global memory through tensors. See [Orchestrating Device Operations](device-operations.md) for the host-side execution story.
+Execution happens across two spaces: the **host side** (CPU) allocates GPU memory, launches kernels, manages data transfers, and coordinates async operations; the **device side** (GPU) concurrently runs kernel code on tile blocks, operating on tiles in registers and accessing global memory through tensors. See [Device Operations](device-operations.md) for the host-side execution story.
 
 ---
 
@@ -103,4 +103,4 @@ Compile-time constants drive specialization: each unique combination of const ge
 
 ---
 
-Continue to [Orchestrating Device Operations](device-operations.md) for the host-side execution story. For tuning tile sizes and architecture-specific hints, see [Tuning for Performance](performance-tuning.md).
+Continue to [Device Operations](device-operations.md) for the host-side execution story. For tuning tile sizes and architecture-specific hints, see [Tuning for Performance](performance-tuning.md).

--- a/cutile-book/guide/interoperability.md
+++ b/cutile-book/guide/interoperability.md
@@ -1,6 +1,12 @@
-# Integrating with CUDA C++
+# Interoperability
 
-The tile model handles dense tensor algebra well — GEMM, element-wise operations, reductions, convolutions — but some algorithms depend on **warp-level primitives** (`__shfl_sync`, `__ballot_sync`, `__reduce_sync`) for things like custom scan/prefix-sum, cooperative groups, or irregular data access patterns. For these, write the kernel in CUDA C++ and integrate it using the approach below. A custom CUDA kernel can participate in the same `DeviceOp` execution model as your tile kernels — sharing streams, chaining with `.then()`, and avoiding unnecessary synchronization.
+cuTile Rust is designed to coexist with existing CUDA infrastructure. This chapter covers three common interop concerns:
+
+- **Integrating custom CUDA C++ kernels** — for algorithms that need warp-level primitives (`__shfl_sync`, `__ballot_sync`, cooperative groups) or irregular access patterns the tile model doesn't cover.
+- **Borrowing foreign CUDA handles** — wrap a `CUcontext` / `CUstream` from another Rust binding crate (cudarc, Candle, hand-rolled FFI) so cuTile kernels can run on handles you already own.
+- **Migrating from other tile DSLs** — conceptual mapping from Triton and cuTile Python.
+
+Custom CUDA kernels participate in the same `DeviceOp` execution model as tile kernels — sharing streams, chaining with `.then()`, and avoiding unnecessary synchronization.
 
 ---
 
@@ -79,11 +85,11 @@ use cuda_async::device_operation::{DeviceOp, ExecutionContext};
 use cuda_async::error::DeviceError;
 use cuda_async::launch::AsyncKernelLaunch;
 use cuda_async::scheduling_policies::SchedulingPolicy;
-use cuda_core::{CudaFunction, LaunchConfig};
+use cuda_core::{Function, LaunchConfig};
 use std::future::IntoFuture;
 
 pub struct ScaleKernel {
-    function: Arc<CudaFunction>,
+    function: Arc<Function>,
     n: u32,
     scale: f32,
     input: Arc<Tensor<f32>>,
@@ -195,6 +201,42 @@ This gives you full access to the CUDA driver API while participating in the `De
 
 ---
 
+## Borrowing Foreign CUDA Handles
+
+If your application already owns CUDA handles through another Rust binding crate — cudarc, Candle, or a hand-rolled `bindgen` wrapper — wrap them into a cuTile `Device`, `Stream`, `Module`, or `Function` without transferring ownership.
+
+The `borrow_raw` constructors take raw C primitives (`*mut c_void` for opaque handles, `c_int` for `CUdevice`) rather than `cuda_bindings` typedefs, so no nominal-type mismatch between binding crates gets in the way:
+
+```rust
+use core::ffi::{c_int, c_void};
+use cuda_core::{Device, Stream};
+
+// `foreign` is a handle bundle from another Rust binding crate (cudarc,
+// Candle, a bindgen wrapper, …). Its `CUcontext` / `CUstream` typedefs are
+// nominally distinct from cuTile's, but the underlying C ABI is identical —
+// cast at the boundary and the handles flow through unchanged.
+
+// Safety: the caller guarantees the handles are valid, outlive the returned
+// wrappers, and are not concurrently destroyed.
+let device = unsafe {
+    Device::borrow_raw(
+        foreign.cu_ctx as *mut c_void,
+        foreign.cu_device as c_int,
+        foreign.ordinal,
+    )
+};
+let stream = unsafe { Stream::borrow_raw(foreign.cu_stream as *mut c_void, &device) };
+
+// cuTile kernels now run on the borrowed stream.
+let result = my_kernel(out, x).sync_on(&stream)?;
+```
+
+Borrowed wrappers skip destruction on drop: `Stream` does not call `cuStreamDestroy`, `Module` does not unload, and `Device` does not release the primary context. The source framework retains full control over handle lifetimes.
+
+`Module::borrow_raw` and `Function::borrow_raw` follow the same pattern for pre-compiled modules and already-resolved functions. See the `cudarc_interop` example in `cutile-examples/examples/` for an end-to-end walkthrough.
+
+---
+
 ## Migrating from Other DSLs
 
 **From Triton.** [Triton](https://triton-lang.org/) and cuTile Rust both let you write kernels in terms of tile-level operations. Many patterns that require explicit warp specialization in Triton are handled implicitly by the cuTile Rust compiler:
@@ -228,4 +270,4 @@ Both front-ends use the same underlying Tile IR compilation pipeline and generat
 
 ---
 
-Continue to [Debugging and Profiling](debugging.md) for troubleshooting. This chapter builds on the `DeviceOp` model introduced in [Orchestrating Device Operations](device-operations.md).
+Continue to [Debugging and Profiling](debugging.md) for troubleshooting. This chapter builds on the `DeviceOp` model introduced in [Device Operations](device-operations.md).

--- a/cutile-book/guide/introduction.md
+++ b/cutile-book/guide/introduction.md
@@ -29,8 +29,8 @@ mod my_module {
 }
 
 fn main() -> Result<(), cuda_async::error::DeviceError> {
-    let ctx = cuda_core::CudaContext::new(0)?;
-    let stream = ctx.new_stream()?;
+    let device = cuda_core::Device::new(0)?;
+    let stream = device.new_stream()?;
 
     let x = api::ones::<f32>(&[32, 32]).sync_on(&stream)?;
     let y = api::ones::<f32>(&[32, 32]).sync_on(&stream)?;
@@ -160,7 +160,7 @@ This is key to performance: global memory is slow compared to on-chip resources.
 - You need maximum portability across GPU *vendors*
 - Your team is deeply invested in the CUDA C++ ecosystem
 
-> **Note**: For algorithms requiring warp-level primitives or custom CUDA C++ kernels, see [Integrating with CUDA C++](interoperability.md); custom kernels can participate in the same `DeviceOp` execution model as your tile kernels.
+> **Note**: For algorithms requiring warp-level primitives or custom CUDA C++ kernels, see [Interoperability](interoperability.md); custom kernels can participate in the same `DeviceOp` execution model as your tile kernels.
 
 ---
 

--- a/cutile-book/guide/operations.md
+++ b/cutile-book/guide/operations.md
@@ -1,3 +1,7 @@
+---
+orphan: true
+---
+
 # Operations and Intrinsics
 
 cuTile Rust provides a rich set of operations for GPU computation. All operations work on tiles and leverage GPU parallelism.

--- a/cutile-book/guide/performance-tuning.md
+++ b/cutile-book/guide/performance-tuning.md
@@ -7,7 +7,7 @@ GPU performance optimization balances three concerns: memory bandwidth (moving d
 :alt: The GPU performance triangle showing memory bandwidth, compute utilization, and occupancy
 ```
 
-For algorithms where peak performance requires warp-level control or integration with hand-tuned CUDA C++ kernels, see [Integrating with CUDA C++](interoperability.md).
+For algorithms where peak performance requires warp-level control or integration with hand-tuned CUDA C++ kernels, see [Interoperability](interoperability.md).
 
 ---
 
@@ -252,4 +252,4 @@ Pre-ship checklist: tile size appropriate for workload and architecture; memory 
 
 ---
 
-Continue to [Integrating with CUDA C++](interoperability.md) for the escape hatch when tile programming isn't enough, or [Debugging and Profiling](debugging.md) for deeper troubleshooting.
+Continue to [Interoperability](interoperability.md) for the escape hatch when tile programming isn't enough, or [Debugging and Profiling](debugging.md) for deeper troubleshooting.

--- a/cutile-book/guide/tile-programming-model.md
+++ b/cutile-book/guide/tile-programming-model.md
@@ -1,3 +1,7 @@
+---
+orphan: true
+---
+
 # The Tile Programming Model
 
 ## Thinking in Tiles

--- a/cutile-book/reference/definitions.md
+++ b/cutile-book/reference/definitions.md
@@ -1,0 +1,136 @@
+---
+orphan: true
+---
+
+# Definitions
+
+This glossary defines key terms as they are used throughout the cuTile Rust book.
+
+---
+
+## Tile
+
+A multi-dimensional array fragment that lives in GPU **registers** during kernel execution. Tiles are the fundamental unit of computation in cuTile Rust: you load data from tensors into tiles, compute on tiles, and store the results back. Tiles have compile-time static shapes and are represented by the type `Tile<E, S>`, where `E` is the element type and `S` is the shape (e.g., `Tile<f32, {[16, 16]}>`).
+
+## Tensor
+
+A multi-dimensional array stored in GPU **global memory** (HBM). Tensors are passed as kernel arguments — `&Tensor<E, S>` for read-only inputs and `&mut Tensor<E, S>` for writable outputs. Tensors do not support direct arithmetic; data must first be loaded into tiles.
+
+## Partition
+
+A logical division of a tensor into a grid of equally sized sub-regions, each of which is processed by one tile block. The term "partition" appears on both the host side and the device side, but refers to different things.
+
+**Host-side partition (mutable tensors only).** Calling `.partition([M, N])` on a `Tensor<T>` produces a `Partition<Tensor<T>>`. This is a host-side wrapper that records the `partition_shape` (the tile dimensions) alongside the original tensor. A host-side `Partition<Tensor<T>>` is what you pass to a kernel launcher in the position of a `&mut Tensor<E, S>` parameter. The `partition_shape` stored in the host-side `Partition` determines the static shape `S` that the kernel sees — for example, passing a `Partition` with `partition_shape = [32, 64]` means the kernel receives a `&mut Tensor<T, {[32, 64]}>`.
+
+Only mutable tensors must be partitioned on the host side. This is because each `&mut Tensor` sub-region is written to by exactly one tile block, satisfying Rust's exclusive access requirement for mutable memory: at most one writer may access a given region at a time. By partitioning before launch, the system guarantees that no two tile blocks write to overlapping memory.
+
+**Shared tensor references (no host-side partition required).** Read-only inputs are passed as `Arc<Tensor<T>>` on the host side, corresponding to `&Tensor<E, S>` in the kernel signature. These do *not* need to be partitioned on the host side — multiple tile blocks may safely read from the same tensor or overlapping regions simultaneously, so there is no exclusive-access constraint to enforce. Instead, shared tensors are partitioned on the device side for greater flexibility in how they are accessed.
+
+**Device-side partition.** Inside a kernel, calling `.partition(const_shape![M, N])` on a `&Tensor` creates a read-only `Partition` view that can be indexed to load individual tiles (e.g., `part.load([i, j])`). This is how shared tensor references are divided into tiles for loading. Because the partitioning happens on the device side, the same `&Tensor` can be partitioned in different ways — or accessed with different indexing patterns — within the same kernel. For example, in GEMM the input matrices `x` and `y` are each partitioned with a different shape inside the kernel body (`const_shape![BM, BK]` and `const_shape![BK, BN]` respectively), even though both were passed as plain `Arc<Tensor<T>>` from the host.
+
+The generated launcher code accepts `Partition<Tensor<T>>` for every `&mut Tensor` parameter and `Arc<Tensor<T>>` for every `&Tensor` parameter.
+
+**Grid dimensions.** A host-side partition's grid is computed by dividing the tensor's shape by the partition shape, rounding up: `grid[i] = ceil(tensor_shape[i] / partition_shape[i])`. The result is mapped to a 3D tuple `(x, y, z)`, with trailing dimensions set to 1 for tensors of rank less than 3. For example, a `[128, 256]` tensor partitioned with `[32, 64]` produces a grid of `(4, 4, 1)`.
+
+**Launch grid inference.** At kernel launch time, the launcher calls `.grid()` on each `&mut Tensor` parameter's host-side `Partition` and collects the resulting grids. If no explicit grid is specified via `.grid()` or `.const_grid()`, the launch grid is **inferred** from these partition grids. When multiple `&mut Tensor` parameters are present, all of their inferred grids must match or the launch will fail with an error. This is how partitioning a tensor on the host side determines how many tile blocks the kernel runs.
+
+## Tile Block
+
+A logical tile thread and the basic unit of concurrent execution on the GPU. Each tile block runs the kernel function once as a single logical thread of execution, operating on one partition of the data. A tile block is identified by its coordinates, obtained via `get_tile_block_id()`. The cuTile Rust compiler maps each tile block to one or more underlying CUDA execution units (thread blocks, clusters, or warps) depending on the target architecture — but from the programmer's perspective, a tile block is simply a single-threaded context that processes one tile of data.
+
+## Tile Thread
+
+An alias for [Tile Block](#tile-block), used throughout this book to emphasize the single-threaded programming model. Each tile thread executes the kernel function once as a single logical thread of execution. The terms "tile thread" and "tile block" are interchangeable — the API uses `get_tile_block_id()` and `get_num_tile_blocks()`, while the guides often say "tile thread" for clarity.
+
+## Concurrent Execution
+
+Multiple tile blocks making progress over a period of time by being scheduled onto available Streaming Multiprocessors (SMs). This aligns with Rust's definition of concurrency — different parts of a program executing *independently*, not necessarily at the exact same instant — extended to the GPU context: when a kernel is launched with more tile blocks than there are SMs, the GPU's hardware scheduler assigns tile blocks to SMs as resources become available. Some tile blocks execute in parallel while others are pending, but from the programmer's perspective all tile blocks are logically concurrent — their relative order of execution is unspecified and they are independent of one another.
+
+On the host side, concurrency also arises through CUDA streams and async/await: multiple `DeviceOp`s submitted to different streams can overlap in time, and the async runtime schedules them without requiring the programmer to specify an exact execution order.
+
+## Parallel Execution
+
+Multiple tile blocks executing **at the same time** on different SMs. All NVIDIA GPUs execute tile blocks in parallel — a modern GPU has tens to over a hundred SMs, each capable of running one or more tile blocks simultaneously. The distinction from concurrency is that parallelism refers specifically to simultaneous execution on separate hardware units, whereas concurrency is the broader concept of managing multiple in-progress tasks. In practice, a kernel launch exhibits both: tile blocks that fit on available SMs run in parallel, while the full set of tile blocks runs concurrently (scheduled over time as SMs become free).
+
+This matches Rust's distinction (see [The Rust Programming Language, Ch. 17](https://doc.rust-lang.org/book/ch17-00-async-await.html#parallelism-and-concurrency)): *parallelism* is work happening at the exact same time on different hardware, while *concurrency* is independently executing tasks making progress over time — which may or may not involve parallelism.
+
+## Streaming Multiprocessor (SM)
+
+The primary processing unit on an NVIDIA GPU. Each SM has its own registers, shared memory, and execution pipelines including Tensor Cores. Tile blocks are scheduled onto SMs by the GPU's hardware scheduler. A single SM can run multiple tile blocks concurrently if it has sufficient resources (registers, shared memory, thread slots). For architecture-specific details on SM resources, see the [CUDA C++ Programming Guide](https://docs.nvidia.com/cuda/cuda-c-programming-guide/).
+
+## Tensor Cores
+
+Specialized hardware units (available on Volta architecture and later) that perform small matrix multiply-accumulate operations in a single instruction. The `mma()` intrinsic in cuTile Rust maps to Tensor Core instructions. Tensor Cores impose alignment requirements on tile dimensions (e.g., dimensions must typically be multiples of 8 or 16 depending on the element type).
+
+## Global Memory (HBM)
+
+The GPU's main memory — High Bandwidth Memory. Global memory has the highest capacity but is slower than shared memory and registers. `Tensor` data resides in global memory.
+
+## Registers (RMEM)
+
+The fastest storage on the GPU, private to each thread within a tile block. `Tile` data lives in registers during computation. Each SM has a fixed register file, so larger tiles consume more registers, potentially reducing occupancy.
+
+## Shared Memory (SMEM)
+
+On-chip memory shared among all threads within a tile block. Shared memory is slower than registers but faster than global memory. In the tile programming model, **you never manage shared memory directly** — you simply load from and store to global memory (HBM), and the underlying [Tile IR](https://docs.nvidia.com/cuda/tile-ir/latest/) compiler and runtime handle the mapping onto shared memory, registers, threads, and tensor cores automatically. For capacity and latency details across GPU architectures, see the [CUDA C++ Programming Guide](https://docs.nvidia.com/cuda/cuda-c-programming-guide/).
+
+## Const Generics
+
+Compile-time constant parameters on kernel functions, such as `const BM: i32`. Const generics enable the compiler to optimize register allocation, unroll loops, and generate architecture-specific code. Changing a const generic value triggers JIT recompilation. See also [Const Generic Arrays](#const-generic-arrays).
+
+## Const Generic Arrays
+
+An **extension to the Rust programming language** that allows const generic parameters to have array types — for example, `const S: [i32; 2]`. Standard Rust only supports scalar const generics (integers, `bool`, `char`), so this syntax is not valid in ordinary Rust code. The cuTile Rust compiler recognizes array const generics and uses them to propagate tile shapes through the type system at compile time.
+
+Const generic arrays are the idiomatic way to parameterize a kernel over its tile shape:
+
+```rust
+#[cutile::entry()]
+fn add<const S: [i32; 2]>(
+    z: &mut Tensor<f32, S>,
+    x: &Tensor<f32, {[-1, -1]}>,
+    y: &Tensor<f32, {[-1, -1]}>,
+) { ... }
+```
+
+Here `S` is inferred from the host-side partition shape passed at launch time. Because `S` is a compile-time constant, the compiler can specialize the generated code for each distinct shape. A new value of `S` triggers JIT recompilation, just like scalar const generics.
+
+## Dynamic Dimensions
+
+Tensor shape dimensions specified as `-1` in the kernel signature (e.g., `Tensor<f32, {[-1, -1]}>`). Dynamic dimensions can vary across kernel launches without triggering recompilation. They carry no compile-time optimization benefit but provide flexibility for problem sizes that change often.
+
+## JIT Compilation
+
+cuTile Rust compiles kernels at first invocation through a multi-stage pipeline: Rust AST → MLIR → cubin. The compiled binary is cached in memory (in a thread-local `HashMap`) so subsequent launches with the same generics are instant. A new combination of const generics or type parameters produces a new compilation.
+
+## DeviceOp
+
+A lazy description of GPU work — allocation, kernel launch, or data transfer — that is not executed until either `.sync_on(&stream)`, `.sync()`, or `.await` is invoked. `DeviceOp`s can be composed with `zip!`, `.then()`, `.map()`, `.shared()`, and `.first()`/`.last()` to build dataflow graphs before submitting GPU work. Kernel launchers accept `Tensor<T>`, `Arc<Tensor<T>>`, `&Tensor<T>`, scalars, and `DeviceOp` arguments directly via `IntoDeviceOp` and `KernelInput`. The return type matches the input type — you get back what you put in.
+
+## DeviceFuture
+
+A `DeviceFuture` is a future that has been assigned resources — specifically, a device stream on which to execute — but has not yet started GPU work. A `DeviceFuture` is created when a `DeviceOp` is scheduled (e.g., via `into_future()`), at which point the scheduling policy selects a stream. The actual GPU work is not submitted until the `DeviceFuture` is polled for the first time, which happens when you `.await` it or `tokio::spawn` it.
+
+## Broadcasting
+
+Replicating a smaller tile (or scalar) to match the shape of a larger tile. Broadcasting is a compile-time transformation — no extra memory is allocated. For example, `a.broadcast(y.shape())` expands a scalar into a tile matching `y`'s partition shape.
+
+## Kernel Fusion
+
+Combining multiple logical operations into a single kernel so that intermediate results stay in registers rather than being written to and read back from global memory. Fused softmax is a canonical example: find-max, subtract, exponentiate, sum, and divide are all performed in one kernel launch.
+
+## Arithmetic Intensity
+
+The ratio of compute operations (FLOPs) to memory operations (bytes transferred). Higher arithmetic intensity means better GPU utilization. A kernel with low arithmetic intensity (e.g., element-wise addition) is **memory-bound**; a kernel with high arithmetic intensity (e.g., matrix multiplication) is **compute-bound**.
+
+## CUDA Stream
+
+An ordered queue of GPU operations. Operations on the same stream execute in submission order; operations on different streams may execute concurrently. cuTile Rust's default async scheduling policy distributes work across a pool of four streams in round-robin fashion.
+
+## Occupancy
+
+The ratio of active warps to the maximum number of warps an SM can support. Higher occupancy generally improves the GPU's ability to hide memory latency by switching between warps. Occupancy is affected by register usage, shared memory usage, and thread block size.
+
+## Warp
+
+A group of 32 GPU threads that execute instructions in lockstep. Warps are the smallest scheduling unit on an SM. Tile sizes that are multiples of 32 align well with warp-level execution.

--- a/cutile-book/reference/deviceop-reference.md
+++ b/cutile-book/reference/deviceop-reference.md
@@ -1,7 +1,11 @@
+---
+orphan: true
+---
+
 # DeviceOp API Reference
 
 Quick-reference for the `DeviceOp` trait and its combinators. For a
-tutorial-style introduction, see [Orchestrating Device Operations](../guide/device-operations.md).
+tutorial-style introduction, see [Device Operations](../guide/device-operations.md).
 
 ---
 
@@ -260,7 +264,7 @@ Bypasses the policy entirely. All operations given the same stream execute
 in call order:
 
 ```rust
-let stream = ctx.new_stream()?;
+let stream = device.new_stream()?;
 let a = op_a.sync_on(&stream)?;  // Stream X
 let b = op_b.sync_on(&stream)?;  // Stream X — guaranteed after op_a
 ```
@@ -415,6 +419,6 @@ complete walkthrough.
 
 ## See Also
 
-- [Orchestrating Device Operations](../guide/device-operations.md) — tutorial-style guide to streams, scheduling, and composition patterns
+- [Device Operations](../guide/device-operations.md) — tutorial-style guide to streams, scheduling, and composition patterns
 - [Tutorial 10: CUDA Graphs](../tutorials/10-cuda-graphs.md) — end-to-end CUDA graph example
-- [Integrating with CUDA C++](../guide/interoperability.md) — integrating custom CUDA C++ kernels into the DeviceOp model
+- [Interoperability](../guide/interoperability.md) — integrating custom CUDA C++ kernels into the DeviceOp model

--- a/cutile-book/reference/host-api.md
+++ b/cutile-book/reference/host-api.md
@@ -1,6 +1,6 @@
 # Host API
 
-Reference for everything host-side: creating and transferring tensors, managing contexts and streams, configuring kernel launches, the `DeviceOp` trait and its combinators, and CUDA graph integration. For tutorial-style introductions, see [Orchestrating Device Operations](../guide/device-operations.md) and [Working with Data](../guide/working-with-data.md).
+Reference for everything host-side: creating and transferring tensors, managing contexts and streams, configuring kernel launches, the `DeviceOp` trait and its combinators, and CUDA graph integration. For tutorial-style introductions, see [Device Operations](../guide/device-operations.md) and [Working with Data](../guide/working-with-data.md).
 
 ---
 
@@ -88,25 +88,25 @@ The host-side `Vec` must remain alive until the op completes — the async copy 
 
 ---
 
-## Context and Streams
+## Devices and Streams
 
-Every host program starts with a `CudaContext` bound to a GPU device, plus one or more `CudaStream`s for scheduling GPU work:
+Every host program starts with a `Device`, plus one or more `Stream`s for scheduling GPU work:
 
 ```rust
-use cuda_core::CudaContext;
+use cuda_core::Device;
 
-let ctx = CudaContext::new(0)?;              // Device ordinal 0
-let stream = ctx.new_stream()?;              // A new stream owned by this context
+let device = Device::new(0)?;              // Device ordinal 0
+let stream = device.new_stream()?;         // A new stream owned by this device
 ```
 
 | Method | Returns | Description |
 |---|---|---|
-| `CudaContext::new(ordinal: usize)` | `Result<Arc<CudaContext>, DriverError>` | Create a context bound to a device ordinal |
-| `CudaContext::device_count()` | `Result<i32, DriverError>` | Number of CUDA-capable devices |
-| `ctx.ordinal()` | `usize` | Device ordinal this context binds |
-| `ctx.new_stream()` | `Result<Arc<CudaStream>, DriverError>` | Create a new stream on this context |
+| `Device::new(ordinal: usize)` | `Result<Arc<Device>, DriverError>` | Create a device handle bound to a GPU ordinal |
+| `Device::device_count()` | `Result<i32, DriverError>` | Number of CUDA-capable devices |
+| `device.ordinal()` | `usize` | GPU ordinal this handle represents |
+| `device.new_stream()` | `Result<Arc<Stream>, DriverError>` | Create a new stream on this device |
 
-Contexts are `Arc`-wrapped for sharing across threads; streams are also `Arc`-wrapped and can be passed to `.sync_on(&stream)` for explicit stream scheduling.
+Devices are `Arc`-wrapped for sharing across threads; streams are also `Arc`-wrapped and can be passed to `.sync_on(&stream)` for explicit stream scheduling.
 
 The default round-robin scheduling policy handles stream assignment automatically for most workloads — these APIs are for when you need explicit stream control (debugging, deterministic ordering, paired with `AsyncKernelLaunch`, or overlapping compute with transfers on dedicated streams).
 
@@ -164,7 +164,7 @@ launcher.set_launch_config(LaunchConfig {
 launcher.await?;  // Executes as a DeviceOp
 ```
 
-See [Integrating with CUDA C++](../guide/interoperability.md) for the full walkthrough and the wrapper pattern that hides `unsafe` at the call site.
+See [Interoperability](../guide/interoperability.md) for the full walkthrough and the wrapper pattern that hides `unsafe` at the call site.
 
 **`.generics(Vec<String>)`** — `#[cutile::entry]`-generated launchers accept this method to bind const generics and type parameters at runtime:
 
@@ -438,7 +438,7 @@ Bypasses the policy entirely. All operations given the same stream execute
 in call order:
 
 ```rust
-let stream = ctx.new_stream()?;
+let stream = device.new_stream()?;
 let a = op_a.sync_on(&stream)?;  // Stream X
 let b = op_b.sync_on(&stream)?;  // Stream X — guaranteed after op_a
 ```
@@ -593,6 +593,6 @@ complete walkthrough.
 
 ## See Also
 
-- [Orchestrating Device Operations](../guide/device-operations.md) — tutorial-style guide to streams, scheduling, and composition patterns
+- [Device Operations](../guide/device-operations.md) — tutorial-style guide to streams, scheduling, and composition patterns
 - [Tutorial 10](../tutorials/10-cuda-graphs.md) — end-to-end CUDA graph example
-- [Integrating with CUDA C++](../guide/interoperability.md) — integrating custom CUDA C++ kernels into the DeviceOp model
+- [Interoperability](../guide/interoperability.md) — integrating custom CUDA C++ kernels into the DeviceOp model

--- a/cutile-book/reference/syntax-reference.md
+++ b/cutile-book/reference/syntax-reference.md
@@ -1,0 +1,919 @@
+---
+orphan: true
+---
+
+# Syntax Snippets
+
+> Note: This is a WIP -- there may be technical inaccuracies.
+
+This comprehensive guide covers all `cutile-rs` syntax from basics to advanced patterns. Use it as a reference when writing kernels.
+
+---
+
+## Module Structure
+
+Every cutile kernel lives inside a module marked with `#[cutile::module]`:
+
+```rust
+#[cutile::module]
+mod my_module {
+    use cutile::core::*;  // Import all tile operations
+
+    #[cutile::entry()]
+    fn my_kernel(/* parameters */) {
+        // Kernel code
+    }
+}
+```
+
+### Entry Point Attributes
+
+The `#[cutile::entry()]` macro supports several options:
+
+```rust
+#[cutile::entry(
+    print_ir = false,           // Print MLIR IR during compilation
+    unchecked_accesses = false, // Skip bounds checking
+    optimization_hints = (
+        sm_120 = (num_cta_in_cga = 1, max_divisibility = 16,),
+    )
+)]
+fn my_kernel() { /* ... */ }
+```
+
+---
+
+## Core Types
+
+### Element Types
+
+```rust
+// Floating point
+f32    // 32-bit float (most common)
+f64    // 64-bit float (double precision)
+f16    // 16-bit float (half precision)
+tf32   // TensorFloat-32
+
+// Integer types
+i8     // 8-bit signed (for integer GEMM)
+i32    // 32-bit signed integer
+i64    // 64-bit signed integer
+u32    // 32-bit unsigned integer
+u64    // 64-bit unsigned integer
+bool   // Boolean
+```
+
+### Tensor Types
+
+| Type | Description | Memory Location |
+|------|-------------|-----------------|
+| `Tensor<E, S>` | Data in global memory | GPU HBM |
+| `Tile<E, S>` | Data in registers | GPU registers |
+| `Partition<E, S>` | Read-only view as tiles | Metadata |
+| `PartitionMut<E, S>` | Mutable view as tiles | Metadata |
+| `PointerTile<P, S>` | Tile of pointers | Registers |
+
+### Shape Syntax
+
+```rust
+// Static shapes (compile-time known)
+Tensor<f32, {[64, 64]}>       // 2D: 64×64
+Tensor<f32, {[128, 256, 512]}>// 3D: 128×256×512
+Tensor<f32, {[]}>             // Scalar
+
+// Dynamic shapes (runtime determined)
+Tensor<f32, {[-1, -1]}>       // 2D dynamic
+Tensor<f32, {[-1, 128]}>      // Mixed: dynamic first, static second
+
+// Const generics for flexible kernels
+fn kernel<const S: [i32; 2]>(x: &mut Tensor<f32, S>) { }
+fn kernel<const BM: i32, const BN: i32>(x: &mut Tensor<f32, {[BM, BN]}>) { }
+```
+
+---
+
+## Kernel Parameters
+
+### Input/Output Tensors
+
+```rust
+#[cutile::entry()]
+fn kernel(
+    // Mutable output (will be written to)
+    output: &mut Tensor<f32, {[BM, BN]}>,
+    
+    // Immutable inputs
+    x: &Tensor<f32, {[-1, -1]}>,
+    y: &Tensor<f32, {[-1, -1]}>,
+    
+    // Scalar parameters
+    scale: f32,
+    num_iters: i32,
+    flag: bool,
+) { }
+```
+
+### Generic Kernels
+
+```rust
+#[cutile::entry()]
+fn generic_kernel<
+    E: ElementType,           // Any element type
+    const BM: i32,            // Tile rows
+    const BN: i32,            // Tile cols
+    const K: i32,             // Full dimension
+>(
+    z: &mut Tensor<E, {[BM, BN]}>,
+    x: &Tensor<E, {[-1, K]}>,
+) { }
+```
+
+---
+
+## Loading and Storing Data
+
+### Basic Load/Store
+
+```rust
+// Load entire output tile into registers
+let tile: Tile<f32, S> = load_tile_mut(output);
+
+// Store tile back to tensor
+output.store(tile);
+
+// Equivalent methods on Tensor
+let tile = output.load();
+output.store(tile);
+```
+
+### Positional Loading (load_tile_like)
+
+Load from a dynamic tensor at the position matching another tile:
+
+```rust
+// Load from x at the same grid position as output tile z
+let tile_x = load_tile_like_2d(x, z);  // 2D tensors
+let tile_y = load_tile_like_2d(y, z);
+```
+
+### Partitioned Loading
+
+For explicit control over which tile to load:
+
+```rust
+// Create partition view
+let part = tensor.partition(const_shape![16, 16]);
+
+// Load specific tile by index
+let pid: (i32, i32, i32) = get_tile_block_id();
+let tile = part.load([pid.0, pid.1]);
+
+// Load with explicit indices
+let tile = part.load([row_idx, col_idx]);
+```
+
+---
+
+## Shape Operations
+
+### Creating Shapes
+
+```rust
+// Using const_shape! macro
+let shape = const_shape![64, 64];
+let shape_3d = const_shape![8, 16, 32];
+
+// Using Shape struct
+let shape: Shape<{[128, 256]}> = Shape::<{[128, 256]}> {
+    dims: &[128i32, 256i32],
+};
+```
+
+### Getting Shape Information
+
+```rust
+// Get shape from tensor
+let shape = tensor.shape();
+
+// Get specific dimension
+let dim0 = get_shape_dim(tensor.shape(), 0i32);
+let dim1 = get_shape_dim(tensor.shape(), 1i32);
+```
+
+### Reshape
+
+Change shape without changing data (total elements must match):
+
+```rust
+// Flatten 2D to 1D
+let flat = tile.reshape(const_shape![BM * BN]);
+
+// Add dimension for broadcasting
+let col_vector = row.reshape(const_shape![BM, 1]);
+
+// Remove dimensions
+let reduced = tile.reshape(const_shape![BM]);
+```
+
+### Broadcast
+
+Expand a smaller tile to a larger shape:
+
+```rust
+// Scalar to tile
+let scalar_tile = 2.0f32.broadcast(const_shape![64, 64]);
+
+// Column vector to matrix
+let col: Tile<f32, {[BM, 1]}> = ...;
+let expanded = col.broadcast(const_shape![BM, BN]);
+
+// Full pattern: reshape then broadcast
+let row_values: Tile<f32, {[BM]}> = reduce_max(tile, 1i32);
+let broadcast = row_values
+    .reshape(const_shape![BM, 1])
+    .broadcast(const_shape![BM, BN]);
+```
+
+### Permute (Transpose)
+
+```rust
+// Define permutation
+let transpose: Array<{[1, 0]}> = Array::<{[1, 0]}> {
+    dims: &[1i32, 0i32],
+};
+
+// Apply permutation: [M, N] → [N, M]
+let transposed = permute(tile, transpose);
+```
+
+---
+
+## Arithmetic Operations
+
+### Basic Arithmetic
+
+```rust
+let c = a + b;    // Addition
+let c = a - b;    // Subtraction
+let c = a * b;    // Multiplication
+let c = a / b;    // Division
+let c = true_div(a, b);  // True division (for floats)
+```
+
+### Scalar Operations
+
+```rust
+let scaled = tile * 2.0f32;
+let shifted = tile + 1.0f32;
+```
+
+### Fused Multiply-Add
+
+```rust
+// Simpler form (defaults to nearest_even rounding)
+let result = fma(x, y, z);
+
+// x * y + z with explicit rounding mode
+let result = fma(x, y, z, "nearest_even");
+```
+
+---
+
+## Mathematical Functions
+
+### Exponential and Logarithmic
+
+```rust
+let y = exp(x);       // e^x
+let y = exp2(x, ftz::Disabled);      // 2^x (faster on GPU)
+let y = log(x);       // Natural log (ln)
+let y = log2(x);      // Log base 2
+let y = sqrt(x, "negative_inf");   // Square root
+let y = rsqrt(x);     // 1/sqrt(x) - fast reciprocal sqrt
+let y = pow(x, y);    // x^y
+```
+
+### Trigonometric
+
+```rust
+let y = sin(x);       // Sine
+let y = cos(x);       // Cosine
+let y = tan(x);       // Tangent
+let y = sinh(x);      // Hyperbolic sine
+let y = cosh(x);      // Hyperbolic cosine
+let y = tanh(x);      // Hyperbolic tangent
+```
+
+### Rounding and Absolute Value
+
+```rust
+let y = ceil(x, "nearest_even");   // Ceiling
+let y = floor(x);                   // Floor
+let y = absf(x);                    // Absolute value (float)
+let y = absi(x);                    // Absolute value (int)
+let y = negf(x);                    // Negation (float)
+let y = negi(x);                    // Negation (int)
+```
+
+---
+
+## Reduction Operations
+
+Reduce along an axis to produce a smaller tile:
+
+```rust
+// Input: Tile<f32, {[BM, BN]}>
+
+// Reduce across columns (axis=1) → Tile<f32, {[BM]}>
+let row_max = reduce_max(tile, 1i32);
+let row_sum = reduce_sum(tile, 1);
+let row_min = reduce_min(tile, 1);
+
+// Reduce across rows (axis=0) → Tile<f32, {[BN]}>
+let col_max = reduce_max(tile, 0i32);
+
+// Product along axis
+let product = reduce_prod(tile, 0i32);
+```
+
+### Custom Reductions with Closures
+
+```rust
+// Sum reduction with closure
+let sum = reduce(tile, 0i32, 0.0f32, |acc, x| acc + x);
+
+// Product reduction
+let product = reduce(tile, 0i32, 1.0f32, |acc, x| acc * x);
+
+// Max reduction with identity element
+let max_val = reduce(tile, 0i32, f32::NEG_INFINITY, |acc, x| max(acc, x));
+```
+
+---
+
+## Scan (Prefix) Operations
+
+Cumulative operations along an axis:
+
+```rust
+// Prefix sum (cumulative sum)
+let prefix_sums: Tile<f32, S> = scan_sum(tile, 0i32, false, 0.0f32);
+//                                              axis   reverse  init
+
+// Custom scan with closure (prefix product)
+let prefix_products = scan(tile, 0i32, false, 1.0f32, |acc, x| acc * x);
+```
+
+---
+
+## Matrix Operations
+
+### Matrix Multiply-Accumulate (MMA)
+
+```rust
+// C = A @ B + C
+let c = mma(a, b, c);
+
+// Shape requirements:
+// A: [M, K]
+// B: [K, N]
+// C: [M, N]
+// Result: [M, N]
+
+// Typical accumulation loop
+let mut acc = constant(0.0f32, const_shape![BM, BN]);
+for i in 0i32..(K / BK) {
+    let tile_x = part_x.load([pid.0, i]);
+    let tile_y = part_y.load([i, pid.1]);
+    acc = mma(tile_x, tile_y, acc);
+}
+```
+
+### Integer MMA
+
+```rust
+// For i8 inputs with i32 accumulator
+let lhs: Tile<i8, {[16, 32]}> = constant(1i8, lhs_shape);
+let rhs: Tile<i8, {[32, 16]}> = constant(1i8, rhs_shape);
+let acc: Tile<i32, {[16, 16]}> = constant(0i32, acc_shape);
+let result = mma(lhs, rhs, acc);
+```
+
+---
+
+## Comparison and Selection
+
+### Element-wise Comparisons
+
+```rust
+let mask = gt_tile(a, b);    // a > b
+let mask = ge_tile(a, b);    // a >= b
+let mask = lt_tile(a, b);    // a < b
+let mask = le_tile(a, b);    // a <= b
+let mask = eq_tile(a, b);    // a == b
+```
+
+### Min/Max
+
+```rust
+// Element-wise max/min of two tiles
+let result = max_tile(a, b);
+let result = min_tile(a, b);
+let result = maxf(a, b);     // Float max
+let result = minf(a, b);     // Float min
+```
+
+### Select (Conditional)
+
+```rust
+// Select elements based on mask
+let result = select(mask, if_true, if_false);
+```
+
+---
+
+## Constants and Special Values
+
+### Creating Constant Tiles
+
+```rust
+let zeros = constant(0.0f32, const_shape![64, 64]);
+let ones = constant(1.0f32, const_shape![64, 64]);
+let neg_inf = constant(f32::NEG_INFINITY, const_shape![BM, 1]);
+let custom = constant(42i64, output.shape());
+```
+
+### Index Generation (Iota)
+
+```rust
+// Create [0, 1, 2, 3, ...] tile
+let indices: Tile<i32, {[64]}> = iota(const_shape![64]);
+```
+
+---
+
+## Type Conversions
+
+### Scalar Conversions
+
+```rust
+let x: f32 = 0.0;
+let x: i32 = convert_scalar::<i32>(x);
+let x: f32 = convert_scalar::<f32>(x);
+let x: f16 = convert_scalar::<f16>(x);
+```
+
+### Tile Type Casting
+
+```rust
+let float_tile: Tile<f32, S> = convert_tile(int_tile);
+let half_tile: Tile<f16, S> = convert_tile(float_tile);
+```
+
+### Integer Extension/Truncation
+
+```rust
+// Truncate to smaller type
+let truncated: Tile<i32, S> = trunci(tile_i64);
+
+// Extend to larger type (sign/zero extend based on source type)
+let extended: Tile<i64, S> = exti(tile_i32);
+```
+
+### Pointer Conversions
+
+```rust
+let ptrs: PointerTile<*mut i64, S> = int_to_ptr(int_tile);
+let ptrs_f32: PointerTile<*mut f32, S> = ptr_to_ptr(ptrs);
+let ints: Tile<i64, S> = ptr_to_int(ptrs);
+```
+
+---
+
+## Control Flow
+
+### For Loops
+
+```rust
+for i in 0i32..10i32 {
+    // Loop body
+    acc = acc + tile;
+}
+
+// With step
+for i in (0i32..100i32).step_by(10) {
+    // ...
+}
+```
+
+### While Loops
+
+```rust
+let mut counter = 0i32;
+while counter < 10i32 {
+    acc = acc + acc;
+    counter = counter + 1i32;
+}
+```
+
+### Infinite Loop with Break
+
+```rust
+loop {
+    acc = acc + acc;
+    if condition {
+        break;
+    }
+}
+```
+
+### If/Else
+
+```rust
+if dynamic_value < 5i32 {
+    sum = sum + sum;
+} else {
+    sum = sum - sum;
+}
+
+// If as expression (returns value)
+let result: Tile<i64, S> = if conditional {
+    constant(2, shape)
+} else {
+    constant(3, shape)
+};
+```
+
+---
+
+## Grid and Block Information
+
+### Getting Tile Position
+
+```rust
+// Get current tile's position in the grid
+let pid: (i32, i32, i32) = get_tile_block_id();
+// pid.0 = x position, pid.1 = y position, pid.2 = z position
+
+// Get total number of tiles in grid
+let npid: (i32, i32, i32) = get_num_tile_blocks();
+```
+
+### Common Indexing Patterns
+
+```rust
+// Batch and head indexing (for attention)
+let h = get_shape_dim(q.shape(), 1i32);
+let batch_idx = pid.0 / h;
+let head_idx = pid.0 % h;
+let seq_idx = pid.1;
+
+// Group query attention
+let kv_head_idx = head_idx / query_group_size;
+```
+
+---
+
+## Utility Functions
+
+### Ceiling Division
+
+```rust
+let num_tiles: i32 = ceil_div(n, BN);  // ceil(n / BN)
+```
+
+### Debug Printing
+
+```rust
+cuda_tile_print!("Value at tile ({}, {}): {}\n", pid.0, pid.1, value);
+cuda_tile_print!("Shape: {} x {}\n", dim0, dim1);
+```
+
+:::{warning}
+GPU printing is slow and should only be used for debugging with small grids.
+:::
+
+### Assertions
+
+```rust
+cuda_tile_assert!(condition, "Error message");
+cuda_tile_assert!(shape_dim_1 != shape_dim_2, "Dimensions must differ");
+```
+
+---
+
+## Scalar/Tile Conversions
+
+```rust
+// Scalar to 0-D tile
+let tile_scalar: Tile<f32, {[]}> = scalar_to_tile(scalar);
+
+// 0-D tile to scalar
+let scalar: f32 = tile_to_scalar(tile_scalar);
+
+// Pointer to tile
+let ptr_tile: PointerTile<*mut f32, {[]}> = pointer_to_tile(ptr);
+let ptr: *mut f32 = tile_to_pointer(ptr_tile);
+```
+
+---
+
+## Advanced: Tensor Slicing
+
+### Extract
+
+Extract slices from a tile:
+
+```rust
+let source: Tile<f32, {[8]}> = load_tile_mut(tensor);
+
+// Extract first half
+let idx0: Tile<i32, {[]}> = scalar_to_tile(0i32);
+let slice0: Tile<f32, {[4]}> = extract(source, [idx0]);
+
+// Extract second half
+let idx1: Tile<i32, {[]}> = scalar_to_tile(1i32);
+let slice1: Tile<f32, {[4]}> = extract(source, [idx1]);
+```
+
+### Concatenate
+
+```rust
+// Concatenate two tiles along an axis
+let result: Tile<f32, {[8]}> = cat(tile_a, tile_b, 0i32);
+```
+
+---
+
+## Advanced: Memory Operations
+
+### Low-Level Partition Views
+
+```rust
+unsafe {
+    let token: Token = new_token_unordered();
+    let partition: PartitionMut<f32, {[128, 256]}> =
+        make_partition_view_mut(&tensor, shape, token);
+    
+    let idx: [i32; 2] = [0i32, 0i32];
+    let tile = load_from_view_mut(&partition, idx);
+    store_to_view_mut(&mut partition, tile, idx, None, false);
+}
+```
+
+### Pointer-Based Load/Store
+
+```rust
+// Build pointer tile
+let ptr_seed: Tile<i64, S> = constant(0i64, shape);
+let ptrs: PointerTile<*mut f32, S> = ptr_to_ptr(int_to_ptr(ptr_seed));
+
+// Load with memory ordering
+let (values, token): (Tile<f32, S>, Token) =
+    load_ptr_tko(ptrs, "relaxed", "device", None, None, None, None);
+
+// Store with memory ordering
+let token: Token =
+    store_ptr_tko(ptrs, values, "relaxed", "device", None, None, None);
+
+// Per-op latency hint
+let (values, token): (Tile<f32, S>, Token) =
+    load_ptr_tko(ptrs, "weak", "tl_blk", None, None, None, Some(4));
+```
+
+Memory orderings: `"relaxed"`, `"weak"`, `"acquire"`, `"release"`, `"acq_rel"`
+Scopes: `"device"`, `"sys"`, `"tl_blk"`
+
+---
+
+## Advanced: Atomic Operations
+
+### Atomic Read-Modify-Write
+
+```rust
+// Atomic add
+let (old_values, token): (Tile<f32, S>, Token) =
+    atomic_rmw_tko(ptrs, increments, "addf", "relaxed", "device", None, None);
+
+// Operations: "add", "addf", "and", "or", "xor", "max", "min", "xchg"
+```
+
+### Atomic Compare-and-Swap
+
+```rust
+let (old_values, token): (Tile<f32, S>, Token) = atomic_cas_tko(
+    ptrs,
+    cmp_values,      // Expected value
+    new_values,      // New value if match
+    "relaxed",       // Memory ordering
+    "device",        // Scope
+    None,            // Optional mask
+    None,            // Optional input token
+);
+```
+
+---
+
+## Advanced: Compiler Hints
+
+### Assume Operations
+
+Provide optimization hints to the compiler:
+
+```rust
+// Assume values are non-negative
+let assumed: Tile<i64, S> = unsafe { assume_bounds_lower::<_, 0>(tile) };
+
+// Assume values are divisible by 16
+let aligned: Tile<i64, S> = unsafe { assume_div_by::<_, 16>(tile) };
+
+// Assume groups have same elements (for 2D tiles)
+let same: Tile<i64, S> = unsafe { assume_same_elements_2d::<_, 2, 4>(tile) };
+```
+
+---
+
+## Common Patterns
+
+### Numerically Stable Softmax
+
+```rust
+fn softmax<const BM: i32, const BN: i32>(
+    x: &Tensor<f32, {[-1, -1]}>,
+    y: &mut Tensor<f32, {[BM, BN]}>,
+) {
+    let tile_x: Tile<f32, {[BM, BN]}> = load_tile_like_2d(x, y);
+
+    // Subtract max for stability
+    let tile_max: Tile<f32, {[BM]}> = reduce_max(tile_x, 1i32);
+    let tile_max = tile_max.reshape(const_shape![BM, 1]).broadcast(y.shape());
+
+    let num = exp(tile_x - tile_max);
+    let denom = reduce_sum(num, 1).reshape(const_shape![BM, 1]).broadcast(y.shape());
+
+    y.store(num / denom);
+}
+```
+
+### Tiled GEMM
+
+```rust
+fn gemm<const BM: i32, const BN: i32, const BK: i32, const K: i32>(
+    z: &mut Tensor<f32, {[BM, BN]}>,
+    x: &Tensor<f32, {[-1, K]}>,
+    y: &Tensor<f32, {[K, -1]}>,
+) {
+    let part_x = x.partition(const_shape![BM, BK]);
+    let part_y = y.partition(const_shape![BK, BN]);
+    let pid: (i32, i32, i32) = get_tile_block_id();
+    
+    let mut acc = constant(0.0f32, const_shape![BM, BN]);
+    for i in 0i32..(K / BK) {
+        let tile_x = part_x.load([pid.0, i]);
+        let tile_y = part_y.load([i, pid.1]);
+        acc = mma(tile_x, tile_y, acc);
+    }
+    
+    z.store(acc);
+}
+```
+
+### Fused Multihead Attention Pattern
+
+```rust
+// Running softmax state
+let mut m_i = constant(f32::NEG_INFINITY, const_shape![BM, 1]);
+let mut l_i = constant(0.0f32, const_shape![BM, 1]);
+let mut acc = constant(0.0f32, const_shape![BM, D]);
+
+for j in 0i32..num_tiles {
+    // Q @ K^T
+    let qk = mma(tq, k_tile_trans, zeros);
+    let qk = qk * qk_scale;
+
+    // Online softmax update
+    let qk_max = reduce_max(qk, 1).reshape(const_shape![BM, 1]);
+    let m_ij = max_tile(m_i, qk_max);
+    let qk = qk - m_ij.broadcast(const_shape![BM, BN]);
+    let p = exp2(qk, ftz::Disabled);
+    let l_ij = reduce_sum(p, 1).reshape(const_shape![BM, 1]);
+    let alpha = exp2(m_i - m_ij, ftz::Disabled);
+    l_i = l_i * alpha + l_ij;
+    acc = acc * alpha.broadcast(const_shape![BM, D]);
+    
+    // P @ V
+    acc = mma(p, v_tile, acc);
+    m_i = m_ij;
+}
+
+acc = true_div(acc, l_i.broadcast(const_shape![BM, D]));
+```
+
+---
+
+## Host-Side API
+
+### Kernel Parameter Types
+
+| Kernel param | Host input | Return type |
+|---|---|---|
+| `&Tensor<T, S>` | `Tensor<T>`, `Arc<Tensor<T>>`, or `&Tensor<T>` | Same as input |
+| `&mut Tensor<T, S>` | `Partition<Tensor<T>>` or `Partition<&mut Tensor<T>>` | Same as input |
+| Scalar (`f32`, `i32`, etc.) | Same scalar | Same scalar |
+| `*mut T` (unsafe only) | `DevicePointer<T>` | `DevicePointer<T>` |
+
+Borrowed forms (`&Tensor<T>`, `Partition<&mut Tensor<T>>`) introduce a
+lifetime that prevents `tokio::spawn` at compile time — use `Arc` and
+owned partitions for spawned tasks.
+
+### Launching Kernels (Sync)
+
+```rust
+use my_module::kernel;
+
+let device = Device::new(0)?;
+let stream = device.new_stream()?;
+
+// Borrow-based: no Arc, no unpartition, no return capture.
+let x = ones::<f32>(&[32, 32]).sync_on(&stream)?;
+let mut z = zeros::<f32>(&[32, 32]).sync_on(&stream)?;
+
+let _ = kernel((&mut z).partition([4, 4]), &x)
+    .generics(vec!["f32".to_string(), "16".to_string()])
+    .sync_on(&stream)?;
+// z already has the result.
+
+// Owned variant (useful when building lazy graphs):
+let x: Arc<Tensor<f32>> = ones(&[32, 32]).sync_on(&stream)?.into();
+let z = zeros(&[32, 32]).partition([4, 4]).sync_on(&stream)?;
+
+let (z, _x) = kernel(z, x)
+    .generics(vec!["f32".to_string(), "16".to_string()])
+    .sync_on(&stream)?;
+let z_host: Vec<f32> = z.unpartition().to_host_vec().sync_on(&stream)?;
+```
+
+### Launching Kernels (Async)
+
+```rust
+use my_module::kernel;
+
+let x = ones(&[32, 32]).map(Into::into);
+let z = zeros(&[32, 32]).partition([4, 4]);
+
+let (z, _x) = kernel(z, x).unzip();
+
+let z_host: Vec<f32> = z.unpartition().await?.to_host_vec().await?;
+```
+
+---
+
+## Quick Reference Tables
+
+### Load Functions
+
+| Function | Use Case |
+|----------|----------|
+| `load_tile_mut(tensor)` | Load entire output tile |
+| `tensor.load()` | Same as above (method form) |
+| `load_tile_like_2d(src, ref)` | Load from src at ref's position |
+| `part.load([i, j])` | Load specific partition tile |
+
+### Store Functions
+
+| Function | Use Case |
+|----------|----------|
+| `tensor.store(tile)` | Store tile to tensor |
+
+### Reduction Functions
+
+| Function | Result Shape | Description |
+|----------|--------------|-------------|
+| `reduce_max(tile, axis)` | Removes axis | Maximum along axis |
+| `reduce_sum(tile, axis)` | Removes axis | Sum along axis |
+| `reduce_min(tile, axis)` | Removes axis | Minimum along axis |
+| `reduce_prod(tile, axis)` | Removes axis | Product along axis |
+| `reduce(tile, axis, init, fn)` | Removes axis | Custom reduction |
+
+### Math Functions
+
+| Float | Integer | Description |
+|-------|---------|-------------|
+| `exp(x)` | — | e^x |
+| `exp2(x, ftz::Disabled)` | — | 2^x |
+| `log(x)` | — | ln(x) |
+| `log2(x)` | — | log₂(x) |
+| `sqrt(x, mode)` | — | √x |
+| `rsqrt(x)` | — | 1/√x |
+| `absf(x)` | `absi(x)` | |x| |
+| `negf(x)` | `negi(x)` | -x |
+| `maxf(a, b)` | — | max(a, b) |
+| `minf(a, b)` | — | min(a, b) |
+
+---
+
+## Next Steps
+
+- Try the [Tutorials](../tutorials/01-hello-world.md) for hands-on examples
+- Learn about the [Memory Hierarchy](../guide/memory-hierarchy.md) for optimization
+- Understand [Async Execution](../guide/async-execution.md) for production code

--- a/cutile-book/tutorials/01-hello-world.md
+++ b/cutile-book/tutorials/01-hello-world.md
@@ -12,7 +12,7 @@ Here is a kernel that prints "hello" from the GPU:
 
 ```rust
 use cuda_async::device_operation::DeviceOp;
-use cuda_core::CudaContext;
+use cuda_core::Device;
 use cutile;
 use cutile::error::Error;
 use cutile::tile_kernel::TileKernel;
@@ -36,8 +36,8 @@ mod hello_world_module {
 use hello_world_module::hello_world_kernel;
 
 fn main() -> Result<(), Error> {
-    let ctx = CudaContext::new(0)?;
-    let stream = ctx.new_stream()?;
+    let device = Device::new(0)?;
+    let stream = device.new_stream()?;
     let launcher = hello_world_kernel();
     launcher.grid((2, 2, 1)).sync_on(&stream)?;
     Ok(())
@@ -85,8 +85,8 @@ The following host-side code will launch the device-side code:
 
 ```rust
 fn main() -> Result<(), Error> {
-    let ctx = CudaContext::new(0)?;             // Connect to GPU
-    let stream = ctx.new_stream()?;             // Create a work queue
+    let device = Device::new(0)?;             // Connect to GPU
+    let stream = device.new_stream()?;             // Create a work queue
     let launcher = hello_world_kernel();   // Get the kernel launcher
     launcher.grid((2, 2, 1)).sync_on(&stream)?; // Launch 2×2×1 = 4 tiles
     Ok(())

--- a/cutile-book/tutorials/02-vector-addition.md
+++ b/cutile-book/tutorials/02-vector-addition.md
@@ -8,7 +8,7 @@ In cutile, tile threads run concurrently and each tile knows its coordinates via
 
 ```rust
 use cuda_async::device_operation::DeviceOp;
-use cuda_core::CudaContext;
+use cuda_core::Device;
 use std::sync::Arc;
 use cutile;
 use cutile::api::{ones, zeros};
@@ -35,8 +35,8 @@ mod my_module {
 use my_module::add;
 
 fn main() -> Result<(), Error> {
-    let ctx = CudaContext::new(0)?;
-    let stream = ctx.new_stream()?;
+    let device = Device::new(0)?;
+    let stream = device.new_stream()?;
     
     // Create input tensors: 32×32 matrices filled with 1.0
     let x: Arc<Tensor<f32>> = ones(&[32, 32]).sync_on(&stream)?.into();

--- a/cutile-book/tutorials/03-saxpy.md
+++ b/cutile-book/tutorials/03-saxpy.md
@@ -22,7 +22,7 @@ Broadcasting is conceptual — the GPU doesn't actually allocate memory for all 
 
 ```rust
 use cuda_async::device_operation::DeviceOp;
-use cuda_core::CudaContext;
+use cuda_core::Device;
 use std::sync::Arc;
 use cutile;
 use cutile::api::arange;
@@ -49,8 +49,8 @@ mod my_module {
 use my_module::saxpy;
 
 fn main() -> Result<(), Error> {
-    let ctx = CudaContext::new(0)?;
-    let stream = ctx.new_stream()?;
+    let device = Device::new(0)?;
+    let stream = device.new_stream()?;
     
     let a = 2.0f32;  // Our scalar multiplier
     

--- a/cutile-book/tutorials/04-matrix-multiplication.md
+++ b/cutile-book/tutorials/04-matrix-multiplication.md
@@ -53,7 +53,7 @@ Each element of A is used BN times. Each element of B is used BM times. This **d
 
 ```rust
 use cuda_async::device_operation::DeviceOp;
-use cuda_core::CudaContext;
+use cuda_core::Device;
 use std::sync::Arc;
 use cutile;
 use cutile::api;
@@ -90,8 +90,8 @@ mod my_module {
 use my_module::gemm;
 
 fn main() -> Result<(), Error> {
-    let ctx = CudaContext::new(0)?;
-    let stream = ctx.new_stream()?;
+    let device = Device::new(0)?;
+    let stream = device.new_stream()?;
 
     let (bm, bn, bk): (i32, i32, i32) = (16, 16, 8);
     let (m, n, k) = (64usize, 64usize, 64usize);

--- a/cutile-book/tutorials/05-fused-softmax.md
+++ b/cutile-book/tutorials/05-fused-softmax.md
@@ -44,7 +44,7 @@ exp(x_i - max) / Σ exp(x_j - max)
 
 ```rust
 use cuda_async::device_operation::DeviceOp;
-use cuda_core::CudaContext;
+use cuda_core::Device;
 use cutile;
 use cutile::api::arange;
 use cutile::error::Error;
@@ -82,8 +82,8 @@ mod my_module {
 use my_module::softmax;
 
 fn main() -> Result<(), Error> {
-    let ctx = CudaContext::new(0)?;
-    let stream = ctx.new_stream()?;
+    let device = Device::new(0)?;
+    let stream = device.new_stream()?;
 
     let (m, n) = (4usize, 8usize);
     let (bm, bn) = (2i32, n as i32);

--- a/cutile-book/tutorials/06-flash-attention.md
+++ b/cutile-book/tutorials/06-flash-attention.md
@@ -122,7 +122,7 @@ For each Q tile (row block of the output):
 
 ```rust
 use cuda_async::device_operation::DeviceOp;
-use cuda_core::CudaContext;
+use cuda_core::Device;
 use std::sync::Arc;
 use cutile;
 use cutile::api::{randn, zeros};
@@ -220,8 +220,8 @@ mod fmha_module {
 use fmha_module::fmha;
 
 fn main() -> Result<(), Error> {
-    let ctx = CudaContext::new(0)?;
-    let stream = ctx.new_stream()?;
+    let device = Device::new(0)?;
+    let stream = device.new_stream()?;
 
     let (batch, heads, seq_len, head_dim) = (2, 4, 128, 64);
     let (bm, bn) = (64, 32);

--- a/cutile-book/tutorials/07-intro-to-async.md
+++ b/cutile-book/tutorials/07-intro-to-async.md
@@ -251,5 +251,5 @@ Time a sync version vs. an async version with overlapped work. Use `std::time::I
 
 ## See also
 
-- [Orchestrating Device Operations](../guide/device-operations.md) — full treatment of `DeviceOp`, streams, and scheduling
+- [Device Operations](../guide/device-operations.md) — full treatment of `DeviceOp`, streams, and scheduling
 - [Host API](../reference/host-api.md) — combinator signatures (`.then()`, `.shared()`, `unzip`, `zip!`) and the full host-side API

--- a/cutile-book/tutorials/08-data-parallel-mlp.md
+++ b/cutile-book/tutorials/08-data-parallel-mlp.md
@@ -230,5 +230,5 @@ What would we need to change to construct a pipeline that overlaps data movement
 
 ## See also
 
-- [Orchestrating Device Operations](../guide/device-operations.md) — stream scheduling and the `DeviceOp` lifecycle
+- [Device Operations](../guide/device-operations.md) — stream scheduling and the `DeviceOp` lifecycle
 - [Host API](../reference/host-api.md) — `.schedule()`, scheduling policies, and execution methods

--- a/cutile-book/tutorials/09-pointer-addition.md
+++ b/cutile-book/tutorials/09-pointer-addition.md
@@ -138,6 +138,6 @@ Write a safe Rust wrapper function around the unsafe kernel that validates the p
 
 ## See also
 
-- [Integrating with CUDA C++](../guide/interoperability.md) — a structured approach to pre-compiled CUDA C++ kernels using `AsyncKernelLaunch` instead of raw pointers
+- [Interoperability](../guide/interoperability.md) — a structured approach to pre-compiled CUDA C++ kernels using `AsyncKernelLaunch` instead of raw pointers
 - [Working with Data](../guide/working-with-data.md) — `PointerTile` and the safety model for pointer-based kernels
 - [DSL API](../reference/dsl-api.md#memory-pointer-based) — `int_to_ptr`, `ptr_to_int`, `ptr_to_ptr`, and atomic operations

--- a/cutile-book/tutorials/10-cuda-graphs.md
+++ b/cutile-book/tutorials/10-cuda-graphs.md
@@ -272,8 +272,8 @@ Each `forward` call:
 
 ```rust
 fn main() -> Result<(), Error> {
-    let ctx = CudaContext::new(0)?;
-    let stream = ctx.new_stream()?;
+    let device = Device::new(0)?;
+    let stream = device.new_stream()?;
 
     let cfg = Config { d: 2048, n_layers: 22, block: 128, bn: 16, bk: 16, eps: 1e-5 };
 
@@ -431,5 +431,5 @@ cargo run -p cutile-examples --example cuda_graphs
 
 ## See also
 
-- [Orchestrating Device Operations](../guide/device-operations.md) — where CUDA graphs fit alongside sync and async execution
+- [Device Operations](../guide/device-operations.md) — where CUDA graphs fit alongside sync and async execution
 - [Host API: CUDA Graph Integration](../reference/host-api.md#cuda-graph-integration) — `.graph_on(stream)` and `CudaGraph::scope` signatures

--- a/cutile-compiler/src/cuda_tile_runtime_utils.rs
+++ b/cutile-compiler/src/cuda_tile_runtime_utils.rs
@@ -6,15 +6,14 @@
 //! Runtime utilities for compiling Tile IR modules to GPU cubins.
 //! Provides GPU detection and bytecode compilation helpers.
 
-use cuda_core::{device, get_device_sm_name, init};
+use cuda_core::{get_device_sm_name, Device};
 use std::env;
 use std::process::Command;
 use uuid::Uuid;
 
 /// Queries the CUDA driver to determine the SM architecture name (e.g. `"sm_90"`) for a device.
 pub fn get_gpu_name(device_id: usize) -> String {
-    unsafe { init(0) }.expect("failed to initialize CUDA driver");
-    let dev = device::get(device_id as i32).expect("failed to get CUDA device");
+    let dev = Device::raw_device(device_id).expect("failed to get CUDA device");
     unsafe { get_device_sm_name(dev) }.expect("failed to get SM name")
 }
 

--- a/cutile-examples/examples/add_refs.rs
+++ b/cutile-examples/examples/add_refs.rs
@@ -28,8 +28,8 @@ mod my_module {
 use my_module::add;
 
 fn main() {
-    let ctx = cuda_core::CudaContext::new(0).unwrap();
-    let stream = ctx.new_stream().unwrap();
+    let device = cuda_core::Device::new(0).unwrap();
+    let stream = device.new_stream().unwrap();
 
     let x = api::ones::<f32>(&[32]).sync_on(&stream).unwrap();
     let y = api::ones::<f32>(&[32]).sync_on(&stream).unwrap();

--- a/cutile-examples/examples/batch_matmul.rs
+++ b/cutile-examples/examples/batch_matmul.rs
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 use cuda_async::device_operation::DeviceOp;
-use cuda_core::CudaContext;
+use cuda_core::Device;
 use cutile::api::{ones, zeros};
 use cutile::error::Error;
 use cutile::tensor::{IntoPartition, Partition, Tensor, ToHostVec};
@@ -46,8 +46,8 @@ mod my_module {
 use my_module::batch_matmul;
 
 fn main() -> Result<(), Error> {
-    let ctx = CudaContext::new(0)?;
-    let stream = ctx.new_stream()?;
+    let device = Device::new(0)?;
+    let stream = device.new_stream()?;
 
     let batch = 4usize;
     let (m, n, k) = (128usize, 256usize, 64usize);

--- a/cutile-examples/examples/book_examples.rs
+++ b/cutile-examples/examples/book_examples.rs
@@ -10,7 +10,7 @@
 //! Run with: cargo run --example book_examples
 
 use cuda_async::device_operation::*;
-use cuda_core::{CudaContext, CudaStream};
+use cuda_core::{Device, Stream};
 use cutile;
 use cutile::api::{arange, ones, randn, zeros};
 use cutile::error::Error;
@@ -41,7 +41,7 @@ mod hello_world_module {
     }
 }
 
-fn test_hello_world(stream: &Arc<CudaStream>) -> Result<(), Error> {
+fn test_hello_world(stream: &Arc<Stream>) -> Result<(), Error> {
     println!("\n=== Tutorial 1: Hello World ===");
     use hello_world_module::hello_world_kernel;
 
@@ -69,7 +69,7 @@ mod vector_add_module {
     }
 }
 
-fn test_vector_addition(stream: &Arc<CudaStream>) -> Result<(), Error> {
+fn test_vector_addition(stream: &Arc<Stream>) -> Result<(), Error> {
     println!("=== Tutorial 2: Vector Addition ===");
     use vector_add_module::add;
 
@@ -107,7 +107,7 @@ mod saxpy_module {
     }
 }
 
-fn test_saxpy(stream: &Arc<CudaStream>) -> Result<(), Error> {
+fn test_saxpy(stream: &Arc<Stream>) -> Result<(), Error> {
     println!("=== Tutorial 3: SAXPY ===");
     use saxpy_module::saxpy;
 
@@ -174,7 +174,7 @@ mod gemm_module {
     }
 }
 
-fn test_gemm(stream: &Arc<CudaStream>) -> Result<(), Error> {
+fn test_gemm(stream: &Arc<Stream>) -> Result<(), Error> {
     println!("=== Tutorial 4: Matrix Multiplication (GEMM) ===");
     use cutile::api;
     use cutile::DType;
@@ -227,7 +227,7 @@ mod softmax_module {
     }
 }
 
-fn test_softmax(stream: &Arc<CudaStream>) -> Result<(), Error> {
+fn test_softmax(stream: &Arc<Stream>) -> Result<(), Error> {
     println!("=== Tutorial 5: Fused Softmax ===");
     use softmax_module::softmax;
 
@@ -350,7 +350,7 @@ mod fmha_module {
     }
 }
 
-fn test_flash_attention(stream: &Arc<CudaStream>) -> Result<(), Error> {
+fn test_flash_attention(stream: &Arc<Stream>) -> Result<(), Error> {
     println!("=== Tutorial 6: Fused Multihead Attention ===");
     use fmha_module::fmha;
 
@@ -408,7 +408,7 @@ fn test_flash_attention(stream: &Arc<CudaStream>) -> Result<(), Error> {
 // ============================================================================
 // Tutorial 7: Intro to Async (sync equivalent — DeviceOp composition)
 // ============================================================================
-fn test_async_composition(stream: &Arc<CudaStream>) -> Result<(), Error> {
+fn test_async_composition(stream: &Arc<Stream>) -> Result<(), Error> {
     println!("=== Tutorial 7: Intro to Async (DeviceOp Composition) ===");
     use vector_add_module::add;
 
@@ -501,7 +501,7 @@ mod mlp_module {
     }
 }
 
-fn test_data_parallel_mlp(stream: &Arc<CudaStream>) -> Result<(), Error> {
+fn test_data_parallel_mlp(stream: &Arc<Stream>) -> Result<(), Error> {
     println!("=== Tutorial 8: Data Parallel MLP ===");
     use cutile::api;
     use cutile::DType;
@@ -596,7 +596,7 @@ mod pointer_add_module {
     }
 }
 
-fn test_pointer_addition(stream: &Arc<CudaStream>) -> Result<(), Error> {
+fn test_pointer_addition(stream: &Arc<Stream>) -> Result<(), Error> {
     println!("=== Tutorial 9: Pointer Addition ===");
     use pointer_add_module::add_ptr;
 
@@ -635,8 +635,8 @@ fn test_pointer_addition(stream: &Arc<CudaStream>) -> Result<(), Error> {
 fn main() -> Result<(), Error> {
     println!("cuTile Rust Book Examples - Verification Suite\n");
 
-    let ctx = CudaContext::new(0)?;
-    let stream = ctx.new_stream()?;
+    let device = Device::new(0)?;
+    let stream = device.new_stream()?;
 
     test_hello_world(&stream)?;
     test_vector_addition(&stream)?;

--- a/cutile-examples/examples/cuda_graphs.rs
+++ b/cutile-examples/examples/cuda_graphs.rs
@@ -12,7 +12,7 @@
  *   cargo run -p cutile-examples --example cuda_graphs
  */
 
-use cuda_core::{CudaContext, CudaStream};
+use cuda_core::{Device, Stream};
 use cutile::error::Error;
 use cutile::prelude::*;
 use std::time::Instant;
@@ -132,7 +132,7 @@ struct LayerBuffers {
 }
 
 impl LayerBuffers {
-    fn allocate(d: usize, stream: &Arc<CudaStream>) -> Result<Self, Error> {
+    fn allocate(d: usize, stream: &Arc<Stream>) -> Result<Self, Error> {
         Ok(Self {
             norm: api::zeros(&[1, d]).sync_on(stream)?,
             q: api::zeros(&[d]).sync_on(stream)?,
@@ -153,16 +153,12 @@ struct GraphModel {
 }
 
 impl GraphModel {
-    fn new(
-        cfg: &Config,
-        weights: &[LayerWeights],
-        stream: &Arc<CudaStream>,
-    ) -> Result<Self, Error> {
+    fn new(cfg: &Config, weights: &[LayerWeights], stream: &Arc<Stream>) -> Result<Self, Error> {
         let mut input: Tensor<f32> = api::ones::<f32>(&[cfg.d]).sync_on(stream)?;
         let mut buffers: Vec<_> = (0..cfg.n_layers)
             .map(|_| LayerBuffers::allocate(cfg.d, stream))
             .collect::<Result<_, _>>()?;
-        stream.synchronize()?;
+        unsafe { stream.synchronize() }?;
 
         // Capture the forward pass as a CUDA graph. Each s.record()
         // records a graph node, releasing borrows between kernels.
@@ -236,7 +232,7 @@ fn eager_forward(
     cfg: &Config,
     weights: &[LayerWeights],
     input: &Tensor<f32>,
-    stream: &Arc<CudaStream>,
+    stream: &Arc<Stream>,
 ) -> Result<Vec<f32>, Error> {
     let mut buffers: Vec<_> = (0..cfg.n_layers)
         .map(|_| LayerBuffers::allocate(cfg.d, stream))
@@ -289,8 +285,8 @@ fn eager_forward(
 // ═══════════════════════════════════════════════════════════════════════════════
 
 fn main() -> Result<(), Error> {
-    let ctx = CudaContext::new(0)?;
-    let stream = ctx.new_stream()?;
+    let device = Device::new(0)?;
+    let stream = device.new_stream()?;
 
     let cfg = Config {
         d: 2048,

--- a/cutile-examples/examples/cuda_graphs_deviceop.rs
+++ b/cutile-examples/examples/cuda_graphs_deviceop.rs
@@ -9,7 +9,7 @@
  *   cargo run -p cutile-examples --example cuda_graphs
  */
 
-use cuda_core::{CudaContext, CudaStream};
+use cuda_core::{Device, Stream};
 use cutile::error::Error;
 use cutile::prelude::*;
 use std::time::Instant;
@@ -133,7 +133,7 @@ struct LayerBuffers {
 }
 
 impl LayerBuffers {
-    fn allocate(d: usize, stream: &Arc<CudaStream>) -> Result<Self, Error> {
+    fn allocate(d: usize, stream: &Arc<Stream>) -> Result<Self, Error> {
         Ok(Self {
             norm: api::zeros(&[1, d]).sync_on(stream)?.into(),
             q: api::zeros(&[d]).sync_on(stream)?.into(),
@@ -160,16 +160,12 @@ struct GraphModel {
 }
 
 impl GraphModel {
-    fn new(
-        cfg: &Config,
-        weights: &[LayerWeights],
-        stream: &Arc<CudaStream>,
-    ) -> Result<Self, Error> {
+    fn new(cfg: &Config, weights: &[LayerWeights], stream: &Arc<Stream>) -> Result<Self, Error> {
         let input: Tensor<f32> = api::rand([cfg.d], None).sync_on(stream)?;
         let buffers: Vec<_> = (0..cfg.n_layers)
             .map(|_| LayerBuffers::allocate(cfg.d, stream))
             .collect::<Result<_, _>>()?;
-        stream.synchronize()?;
+        unsafe { stream.synchronize() }?;
 
         // Create an Arc that shares input's device memory for build_forward.
         // This requires aliased storage (input + input_arc point to same
@@ -201,7 +197,7 @@ impl GraphModel {
     }
 
     /// Returns the stream the graph was captured on.
-    fn stream(&self) -> &Arc<CudaStream> {
+    fn stream(&self) -> &Arc<Stream> {
         self.graph.stream()
     }
 
@@ -291,7 +287,7 @@ impl GraphModel {
 // Warmup — compile all kernels once so JIT cost is excluded from benchmarks
 // ═══════════════════════════════════════════════════════════════════════════════
 
-fn warmup(cfg: &Config, weights: &[LayerWeights], stream: &Arc<CudaStream>) -> Result<(), Error> {
+fn warmup(cfg: &Config, weights: &[LayerWeights], stream: &Arc<Stream>) -> Result<(), Error> {
     println!("Warming up (compiling kernels)...");
     let h: Arc<Tensor<f32>> = api::rand([cfg.d], None).sync_on(stream)?.into();
     let h_2d: Arc<Tensor<f32>> = h
@@ -330,7 +326,7 @@ fn eager_forward(
     cfg: &Config,
     weights: &[LayerWeights],
     input: &Arc<Tensor<f32>>,
-    stream: &Arc<CudaStream>,
+    stream: &Arc<Stream>,
 ) -> Result<Vec<f32>, Error> {
     let buffers: Vec<_> = (0..cfg.n_layers)
         .map(|_| LayerBuffers::allocate(cfg.d, stream))
@@ -349,8 +345,8 @@ fn eager_forward(
 // ═══════════════════════════════════════════════════════════════════════════════
 
 fn main() -> Result<(), Error> {
-    let ctx = CudaContext::new(0)?;
-    let stream = ctx.new_stream()?;
+    let device = Device::new(0)?;
+    let stream = device.new_stream()?;
 
     let cfg = Config {
         d: 2048,

--- a/cutile-examples/examples/cudarc_interop.rs
+++ b/cutile-examples/examples/cudarc_interop.rs
@@ -1,0 +1,120 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Borrows external CUDA handles into cutile via `Device::borrow_raw` and
+//! `Stream::borrow_raw`.
+//!
+//! The example is structured around a simulated third-party library
+//! (`foreign_cuda` below) that exposes its own `CUcontext` / `CUdevice` /
+//! `CUstream` typedefs. These are nominally distinct from
+//! `cuda_bindings`' typedefs — even though the underlying C ABI is
+//! identical — which is exactly the situation a real cudarc, bindgen, or
+//! hand-rolled-FFI caller finds themselves in.
+//!
+//! `borrow_raw` sidesteps the mismatch by taking `*mut c_void` + `c_int`,
+//! so the caller casts foreign pointer typedefs to primitives once at the
+//! boundary and keeps cutile binding-agnostic.
+//!
+//! The example demonstrates three properties:
+//!   1. A `ForeignHandles` bundle typed against foreign typedefs can be
+//!      turned into a cutile `Device`/`Stream` with only `as` casts.
+//!   2. A borrowed `Stream` drives a cutile kernel via `sync_on`.
+//!   3. Dropping the borrowed wrappers does NOT destroy the underlying
+//!      handles — the `source_*` handles still work afterward.
+
+use core::ffi::{c_int, c_void};
+use cuda_core::{Device, Stream};
+use cutile::error::Error;
+use cutile::prelude::*;
+
+/// Stand-in for a third-party CUDA bindings crate (cudarc, a newer
+/// bindgen run of `cuda.h`, etc.). The opaque structs and typedefs are
+/// intentionally distinct from `cuda_bindings::*` to prove that
+/// `borrow_raw` doesn't require our binding-crate's typedefs at the
+/// call site.
+#[allow(non_camel_case_types)]
+mod foreign_cuda {
+    use core::ffi::c_int;
+
+    pub enum CUctx_st {}
+    pub enum CUstream_st {}
+
+    pub type CUcontext = *mut CUctx_st;
+    pub type CUdevice = c_int;
+    pub type CUstream = *mut CUstream_st;
+
+    /// What the third-party framework hands to its embedders.
+    pub struct ForeignHandles {
+        pub cu_ctx: CUcontext,
+        pub cu_device: CUdevice,
+        pub cu_stream: CUstream,
+        pub ordinal: usize,
+    }
+}
+
+#[cutile::module]
+mod tile_add {
+    use cutile::core::*;
+
+    #[cutile::entry()]
+    pub fn add<const S: [i32; 1]>(
+        z: &mut Tensor<f32, S>,
+        x: &Tensor<f32, { [-1] }>,
+        y: &Tensor<f32, { [-1] }>,
+    ) {
+        let tx = load_tile_like_1d(x, z);
+        let ty = load_tile_like_1d(y, z);
+        z.store(tx + ty);
+    }
+}
+
+fn main() -> Result<(), Error> {
+    const N: usize = 1024;
+    const TILE: usize = 128;
+
+    let source_device = Device::new(0)?;
+    let source_stream = source_device.new_stream()?;
+
+    // Pretend these came from a third-party framework. Pointer-to-pointer
+    // and int-to-int casts are zero-cost; the types are nominally
+    // different but ABI-identical.
+    let foreign = foreign_cuda::ForeignHandles {
+        cu_ctx: source_device.cu_ctx() as foreign_cuda::CUcontext,
+        cu_device: source_device.cu_device() as foreign_cuda::CUdevice,
+        cu_stream: source_stream.cu_stream() as foreign_cuda::CUstream,
+        ordinal: source_device.ordinal(),
+    };
+
+    // TODO (hme): document safety — the foreign handles are derived from
+    // `source_*` above, which outlive the borrowed wrappers.
+    let borrowed_device = unsafe {
+        Device::borrow_raw(
+            foreign.cu_ctx as *mut c_void,
+            foreign.cu_device as c_int,
+            foreign.ordinal,
+        )
+    };
+    let borrowed_stream =
+        unsafe { Stream::borrow_raw(foreign.cu_stream as *mut c_void, &borrowed_device) };
+
+    let x = api::ones::<f32>(&[N]).sync_on(&borrowed_stream)?;
+    let y = api::ones::<f32>(&[N]).sync_on(&borrowed_stream)?;
+    let z = api::zeros::<f32>(&[N]).sync_on(&borrowed_stream)?;
+
+    let (z, _x, _y) = tile_add::add(z.partition([TILE]), x, y).sync_on(&borrowed_stream)?;
+    let z = z.unpartition();
+    let host = z.to_host_vec().sync_on(&borrowed_stream)?;
+    assert!(host.iter().all(|v| *v == 2.0));
+
+    drop(borrowed_stream);
+    drop(borrowed_device);
+
+    let probe = api::zeros::<f32>(&[4]).sync_on(&source_stream)?;
+    let probe_host = probe.to_host_vec().sync_on(&source_stream)?;
+    assert_eq!(probe_host, vec![0.0; 4]);
+
+    println!("cudarc_interop: borrowed stream ran kernel; source handles still alive.");
+    Ok(())
+}

--- a/cutile-examples/examples/dropout.rs
+++ b/cutile-examples/examples/dropout.rs
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 use cuda_async::device_operation::DeviceOp;
-use cuda_core::CudaContext;
+use cuda_core::Device;
 use cutile::api::{rand, randn, zeros};
 use cutile::error::Error;
 use cutile::tensor::{IntoPartition, Partition, Tensor, ToHostVec};
@@ -36,8 +36,8 @@ mod my_module {
 use my_module::dropout;
 
 fn main() -> Result<(), Error> {
-    let ctx = CudaContext::new(0)?;
-    let stream = ctx.new_stream()?;
+    let device = Device::new(0)?;
+    let stream = device.new_stream()?;
     let (m,) = (16,);
     let bm = 4;
     let p: f32 = 0.4;

--- a/cutile-examples/examples/flash_attention.rs
+++ b/cutile-examples/examples/flash_attention.rs
@@ -5,7 +5,7 @@
 extern crate core;
 
 use cuda_async::device_operation::{DeviceOp, Unzippable6};
-use cuda_core::CudaContext;
+use cuda_core::Device;
 use cutile;
 use cutile::api::{randn, zeros};
 use cutile::error::Error;
@@ -154,9 +154,9 @@ fn fmha(
     bbh: usize, // batch * num_heads part size.
 ) -> Result<(), Error> {
     // Create a context. Device 0 is associated with the context.
-    let ctx = CudaContext::new(0)?;
+    let device = Device::new(0)?;
     // Create a new stream on which we run CUDA operations.
-    let stream = ctx.new_stream()?;
+    let stream = device.new_stream()?;
 
     let seed = 123;
     let q: Arc<Tensor<f32>> = randn(0f32, 1., [b, h, m, d], Some(seed))

--- a/cutile-examples/examples/flash_attention_causal.rs
+++ b/cutile-examples/examples/flash_attention_causal.rs
@@ -5,7 +5,7 @@
 extern crate core;
 
 use cuda_async::device_operation::DeviceOp;
-use cuda_core::CudaContext;
+use cuda_core::Device;
 use cutile::api::{randn, zeros};
 use cutile::error::Error;
 use cutile::tensor::{IntoPartition, Partition, Tensor, ToHostVec};
@@ -213,8 +213,8 @@ fn fmha_ref_cpu(
 }
 
 fn run_attention_fmha(causal: bool) -> Result<(), Error> {
-    let ctx = CudaContext::new(0)?;
-    let stream = ctx.new_stream()?;
+    let device = Device::new(0)?;
+    let stream = device.new_stream()?;
 
     let (batch, heads, heads_kv, seq_len, head_dim) = (2usize, 8usize, 8usize, 64usize, 32usize);
     let (bm, bn) = (32, 32);

--- a/cutile-examples/examples/gemm.rs
+++ b/cutile-examples/examples/gemm.rs
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 use cuda_async::device_operation::*;
-use cuda_core::CudaContext;
+use cuda_core::Device;
 use cutile::api;
 use cutile::error::Error;
 use cutile::tensor::*;
@@ -37,8 +37,8 @@ mod my_module {
 }
 
 fn gemm<T: DType + std::fmt::Display>() -> Result<(), Error> {
-    let ctx = CudaContext::new(0)?;
-    let stream = ctx.new_stream()?;
+    let device = Device::new(0)?;
+    let stream = device.new_stream()?;
     let scale = 2usize.pow(10); // On the order of megabytes.
     let (bm, bn, bk) = (16, 16, 8);
     let (m, n, k) = (

--- a/cutile-examples/examples/gemm_static.rs
+++ b/cutile-examples/examples/gemm_static.rs
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 use cuda_async::device_operation::*;
-use cuda_core::CudaContext;
+use cuda_core::Device;
 use cutile::api;
 use cutile::error::Error;
 use cutile::tensor::*;
@@ -46,8 +46,8 @@ mod my_module {
 }
 
 fn gemm<T: DType + std::fmt::Display>() -> Result<(), Error> {
-    let ctx = CudaContext::new(0)?;
-    let stream = ctx.new_stream()?;
+    let device = Device::new(0)?;
+    let stream = device.new_stream()?;
     let scale = 2usize.pow(10); // On the order of megabytes.
     let (bm, bn, bk) = (16, 16, 8);
     let (m, n, k) = (

--- a/cutile-examples/examples/hello_world.rs
+++ b/cutile-examples/examples/hello_world.rs
@@ -5,7 +5,7 @@
 #![allow(unused_variables)]
 
 use cuda_async::device_operation::DeviceOp;
-use cuda_core::CudaContext;
+use cuda_core::Device;
 use cutile::error::Error;
 use cutile::tile_kernel::TileKernel;
 
@@ -33,8 +33,8 @@ mod hello_world_module {
 use hello_world_module::hello_world_kernel;
 
 fn main() -> Result<(), Error> {
-    let ctx = CudaContext::new(0)?;
-    let stream = ctx.new_stream()?;
+    let device = Device::new(0)?;
+    let stream = device.new_stream()?;
     let launcher = hello_world_kernel();
     launcher.grid((1, 1, 1)).sync_on(&stream)?;
     Ok(())

--- a/cutile-examples/examples/inter_module.rs
+++ b/cutile-examples/examples/inter_module.rs
@@ -66,8 +66,8 @@ mod my_kernels {
 use my_kernels::{apply_relu, apply_relu_square};
 
 fn main() -> Result<(), Error> {
-    let ctx: Arc<CudaContext> = CudaContext::new(0)?;
-    let stream = ctx.new_stream()?;
+    let device: Arc<Device> = Device::new(0)?;
+    let stream = device.new_stream()?;
     let block: usize = 64;
     let n: usize = 128;
 

--- a/cutile-examples/examples/interop.rs
+++ b/cutile-examples/examples/interop.rs
@@ -21,7 +21,7 @@ use cuda_async::device_operation::DeviceOp;
 use cuda_async::device_operation::ExecutionContext;
 use cuda_async::error::DeviceError;
 use cuda_async::launch::AsyncKernelLaunch;
-use cuda_core::{CudaFunction, LaunchConfig};
+use cuda_core::{Function, LaunchConfig};
 use cutile::api::{arange, zeros};
 use cutile::tensor::{IntoPartition, Tensor, ToHostVec};
 use std::future::IntoFuture;
@@ -108,7 +108,7 @@ $done:
 // ---------------------------------------------------------------------------
 
 struct ScaleKernel {
-    function: Arc<CudaFunction>,
+    function: Arc<Function>,
     n: u32,
     scale: f32,
     input: Arc<Tensor<f32>>,

--- a/cutile-examples/examples/rms_norm.rs
+++ b/cutile-examples/examples/rms_norm.rs
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 use cuda_async::device_operation::DeviceOp;
-use cuda_core::CudaContext;
+use cuda_core::Device;
 use cutile::api::{randn, zeros};
 use cutile::error::Error;
 use cutile::tensor::{IntoPartition, Partition, Tensor, ToHostVec};
@@ -65,9 +65,9 @@ use my_module::rms_norm;
 
 fn main() -> Result<(), Error> {
     // Create a context. Device 0 is associated with the context.
-    let ctx = CudaContext::new(0)?;
+    let device = Device::new(0)?;
     // Create a new stream on which we run CUDA operations.
-    let stream = ctx.new_stream()?;
+    let stream = device.new_stream()?;
     let (m, n) = (4, 8);
     let block_size = 2;
     let generics = vec![n.to_string(), block_size.to_string()];

--- a/cutile-examples/examples/saxpy.rs
+++ b/cutile-examples/examples/saxpy.rs
@@ -22,9 +22,9 @@ use my_module::saxpy;
 // TODO (hme): Answer question about whether main should return Result<(), ...>
 fn main() -> Result<(), Error> {
     // Create a context. Device 0 is associated with the context.
-    let ctx = CudaContext::new(0)?;
+    let device = Device::new(0)?;
     // Create a new stream on which we run CUDA operations.
-    let stream = ctx.new_stream()?;
+    let stream = device.new_stream()?;
     let a = 2.0;
     let input: Arc<Tensor<f32>> = api::arange(2usize.pow(5)).sync_on(&stream)?.into();
     let x: Arc<Tensor<f32>> = input

--- a/cutile-examples/examples/softmax.rs
+++ b/cutile-examples/examples/softmax.rs
@@ -29,9 +29,9 @@ use my_module::softmax;
 
 fn main() -> Result<(), Error> {
     // Create a context. Device 0 is associated with the context.
-    let ctx = CudaContext::new(0)?;
+    let device = Device::new(0)?;
     // Create a new stream on which we run CUDA operations.
-    let stream = ctx.new_stream()?;
+    let stream = device.new_stream()?;
     let (m, n) = (4, 8);
     let (bm, bn) = (2, n);
     let input: Arc<Tensor<f32>> = api::arange(m * n).sync_on(&stream)?.into();

--- a/cutile-examples/examples/tensor_permute.rs
+++ b/cutile-examples/examples/tensor_permute.rs
@@ -5,7 +5,7 @@
 extern crate core;
 
 use cuda_async::device_operation::DeviceOp;
-use cuda_core::CudaContext;
+use cuda_core::Device;
 use cutile::api::DeviceOpReshape;
 use cutile::api::{arange, zeros};
 use cutile::error::Error;
@@ -73,8 +73,8 @@ const N_CTX: usize = 1024;
 const HEAD_DIM: usize = 64;
 
 fn main() -> Result<(), Error> {
-    let ctx = CudaContext::new(0)?;
-    let stream = ctx.new_stream()?;
+    let device = Device::new(0)?;
+    let stream = device.new_stream()?;
 
     let b = BATCH; // = batch size.
     let h = N_HEADS; // = number of heads (query).

--- a/cutile-examples/examples/tensor_slicing.rs
+++ b/cutile-examples/examples/tensor_slicing.rs
@@ -44,8 +44,8 @@ mod my_module {
 use my_module::{add, scale};
 
 fn main() -> Result<(), Error> {
-    let ctx = CudaContext::new(0)?;
-    let stream = ctx.new_stream()?;
+    let device = Device::new(0)?;
+    let stream = device.new_stream()?;
     let block = 128;
 
     // Create a 1024-element tensor: [0, 1, 2, ..., 1023]

--- a/cutile-examples/src/lib.rs
+++ b/cutile-examples/src/lib.rs
@@ -9,7 +9,7 @@ use candle_core::WithDType;
 use candle_nn::ops::softmax;
 use cuda_core::DType;
 
-use cuda_core::{get_device_clock_rate, CudaContext};
+use cuda_core::{get_device_clock_rate, Device};
 
 /// Convert a host slice to a candle CPU tensor.
 pub fn to_candle_tensor<T: DType + WithDType>(data: &[T], shape: &[usize]) -> candle_core::Tensor {
@@ -126,21 +126,21 @@ pub fn rtx_5090_tensorcore_f16_sol_tflops_at(clock_speed: f64) -> f64 {
 
 /// Returns RTX 5090 theoretical peak f16 tensor core TFLOPS using the device's clock rate.
 pub fn rtx_5090_tensorcore_f16_sol_tflops(device_id: usize) -> f64 {
-    let ctx = CudaContext::new(device_id).unwrap();
-    let clock_rate = unsafe { get_device_clock_rate(ctx.cu_device()).unwrap() } as f64;
+    let device = Device::new(device_id).unwrap();
+    let clock_rate = unsafe { get_device_clock_rate(device.cu_device()).unwrap() } as f64;
     rtx_5090_tensorcore_f16_sol_tflops_at(clock_rate)
 }
 
 #[cfg(test)]
 mod test_peak {
     use crate::rtx_5090_tensorcore_f16_sol_tflops_at;
-    use cuda_core::{get_device_clock_rate, CudaContext};
+    use cuda_core::{get_device_clock_rate, Device};
 
     #[test]
     fn test_5090() {
-        let ctx = CudaContext::new(0).unwrap();
+        let device = Device::new(0).unwrap();
         // This appears to be correct / matches architecture documentation.
-        let clock_rate = unsafe { get_device_clock_rate(ctx.cu_device()).unwrap() } as f64;
+        let clock_rate = unsafe { get_device_clock_rate(device.cu_device()).unwrap() } as f64;
         let clock_mhz = clock_rate * 1e-3;
         println!(
             "rtx_5090 @ {}Mhz max tflops = {}",

--- a/cutile-macro/src/_module.rs
+++ b/cutile-macro/src/_module.rs
@@ -201,14 +201,15 @@ pub fn module(attributes: TokenStream, item: TokenStream) -> TokenStream {
     let mut module_item = parse_macro_input!(item as ItemMod);
     module_item.attrs = attrs.into();
 
-    module_inner(
+    match module_inner(
         &module_item,
         is_core,
         &tile_rust_crate_root,
         raw_item_source,
-    )
-    .unwrap_or_else(|Error::Syn(e)| e.to_compile_error())
-    .into()
+    ) {
+        Ok(ts) => ts.into(),
+        Err(err) => err.to_compile_error().into(),
+    }
 }
 
 /// Fallible inner implementation of the `module` macro.
@@ -272,10 +273,7 @@ fn module_inner(
             }
             syn::Item::Trait(trait_item) => {
                 if !is_core {
-                    return trait_item.err(concat!(
-                        "Unsupported item type in non-core module: ",
-                        "trait definitions are only allowed in core modules."
-                    ));
+                    return trait_item.err("Unsupported item type in non-core module: trait definitions are only allowed in core modules.");
                 }
                 ast_content.push(Item::Trait(trait_item.clone()));
                 let item_clone = trait_item.clone();
@@ -286,10 +284,7 @@ fn module_inner(
             }
             syn::Item::Impl(impl_item) => {
                 if !is_core {
-                    return impl_item.err(concat!(
-                        "Unsupported item type in non-core module: ",
-                        "impl blocks are only allowed in core modules."
-                    ));
+                    return impl_item.err("Unsupported item type in non-core module: impl blocks are only allowed in core modules.");
                 }
                 ast_content.push(Item::Impl(impl_item.clone()));
                 let item_clone = impl_item.clone();
@@ -297,10 +292,7 @@ fn module_inner(
             }
             syn::Item::Macro(macro_item) => {
                 if !is_core {
-                    return macro_item.err(concat!(
-                        "Unsupported item type in non-core module: ",
-                        "macro invocations are only allowed in core modules."
-                    ));
+                    return macro_item.err("Unsupported item type in non-core module: macro invocations are only allowed in core modules.");
                 }
                 ast_content.push(Item::Macro(macro_item.clone()));
                 let item_clone = macro_item.clone();
@@ -346,7 +338,7 @@ fn module_inner(
                 use #tile_rust_crate_root::tile_kernel::{*};
                 use #tile_rust_crate_root::cuda_async::error::{*};
                 use #tile_rust_crate_root::cuda_async::scheduling_policies::SchedulingPolicy;
-                use #tile_rust_crate_root::cuda_core::{CudaContext, CudaFunction, CudaModule, CudaStream, DriverError, LaunchConfig};
+                use #tile_rust_crate_root::cuda_core::{Device, Function, Module, Stream, DriverError, LaunchConfig};
                 // use #tile_rust_crate_root::cutile_compiler::cuda_tile::ModuleOperation;
                 // use #tile_rust_crate_root::cutile_compiler::compiler::{CUDATileModules, CUDATileFunctionCompiler};
                 // Module asts and generated type data.
@@ -793,12 +785,11 @@ pub fn kernel_launcher(module_ident: &Ident, item: &ItemFn) -> Result<TokenStrea
         #device_op_impl
     };
 
-    let _entry_attrs = get_meta_list_by_last_segment("entry", &item.attrs).ok_or_else(|| {
-        item.sig.ident.error(&format!(
-            "Unexpected entry point {}: Missing entry annotation.",
-            function_name
-        ))
-    })?;
+    let Some(_entry_attrs) = get_meta_list_by_last_segment("entry", &item.attrs) else {
+        return item.sig.ident.err(&format!(
+            "Unexpected entry point {function_name}: Missing entry annotation."
+        ));
+    };
 
     if let Ok(dir) = env::var("DUMP_KERNEL_LAUNCHER_DIR") {
         let file = parse_file(&result.to_string()).expect("Failed to parse file.");

--- a/cutile-macro/src/error.rs
+++ b/cutile-macro/src/error.rs
@@ -7,6 +7,13 @@
 //!
 //! Provides span-aware error construction for producing compile-time error messages.
 
+use proc_macro2::{Span, TokenStream as TokenStream2};
+use std::{
+    error,
+    fmt::{self, Display, Formatter},
+};
+use syn::spanned::Spanned;
+
 /// Unified error type for proc-macro diagnostics.
 #[derive(Debug)]
 pub enum Error {
@@ -14,40 +21,56 @@ pub enum Error {
     Syn(syn::Error),
 }
 
-impl std::error::Error for Error {}
+impl From<syn::Error> for Error {
+    fn from(error: syn::Error) -> Self {
+        Self::Syn(error)
+    }
+}
 
-impl std::fmt::Display for Error {
-    fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl Error {
+    pub fn to_compile_error(&self) -> TokenStream2 {
+        match self {
+            Self::Syn(err) => err.to_compile_error(),
+        }
+    }
+}
+
+impl Display for Error {
+    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
         match self {
             Self::Syn(error) => write!(formatter, "Syntax error: {error}"),
         }
     }
 }
 
-impl<T> From<Error> for Result<T, Error> {
-    #[inline]
-    fn from(value: Error) -> Self {
-        Err(value)
-    }
+impl error::Error for Error {}
+
+/// Create an `Error` at the given span.
+pub fn syn_err(span: Span, message: &str) -> Error {
+    syn::Error::new(span, message).into()
+}
+
+/// Return `Err(Error)` at the given span with an arbitrary `Ok` type.
+pub fn syn_error_at<T>(span: Span, message: &str) -> Result<T, Error> {
+    Err(syn_err(span, message))
+}
+
+/// Return `Err(Error)` at `Span::call_site()` with an arbitrary `Ok` type.
+pub fn call_site_error<T>(message: &str) -> Result<T, Error> {
+    syn_error_at(Span::call_site(), message)
 }
 
 /// Extension trait for producing span-anchored errors from any `Spanned` item.
 pub trait SpannedError {
-    /// Return `Error` anchored to this item's span.
-    fn error(&self, message: &str) -> Error;
     /// Return `Err(Error)` anchored to this item's span, with an arbitrary `Ok` type.
     fn err<T>(&self, message: &str) -> Result<T, Error>;
 }
 
 impl<S> SpannedError for S
 where
-    S: syn::spanned::Spanned,
+    S: Spanned,
 {
-    fn error(&self, message: &str) -> Error {
-        Error::Syn(syn::Error::new(self.span(), message))
-    }
-    #[inline]
     fn err<T>(&self, message: &str) -> Result<T, Error> {
-        self.error(message).into()
+        syn_error_at(self.span(), message)
     }
 }

--- a/cutile-macro/src/kernel_launcher_generator.rs
+++ b/cutile-macro/src/kernel_launcher_generator.rs
@@ -566,9 +566,9 @@ pub fn generate_kernel_launcher(
                         .err("Pointers can only be used in unsafe kernel entry points.");
                 }
                 let ptr_str = ptr_type.to_token_stream().to_string();
-                let (is_mutable, type_name) = get_ptr_type(&ptr_str).ok_or_else(|| {
-                    ptr_type.error(&format!("Unexpected pointer type: {}", ptr_str))
-                })?;
+                let Some((is_mutable, type_name)) = get_ptr_type(&ptr_str) else {
+                    return ptr_type.err(&format!("Unexpected pointer type: {}", ptr_str));
+                };
                 if !is_mutable {
                     return ptr_type.err("Pointers must be * mut.");
                 }
@@ -1196,9 +1196,9 @@ fn get_tensor_code(
 ) -> Result<TensorLaunchCode, Error> {
     // FnArg
     let (type_ident, type_generic_args) = get_ident_generic_args(&Type::Reference(ty.clone()));
-    let type_ident = type_ident
-        .ok_or_else(|| ty.error("Expected a named type identifier for tensor parameter."))?;
-
+    let Some(type_ident) = type_ident else {
+        return ty.err("Expected a named type identifier for tensor parameter.");
+    };
     if type_ident != "Tensor" {
         return ty.err(&format!("Expected Tensor type, got {}.", type_ident));
     }

--- a/cutile-macro/src/rewrite_variadics.rs
+++ b/cutile-macro/src/rewrite_variadics.rs
@@ -87,7 +87,7 @@
 //! - Pattern matching and variable bindings
 
 use crate::{
-    error::{Error, SpannedError},
+    error::{syn_err, Error},
     types::{
         concrete_name, get_variadic_function_suffix, get_variadic_method_data,
         get_variadic_op_data, get_variadic_trait_type_data, get_variadic_type_data,
@@ -168,9 +168,12 @@ fn try_get_path_expr_ident_str(maybe_path_expr: &Expr) -> Result<Option<String>,
     match maybe_path_expr {
         Expr::Path(path_expr) => {
             if path_expr.path.segments.len() != 1 {
-                return path_expr.path.err(&format!(
-                    "Expected single-segment path, got: {:?}",
-                    path_expr.path.segments.to_token_stream().to_string()
+                return Err(syn_err(
+                    path_expr.path.span(),
+                    &format!(
+                        "Expected single-segment path, got: {:?}",
+                        path_expr.path.segments.to_token_stream().to_string()
+                    ),
                 ));
             }
             let fn_name = path_expr.path.segments[0].ident.to_string();
@@ -204,7 +207,7 @@ fn get_vod_from_call(expr: &mut ExprCall) -> Result<Option<VariadicOpData>, Erro
                     .path
                     .segments
                     .last()
-                    .ok_or_else(|| path_expr.error("Expected at least one path segment"))?
+                    .ok_or_else(|| syn_err(path_expr.span(), "Expected at least one path segment"))?
                     .ident
                     .to_string();
                 Some(fn_name)
@@ -274,29 +277,33 @@ fn get_ident_generic_args(
 ) -> Result<(Ident, AngleBracketedGenericArguments), Error> {
     match ty {
         Type::Path(type_path) => {
-            let last_seg = type_path
-                .path
-                .segments
-                .last()
-                .ok_or_else(|| type_path.error("Expected at least one path segment"))?;
+            let result_type = type_path.clone();
+            let maybe_last_seg =
+                result_type.path.segments.last().ok_or_else(|| {
+                    syn_err(type_path.span(), "Expected at least one path segment")
+                })?;
+            let last_seg = maybe_last_seg.clone();
             if last_seg.ident != vtd.name {
-                return last_seg.ident.err(&format!(
-                    "get_ident_generic_args: Expected type '{}', got '{}'",
-                    vtd.name, last_seg.ident
+                return Err(syn_err(
+                    last_seg.ident.span(),
+                    &format!(
+                        "get_ident_generic_args: Expected type '{}', got '{}'",
+                        vtd.name, last_seg.ident
+                    ),
                 ));
             }
-            match &last_seg.arguments {
+            match last_seg.arguments {
                 // The type takes a const generic array as a type param:
                 // f(..., shape: Shape<D>) -> ()
                 PathArguments::AngleBracketed(type_params) => {
                     // This is a type of the form T<...>
                     Ok((last_seg.ident.clone(), type_params.clone()))
                 }
-                _ => type_path.err("Unexpected generic arguments"),
+                _ => Err(syn_err(type_path.span(), "Unexpected generic arguments")),
             }
         }
         Type::Reference(ref_type) => get_ident_generic_args(&ref_type.elem, vtd),
-        _ => ty.err("Unexpected type"),
+        _ => Err(syn_err(ty.span(), "Unexpected type")),
     }
 }
 
@@ -398,15 +405,6 @@ fn get_concrete_op_or_method_ident_from_types(
 
     let mut missing_idx = vec![];
     let mut missing_types = vec![];
-
-    let op_error = |msg: &_| op_or_method_ident.error(msg);
-    let fn_error = |msg: &str| {
-        op_error(&format!(
-            "get_concrete_op_ident_from_types({}, ...): {}",
-            op_or_method_ident, msg
-        ))
-    };
-
     for (idx, expected_type_name, vod_cga_var_names) in vod.input_map {
         // Go through the input map and attempt to map from VOD -
         let Some(ty) = &input_types[idx] else {
@@ -414,41 +412,33 @@ fn get_concrete_op_or_method_ident_from_types(
             missing_types.push(expected_type_name);
             continue;
         };
-        let vtd = get_vtd(ty)?.ok_or_else(|| {
-            op_error(&format!(
-                concat!(
-                    "Unable to infer type for argument {} for call to {}. Expected {}. ",
-                    "Required by calls to variadic functions and methods."
-                ),
-                idx, op_or_method_ident, expected_type_name
-            ))
-        })?;
-
+        let Some(vtd) = get_vtd(ty)? else {
+            return Err(syn_err(
+                op_or_method_ident.span(),
+                &format!("Unable to infer type for argument {idx} for call to {op_or_method_ident}. Expected {expected_type_name}. Required by calls to variadic functions and methods."),
+            ));
+        };
         // Get the cga_instances from const_instances. These are ordered.
         // Match them in order to the const var structure of the VariadicOpData type.
-        let cga_instances = get_cga_type(ty, const_instances)?.ok_or_else(|| {
-            fn_error(&format!(
-                "Unable to get cga instances for type: {}",
-                ty.to_token_stream()
-            ))
-        })?;
-
+        let Some(cga_instances) = get_cga_type(ty, const_instances)? else {
+            return Err(syn_err(
+                op_or_method_ident.span(),
+                &format!("get_concrete_op_ident_from_types({op_or_method_ident}, ...): Unable to get cga instances for type: {}", ty.to_token_stream()),
+            ));
+        };
         // This is a variadic type with cga instances.
         let type_name = vtd.name;
         if expected_type_name != type_name {
-            return fn_error(&format!(
-                "Unexpected positional argument type: {:#?}",
-                (idx, ty.to_token_stream())
-            ))
-            .into();
+            return Err(syn_err(
+                op_or_method_ident.span(),
+                &format!("get_concrete_op_ident_from_types({op_or_method_ident}, ...): Unexpected positional argument type: {:#?}", (idx, ty.to_token_stream())),
+            ));
         }
         if vod_cga_var_names.len() != cga_instances.n.len() {
-            return fn_error(&format!(
-                "Expected {} cga instances for {type_name}, got {:?}.",
-                vod_cga_var_names.len(),
-                cga_instances.n
-            ))
-            .into();
+            return Err(syn_err(
+                op_or_method_ident.span(),
+                &format!("get_concrete_op_ident_from_types({op_or_method_ident}, ...): Expected {} cga instances for {type_name}, got {:?}.", vod_cga_var_names.len(), cga_instances.n),
+            ));
         }
         for (cga_var_name, (&cga_var_length, cga_arg_string)) in vod_cga_var_names.iter().zip(
             cga_instances
@@ -456,22 +446,20 @@ fn get_concrete_op_or_method_ident_from_types(
                 .iter()
                 .zip(cga_instances.cga_arg_strings.iter()),
         ) {
-            let cga_var_length_var = vod
-                .cga_map
-                .get(cga_var_name)
-                .ok_or_else(|| op_error(&format!("Missing cga_map entry for '{cga_var_name}'")))?;
+            let cga_var_length_var = vod.cga_map.get(cga_var_name).ok_or_else(|| {
+                syn_err(
+                    op_or_method_ident.span(),
+                    &format!("Missing cga_map entry for '{cga_var_name}'"),
+                )
+            })?;
             vod_cga_name_to_context_cga_name.insert(cga_var_name, cga_arg_string.clone());
             if let Some(&current_var_length) = const_length_values.get(cga_var_length_var) {
                 // If we've already recorded this cga instance, make sure other instances are equivalent.
                 if current_var_length != cga_var_length {
-                    return fn_error(&format!(
-                        concat!(
-                            "CGA instance var length mismatch. ",
-                            "Expected {} but got {} for cga {}."
-                        ),
-                        current_var_length, cga_var_length, cga_var_name
-                    ))
-                    .into();
+                    return Err(syn_err(
+                        op_or_method_ident.span(),
+                        &format!("get_concrete_op_ident_from_types({op_or_method_ident}, ...): CGA instance var length mismatch. Expected {current_var_length} but got {cga_var_length} for cga {cga_var_name}."),
+                    ));
                 }
             } else {
                 const_length_values.insert(cga_var_length_var, cga_var_length);
@@ -483,66 +471,71 @@ fn get_concrete_op_or_method_ident_from_types(
     // The keys of const_length_values are the length values in "VOD space," or the const_length_vars for the corresponding variadic op data entry.
 
     if const_length_values.len() > vod.const_length_vars.len() {
-        return fn_error(&format!(
-            "Unexpected number of cga instances: {:#?} ",
-            const_length_values
-        ))
-        .into();
+        return Err(syn_err(
+            op_or_method_ident.span(),
+            &format!("get_concrete_op_ident_from_types({op_or_method_ident}, ...): Unexpected number of cga instances: {:#?} ", const_length_values),
+        ));
     } else if const_length_values.len() < vod.const_length_vars.len() {
         // Try to get the last cga instance from the output type.
-        let output_type = output_type.as_ref().ok_or_else(|| {
-            op_error(&format!(
-                concat!(
-                    "Unable to infer call to {}. ",
-                    "Try binding it to a statically typed variable.\n",
-                    "Debug info:\n",
-                    "const_length_values={:#?}, ",
-                    "vod.const_length_vars={:#?}"
+        if output_type.is_none() {
+            return Err(syn_err(
+                op_or_method_ident.span(),
+                &format!("Unable to infer call to {}. Try binding it to a statically typed variable. \nDebug info:\n const_length_values={:#?}, vod.const_length_vars={:#?}",
+                    op_or_method_ident,
+                    const_length_values,
+                    vod.const_length_vars),
+            ));
+        }
+        let output_type = output_type.clone().unwrap();
+
+        let maybe_vtd = get_vtd(&output_type)?;
+        if maybe_vtd.is_none() {
+            return Err(syn_err(
+                op_or_method_ident.span(),
+                &format!(
+                    "Unable to infer call to {}. Try binding it to a statically typed variable.",
+                    op_or_method_ident
                 ),
-                op_or_method_ident, const_length_values, vod.const_length_vars
-            ))
-        })?;
-
-        let vtd = get_vtd(output_type)?.ok_or_else(|| {
-            op_error(&format!(
-                "Unable to infer call to {}. Try binding it to a statically typed variable.",
-                op_or_method_ident
-            ))
-        })?;
-
-        let cga_instances = get_cga_type(output_type, const_instances)?.ok_or_else(|| {
-            fn_error(&format!(
-                "Unable to get cga instances for output type: {}",
-                output_type.to_token_stream()
-            ))
-        })?;
+            ));
+        }
+        let vtd = maybe_vtd.unwrap();
+        let cga_instances = get_cga_type(&output_type, const_instances)?;
+        if cga_instances.is_none() {
+            return Err(syn_err(
+                op_or_method_ident.span(),
+                &format!("get_concrete_op_ident_from_types({op_or_method_ident}, ...): Unable to get cga instances for output type: {}", output_type.to_token_stream()),
+            ));
+        }
+        let cga_instances = cga_instances.unwrap();
 
         let (expected_type_name, vod_cga_var_names) = vod.output_map;
         if expected_type_name != vtd.name {
-            return fn_error(&format!(
-                "Unexpected output type: {}",
-                output_type.to_token_stream()
-            ))
-            .into();
+            return Err(syn_err(
+                op_or_method_ident.span(),
+                &format!("get_concrete_op_ident_from_types({op_or_method_ident}, ...): Unexpected output type: {}", output_type.to_token_stream()),
+            ));
         }
         if vod_cga_var_names.len() != cga_instances.n.len() {
-            return fn_error(&format!(
-                "Expected {} cga instances, got {}.",
-                vod_cga_var_names.len(),
-                cga_instances.n.len()
-            ))
-            .into();
+            return Err(syn_err(
+                op_or_method_ident.span(),
+                &format!("get_concrete_op_ident_from_types({op_or_method_ident}, ...): Expected {} cga instances, got {}.", vod_cga_var_names.len(), cga_instances.n.len()),
+            ));
         }
         for (cga_var_name, &cga_var_length) in vod_cga_var_names.iter().zip(cga_instances.n.iter())
         {
-            let cga_var_length_var = vod
-                .cga_map
-                .get(cga_var_name)
-                .ok_or_else(|| op_error(&format!("Missing cga_map entry for '{cga_var_name}'")))?;
+            let cga_var_length_var = vod.cga_map.get(cga_var_name).ok_or_else(|| {
+                syn_err(
+                    op_or_method_ident.span(),
+                    &format!("Missing cga_map entry for '{cga_var_name}'"),
+                )
+            })?;
             if let Some(&current_var_length) = const_length_values.get(cga_var_length_var) {
                 // If we've already recorded this cga instance, make sure other instances are equivalent.
                 if current_var_length != cga_var_length {
-                    return fn_error("CGA instance var length mismatch for output type.").into();
+                    return Err(syn_err(
+                        op_or_method_ident.span(),
+                        &format!("get_concrete_op_ident_from_types({op_or_method_ident}, ...): CGA instance var length mismatch for output type."),
+                    ));
                 }
             } else {
                 const_length_values.insert(cga_var_length_var, cga_var_length);
@@ -551,14 +544,10 @@ fn get_concrete_op_or_method_ident_from_types(
     }
 
     if const_length_values.len() != vod.const_length_vars.len() {
-        return op_error(&format!(
-            concat!(
-                "Unable to infer type for argument(s) {:?} for call to {}. ",
-                "Expected {:?}. Required by calls to variadic functions and methods."
-            ),
-            missing_idx, op_or_method_ident, missing_types
-        ))
-        .into();
+        return Err(syn_err(
+            op_or_method_ident.span(),
+            &format!("Unable to infer type for argument(s) {missing_idx:?} for call to {op_or_method_ident}. Expected {missing_types:?}. Required by calls to variadic functions and methods."),
+        ));
     }
 
     // TODO (hme): Separate this whole thing into two functions: One for output inference, and one for desugaring.
@@ -567,12 +556,18 @@ fn get_concrete_op_or_method_ident_from_types(
     } else {
         let (return_type_name, return_type_generic_args) = vod.return_type;
         if return_type_generic_args.is_empty() {
-            let ty = syn::parse::<Type>(
-                return_type_name
-                    .parse()
-                    .map_err(|_| op_error(&format!("Unable to parse {return_type_name}")))?,
-            )
-            .map_err(|e| op_error(&format!("Unable to parse {return_type_name}: {e}")))?;
+            let ty = syn::parse::<Type>(return_type_name.parse().map_err(|_| {
+                syn_err(
+                    op_or_method_ident.span(),
+                    &format!("Unable to parse {return_type_name}"),
+                )
+            })?)
+            .map_err(|e| {
+                syn_err(
+                    op_or_method_ident.span(),
+                    &format!("Unable to parse {return_type_name}: {e}"),
+                )
+            })?;
             Some(ty)
         } else {
             let mut missing_cgas = vec![];
@@ -591,15 +586,10 @@ fn get_concrete_op_or_method_ident_from_types(
             if return_type_generic_arg_strings.len() != num_cgas {
                 // Return the given output_type if it is not none.
                 if output_type.is_none() {
-                    return op_error(&format!(
-                        concat!(
-                            "Failed to infer return type generic args {:?}\n",
-                            "op={}\n",
-                            "vod_cga_name_to_context_cga_name={:#?}"
-                        ),
-                        missing_cgas, op_or_method_ident, vod_cga_name_to_context_cga_name
-                    ))
-                    .into();
+                    return Err(syn_err(
+                        op_or_method_ident.span(),
+                        &format!("Failed to infer return type generic args {:?} \nop={} \nvod_cga_name_to_context_cga_name={vod_cga_name_to_context_cga_name:#?}", missing_cgas, op_or_method_ident),
+                    ));
                 }
                 output_type
             } else {
@@ -608,37 +598,39 @@ fn get_concrete_op_or_method_ident_from_types(
                     return_type_name,
                     return_type_generic_arg_strings.join(", ")
                 );
-                let ty = syn::parse::<Type>(
-                    return_type_str
-                        .parse()
-                        .map_err(|_| op_error(&format!("Unable to parse {return_type_str}")))?,
-                )
-                .map_err(|e| op_error(&format!("Unable to parse {return_type_str}: {e}")))?;
+                let ty = syn::parse::<Type>(return_type_str.parse().map_err(|_| {
+                    syn_err(
+                        op_or_method_ident.span(),
+                        &format!("Unable to parse {return_type_str}"),
+                    )
+                })?)
+                .map_err(|e| {
+                    syn_err(
+                        op_or_method_ident.span(),
+                        &format!("Unable to parse {return_type_str}: {e}"),
+                    )
+                })?;
                 Some(ty)
             }
         }
     };
 
     if vod.const_length_vars.len() != const_length_values.len() {
-        return op_error(&format!(
-            "Failed to infer op name from given parameters {op_or_method_ident}"
-        ))
-        .into();
+        return Err(syn_err(
+            op_or_method_ident.span(),
+            &format!("Failed to infer op name from given parameters {op_or_method_ident}"),
+        ));
     }
-    let length_vec = vod
-        .const_length_vars
-        .iter()
-        .map(|const_length_var| {
-            const_length_values
-                .get(const_length_var)
-                .copied()
-                .ok_or_else(|| {
-                    op_error(&format!(
-                        "Missing const_length_value for '{const_length_var}'"
-                    ))
-                })
-        })
-        .collect::<Result<Vec<_>, _>>()?;
+    let mut length_vec = Vec::with_capacity(vod.const_length_vars.len());
+    for const_length_var in vod.const_length_vars {
+        let val = const_length_values.get(const_length_var).ok_or_else(|| {
+            syn_err(
+                op_or_method_ident.span(),
+                &format!("Missing const_length_value for '{const_length_var}'"),
+            )
+        })?;
+        length_vec.push(*val);
+    }
     let ident = get_variadic_op_ident(op_or_method_ident, &length_vec);
     Ok((ident, rtype))
 }
@@ -717,17 +709,23 @@ impl ConstInstances {
         {
             let length_instance = *length_instance as u32;
             if length_var_name != &cga.length_var {
-                return Span::call_site().err(&format!(
-                    "CGA length var name mismatch: expected '{}', got '{}'",
-                    cga.length_var, length_var_name
+                return Err(syn_err(
+                    Span::call_site(),
+                    &format!(
+                        "CGA length var name mismatch: expected '{}', got '{}'",
+                        cga.length_var, length_var_name
+                    ),
                 ));
             }
             if let Some(existing_length) = inst_u32.insert(length_var_name.clone(), length_instance)
             {
                 if existing_length != length_instance {
-                    return Span::call_site().err(&format!(
-                        "CGA length instance mismatch for '{}': expected {}, got {}",
-                        length_var_name, existing_length, length_instance
+                    return Err(syn_err(
+                        Span::call_site(),
+                        &format!(
+                            "CGA length instance mismatch for '{}': expected {}, got {}",
+                            length_var_name, existing_length, length_instance
+                        ),
                     ));
                 }
             }
@@ -757,17 +755,17 @@ impl ConstInstances {
     fn instantiate_var_cgas(&self, var_cgas: &[VarCGAParameter]) -> Result<Self, Error> {
         let mut result = self.clone();
         for cga in var_cgas {
-            let n = result
-                .inst_u32
-                .get(&cga.length_var)
-                .copied()
-                .ok_or_else(|| {
-                    Span::call_site().error(&format!(
+            if !result.inst_u32.contains_key(&cga.length_var) {
+                return Err(syn_err(
+                    Span::call_site(),
+                    &format!(
                         "instantiate_var_cgas: Missing inst_u32 entry for '{}'",
                         cga.length_var
-                    ))
-                })?;
-            result.inst_array.insert(cga.name.clone(), cga.instance(n));
+                    ),
+                ));
+            }
+            let n = result.inst_u32.get(&cga.length_var).unwrap();
+            result.inst_array.insert(cga.name.clone(), cga.instance(*n));
             result.var_arrays.insert(cga.name.clone(), cga.clone());
         }
         Ok(result)
@@ -782,9 +780,12 @@ impl ConstInstances {
             let n: u32 = n_list[i];
             let cga = &var_cgas[i];
             if result.inst_u32.contains_key(&cga.length_var) {
-                return Span::call_site().err(&format!(
-                    "instantiate_new_var_cgas: inst_u32 already contains entry for '{}'",
-                    cga.length_var
+                return Err(syn_err(
+                    Span::call_site(),
+                    &format!(
+                        "instantiate_new_var_cgas: inst_u32 already contains entry for '{}'",
+                        cga.length_var
+                    ),
                 ));
             }
             result.inst_u32.insert(cga.length_var.clone(), n);
@@ -828,14 +829,18 @@ impl VariadicLengthIterator {
         if let Some(variadic_length_vars) = attribute_list.parse_string_arr("variadic_length_vars")
         {
             for var in variadic_length_vars {
-                let len = attribute_list.parse_int(var.as_str()).ok_or_else(|| {
-                    Span::call_site().error(&format!("Missing attribute value for '{var}'"))
-                })? + 1;
-                let len = len as _;
+                let len = (attribute_list.parse_int(var.as_str()).ok_or_else(|| {
+                    syn_err(
+                        Span::call_site(),
+                        &format!("Missing attribute value for '{var}'"),
+                    )
+                })? + 1) as usize;
                 i_max *= len;
                 if variadic_lengths.insert(var.clone(), len).is_some() {
-                    return Span::call_site()
-                        .err(&format!("Duplicate variadic_length_var '{var}'"));
+                    return Err(syn_err(
+                        Span::call_site(),
+                        &format!("Duplicate variadic_length_var '{var}'"),
+                    ));
                 }
             }
         }
@@ -844,13 +849,18 @@ impl VariadicLengthIterator {
             let var = cga.length_var.clone();
             cga_length_vars.push(var.clone());
             // This is so we don't need to explicitly specify the variadic_length_vars attribute.
-            let len = attribute_list.parse_int(var.as_str()).ok_or_else(|| {
-                Span::call_site().error(&format!("Missing attribute value for '{var}'"))
-            })? + 1;
-            let len = len as _;
-            if let Some(&variadic_length) = variadic_lengths.get(&var) {
-                if variadic_length != len {
-                    return Span::call_site().err(&format!("Variadic length mismatch for '{var}'"));
+            let len = (attribute_list.parse_int(var.as_str()).ok_or_else(|| {
+                syn_err(
+                    Span::call_site(),
+                    &format!("Missing attribute value for '{var}'"),
+                )
+            })? + 1) as usize;
+            if variadic_lengths.contains_key(&var) {
+                if *variadic_lengths.get(&var).unwrap() != len {
+                    return Err(syn_err(
+                        Span::call_site(),
+                        &format!("Variadic length mismatch for '{var}'"),
+                    ));
                 }
             } else {
                 i_max *= len;
@@ -971,13 +981,16 @@ pub fn variadic_struct(
     item: ItemStruct,
 ) -> Result<Vec<(ItemStruct, Option<ItemImpl>)>, Error> {
     // println!("item: {item:#?}");
-    let vtd = get_variadic_type_data(item.ident.to_string().as_str()).ok_or_else(|| {
-        item.ident.error(&format!(
-            "Generating {} requires a corresponding entry in VARIADIC_TYPES",
-            item.ident
-        ))
-    });
-
+    let vtd = get_variadic_type_data(item.ident.to_string().as_str());
+    if vtd.is_none() {
+        return Err(syn_err(
+            item.ident.span(),
+            &format!(
+                "Generating {} requires a corresponding entry in VARIADIC_TYPES",
+                item.ident
+            ),
+        ));
+    }
     let cgas = parse_var_cgas(&item.generics);
     let cga_iter = VariadicLengthIterator::new(attributes, &cgas)?;
 
@@ -986,10 +999,13 @@ pub fn variadic_struct(
     let vtd = vtd.unwrap();
     let num_cgas = vtd.num_cgas();
     if cgas.len() as u32 != num_cgas {
-        return item.ident.err(&format!(
-            "Expected {} const generic arrays, got {}",
-            num_cgas,
-            cgas.len()
+        return Err(syn_err(
+            item.ident.span(),
+            &format!(
+                "Expected {} const generic arrays, got {}",
+                num_cgas,
+                cgas.len()
+            ),
         ));
     }
     let mut result: Vec<(ItemStruct, Option<ItemImpl>)> = vec![];
@@ -1076,15 +1092,16 @@ pub fn variadic_struct(
                     }}
                 "#
                 );
-                let parsed_impl = syn::parse::<ItemImpl>(
-                    constructor_impl
-                        .parse()
-                        .map_err(|_| item.ident.error("Failed to parse constructor impl"))?,
-                )
-                .map_err(|e| {
-                    item.ident
-                        .error(&format!("Failed to parse constructor impl: {e}"))
-                })?;
+                let parsed_impl =
+                    syn::parse::<ItemImpl>(constructor_impl.parse().map_err(|_| {
+                        syn_err(item.ident.span(), "Failed to parse constructor impl")
+                    })?)
+                    .map_err(|e| {
+                        syn_err(
+                            item.ident.span(),
+                            &format!("Failed to parse constructor impl: {e}"),
+                        )
+                    })?;
                 // println!("parsed_impl: {parsed_impl:#?}");
                 Some(parsed_impl)
             }
@@ -1261,17 +1278,12 @@ fn rewrite_fn_sig(sig: &mut Signature, const_instances: &ConstInstances) -> Resu
 /// ```
 pub fn variadic_op(attributes: &SingleMetaList, item: ItemFn) -> Result<Vec<ItemFn>, Error> {
     let op_name = item.sig.ident.to_string();
-    get_variadic_op_data(&op_name).ok_or_else(|| {
-        item.sig.ident.error(&format!(
-            concat!(
-                "Variadic op data not found for {}. ",
-                "VariadicOpData entry is required ",
-                "for ops with cuda_tile::variadic_op annotation."
-            ),
-            op_name
-        ))
-    })?;
-
+    if get_variadic_op_data(&op_name).is_none() {
+        return Err(syn_err(
+            item.sig.ident.span(),
+            &format!("Variadic op data not found for {op_name}. VariadicOpData entry is required for ops with cuda_tile::variadic_op annotation."),
+        ));
+    }
     let cgas = parse_var_cgas(&item.sig.generics);
     // This ensures to not duplicate cgas with the same n.
     // let fn_types = get_sig_types(&item.sig, None);
@@ -1303,28 +1315,31 @@ fn desugar_generics(
                         .inst_array
                         .get(const_param_name.as_str())
                         .ok_or_else(|| {
-                            const_param.ident.error(&format!(
-                                "Missing inst_array entry for '{const_param_name}'"
-                            ))
+                            syn_err(
+                                const_param.ident.span(),
+                                &format!("Missing inst_array entry for '{const_param_name}'"),
+                            )
                         })?;
                     if cga.element_type != "i32" {
-                        return const_param.ident.err(&format!(
-                            "Expected element_type 'i32', got '{}'",
-                            cga.element_type
+                        return Err(syn_err(
+                            const_param.ident.span(),
+                            &format!("Expected element_type 'i32', got '{}'", cga.element_type),
                         ));
                     }
                     for i in 0..cga.length {
                         let const_str = format!("const {}{}: {}", cga.name, i, cga.element_type);
                         let generic_param =
                             syn::parse::<GenericParam>(const_str.parse().map_err(|_| {
-                                const_param
-                                    .ident
-                                    .error(&format!("Failed to parse generic param '{const_str}'"))
+                                syn_err(
+                                    const_param.ident.span(),
+                                    &format!("Failed to parse generic param '{const_str}'"),
+                                )
                             })?)
                             .map_err(|e| {
-                                const_param.ident.error(&format!(
-                                    "Failed to parse generic param '{const_str}': {e}"
-                                ))
+                                syn_err(
+                                    const_param.ident.span(),
+                                    &format!("Failed to parse generic param '{const_str}': {e}"),
+                                )
                             })?;
                         concrete_type_params.push(generic_param);
                     }
@@ -1343,33 +1358,43 @@ fn expand_cga(
     path: &Path,
     instances: &ConstInstances,
 ) -> Result<AngleBracketedGenericArguments, Error> {
-    let last_seg = path
-        .segments
-        .last()
-        .ok_or_else(|| path.error("Expected at least one path segment in expand_cga"))?;
+    let _result_path = path.clone();
+    let last_seg = path.segments.last().ok_or_else(|| {
+        syn_err(
+            path.span(),
+            "Expected at least one path segment in expand_cga",
+        )
+    })?;
     let param_name = last_seg.ident.to_string();
     // Is it a variadic type or is it expecting a variadic type parameter?
-    let cga = instances.inst_array.get(&param_name).ok_or_else(|| {
-        path.error(&format!(
-            "{} is not a const generic array.",
-            path.to_token_stream()
+    if instances.inst_array.contains_key(&param_name) {
+        // The type is a const generic array, e.g. the D in f(..., shape: D) -> ()
+        let cga = instances.inst_array.get(&param_name).unwrap();
+        let mut generic_args_result: Vec<String> = vec![];
+        for j in 0..cga.length {
+            generic_args_result.push(format!("{}{}", cga.name, j));
+        }
+        let formatted = format!("<{}>", generic_args_result.join(","));
+        Ok(
+            syn::parse::<AngleBracketedGenericArguments>(formatted.parse().map_err(|_| {
+                syn_err(
+                    path.span(),
+                    &format!("Failed to parse angle bracketed args '{formatted}'"),
+                )
+            })?)
+            .map_err(|e| {
+                syn_err(
+                    path.span(),
+                    &format!("Failed to parse angle bracketed args '{formatted}': {e}"),
+                )
+            })?,
+        )
+    } else {
+        Err(syn_err(
+            path.span(),
+            &format!("{} is not a const generic array.", path.to_token_stream()),
         ))
-    })?;
-    // The type is a const generic array, e.g. the D in f(..., shape: D) -> ()
-    let generic_args_result = (0..cga.length)
-        .map(|i| format!("{}{}", cga.name, i))
-        .collect::<Vec<_>>();
-    let formatted = format!("<{}>", generic_args_result.join(","));
-    syn::parse(formatted.parse().map_err(|_| {
-        path.error(&format!(
-            "Failed to parse angle bracketed args '{formatted}'"
-        ))
-    })?)
-    .map_err(|e| {
-        path.error(&format!(
-            "Failed to parse angle bracketed args '{formatted}': {e}"
-        ))
-    })
+    }
 }
 
 /// Desugars variadic types in a path, replacing CGA syntax with concrete type names and args.
@@ -1381,9 +1406,12 @@ fn desugar_path(path: &Path, instances: &ConstInstances) -> Result<Path, Error> 
         if instances.inst_array.contains_key(&param_name) {
             // The type is a const generic array: f(..., shape: D) -> ()
             // The result produced by this case is not supported syntax.
-            return seg.ident.err(&format!(
-                "Unexpected use of desugar_path for {}",
-                path.to_token_stream()
+            return Err(syn_err(
+                seg.ident.span(),
+                &format!(
+                    "Unexpected use of desugar_path for {}",
+                    path.to_token_stream()
+                ),
             ));
             // let cga = instances.inst_array.get(&param_name).unwrap();
             // let mut generic_args_result: Vec<String> = vec![];
@@ -1413,13 +1441,14 @@ fn desugar_path(path: &Path, instances: &ConstInstances) -> Result<Path, Error> 
                     let variadic_type_data: Option<VariadicTypeData> =
                         get_variadic_type_data(seg.ident.to_string().as_str());
                     if variadic_type_data.is_some() {
-                        return seg.ident.err(
+                        return Err(syn_err(
+                            seg.ident.span(),
                             "Variadic type arguments are required to desugar variadic types.",
-                        );
+                        ));
                     }
                     (seg.ident.clone(), PathArguments::None)
                 }
-                _ => return seg.ident.err("Unexpected Path arguments."),
+                _ => return Err(syn_err(seg.ident.span(), "Unexpected Path arguments.")),
             };
             let result_seg = PathSegment {
                 ident: last_type_ident,
@@ -1444,10 +1473,10 @@ fn desugar_generic_arguments(
                 *arg = GenericArgument::Type(desugar_ty(ty, const_instances)?);
             }
             _ => {
-                return span.err(&format!(
-                    "Unsupported generic argument {}",
-                    arg.to_token_stream()
-                ));
+                return Err(syn_err(
+                    span,
+                    &format!("Unsupported generic argument {}", arg.to_token_stream()),
+                ))
             }
         }
     }
@@ -1462,7 +1491,10 @@ fn desugar_ty(ty: &Type, instances: &ConstInstances) -> Result<Type, Error> {
             // Special case: For Option<T>, recursively desugar T but don't try to
             // expand Option itself as a variadic type
             let last_segment = type_path.path.segments.last().ok_or_else(|| {
-                type_path.error("Expected at least one path segment in desugar_ty")
+                syn_err(
+                    type_path.span(),
+                    "Expected at least one path segment in desugar_ty",
+                )
             })?;
             if last_segment.ident == "Option" {
                 let mut result_type = type_path.clone();
@@ -1494,10 +1526,16 @@ fn desugar_ty(ty: &Type, instances: &ConstInstances) -> Result<Type, Error> {
             if instances.inst_u32.contains_key(&arr_len) {
                 let n = instances.inst_u32.get(&arr_len).unwrap();
                 result.len = syn::parse::<Expr>(format!("{}", n).parse().map_err(|_| {
-                    type_array.error(&format!("Failed to parse array length '{n}'"))
+                    syn_err(
+                        type_array.span(),
+                        &format!("Failed to parse array length '{n}'"),
+                    )
                 })?)
                 .map_err(|e| {
-                    type_array.error(&format!("Failed to parse array length '{n}': {e}"))
+                    syn_err(
+                        type_array.span(),
+                        &format!("Failed to parse array length '{n}': {e}"),
+                    )
                 })?;
             }
             result.into()
@@ -1541,7 +1579,9 @@ fn desugar_cga(
                             .path
                             .segments
                             .last()
-                            .ok_or_else(|| type_path.error("Expected at least one path segment"))?
+                            .ok_or_else(|| {
+                                syn_err(type_path.span(), "Expected at least one path segment")
+                            })?
                             .ident
                             .to_string();
                         if instances.inst_array.contains_key(&last_ident) {
@@ -1577,14 +1617,17 @@ fn desugar_cga(
                         // TODO (hme): Would be great to get rid of this syntax.
                         // This is something like Tensor<E, {[...]}>
                         if block_expr.block.stmts.len() != 1 {
-                            return block_expr.err(&format!(
-                                "Expected exactly 1 statement in block expression, got {}",
-                                block_expr.block.stmts.len()
+                            return Err(syn_err(
+                                block_expr.span(),
+                                &format!(
+                                    "Expected exactly 1 statement in block expression, got {}",
+                                    block_expr.block.stmts.len()
+                                ),
                             ));
                         }
                         let statement = &block_expr.block.stmts[0];
                         let Stmt::Expr(statement_expr, _) = statement else {
-                            return block_expr.err("Unexpected block expression.");
+                            return Err(syn_err(block_expr.span(), "Unexpected block expression."));
                         };
                         match statement_expr {
                             Expr::Array(array_expr) => {
@@ -1607,16 +1650,17 @@ fn desugar_cga(
                                     Expr::Path(len_path) => {
                                         // This is something like Tensor<E, {[-1; N]}>
                                         let num_rep_var = len_path.to_token_stream().to_string();
-                                        let num_repetitions = instances
-                                            .inst_u32
-                                            .get(&num_rep_var)
-                                            .copied()
-                                            .ok_or_else(|| {
-                                                len_path.error(&format!(
+                                        if !instances.inst_u32.contains_key(&num_rep_var) {
+                                            return Err(syn_err(
+                                                len_path.span(),
+                                                &format!(
                                                     "Expected instance for generic argument {}",
                                                     num_rep_var
-                                                ))
-                                            })?;
+                                                ),
+                                            ));
+                                        }
+                                        let num_repetitions =
+                                            *instances.inst_u32.get(&num_rep_var).unwrap();
                                         for _ in 0..num_repetitions {
                                             generic_args_result.push(thing_to_repeat.clone());
                                         }
@@ -1629,9 +1673,12 @@ fn desugar_cga(
                                             .to_string()
                                             .parse::<u32>()
                                             .map_err(|e| {
-                                                len_lit.error(&format!(
-                                                    "Failed to parse repeat length as u32: {e}"
-                                                ))
+                                                syn_err(
+                                                    len_lit.span(),
+                                                    &format!(
+                                                        "Failed to parse repeat length as u32: {e}"
+                                                    ),
+                                                )
                                             })?;
                                         for _ in 0..num_repetitions {
                                             generic_args_result.push(thing_to_repeat.clone());
@@ -1639,7 +1686,10 @@ fn desugar_cga(
                                         num_repetitions
                                     }
                                     _ => {
-                                        return generic_args.err("Unexpected repeat expression.");
+                                        return Err(syn_err(
+                                            generic_args.span(),
+                                            "Unexpected repeat expression.",
+                                        ))
                                     }
                                 };
                                 expanded_param_name = match &variadic_type_data {
@@ -1647,7 +1697,12 @@ fn desugar_cga(
                                     None => type_ident.to_string(),
                                 };
                             }
-                            _ => return block_expr.err("Unexpected block expression."),
+                            _ => {
+                                return Err(syn_err(
+                                    block_expr.span(),
+                                    "Unexpected block expression.",
+                                ))
+                            }
                         }
                     }
                     Expr::Lit(lit_expr) => {
@@ -1667,15 +1722,17 @@ fn desugar_cga(
     let formatted = format!("<{}>", generic_args_result.join(","));
     Ok((
         expanded_param_ident,
-        syn::parse(formatted.parse().map_err(|_| {
-            type_ident.error(&format!(
-                "Failed to parse angle bracketed args '{formatted}'"
-            ))
+        syn::parse::<AngleBracketedGenericArguments>(formatted.parse().map_err(|_| {
+            syn_err(
+                type_ident.span(),
+                &format!("Failed to parse angle bracketed args '{formatted}'"),
+            )
         })?)
         .map_err(|e| {
-            type_ident.error(&format!(
-                "Failed to parse angle bracketed args '{formatted}': {e}"
-            ))
+            syn_err(
+                type_ident.span(),
+                &format!("Failed to parse angle bracketed args '{formatted}': {e}"),
+            )
         })?,
     ))
 }
@@ -1703,8 +1760,10 @@ fn get_cga_type(
                             .segments
                             .last()
                             .ok_or_else(|| {
-                                type_path
-                                    .error("Expected at least one path segment in get_cga_type")
+                                syn_err(
+                                    type_path.span(),
+                                    "Expected at least one path segment in get_cga_type",
+                                )
                             })?
                             .ident
                             .to_string();
@@ -1716,9 +1775,12 @@ fn get_cga_type(
                         }
                     }
                     Type::Reference(type_ref) => {
-                        return type_ref.err(&format!(
-                            "get_cga_type: Type::Reference not supported: {}",
-                            type_ref.to_token_stream()
+                        return Err(syn_err(
+                            type_ref.span(),
+                            &format!(
+                                "get_cga_type: Type::Reference not supported: {}",
+                                type_ref.to_token_stream()
+                            ),
                         ));
                     }
                     _ => {}
@@ -1729,14 +1791,17 @@ fn get_cga_type(
                 // TODO (hme): Would be great to get rid of this syntax.
                 // This is something like Tensor<E, {[...]}>
                 if block_expr.block.stmts.len() != 1 {
-                    return block_expr.err(&format!(
-                        "Expected exactly 1 statement in block expression, got {}",
-                        block_expr.block.stmts.len()
+                    return Err(syn_err(
+                        block_expr.span(),
+                        &format!(
+                            "Expected exactly 1 statement in block expression, got {}",
+                            block_expr.block.stmts.len()
+                        ),
                     ));
                 }
                 let statement = &block_expr.block.stmts[0];
                 let Stmt::Expr(statement_expr, _) = statement else {
-                    return block_expr.err("Unexpected block expression.");
+                    return Err(syn_err(block_expr.span(), "Unexpected block expression."));
                 };
                 match statement_expr {
                     Expr::Array(array_expr) => {
@@ -1751,17 +1816,17 @@ fn get_cga_type(
                             Expr::Path(len_path) => {
                                 // This is something like Tensor<E, {[-1; N]}>
                                 let num_rep_var = len_path.to_token_stream().to_string();
-                                let num_repetitions = const_instances
-                                    .inst_u32
-                                    .get(&num_rep_var)
-                                    .copied()
-                                    .ok_or_else(|| {
-                                        len_path.error(&format!(
+                                if !const_instances.inst_u32.contains_key(&num_rep_var) {
+                                    return Err(syn_err(
+                                        len_path.span(),
+                                        &format!(
                                             "Expected instance for generic argument {}",
                                             num_rep_var
-                                        ))
-                                    })?;
-                                n.push(num_repetitions);
+                                        ),
+                                    ));
+                                }
+                                let num_rep = const_instances.inst_u32.get(&num_rep_var).unwrap();
+                                n.push(*num_rep);
                                 cgas.push(Some(generic_arg.to_token_stream().to_string()));
                             }
                             Expr::Lit(len_lit) => {
@@ -1771,17 +1836,18 @@ fn get_cga_type(
                                     .to_string()
                                     .parse::<u32>()
                                     .map_err(|e| {
-                                        len_lit.error(&format!(
-                                            "Failed to parse repeat length as u32: {e}"
-                                        ))
+                                        syn_err(
+                                            len_lit.span(),
+                                            &format!("Failed to parse repeat length as u32: {e}"),
+                                        )
                                     })?;
                                 n.push(num_repetitions);
                                 cgas.push(Some(generic_arg.to_token_stream().to_string()));
                             }
-                            _ => return ty.err("Unexpected repeat expression."),
+                            _ => return Err(syn_err(ty.span(), "Unexpected repeat expression.")),
                         }
                     }
-                    _ => return block_expr.err("Unexpected block expression."),
+                    _ => return Err(syn_err(block_expr.span(), "Unexpected block expression.")),
                 }
             }
             _ => {}
@@ -1789,10 +1855,13 @@ fn get_cga_type(
     }
 
     if n.len() != cgas.len() {
-        return ty.err(&format!(
-            "get_cga_type: n.len() ({}) != cgas.len() ({})",
-            n.len(),
-            cgas.len()
+        return Err(syn_err(
+            ty.span(),
+            &format!(
+                "get_cga_type: n.len() ({}) != cgas.len() ({})",
+                n.len(),
+                cgas.len()
+            ),
         ));
     }
     Ok(Some(ConstGenericArrayType {
@@ -1909,9 +1978,10 @@ impl RewriteVariadicsPass {
             return Ok(item);
         }
         if const_instances.inst_u32.len() != 1 {
-            return item
-                .ident
-                .err("Only one CGA is permitted for variadic traits.");
+            return Err(syn_err(
+                item.ident.span(),
+                "Only one CGA is permitted for variadic traits.",
+            ));
         }
         let key = const_instances.inst_u32.keys().next().unwrap();
         let n = *const_instances.inst_u32.get(key).unwrap();
@@ -1934,13 +2004,13 @@ impl RewriteVariadicsPass {
                             // It's not okay to make this assumption here, but we don't actually know the type.
                             let self_type =
                                 syn::parse2::<syn::Type>("Self".parse().map_err(|_| {
-                                    result.sig.ident.error("Failed to parse 'Self' type")
+                                    syn_err(result.sig.ident.span(), "Failed to parse 'Self' type")
                                 })?)
                                 .map_err(|e| {
-                                    result
-                                        .sig
-                                        .ident
-                                        .error(&format!("Failed to parse 'Self' type: {e}"))
+                                    syn_err(
+                                        result.sig.ident.span(),
+                                        &format!("Failed to parse 'Self' type: {e}"),
+                                    )
                                 })?;
                             let (inputs, output) = get_sig_types(&result.sig, Some(&self_type));
                             let inputs = inputs.into_iter().map(Some).collect::<Vec<_>>();
@@ -1961,7 +2031,7 @@ impl RewriteVariadicsPass {
                 TraitItem::Const(const_item) => {
                     impl_items.push(TraitItem::Const(const_item.clone()));
                 }
-                _ => return concrete_item.err("Unsupported impl item"),
+                _ => return Err(syn_err(concrete_item.span(), "Unsupported impl item")),
             }
         }
         item.items = impl_items;
@@ -1979,18 +2049,25 @@ impl RewriteVariadicsPass {
         desugar_generics(&mut item.generics, const_instances)?;
         let mut variadic_trait_vtd = None;
         // Update generics in trait definition.
-        if let Some((_, path, _)) = &mut item.trait_ {
-            let span = path.span();
-            let last_seg = path
-                .segments
-                .last_mut()
-                .ok_or_else(|| span.error("Expected at least one path segment in trait path"))?;
+        if let Some(trait_) = &mut item.trait_ {
+            let path_copy = trait_.1.clone();
+            let path = &mut trait_.1;
+            if path.segments.is_empty() {
+                return Err(syn_err(
+                    path.span(),
+                    "Expected at least one path segment in trait path",
+                ));
+            }
+            let last_seg = path.segments.last_mut().unwrap();
             let ident_vtd = get_variadic_type_data(last_seg.ident.to_string().as_str());
             if let Some(vtd) = ident_vtd {
                 if const_instances.inst_u32.len() != 1 {
-                    return path.err("Only one CGA is permitted for variadic traits.");
+                    return Err(syn_err(
+                        path.span(),
+                        "Only one CGA is permitted for variadic traits.",
+                    ));
                 }
-                *path = desugar_path(path, const_instances)?;
+                *path = desugar_path(&path_copy, const_instances)?;
                 variadic_trait_vtd = Some(vtd);
             } else if let PathArguments::AngleBracketed(path_args) = &mut last_seg.arguments {
                 desugar_generic_arguments(path_args, const_instances)?
@@ -2015,10 +2092,7 @@ impl RewriteVariadicsPass {
                     match attributes {
                         Some(attributes) => {
                             if variadic_trait_vtd.is_some() {
-                                return fn_impl.sig.ident.err(concat!(
-                                    "variadic_impl_fn attributes ",
-                                    "are not supported for variadic traits."
-                                ));
+                                return Err(syn_err(fn_impl.sig.ident.span(), "variadic_impl_fn attributes are not supported for variadic traits."));
                             }
                             clear_attributes(
                                 HashSet::from(["cuda_tile :: variadic_impl_fn"]),
@@ -2048,7 +2122,7 @@ impl RewriteVariadicsPass {
                         }
                     }
                 }
-                _ => return concrete_item.err("Unsupported impl item."),
+                _ => return Err(syn_err(concrete_item.span(), "Unsupported impl item.")),
             }
         }
         item.items = impl_items;
@@ -2115,7 +2189,12 @@ impl RewriteVariadicsPass {
                     let name = {
                         match &*fn_param.pat {
                             Pat::Ident(ident) => ident.ident.to_string(),
-                            _ => return fn_param.err("Unexpected function param pattern."),
+                            _ => {
+                                return Err(syn_err(
+                                    fn_param.span(),
+                                    "Unexpected function param pattern.",
+                                ))
+                            }
                         }
                     };
                     let ty = &*fn_param.ty;
@@ -2127,10 +2206,13 @@ impl RewriteVariadicsPass {
                     );
                 }
                 FnArg::Receiver(_fn_self) => {
-                    let self_ty = self_ty.cloned().ok_or_else(|| {
-                        sig.ident
-                            .error("bind_parameters for impls requires self_ty.")
-                    })?;
+                    if self_ty.is_none() {
+                        return Err(syn_err(
+                            sig.ident.span(),
+                            "bind_parameters for impls requires self_ty.",
+                        ));
+                    }
+                    let self_ty = self_ty.unwrap().clone();
                     variables.insert("self".to_string(), Binding { ty: Some(self_ty) });
                 }
             }
@@ -2185,7 +2267,10 @@ impl RewriteVariadicsPass {
                                     continue;
                                 }
                                 _ => {
-                                    return pat_type.err("let binding LHS not implemented.");
+                                    return Err(syn_err(
+                                        pat_type.span(),
+                                        "let binding LHS not implemented.",
+                                    ))
                                 }
                             }
                             binding_ty = Some(*pat_type.ty.clone());
@@ -2211,10 +2296,12 @@ impl RewriteVariadicsPass {
                             }
                             continue; // Skip normal single-variable logic
                         }
-                        _ => return local.err("Local pattern type not supported"),
+                        _ => return Err(syn_err(local.span(), "Local pattern type not supported")),
                     }
-                    let binding_name =
-                        binding_name.ok_or_else(|| local.error("Unable to rewrite expr."))?;
+                    if binding_name.is_none() {
+                        return Err(syn_err(local.span(), "Unable to rewrite expr."));
+                    }
+                    let binding_name = binding_name.unwrap();
                     if let Some(init) = &mut local.init {
                         // Rewrite the expression but preserve explicit type annotations
                         let inferred_ty = self.rewrite_expr(
@@ -2236,49 +2323,79 @@ impl RewriteVariadicsPass {
                     );
                 }
                 Stmt::Item(item) => {
-                    let (ty, name) = match item {
+                    let mut binding_name: Option<String> = None;
+                    let binding_ty: Option<Type> = match item {
                         Item::Const(const_item) => {
+                            binding_name = Some(const_item.ident.to_string());
                             let return_type = Some(*const_item.ty.clone());
                             // This is like a let binding with limitations.
-                            (
-                                self.rewrite_expr(
-                                    &mut const_item.expr,
-                                    const_instances,
-                                    variables,
-                                    return_type,
-                                )?,
-                                const_item.ident.to_string(),
-                            )
+                            self.rewrite_expr(
+                                &mut const_item.expr,
+                                const_instances,
+                                variables,
+                                return_type,
+                            )?
                         }
                         _ => {
-                            return item.err(&format!(
-                                "{}\nOnly const local item definitions are supported.",
-                                item.to_token_stream()
+                            return Err(syn_err(
+                                item.span(),
+                                &format!(
+                                    "{}\nOnly const local item definitions are supported.",
+                                    item.to_token_stream()
+                                ),
                             ))
                         }
                     };
-                    variables.insert(name, Binding { ty });
+                    let Some(binding_name) = binding_name else {
+                        return Err(syn_err(item.span(), "Unable to rewrite expr."));
+                    };
+                    variables.insert(
+                        binding_name.clone(),
+                        Binding {
+                            ty: binding_ty.clone(),
+                        },
+                    );
                 }
                 Stmt::Expr(expr, semicolon) => {
                     let ty =
                         self.rewrite_expr(expr, const_instances, variables, return_type.clone())?;
                     match expr {
                         Expr::Assign(assign_expr) => {
-                            let binding_name = match assign_expr.left.as_ref() {
+                            let binding_name: String;
+                            let mut binding_ty: Option<Type> = None;
+                            match &mut *assign_expr.left {
                                 Expr::Path(path_expr) => {
                                     if path_expr.path.segments.len() != 1 {
-                                        return path_expr
-                                            .err("Expected single-segment path in assignment");
+                                        return Err(syn_err(
+                                            path_expr.span(),
+                                            "Expected single-segment path in assignment",
+                                        ));
                                     }
-                                    path_expr.path.segments[0].ident.to_string()
+                                    binding_name = path_expr.path.segments[0].ident.to_string()
                                 }
-                                _ => return assign_expr.err("Expr::Assign not supported"),
-                            };
+                                _ => {
+                                    return Err(syn_err(
+                                        assign_expr.span(),
+                                        "Expr::Assign not supported",
+                                    ))
+                                }
+                            }
                             // The computed binding type ty is expected to be None.
                             // Types are only needed in this pass to compute concrete variadic
                             // type and op names.
-                            let ty = variables.get(&binding_name).and_then(|old| old.ty.clone());
-                            variables.insert(binding_name, Binding { ty });
+                            binding_ty = match variables.get(&binding_name) {
+                                Some(old) => old.ty.clone(),
+                                None => {
+                                    // This is invalid, but let Rust generate a nice error.
+                                    None
+                                }
+                            };
+                            let _ = variables.insert(
+                                binding_name,
+                                Binding {
+                                    ty: binding_ty.clone(),
+                                },
+                            );
                         }
                         Expr::Return(_return_expr) => {
                             return_type = ty;
@@ -2314,26 +2431,39 @@ impl RewriteVariadicsPass {
                 // );
                 // We rewrite the entire expr to desugared array.
                 // Extract info we need before borrowing expr mutably.
-                let Expr::Path(path_expr) = index_expr.expr.as_ref() else {
-                    return index_expr.expr.err(&format!(
-                        "Index expression not supported: {}",
-                        index_expr.expr.to_token_stream()
+                let index_span = index_expr.span();
+                let inner_expr_span = index_expr.expr.span();
+                let is_path = matches!(&*index_expr.expr, Expr::Path(_));
+                if !is_path {
+                    return Err(syn_err(
+                        inner_expr_span,
+                        &format!(
+                            "Index expression not supported: {}",
+                            index_expr.expr.to_token_stream()
+                        ),
                     ));
+                }
+                let path_expr = match &*index_expr.expr {
+                    Expr::Path(p) => p.clone(),
+                    _ => unreachable!(),
                 };
                 let expr_str = path_expr.to_token_stream().to_string();
                 if let Some(cga) = const_instances.inst_array.get(&expr_str) {
                     let expanded_cga = expand_cga(&path_expr.path, const_instances)?;
                     let index = parse_signed_literal_as_i32(&index_expr.index);
                     if !(0 <= index && (index as u32) < cga.length) {
-                        return index_expr.err(&format!(
-                            "Index {index} out of bounds for CGA of length {}",
-                            cga.length
+                        return Err(syn_err(
+                            index_span,
+                            &format!(
+                                "Index {index} out of bounds for CGA of length {}",
+                                cga.length
+                            ),
                         ));
                     }
                     if cga.element_type != "i32" {
-                        return index_expr.err(&format!(
-                            "Expected element_type 'i32', got '{}'",
-                            cga.element_type
+                        return Err(syn_err(
+                            index_span,
+                            &format!("Expected element_type 'i32', got '{}'", cga.element_type),
                         ));
                     }
                     let desugared_idx_expression = expanded_cga.args[index as usize].clone();
@@ -2341,8 +2471,14 @@ impl RewriteVariadicsPass {
                     let return_type: Type = parse_quote! { i32 };
                     Ok(Some(return_type))
                 } else {
+                    let expr_span = expr.span();
+                    let index_expr = match expr {
+                        Expr::Index(ie) => ie,
+                        _ => unreachable!(),
+                    };
+                    let index_expr_expr = &mut *index_expr.expr;
                     match self.rewrite_expr(
-                        index_expr.expr.as_mut(),
+                        index_expr_expr,
                         const_instances,
                         variables,
                         return_type,
@@ -2350,12 +2486,18 @@ impl RewriteVariadicsPass {
                         Some(Type::Array(ty)) => Ok(Some(*ty.elem.clone())),
                         Some(Type::Reference(ty)) => {
                             let Type::Slice(slice_ty) = *ty.elem.clone() else {
-                                return expr.err("Index expression not supported (reference)");
+                                return Err(syn_err(
+                                    expr_span,
+                                    "Index expression not supported (reference)",
+                                ));
                             };
                             Ok(Some(*slice_ty.elem.clone()))
                         }
-                        None => expr.err("Failed to compute type for index expression"),
-                        Some(_other) => expr.err("Index expression not supported"),
+                        None => Err(syn_err(
+                            expr_span,
+                            "Failed to compute type for index expression",
+                        )),
+                        Some(_other) => Err(syn_err(expr_span, "Index expression not supported")),
                     }
                 }
             }
@@ -2473,24 +2615,24 @@ impl RewriteVariadicsPass {
                     .path
                     .segments
                     .last_mut()
-                    .ok_or_else(|| path_span.error("Expected at least one path segment"))?;
+                    .ok_or_else(|| syn_err(path_span, "Expected at least one path segment"))?;
                 let name = last_seg.ident.to_string();
                 if let Some(n) = const_instances.inst_u32.get(name.as_str()) {
                     // This is a const generic primitive.
                     let new_expr = syn::parse::<Expr>(
                         format!("{n}")
                             .parse()
-                            .map_err(|_| path_span.error(&format!("Failed to parse '{n}'")))?,
+                            .map_err(|_| syn_err(path_span, &format!("Failed to parse '{n}'")))?,
                     )
-                    .map_err(|e| path_span.error(&format!("Failed to parse '{n}': {e}")))?;
+                    .map_err(|e| syn_err(path_span, &format!("Failed to parse '{n}': {e}")))?;
                     *expr = new_expr;
                     return Ok(Some(
                         syn::parse::<Type>(
                             "i32"
                                 .parse()
-                                .map_err(|_| path_span.error("Failed to parse 'i32'"))?,
+                                .map_err(|_| syn_err(path_span, "Failed to parse 'i32'"))?,
                         )
-                        .map_err(|e| path_span.error(&format!("Failed to parse 'i32': {e}")))?,
+                        .map_err(|e| syn_err(path_span, &format!("Failed to parse 'i32': {e}")))?,
                     ));
                 }
                 self.rewrite_path_expr_type(
@@ -2570,17 +2712,20 @@ impl RewriteVariadicsPass {
             Expr::Struct(struct_expr) => {
                 // TODO (hme): Similar code fragment in desugar_ty.
                 //  Can this be refactored into a rewrite for any PathSegment?
-                let span = struct_expr.span();
-                let last_seg = struct_expr.path.segments.last_mut().ok_or_else(|| {
-                    span.error("Expected at least one path segment in struct expression")
-                })?;
+                if struct_expr.path.segments.is_empty() {
+                    return Err(syn_err(
+                        struct_expr.span(),
+                        "Expected at least one path segment in struct expression",
+                    ));
+                }
+                let last_seg = struct_expr.path.segments.last_mut().unwrap();
                 let name = last_seg.ident.to_string();
                 let vtd = get_variadic_type_data(name.as_str());
                 if let Some(_vtd) = vtd {
                     if return_type.is_none() {
-                        return struct_expr.err(concat!(
-                            "Variadic structs require a static type annotation. ",
-                            "Try assigning to a statically typed let binding."
+                        return Err(syn_err(
+                            struct_expr.span(),
+                            "Variadic structs require a static type annotation. Try assigning to a statically typed let binding.",
                         ));
                     }
                     let (last_type_ident, last_seg_args) = match &last_seg.arguments {
@@ -2593,7 +2738,7 @@ impl RewriteVariadicsPass {
                             )
                         }
                         PathArguments::None => (last_seg.ident.clone(), PathArguments::None),
-                        _ => return struct_expr.err("Unexpected Path arguments."),
+                        _ => return Err(syn_err(struct_expr.span(), "Unexpected Path arguments.")),
                     };
                     *last_seg = PathSegment {
                         ident: last_type_ident,
@@ -2605,7 +2750,9 @@ impl RewriteVariadicsPass {
                     // This check may not be necessary.
                     match &mut field.member {
                         Member::Named(_named) => {}
-                        Member::Unnamed(_idx) => return struct_expr.err("Tuples not supported."),
+                        Member::Unnamed(_idx) => {
+                            return Err(syn_err(struct_expr.span(), "Tuples not supported."))
+                        }
                     }
                 }
                 Ok(return_type)
@@ -2659,11 +2806,18 @@ impl RewriteVariadicsPass {
                                     if punct.as_char() == ',' {
                                         continue;
                                     } else {
-                                        return mac_expr
-                                            .err(&format!("Unexpected punctuation {punct:}"));
+                                        return Err(syn_err(
+                                            mac_expr.span(),
+                                            &format!("Unexpected punctuation {punct:}"),
+                                        ));
                                     }
                                 }
-                                _ => return mac_expr.err(&format!("Unexpected token {:?}", token)),
+                                _ => {
+                                    return Err(syn_err(
+                                        mac_expr.span(),
+                                        &format!("Unexpected token {:?}", token),
+                                    ))
+                                }
                             }
                         }
                         let cga_str = format!("{{[{}]}}", args.join(", "));
@@ -2675,18 +2829,18 @@ impl RewriteVariadicsPass {
                         let mac_span = mac_expr.span();
                         let shape_fmt = format!("{ty_str}::<{cga_str}>::const_new()");
                         let shape_expr = syn::parse2::<Expr>(shape_fmt.parse().map_err(|_| {
-                            mac_span.error(&format!("Failed to parse '{shape_fmt}'"))
+                            syn_err(mac_span, &format!("Failed to parse '{shape_fmt}'"))
                         })?)
                         .map_err(|e| {
-                            mac_span.error(&format!("Failed to parse '{shape_fmt}': {e}"))
+                            syn_err(mac_span, &format!("Failed to parse '{shape_fmt}': {e}"))
                         })?;
                         *expr = shape_expr;
                         let shape_str = format!("{ty_str}<{cga_str}>");
                         let shape_ty = syn::parse::<Type>(shape_str.parse().map_err(|_| {
-                            mac_span.error(&format!("Failed to parse '{shape_str}'"))
+                            syn_err(mac_span, &format!("Failed to parse '{shape_str}'"))
                         })?)
                         .map_err(|e| {
-                            mac_span.error(&format!("Failed to parse '{shape_str}': {e}"))
+                            syn_err(mac_span, &format!("Failed to parse '{shape_str}': {e}"))
                         })?;
                         // println!("Expr::Macro const_shape: {shape_expr}, {shape_ty:#?}");
                         self.rewrite_expr(&mut *expr, const_instances, variables, Some(shape_ty))
@@ -2709,7 +2863,7 @@ impl RewriteVariadicsPass {
                 // The compiler will handle parsing and compilation of closure bodies
                 Ok(return_type)
             }
-            _ => expr.err("Expression type not supported"),
+            _ => Err(syn_err(expr.span(), "Expression type not supported")),
         }
     }
 
@@ -2756,9 +2910,16 @@ impl RewriteVariadicsPass {
         // Derive name of method call.
         let method_ident = &expr.method;
         let method_name = method_ident.to_string();
-        let self_ty = self
-            .rewrite_expr(&mut expr.receiver, const_instances, variables, None)?
-            .ok_or_else(|| expr.receiver.error("Unable to infer receiver type"))?;
+        let self_ty =
+            match self.rewrite_expr(&mut expr.receiver, const_instances, variables, None)? {
+                Some(ty) => ty,
+                None => {
+                    return Err(syn_err(
+                        expr.receiver.span(),
+                        "Unable to infer receiver type",
+                    ))
+                }
+            };
         // This may be a primitive which implements a supported variadic trait.
         let maybe_primitive_type = self_ty.to_token_stream().to_string();
         let variadic_meta = get_variadic_trait_impl_meta_data(&maybe_primitive_type, &method_name)?;
@@ -2822,12 +2983,20 @@ impl RewriteVariadicsPass {
                 // Actually perform function call rewrite.
                 let last_seg = match &mut *expr.func {
                     Expr::Path(path_expr) => {
-                        let span = path_expr.span();
-                        path_expr.path.segments.last_mut().ok_or_else(|| {
-                            span.error("Expected at least one path segment in function call")
-                        })?
+                        if path_expr.path.segments.is_empty() {
+                            return Err(syn_err(
+                                path_expr.span(),
+                                "Expected at least one path segment in function call",
+                            ));
+                        }
+                        path_expr.path.segments.last_mut().unwrap()
                     }
-                    _ => return expr.func.err("Unexpected function call expression."),
+                    _ => {
+                        return Err(syn_err(
+                            expr.func.span(),
+                            "Unexpected function call expression.",
+                        ))
+                    }
                 };
                 let mut maybe_input_types = vec![];
                 for arg in &mut expr.args {

--- a/cutile-macro/src/types.rs
+++ b/cutile-macro/src/types.rs
@@ -62,10 +62,9 @@
 //! ```
 
 use phf::phf_map;
-use proc_macro2::Span;
 use std::collections::HashMap;
 
-use crate::error::{Error, SpannedError};
+use crate::error::{call_site_error, Error};
 
 /// Generates a suffix string for a variadic type based on its rank.
 ///
@@ -470,7 +469,7 @@ pub fn get_variadic_method_data(
         ]),
         "Tile" => HashMap::from([("reshape", "reshape"), ("broadcast", "broadcast")]),
         "BroadcastScalar" => HashMap::from([("broadcast", "broadcast_scalar")]),
-        _ => return Span::call_site().err(&format!("Unexpected variadic type: {}", vtd.name)),
+        _ => return call_site_error(&format!("Unexpected variadic type: {}", vtd.name)),
     };
     match method2op.get(method_name) {
         Some(op_name) => Ok(Some((
@@ -1162,9 +1161,9 @@ impl Iterator for ConstGenericArrayTypeListIterator {
                         self.state.push(item);
                     }
                     None => {
-                        return Some(Span::call_site().err(
+                        return Some(call_site_error(
                             "ConstGenericArrayTypeListIterator: iterator was empty on first pass.",
-                        ));
+                        ))
                     }
                 }
             }

--- a/cutile-macro/src/validate_dsl_syntax.rs
+++ b/cutile-macro/src/validate_dsl_syntax.rs
@@ -112,23 +112,19 @@ pub fn validate_entry_point_parameters(item: &ItemFn) -> Result<(), Error> {
                 };
                 let type_name = ident.to_string();
                 if type_name != "Tensor" {
-                    return ty.err(&format!(
+                    ty.err(&format!(
                         "References to {} as parameters are not supported.",
                         type_name
-                    ));
+                    ))?;
                 }
             }
             Type::Path(path_ty) => {
                 let ident = get_ident_from_path(&path_ty.path);
                 let type_name = ident.to_string();
                 if type_name == "Tensor" {
-                    return ty.err(concat!(
-                        "Tensors cannot be moved into kernel functions. ",
-                        "&mut Tensor corresponds to ",
-                        "a partitioned tensor argument (e.g. x.partition([...])), ",
-                        "and &Tensor corresponds to ",
-                        "a tensor reference argument (e.g. Arc::new(x) or x.into())."
-                    ));
+                    ty.err("Tensors cannot be moved into kernel functions. \
+                                  &mut Tensor corresponds to a partitioned tensor argument (e.g. x.partition([...])), \
+                                  and &Tensor corresponds to a tensor reference argument (e.g. Arc::new(x) or x.into()).")?;
                 }
             }
             Type::Ptr(ptr_type) => {
@@ -138,10 +134,10 @@ pub fn validate_entry_point_parameters(item: &ItemFn) -> Result<(), Error> {
                 };
             }
             _ => {
-                return ty.err(&format!(
+                ty.err(&format!(
                     "{} is not a supported parameter type.",
                     ty.to_token_stream()
-                ));
+                ))?;
             }
         }
     }

--- a/cutile/src/prelude.rs
+++ b/cutile/src/prelude.rs
@@ -29,7 +29,7 @@ pub use crate::tensor::{
 pub use crate::tile_kernel::{PartitionOp, TileKernel, ToHostVecOp};
 
 // Common types from cuda-core
-pub use cuda_core::{CudaContext, DType};
+pub use cuda_core::{DType, Device};
 
 // Common dependencies
 pub use std::sync::Arc;

--- a/cutile/src/tile_kernel.rs
+++ b/cutile/src/tile_kernel.rs
@@ -8,7 +8,7 @@
 use anyhow::{Context, Result};
 use cuda_async::error::DeviceError;
 use cuda_core::DType;
-use cuda_core::{memcpy_dtoh_async, CudaFunction};
+use cuda_core::{memcpy_dtoh_async, Function};
 use cutile_compiler::ast::Module;
 use cutile_compiler::compiler::{CUDATileFunctionCompiler, CUDATileModules};
 use cutile_compiler::cuda_tile_runtime_utils::{compile_tile_ir_module, get_gpu_name};
@@ -174,7 +174,7 @@ pub fn compile_from_context<F: Fn() -> Vec<Module>>(
     scalar_hints: Vec<(String, DivHint)>,
     const_grid: Option<(u32, u32, u32)>,
     compile_options: CompileOptions,
-) -> Result<(Arc<CudaFunction>, Arc<Validator>), Error> {
+) -> Result<(Arc<Function>, Arc<Validator>), Error> {
     let device_id: usize = ctx.get_device_id();
     // Compilation constructs a lookup key.
     let key = TileFunctionKey::new(
@@ -442,7 +442,7 @@ where
         scalar_hints: Vec<(String, DivHint)>,
         grid: Option<(u32, u32, u32)>,
         compile_options: CompileOptions,
-    ) -> Result<(Arc<CudaFunction>, Arc<Validator>), Error> {
+    ) -> Result<(Arc<Function>, Arc<Validator>), Error> {
         compile_from_context(
             ctx,
             module_asts,

--- a/cutile/tests/slice_non_divisible.rs
+++ b/cutile/tests/slice_non_divisible.rs
@@ -472,8 +472,8 @@ fn gemm_non_divisible_m_and_n() {
             k.to_string(),
         ];
 
-        let ctx = cuda_core::CudaContext::new(0).unwrap();
-        let stream = ctx.new_stream().unwrap();
+        let device = cuda_core::Device::new(0).unwrap();
+        let stream = device.new_stream().unwrap();
 
         let z = api::zeros::<f32>(&[m, n])
             .sync_on(&stream)


### PR DESCRIPTION
Removes the `CudaContext` / `CudaStream` / `CudaModule` / `CudaFunction` aliases in favor of `Device` / `Stream` / `Module` / `Function`, dropping the `Cuda` prefix that was redundant inside `cuda_core`. Variable and field names (`ctx`, `cuda_context`, etc.) are renamed to `device` throughout.

Adds `borrow_raw` constructors on `Device` / `Stream` / `Module` / `Function` so callers holding CUDA handles from another binding crate (cudarc, Candle, hand-rolled FFI) can wrap them into cuTile types without transferring ownership. The constructors accept `*mut c_void` + `c_int` primitives rather than `cuda_bindings` typedefs, so there's no nominal-type coupling between binding crates.

Addresses https://github.com/NVlabs/cutile-rs/issues/69 and first step of https://github.com/NVlabs/cutile-rs/issues/84.