### PR TITLE
fix: bytecode defaults and silent drops in JIT compiler

### DIFF
--- a/cutile-compiler/src/compiler/compile_cuda_tile_op.rs
+++ b/cutile-compiler/src/compiler/compile_cuda_tile_op.rs
@@ -403,7 +403,9 @@ impl<'m> CUDATileFunctionCompiler<'m> {
         let mut padding_count: i64 = 0;
         let mut token_count: i64 = 0;
 
-        if let Some(mask_arg) = super::shared_utils::resolve_option_arg(&call_expr.args[3], ctx) {
+        if let super::shared_utils::OptionArg::Some(mask_arg) =
+            super::shared_utils::resolve_option_arg_checked(&call_expr.args[3], ctx, "mask")?
+        {
             if let Some(mask_value) =
                 self.compile_expression(module, block_id, &mask_arg, generic_args, ctx, None)?
             {
@@ -414,7 +416,12 @@ impl<'m> CUDATileFunctionCompiler<'m> {
             }
         }
 
-        if let Some(padding_arg) = super::shared_utils::resolve_option_arg(&call_expr.args[4], ctx)
+        if let super::shared_utils::OptionArg::Some(padding_arg) =
+            super::shared_utils::resolve_option_arg_checked(
+                &call_expr.args[4],
+                ctx,
+                "padding_value",
+            )?
         {
             if let Some(padding_value) =
                 self.compile_expression(module, block_id, &padding_arg, generic_args, ctx, None)?
@@ -463,7 +470,9 @@ impl<'m> CUDATileFunctionCompiler<'m> {
             }
         }
 
-        if let Some(token_arg) = super::shared_utils::resolve_option_arg(&call_expr.args[5], ctx) {
+        if let super::shared_utils::OptionArg::Some(token_arg) =
+            super::shared_utils::resolve_option_arg_checked(&call_expr.args[5], ctx, "token")?
+        {
             if let Some(token_value) =
                 self.compile_expression(module, block_id, &token_arg, generic_args, ctx, None)?
             {
@@ -474,20 +483,16 @@ impl<'m> CUDATileFunctionCompiler<'m> {
             }
         }
 
-        // arg[6]: latency (Option<i32>)
+        // arg[6]: latency (Option<i32>) — accepts Some(literal) or Some(const-generic),
+        // errors on anything else so the hint is never silently dropped.
         let mut hint_params: HashMap<String, i32> = HashMap::new();
-        if let Some(latency_arg) = super::shared_utils::resolve_option_arg(&call_expr.args[6], ctx)
-        {
-            if let Expr::Lit(ExprLit {
-                lit: Lit::Int(int_lit),
-                ..
-            }) = latency_arg
-            {
-                hint_params.insert(
-                    "latency".to_string(),
-                    int_lit.base10_parse::<i32>().unwrap(),
-                );
-            }
+        if let Some(latency) = super::shared_utils::extract_optional_i32_hint(
+            &call_expr.args[6],
+            generic_args,
+            ctx,
+            "latency",
+        )? {
+            hint_params.insert("latency".to_string(), latency);
         }
 
         let operand_segments: Vec<i64> = vec![1, mask_count, padding_count, token_count];
@@ -609,7 +614,9 @@ impl<'m> CUDATileFunctionCompiler<'m> {
         let mut operands = vec![dest_ptr, tile_value];
         let mut mask_count: i64 = 0;
         let mut token_count: i64 = 0;
-        if let Some(mask_arg) = super::shared_utils::resolve_option_arg(&call_expr.args[4], ctx) {
+        if let super::shared_utils::OptionArg::Some(mask_arg) =
+            super::shared_utils::resolve_option_arg_checked(&call_expr.args[4], ctx, "mask")?
+        {
             if let Some(mask_value) =
                 self.compile_expression(module, block_id, &mask_arg, generic_args, ctx, None)?
             {
@@ -619,7 +626,9 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                 }
             }
         }
-        if let Some(token_arg) = super::shared_utils::resolve_option_arg(&call_expr.args[5], ctx) {
+        if let super::shared_utils::OptionArg::Some(token_arg) =
+            super::shared_utils::resolve_option_arg_checked(&call_expr.args[5], ctx, "token")?
+        {
             if let Some(token_value) =
                 self.compile_expression(module, block_id, &token_arg, generic_args, ctx, None)?
             {
@@ -629,20 +638,16 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                 }
             }
         }
-        // arg[6]: latency (Option<i32>)
+        // arg[6]: latency (Option<i32>) — accepts Some(literal) or Some(const-generic),
+        // errors on anything else so the hint is never silently dropped.
         let mut hint_params: HashMap<String, i32> = HashMap::new();
-        if let Some(latency_arg) = super::shared_utils::resolve_option_arg(&call_expr.args[6], ctx)
-        {
-            if let Expr::Lit(ExprLit {
-                lit: Lit::Int(int_lit),
-                ..
-            }) = latency_arg
-            {
-                hint_params.insert(
-                    "latency".to_string(),
-                    int_lit.base10_parse::<i32>().unwrap(),
-                );
-            }
+        if let Some(latency) = super::shared_utils::extract_optional_i32_hint(
+            &call_expr.args[6],
+            generic_args,
+            ctx,
+            "latency",
+        )? {
+            hint_params.insert("latency".to_string(), latency);
         }
 
         let operand_segments: Vec<i64> = vec![1, 1, mask_count, token_count];
@@ -786,7 +791,9 @@ impl<'m> CUDATileFunctionCompiler<'m> {
         let mut operands = vec![ptrs, arg];
         let mut mask_count: i64 = 0;
         let mut token_count: i64 = 0;
-        if let Some(mask_arg) = super::shared_utils::resolve_option_arg(&call_expr.args[5], ctx) {
+        if let super::shared_utils::OptionArg::Some(mask_arg) =
+            super::shared_utils::resolve_option_arg_checked(&call_expr.args[5], ctx, "mask")?
+        {
             if let Some(mask_value) =
                 self.compile_expression(module, block_id, &mask_arg, generic_args, ctx, None)?
             {
@@ -796,7 +803,9 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                 }
             }
         }
-        if let Some(token_arg) = super::shared_utils::resolve_option_arg(&call_expr.args[6], ctx) {
+        if let super::shared_utils::OptionArg::Some(token_arg) =
+            super::shared_utils::resolve_option_arg_checked(&call_expr.args[6], ctx, "token")?
+        {
             if let Some(token_value) =
                 self.compile_expression(module, block_id, &token_arg, generic_args, ctx, None)?
             {
@@ -958,7 +967,9 @@ impl<'m> CUDATileFunctionCompiler<'m> {
         let mut operands = vec![ptrs, cmp, val];
         let mut mask_count: i64 = 0;
         let mut token_count: i64 = 0;
-        if let Some(mask_arg) = super::shared_utils::resolve_option_arg(&call_expr.args[5], ctx) {
+        if let super::shared_utils::OptionArg::Some(mask_arg) =
+            super::shared_utils::resolve_option_arg_checked(&call_expr.args[5], ctx, "mask")?
+        {
             if let Some(mask_value) =
                 self.compile_expression(module, block_id, &mask_arg, generic_args, ctx, None)?
             {
@@ -968,7 +979,9 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                 }
             }
         }
-        if let Some(token_arg) = super::shared_utils::resolve_option_arg(&call_expr.args[6], ctx) {
+        if let super::shared_utils::OptionArg::Some(token_arg) =
+            super::shared_utils::resolve_option_arg_checked(&call_expr.args[6], ctx, "token")?
+        {
             if let Some(token_value) =
                 self.compile_expression(module, block_id, &token_arg, generic_args, ctx, None)?
             {
@@ -1143,13 +1156,10 @@ impl<'m> CUDATileFunctionCompiler<'m> {
         }
         // Handle disallow_tma: bool parameter.
         if let Some(i) = fn_params.iter().position(|s| s == "disallow_tma") {
-            if let Expr::Lit(syn::ExprLit {
-                lit: Lit::Bool(b), ..
-            }) = &call_expr.args[i]
-            {
-                if b.value {
-                    hint_params.insert("allow_tma".to_string(), 0);
-                }
+            let disallow =
+                super::shared_utils::extract_bool_arg(&call_expr.args[i], "disallow_tma")?;
+            if disallow {
+                hint_params.insert("allow_tma".to_string(), 0);
             }
         }
         if let Some(load_store_hints_attr) =
@@ -1310,13 +1320,10 @@ impl<'m> CUDATileFunctionCompiler<'m> {
         }
         // Handle disallow_tma: bool parameter.
         if let Some(i) = fn_params.iter().position(|s| s == "disallow_tma") {
-            if let Expr::Lit(syn::ExprLit {
-                lit: Lit::Bool(b), ..
-            }) = &call_expr.args[i]
-            {
-                if b.value {
-                    hint_params.insert("allow_tma".to_string(), 0);
-                }
+            let disallow =
+                super::shared_utils::extract_bool_arg(&call_expr.args[i], "disallow_tma")?;
+            if disallow {
+                hint_params.insert("allow_tma".to_string(), 0);
             }
         }
         if let Some(load_store_hints_attr) =
@@ -1649,15 +1656,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                 cutile_ir::ir::Type::Scalar(elem_scalar_scan),
             )])
         };
-        let reverse_value = if let Expr::Lit(lit_expr) = &call_expr.args[2] {
-            if let syn::Lit::Bool(lit_bool) = &lit_expr.lit {
-                lit_bool.value
-            } else {
-                false
-            }
-        } else {
-            false
-        };
+        let reverse_value = super::shared_utils::extract_bool_arg(&call_expr.args[2], "reverse")?;
 
         let (op_id, results) = OpBuilder::new(Opcode::Scan, self.ir_location(&call_expr.span()))
             .result(result_ir_ty)

--- a/cutile-compiler/src/compiler/compile_expression.rs
+++ b/cutile-compiler/src/compiler/compile_expression.rs
@@ -1708,9 +1708,15 @@ impl<'m> CUDATileFunctionCompiler<'m> {
 }
 
 /// Convert a CUDA Tile element type string (e.g. "f32", "i32") to a tile-ir scalar tile Type.
+///
+/// Panics on an unknown element-type name: `cuda_tile_ty` is compiler-internal
+/// (derived from `TileRustType::get_cuda_tile_element_type`), not user input,
+/// so an unknown value indicates an internal compiler bug. Panicking turns
+/// what was previously a silent `I32` default into a loud failure.
 fn cuda_tile_element_type_to_tile_ir(cuda_tile_ty: &str) -> cutile_ir::ir::Type {
-    use cutile_ir::ir::{ScalarType, TileElementType, TileType, Type};
-    let scalar = super::_type::scalar_from_name(cuda_tile_ty).unwrap_or(ScalarType::I32);
+    use cutile_ir::ir::{TileElementType, TileType, Type};
+    let scalar = super::_type::scalar_from_name(cuda_tile_ty)
+        .unwrap_or_else(|| panic!("compiler internal: unknown element type `{cuda_tile_ty}`"));
     Type::Tile(TileType {
         shape: vec![],
         element_type: TileElementType::Scalar(scalar),
@@ -1748,27 +1754,34 @@ fn build_constant_op(
 }
 
 /// Encode a literal value string into bytes for a DenseElements attribute.
+///
+/// `lit_string` is produced by the compiler from a validated Rust literal
+/// (e.g. `syn::LitInt::base10_digits()`) or from a hex-typed constant such
+/// as `T::ZERO`, so decimal and hex forms are both accepted. Parse failures
+/// indicate an internal compiler bug, not user error: we panic with context
+/// rather than silently producing zero bytes (the pre-fix behavior of
+/// `.unwrap_or(0)` silently coerced any unparseable integer to `0`, which
+/// happened to be correct only when the intended value was zero).
 pub fn encode_literal_bytes(lit_string: &str, cuda_tile_ty: &str) -> Vec<u8> {
     use cutile_ir::ir::ScalarType;
-    let scalar = super::_type::scalar_from_name(cuda_tile_ty).unwrap_or(ScalarType::I32);
+    let scalar = super::_type::scalar_from_name(cuda_tile_ty)
+        .unwrap_or_else(|| panic!("compiler internal: unknown element type `{cuda_tile_ty}`"));
     match scalar {
-        ScalarType::I1 => vec![if lit_string != "0" { 0xFF } else { 0x00 }],
-        ScalarType::I8 => {
-            let v: i8 = lit_string.parse().unwrap_or(0);
-            v.to_le_bytes().to_vec()
-        }
-        ScalarType::I16 => {
-            let v: i16 = lit_string.parse().unwrap_or(0);
-            v.to_le_bytes().to_vec()
-        }
-        ScalarType::I32 => {
-            let v: i32 = lit_string.parse().unwrap_or(0);
-            v.to_le_bytes().to_vec()
-        }
-        ScalarType::I64 => {
-            let v: i64 = lit_string.parse().unwrap_or(0);
-            v.to_le_bytes().to_vec()
-        }
+        ScalarType::I1 => vec![if lit_string != "0" && lit_string != "0x0" {
+            0xFF
+        } else {
+            0x00
+        }],
+        ScalarType::I8 => (parse_int_or_hex(lit_string, "i8") as i8)
+            .to_le_bytes()
+            .to_vec(),
+        ScalarType::I16 => (parse_int_or_hex(lit_string, "i16") as i16)
+            .to_le_bytes()
+            .to_vec(),
+        ScalarType::I32 => (parse_int_or_hex(lit_string, "i32") as i32)
+            .to_le_bytes()
+            .to_vec(),
+        ScalarType::I64 => parse_int_or_hex(lit_string, "i64").to_le_bytes().to_vec(),
         ScalarType::F16 => {
             let v = parse_float_or_hex(lit_string);
             half::f16::from_f64(v).to_le_bytes().to_vec()
@@ -1785,19 +1798,51 @@ pub fn encode_literal_bytes(lit_string: &str, cuda_tile_ty: &str) -> Vec<u8> {
             let v = parse_float_or_hex(lit_string);
             v.to_le_bytes().to_vec()
         }
-        _ => {
-            let v: i32 = lit_string.parse().unwrap_or(0);
-            v.to_le_bytes().to_vec()
-        }
+        other => panic!(
+            "compiler internal: `encode_literal_bytes` does not handle scalar type `{other:?}` \
+             for literal `{lit_string}`"
+        ),
+    }
+}
+
+/// Parse an integer literal string, accepting both decimal and hex (`0x...`)
+/// forms. Returns the value widened to `i64`. Panics on a malformed literal;
+/// the string is compiler-internal, so failure indicates a compiler bug
+/// rather than bad user input.
+fn parse_int_or_hex(s: &str, target_ty: &str) -> i64 {
+    let (negative, rest) = if let Some(rest) = s.strip_prefix('-') {
+        (true, rest)
+    } else {
+        (false, s)
+    };
+    let magnitude = if let Some(hex) = rest.strip_prefix("0x").or_else(|| rest.strip_prefix("0X")) {
+        i64::from_str_radix(hex, 16).unwrap_or_else(|e| {
+            panic!("compiler internal: cannot parse hex literal `{s}` as `{target_ty}`: {e}")
+        })
+    } else {
+        rest.parse::<i64>().unwrap_or_else(|e| {
+            panic!("compiler internal: cannot parse literal `{s}` as `{target_ty}`: {e}")
+        })
+    };
+    if negative {
+        -magnitude
+    } else {
+        magnitude
     }
 }
 
 /// Parse a float literal string, handling both decimal ("3.14") and hex ("0x40490fdb") forms.
+///
+/// Panics on a malformed literal; `s` is derived from a Rust literal that
+/// already passed `syn` parsing, so failure here indicates an internal
+/// compiler bug rather than bad user input.
 fn parse_float_or_hex(s: &str) -> f64 {
     if s.starts_with("0x") || s.starts_with("-0x") {
         let negative = s.starts_with('-');
         let hex = if negative { &s[3..] } else { &s[2..] };
-        let bits = u64::from_str_radix(hex, 16).unwrap_or(0);
+        let bits = u64::from_str_radix(hex, 16).unwrap_or_else(|e| {
+            panic!("compiler internal: cannot parse float hex literal `{s}`: {e}")
+        });
         let v = match hex.len() {
             1..=4 => half::f16::from_bits(bits as u16).to_f64(),
             5..=8 => f32::from_bits(bits as u32) as f64,
@@ -1809,6 +1854,130 @@ fn parse_float_or_hex(s: &str) -> f64 {
             v
         }
     } else {
-        s.parse::<f64>().unwrap_or(0.0)
+        s.parse::<f64>()
+            .unwrap_or_else(|e| panic!("compiler internal: cannot parse float literal `{s}`: {e}"))
+    }
+}
+
+// =========================================================================
+// Tests
+// =========================================================================
+
+#[cfg(test)]
+mod literal_encoding_tests {
+    //! Regression tests for integer literal encoding.
+    //!
+    //! Before the fix, `encode_literal_bytes` did `lit_string.parse::<iN>()
+    //! .unwrap_or(0)`, which silently returned 0 for any unparseable input —
+    //! including every hex literal, since `parse::<iN>()` only accepts
+    //! decimal. The `T::ZERO` path emits hex (`0x0`), so the old code
+    //! coincidentally produced correct bytes for zero only. Any other hex
+    //! value (e.g. `T::ONE` = `0x1`) would have silently become `0`.
+    use super::encode_literal_bytes;
+
+    #[test]
+    fn int_zero_decimal() {
+        assert_eq!(encode_literal_bytes("0", "i32"), vec![0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn int_zero_hex_matches_decimal() {
+        assert_eq!(
+            encode_literal_bytes("0x0", "i32"),
+            encode_literal_bytes("0", "i32"),
+            "hex `0x0` must encode identically to decimal `0`"
+        );
+    }
+
+    #[test]
+    fn int_nonzero_hex_does_not_silently_become_zero() {
+        // Pre-fix, this would have silently returned [0,0,0,0] because
+        // `"0x2a".parse::<i32>()` errors and .unwrap_or(0) kicks in.
+        let bytes = encode_literal_bytes("0x2a", "i32");
+        assert_eq!(
+            bytes,
+            42_i32.to_le_bytes().to_vec(),
+            "hex `0x2a` must encode as 42 (little-endian), not 0"
+        );
+    }
+
+    #[test]
+    fn int_decimal_nonzero() {
+        assert_eq!(
+            encode_literal_bytes("42", "i32"),
+            42_i32.to_le_bytes().to_vec()
+        );
+    }
+
+    #[test]
+    fn int_negative_decimal() {
+        assert_eq!(
+            encode_literal_bytes("-7", "i32"),
+            (-7_i32).to_le_bytes().to_vec()
+        );
+    }
+
+    #[test]
+    fn int_negative_hex() {
+        assert_eq!(
+            encode_literal_bytes("-0x10", "i32"),
+            (-16_i32).to_le_bytes().to_vec()
+        );
+    }
+
+    #[test]
+    fn int_i64_hex() {
+        assert_eq!(
+            encode_literal_bytes("0xff", "i64"),
+            255_i64.to_le_bytes().to_vec()
+        );
+    }
+
+    #[test]
+    fn int_i8_decimal() {
+        assert_eq!(
+            encode_literal_bytes("-1", "i8"),
+            (-1_i8).to_le_bytes().to_vec()
+        );
+    }
+
+    #[test]
+    fn int_i16_hex() {
+        assert_eq!(
+            encode_literal_bytes("0x100", "i16"),
+            256_i16.to_le_bytes().to_vec()
+        );
+    }
+
+    #[test]
+    fn bool_zero_decimal_is_false() {
+        assert_eq!(encode_literal_bytes("0", "i1"), vec![0x00]);
+    }
+
+    #[test]
+    fn bool_zero_hex_is_false() {
+        // Pre-fix, the i1 arm compared lit_string to "0" literally, so
+        // `"0x0"` would have been treated as `true` (0xFF). Confirm the fix.
+        assert_eq!(encode_literal_bytes("0x0", "i1"), vec![0x00]);
+    }
+
+    #[test]
+    fn bool_one_is_true() {
+        assert_eq!(encode_literal_bytes("1", "i1"), vec![0xFF]);
+    }
+
+    #[test]
+    #[should_panic(expected = "unknown element type")]
+    fn unknown_element_type_panics() {
+        // Pre-fix this would have silently defaulted to `i32` and happily
+        // produced [0,0,0,0]. Now it panics with a descriptive message.
+        encode_literal_bytes("42", "complex64");
+    }
+
+    #[test]
+    #[should_panic(expected = "cannot parse literal")]
+    fn malformed_int_literal_panics() {
+        // Pre-fix this would have silently returned 0.
+        encode_literal_bytes("not_a_number", "i32");
     }
 }

--- a/cutile-compiler/src/compiler/compile_intrinsic.rs
+++ b/cutile-compiler/src/compiler/compile_intrinsic.rs
@@ -44,22 +44,35 @@ fn get_signedness_str(element_type_str: &str) -> &'static str {
 /// `cutile_ir::ir::Type`.  Tries `types::convert_type` first (handles
 /// primitives), then falls back to building a tile type from the
 /// element-type name and shape when the type instance is structured.
+///
+/// Returns `Ok(None)` when the type is neither primitive nor structured
+/// (legitimately "not applicable"). Propagates the original `JITError` from
+/// `get_cuda_tile_element_type` rather than collapsing it to `None`, so a
+/// misconfigured type doesn't surface as a generic "failed to obtain
+/// tile-ir type" message upstream.
 fn tile_ir_type_from_trt(
     trt: &TileRustType,
     primitives: &HashMap<(String, String), syn::ItemImpl>,
-) -> Option<cutile_ir::ir::Type> {
+) -> Result<Option<cutile_ir::ir::Type>, crate::error::JITError> {
     // Fast path: primitives and simple cases handled by convert_type.
     if let Some(ty) = types::convert_type(trt) {
-        return Some(ty);
+        return Ok(Some(ty));
     }
     // Structured types: extract element name + shape from the TypeInstance.
     if let TypeInstance::StructuredType(inst) = &trt.type_instance {
         // Use the same element-type resolution path the old compiler uses.
-        let elem_name = trt.get_cuda_tile_element_type(primitives).ok()??;
-        let shape: Vec<i64> = inst.shape.iter().map(|&d| d as i64).collect();
-        return types::make_tile_type(&elem_name, &shape);
+        // `get_cuda_tile_element_type` returns `Err` for unsupported kinds
+        // (preserve the error) and `Ok(None)` when element resolution
+        // genuinely produced nothing (treated as "not applicable" here).
+        match trt.get_cuda_tile_element_type(primitives)? {
+            Some(elem_name) => {
+                let shape: Vec<i64> = inst.shape.iter().map(|&d| d as i64).collect();
+                return Ok(types::make_tile_type(&elem_name, &shape));
+            }
+            None => return Ok(None),
+        }
     }
-    None
+    Ok(None)
 }
 
 impl<'m> CUDATileFunctionCompiler<'m> {
@@ -644,12 +657,29 @@ impl<'m> CUDATileFunctionCompiler<'m> {
 
                 // Build the reduce op itself.
                 // Build a properly typed identities attribute from the hex identity.
+                // `element_type` and `identity` are compiler-internal strings;
+                // a failure to parse either is a compiler bug, not user error.
                 let identity_attr = {
-                    let scalar_ty = super::_type::scalar_from_name(&element_type)
-                        .unwrap_or(cutile_ir::ir::ScalarType::I32);
+                    let scalar_ty = super::_type::scalar_from_name(&element_type).ok_or_else(
+                        || {
+                            self.jit_error(
+                                &call_expr.span(),
+                                &format!(
+                                    "compiler internal: unknown reduce element type `{element_type}`"
+                                ),
+                            )
+                        },
+                    )?;
                     let ir_ty = cutile_ir::ir::Type::Scalar(scalar_ty);
                     let hex_str = identity.trim_start_matches("0x").trim_start_matches("0X");
-                    let bits = u64::from_str_radix(hex_str, 16).unwrap_or(0);
+                    let bits = u64::from_str_radix(hex_str, 16).map_err(|e| {
+                        self.jit_error(
+                            &call_expr.span(),
+                            &format!(
+                                "compiler internal: reduce identity `{identity}` is not a valid hex literal: {e}"
+                            ),
+                        )
+                    })?;
                     if scalar_ty.is_float() {
                         let float_val = match element_type.as_str() {
                             "f32" => f32::from_bits(bits as u32) as f64,
@@ -894,16 +924,16 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                             return Ok(Some(arg));
                         }
                         let output_type =
-                            tile_ir_type_from_trt(&new_type_compiled, &self.modules.primitives())
+                            tile_ir_type_from_trt(&new_type_compiled, &self.modules.primitives())?
                                 .ok_or_else(|| {
-                                self.jit_error(
-                                    &call_expr.span(),
-                                    &format!(
-                                        "Failed to obtain tile-ir type for convert {}",
-                                        call_expr.to_token_stream().to_string()
-                                    ),
-                                )
-                            })?;
+                                    self.jit_error(
+                                        &call_expr.span(),
+                                        &format!(
+                                            "Failed to obtain tile-ir type for convert {}",
+                                            call_expr.to_token_stream().to_string()
+                                        ),
+                                    )
+                                })?;
                         // These aren't required for all ops.
                         let (op_id, results) = match (
                             old_element_type_str.as_str(),

--- a/cutile-compiler/src/compiler/shared_utils.rs
+++ b/cutile-compiler/src/compiler/shared_utils.rs
@@ -355,17 +355,38 @@ pub fn extract_string_literal(
 
 /// Helper to resolve compile-time optional argument.
 /// Returns the inner expression if it is Some(expr), or None if it is None.
+///
+/// **Note:** this legacy helper conflates "explicit `None`" with "unparseable"
+/// — both return `None`. New code should prefer
+/// [`resolve_option_arg_checked`], which distinguishes the two so that
+/// callers can fail loudly on unparseable args rather than silently dropping
+/// them.
 pub fn resolve_option_arg(expr: &syn::Expr, ctx: &CompilerContext) -> Option<syn::Expr> {
+    match resolve_option_arg_internal(expr, ctx) {
+        OptionArgOutcome::None => None,
+        OptionArgOutcome::Some(inner) => Some(inner),
+        OptionArgOutcome::Unparseable => None,
+    }
+}
+
+enum OptionArgOutcome {
+    None,
+    Some(syn::Expr),
+    Unparseable,
+}
+
+fn resolve_option_arg_internal(expr: &syn::Expr, ctx: &CompilerContext) -> OptionArgOutcome {
     use syn::Expr;
     if let Expr::Call(call) = expr {
         if let Expr::Path(path) = &*call.func {
             if path.path.segments.last().unwrap().ident == "Some" {
-                return Some(call.args[0].clone());
+                return OptionArgOutcome::Some(call.args[0].clone());
             }
         }
+        return OptionArgOutcome::Unparseable;
     } else if let Expr::Path(path) = expr {
         if path.path.segments.len() == 1 && path.path.segments.last().unwrap().ident == "None" {
-            return None;
+            return OptionArgOutcome::None;
         }
         let var_name = path.path.segments.last().unwrap().ident.to_string();
         if let Some(val) = ctx.vars.get(&var_name) {
@@ -373,20 +394,112 @@ pub fn resolve_option_arg(expr: &syn::Expr, ctx: &CompilerContext) -> Option<syn
                 if let Expr::Call(call) = ast {
                     if let Expr::Path(path) = &*call.func {
                         if path.path.segments.last().unwrap().ident == "Some" {
-                            return Some(call.args[0].clone());
+                            return OptionArgOutcome::Some(call.args[0].clone());
                         }
                     }
                 } else if let Expr::Path(path) = ast {
                     if path.path.segments.len() == 1
                         && path.path.segments.last().unwrap().ident == "None"
                     {
-                        return None;
+                        return OptionArgOutcome::None;
                     }
                 }
+                return OptionArgOutcome::Unparseable;
             }
         }
+        return OptionArgOutcome::Unparseable;
     }
-    None
+    OptionArgOutcome::Unparseable
+}
+
+/// Three-way result of resolving an `Option<T>`-typed DSL argument.
+#[derive(Debug, Clone)]
+pub enum OptionArg {
+    /// Caller passed a literal `None`.
+    None,
+    /// Caller passed `Some(<inner>)`.
+    Some(syn::Expr),
+}
+
+/// Resolve an expression expected to be an `Option<T>` literal.
+///
+/// Unlike [`resolve_option_arg`], this variant rejects unparseable
+/// expressions with a [`JITError`] rather than silently returning `None`.
+/// Use this when a silently-dropped argument would be a correctness bug
+/// (e.g. an optional hint, a mask, an input token).
+pub fn resolve_option_arg_checked(
+    expr: &syn::Expr,
+    ctx: &CompilerContext,
+    param_name: &str,
+) -> Result<OptionArg, JITError> {
+    match resolve_option_arg_internal(expr, ctx) {
+        OptionArgOutcome::None => Ok(OptionArg::None),
+        OptionArgOutcome::Some(inner) => Ok(OptionArg::Some(inner)),
+        OptionArgOutcome::Unparseable => SourceLocation::unknown().jit_error_result(&format!(
+            "`{param_name}` must be `None` or `Some(...)`, got `{}`",
+            expr.to_token_stream().to_string()
+        )),
+    }
+}
+
+/// Resolve an optional integer DSL argument (e.g. `latency: Option<i32>`).
+///
+/// Accepts either an integer literal (`Some(5)`) or a const-generic path
+/// (`Some(L)` where `L` was bound to an i32 in `generic_args`).  Any other
+/// expression shape — including a runtime variable, a binary expression, or
+/// an unresolved path — produces a [`JITError`] instead of being silently
+/// dropped.
+pub fn extract_optional_i32_hint(
+    arg: &syn::Expr,
+    generic_args: &crate::generics::GenericVars,
+    ctx: &CompilerContext,
+    param_name: &str,
+) -> Result<Option<i32>, JITError> {
+    use syn::{Expr, ExprLit, Lit};
+    match resolve_option_arg_checked(arg, ctx, param_name)? {
+        OptionArg::None => Ok(None),
+        OptionArg::Some(inner) => match &inner {
+            Expr::Lit(ExprLit {
+                lit: Lit::Int(n), ..
+            }) => Ok(Some(n.base10_parse::<i32>().map_err(|e| {
+                SourceLocation::unknown().jit_error(&format!(
+                    "`{param_name}`: invalid integer literal `{}`: {e}",
+                    n.to_string()
+                ))
+            })?)),
+            Expr::Path(path_expr) => {
+                let ident = get_ident_from_path_expr(path_expr).to_string();
+                match generic_args.get_i32(&ident) {
+                    Some(v) => Ok(Some(v)),
+                    None => SourceLocation::unknown().jit_error_result(&format!(
+                        "`{param_name}`: const generic `{ident}` has no resolved value"
+                    )),
+                }
+            }
+            _ => SourceLocation::unknown().jit_error_result(&format!(
+                "`{param_name}` must be a literal integer or const generic, got `{}`",
+                inner.to_token_stream().to_string()
+            )),
+        },
+    }
+}
+
+/// Resolve a required boolean DSL argument (e.g. `disallow_tma: bool`,
+/// `scan_reverse: bool`).
+///
+/// Accepts only a bool literal; any other expression shape produces a
+/// [`JITError`].
+pub fn extract_bool_arg(arg: &syn::Expr, param_name: &str) -> Result<bool, JITError> {
+    use syn::{Expr, ExprLit, Lit};
+    match arg {
+        Expr::Lit(ExprLit {
+            lit: Lit::Bool(b), ..
+        }) => Ok(b.value),
+        _ => SourceLocation::unknown().jit_error_result(&format!(
+            "`{param_name}` must be a literal `true` or `false`, got `{}`",
+            arg.to_token_stream().to_string()
+        )),
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/cutile-compiler/src/compiler/tile_rust_type.rs
+++ b/cutile-compiler/src/compiler/tile_rust_type.rs
@@ -200,7 +200,9 @@ impl TileRustType {
         } else {
             format!("Tile<{element_name}, {{ {shape:?} }}>")
         };
-        let rust_ty = syn::parse_str::<syn::Type>(&rust_ty_str).ok()?;
+        let rust_ty = syn::parse_str::<syn::Type>(&rust_ty_str).unwrap_or_else(|e| {
+            panic!("compiler internal: synthesized Tile type `{rust_ty_str}` failed to parse: {e}")
+        });
         Some(TileRustType {
             kind: Kind::StructuredType,
             cuda_tile_name: Some("!cuda_tile.tile".into()),
@@ -227,9 +229,10 @@ impl TileRustType {
             )),
         });
         let type_str = format!("!cuda_tile.tile<!cuda_tile.ptr<{element_name}>>");
-        let rust_ty =
-            syn::parse_str::<syn::Type>(&format!("PointerTile<* mut {element_name}, {{[]}}>"))
-                .ok()?;
+        let ptr_ty_str = format!("PointerTile<* mut {element_name}, {{[]}}>");
+        let rust_ty = syn::parse_str::<syn::Type>(&ptr_ty_str).unwrap_or_else(|e| {
+            panic!("compiler internal: synthesized ptr type `{ptr_ty_str}` failed to parse: {e}")
+        });
         Some(TileRustType {
             kind: Kind::PrimitiveType,
             cuda_tile_name: Some("!cuda_tile.tile".into()),

--- a/cutile-ir/src/bytecode/op_writer.rs
+++ b/cutile-ir/src/bytecode/op_writer.rs
@@ -19,10 +19,20 @@
 //! Ported from generated `Bytecode.inc` in the `cuda-tile` submodule.
 
 use super::encoding::EncodingWriter;
+use super::enums::BytecodeVersion;
 use super::opcode::Opcode;
 use super::writer::WriterCtx;
 use crate::ir::{Attribute, Operation};
 use crate::{Error, Result};
+
+/// The bytecode version that introduced v13.2-era op-field additions
+/// (NegI.overflow, TanH.rounding_mode, For.unsigned_cmp flag,
+/// Print.token result+flags+optional-operand).
+const V_13_2: BytecodeVersion = BytecodeVersion {
+    major: 13,
+    minor: 2,
+    tag: 0,
+};
 
 // =========================================================================
 // Per-op dispatch entry point
@@ -50,15 +60,19 @@ pub(super) fn write_op_body(
         // ----- v13.2: NegI gains overflow attr -----
         NegI => {
             write_result_types(op, w, ctx)?;
-            // overflow defaults to NONE (0) if not set
-            write_inline_attr_or_default(op, "overflow", 0, w, ctx)?;
+            if ctx.version >= V_13_2 {
+                // overflow: DefaultValuedAttr<IntegerOverflow, NONE>
+                write_inline_attr_or_default(op, "overflow", 0, w, ctx)?;
+            }
             write_operands(op, w, ctx, false)?;
         }
         // ----- v13.2: TanH gains rounding_mode attr -----
         TanH => {
             write_result_types(op, w, ctx)?;
-            // rounding_mode defaults to FULL (5) if not set
-            write_inline_attr_or_default(op, "rounding_mode", 5, w, ctx)?;
+            if ctx.version >= V_13_2 {
+                // rounding_mode: DefaultValuedAttr<RoundingMode, FULL>
+                write_inline_attr_or_default(op, "rounding_mode", 5, w, ctx)?;
+            }
             write_operands(op, w, ctx, false)?;
         }
 
@@ -67,10 +81,11 @@ pub(super) fn write_op_body(
             write_result_types(op, w, ctx)?;
         }
 
-        // ----- Required attributes only -----
+        // ----- DefaultValuedAttr: `overflow` defaults to IntegerOverflow::None (0) -----
         AddI | MulI | SubI | ShLI | TruncI => {
             write_result_types(op, w, ctx)?;
-            write_inline_attr(op, "overflow", w, ctx)?;
+            // overflow: DefaultValuedAttr<IntegerOverflow, NONE>
+            write_inline_attr_or_default(op, "overflow", 0, w, ctx)?;
             write_operands(op, w, ctx, false)?;
         }
         ShRI | ExtI => {
@@ -117,12 +132,14 @@ pub(super) fn write_op_body(
         DivI => {
             write_result_types(op, w, ctx)?;
             write_inline_attr(op, "signedness", w, ctx)?;
-            write_inline_attr(op, "rounding", w, ctx)?;
+            // rounding: DefaultValuedAttr<RoundingMode, ZERO>
+            write_inline_attr_or_default(op, "rounding", 1, w, ctx)?;
             write_operands(op, w, ctx, false)?;
         }
         FToF => {
             write_result_types(op, w, ctx)?;
-            write_inline_attr(op, "rounding_mode", w, ctx)?;
+            // rounding_mode: DefaultValuedAttr<RoundingMode, NEAREST_EVEN>
+            write_inline_attr_or_default(op, "rounding_mode", 0, w, ctx)?;
             write_operands(op, w, ctx, false)?;
         }
         FToI => {
@@ -239,7 +256,8 @@ pub(super) fn write_op_body(
             write_result_types(op, w, ctx)?;
             write_inline_attr(op, "sym_name", w, ctx)?;
             write_inline_attr(op, "value", w, ctx)?;
-            write_inline_attr(op, "alignment", w, ctx)?;
+            // alignment: DefaultValuedAttr<I64Attr, "0">
+            write_inline_attr_or_default(op, "alignment", 0, w, ctx)?;
         }
 
         // ----- Module: result types + attr + regions -----
@@ -256,27 +274,74 @@ pub(super) fn write_op_body(
             write_operands(op, w, ctx, true)?;
         }
 
-        // ----- Print: result count + v13.2 flags + attributes + variadic operands -----
+        // ----- Print (v13.1: str + sized-variadic args) -----
+        // ----- Print (v13.2: + optional token result + flags + optional token operand) -----
+        // Operand groups (when `operandSegmentSizes` is set): 0 = args, 1 = token.
+        // Callers that don't set segment sizes have no token operand.
         Print => {
             w.write_varint(op.result_types.len() as u64);
             write_result_types(op, w, ctx)?;
-            // v13.2: flags field (bit 0 = has token operand)
-            // The token is the last operand if present; we check via
-            // the "has_token" attr or by result count (token result).
-            let flags = 0u64; // TODO: set bit 0 if token present
-            w.write_varint(flags);
-            write_inline_attr(op, "str", w, ctx)?;
-            write_operands(op, w, ctx, true)?;
-            // v13.2: optional token operand (not written if flags bit 0 is 0)
+            let has_segments = op
+                .attributes
+                .iter()
+                .any(|(n, _)| n == "operandSegmentSizes");
+            let (args_count, has_token) = if has_segments {
+                let sizes = operand_segment_sizes(op);
+                (
+                    sizes.first().copied().unwrap_or(0) as usize,
+                    sizes.get(1).copied().unwrap_or(0) > 0,
+                )
+            } else {
+                (op.operands.len(), false)
+            };
+            if ctx.version >= V_13_2 {
+                let flags: u64 = if has_token { 1 } else { 0 };
+                w.write_varint(flags);
+                write_inline_attr(op, "str", w, ctx)?;
+                // sized variadic args (group 0)
+                w.write_varint(args_count as u64);
+                for &operand in op.operands.iter().take(args_count) {
+                    let idx =
+                        ctx.value_map.get(&operand).copied().ok_or_else(|| {
+                            Error::BytecodeWrite("Print arg not in value map".into())
+                        })?;
+                    w.write_varint(idx);
+                }
+                // optional token (group 1, one operand if present)
+                if has_token {
+                    let operand = op.operands[args_count];
+                    let idx = ctx.value_map.get(&operand).copied().ok_or_else(|| {
+                        Error::BytecodeWrite("Print token not in value map".into())
+                    })?;
+                    w.write_varint(idx);
+                }
+            } else {
+                if has_token {
+                    return Err(Error::BytecodeWrite(
+                        "Print with token operand requires bytecode v13.2+".into(),
+                    ));
+                }
+                write_inline_attr(op, "str", w, ctx)?;
+                w.write_varint(args_count as u64);
+                for &operand in op.operands.iter().take(args_count) {
+                    let idx =
+                        ctx.value_map.get(&operand).copied().ok_or_else(|| {
+                            Error::BytecodeWrite("Print arg not in value map".into())
+                        })?;
+                    w.write_varint(idx);
+                }
+            }
         }
 
         // ----- Variadic results + regions -----
         For => {
             w.write_varint(op.result_types.len() as u64);
             write_result_types(op, w, ctx)?;
-            // v13.2: flags field for unsignedCmp (bit 0)
-            let flags = flag_if_present(op, "unsigned_cmp", 0);
-            w.write_varint(flags);
+            if ctx.version >= V_13_2 {
+                // v13.2: flags field for unsignedCmp (bit 0)
+                let flags = flag_if_present(op, "unsigned_cmp", 0);
+                w.write_varint(flags);
+            }
             write_operands(op, w, ctx, true)?;
             write_regions(op, w, ctx)?;
         }

--- a/cutile-ir/src/bytecode/writer.rs
+++ b/cutile-ir/src/bytecode/writer.rs
@@ -45,6 +45,7 @@ pub fn write_bytecode_version(module: &Module, version: BytecodeVersion) -> Resu
     // Initialize writer context with all managers.
     let mut ctx = WriterCtx {
         module,
+        version,
         value_map: HashMap::new(),
         next_idx: 0,
         strings: StringManager::new(),
@@ -813,6 +814,9 @@ fn write_function_body(ctx: &mut WriterCtx, func_op: OpId) -> Result<Vec<u8>> {
 /// `&mut` to per-op writers and recursive region/block writers.
 pub(super) struct WriterCtx<'a> {
     pub module: &'a Module,
+    /// Target bytecode version. Per-op writers consult this to gate
+    /// fields that were added in specific minor versions.
+    pub version: BytecodeVersion,
     pub value_map: HashMap<Value, u64>,
     pub next_idx: u64,
     pub strings: StringManager,

--- a/cutile-ir/tests/per_op_roundtrip.rs
+++ b/cutile-ir/tests/per_op_roundtrip.rs
@@ -2069,3 +2069,175 @@ fn roundtrip_make_tensor_view_2d() {
     );
     assert_roundtrip(&module);
 }
+
+// =========================================================================
+// DefaultValuedAttr regression tests.
+//
+// In C++/Python the writer materializes the default for
+// `DefaultValuedAttr<...>` attributes (via `populateDefaultProperties` /
+// caller-side default argument). Our Rust port reads from `op.attributes`
+// at write time, so the writer must tolerate the attr being absent and
+// serialize the TableGen-declared default. Without this support,
+// `write_bytecode` panics on any op produced by a path that doesn't
+// explicitly set the attr (e.g., `exti` → `trunci` conversion that omits
+// `overflow`; a `FToF` that omits `rounding_mode`; a `Global` without
+// alignment; etc.).
+//
+// Each test below builds an op WITHOUT the relevant attr and asserts the
+// write+decode succeeds. They protect against reintroducing the
+// `write_inline_attr` panic that blocked the kernel-generation workflow
+// on AddI/MulI/SubI/ShLI/TruncI (overflow), DivI (rounding), FToF
+// (rounding_mode), and Global (alignment).
+// =========================================================================
+
+#[test]
+fn default_valued_addi_overflow_absent() {
+    let module = build_kernel(
+        "addi_default_ov",
+        &[tile_i32(), tile_i32()],
+        |m, b, args| {
+            let (op, _) = OpBuilder::new(Opcode::AddI, Location::Unknown)
+                .operand(args[0])
+                .operand(args[1])
+                .result(tile_i32())
+                // NOTE: no .attr("overflow", ...) — should default to NONE (0).
+                .build(m);
+            append_op(m, b, op);
+        },
+    );
+    assert_roundtrip(&module);
+}
+
+#[test]
+fn default_valued_muli_overflow_absent() {
+    let module = build_kernel(
+        "muli_default_ov",
+        &[tile_i32(), tile_i32()],
+        |m, b, args| {
+            let (op, _) = OpBuilder::new(Opcode::MulI, Location::Unknown)
+                .operand(args[0])
+                .operand(args[1])
+                .result(tile_i32())
+                .build(m);
+            append_op(m, b, op);
+        },
+    );
+    assert_roundtrip(&module);
+}
+
+#[test]
+fn default_valued_subi_overflow_absent() {
+    let module = build_kernel(
+        "subi_default_ov",
+        &[tile_i32(), tile_i32()],
+        |m, b, args| {
+            let (op, _) = OpBuilder::new(Opcode::SubI, Location::Unknown)
+                .operand(args[0])
+                .operand(args[1])
+                .result(tile_i32())
+                .build(m);
+            append_op(m, b, op);
+        },
+    );
+    assert_roundtrip(&module);
+}
+
+#[test]
+fn default_valued_shli_overflow_absent() {
+    let module = build_kernel(
+        "shli_default_ov",
+        &[tile_i32(), tile_i32()],
+        |m, b, args| {
+            let (op, _) = OpBuilder::new(Opcode::ShLI, Location::Unknown)
+                .operand(args[0])
+                .operand(args[1])
+                .result(tile_i32())
+                .build(m);
+            append_op(m, b, op);
+        },
+    );
+    assert_roundtrip(&module);
+}
+
+#[test]
+fn default_valued_trunci_overflow_absent() {
+    let tile_i64 = Type::Tile(TileType {
+        shape: vec![128],
+        element_type: TileElementType::Scalar(ScalarType::I64),
+    });
+    let module = build_kernel("trunci_default_ov", &[tile_i64], |m, b, args| {
+        let (op, _) = OpBuilder::new(Opcode::TruncI, Location::Unknown)
+            .operand(args[0])
+            .result(tile_i32())
+            .build(m);
+        append_op(m, b, op);
+    });
+    assert_roundtrip(&module);
+}
+
+#[test]
+fn default_valued_divi_rounding_absent() {
+    let module = build_kernel(
+        "divi_default_rm",
+        &[tile_i32(), tile_i32()],
+        |m, b, args| {
+            let (op, _) = OpBuilder::new(Opcode::DivI, Location::Unknown)
+                .operand(args[0])
+                .operand(args[1])
+                .result(tile_i32())
+                .attr("signedness", Attribute::i32(1)) // required (non-default)
+                // NOTE: no .attr("rounding", ...) — should default to ZERO (1).
+                .build(m);
+            append_op(m, b, op);
+        },
+    );
+    assert_roundtrip(&module);
+}
+
+#[test]
+fn default_valued_ftof_rounding_mode_absent() {
+    // f32 → f16 down-cast; rounding_mode omitted should default to NEAREST_EVEN (0).
+    let tile_f16 = Type::Tile(TileType {
+        shape: vec![128],
+        element_type: TileElementType::Scalar(ScalarType::F16),
+    });
+    let module = build_kernel("ftof_default_rm", &[tile_f32()], |m, b, args| {
+        let (op, _) = OpBuilder::new(Opcode::FToF, Location::Unknown)
+            .operand(args[0])
+            .result(tile_f16)
+            .build(m);
+        append_op(m, b, op);
+    });
+    assert_roundtrip(&module);
+}
+
+// =========================================================================
+// v13.2 field coverage: ensure NegI / TanH / For / Print all write without
+// panic even if their v13.2 attribute is absent.
+// =========================================================================
+
+#[test]
+fn default_valued_negi_overflow_absent() {
+    let module = build_kernel("negi_default_ov", &[tile_i32()], |m, b, args| {
+        let (op, _) = OpBuilder::new(Opcode::NegI, Location::Unknown)
+            .operand(args[0])
+            .result(tile_i32())
+            // no overflow attr; defaults to NONE (0)
+            .build(m);
+        append_op(m, b, op);
+    });
+    assert_roundtrip(&module);
+}
+
+#[test]
+fn default_valued_tanh_rounding_mode_absent() {
+    let module = build_kernel("tanh_default_rm", &[tile_f32()], |m, b, args| {
+        let (op, _) = OpBuilder::new(Opcode::TanH, Location::Unknown)
+            .operand(args[0])
+            .result(tile_f32())
+            // no rounding_mode; defaults to FULL (5)
+            .build(m);
+        append_op(m, b, op);
+    });
+    assert_roundtrip(&module);
+}

--- a/cutile/tests/integer_ops.rs
+++ b/cutile/tests/integer_ops.rs
@@ -40,6 +40,37 @@ mod integer_ops_module {
         let result: Tile<u32, S> = maxi(x, y);
         output.store(result);
     }
+
+    // ----- Kernels that exercise the bytecode writer's DefaultValuedAttr
+    // path. Before the fix, write_bytecode panicked with
+    // `missing attribute 'overflow' on op <...>` because the DSL macro
+    // emits these ops without an explicit overflow attr; the compiler
+    // passes that through; and op_writer.rs used write_inline_attr instead
+    // of write_inline_attr_or_default.
+
+    #[cutile::entry()]
+    fn trunci_kernel<const S: [i32; 1]>(output: &mut Tensor<i64, S>) {
+        let x: Tile<i64, S> = load_tile_mut(output);
+        let t: Tile<i32, S> = trunci(x);
+        let e: Tile<i64, S> = exti(t);
+        output.store(e);
+    }
+
+    #[cutile::entry()]
+    fn shli_kernel<const S: [i32; 1]>(output: &mut Tensor<i64, S>) {
+        let x: Tile<i64, S> = load_tile_mut(output);
+        let y: Tile<i64, S> = load_tile_mut(output);
+        let z: Tile<i64, S> = shli(x, y);
+        output.store(z);
+    }
+
+    #[cutile::entry()]
+    fn addi_kernel<const S: [i32; 1]>(output: &mut Tensor<i64, S>) {
+        let x: Tile<i64, S> = load_tile_mut(output);
+        let y: Tile<i64, S> = load_tile_mut(output);
+        let z: Tile<i64, S> = x + y; // lowers to AddI
+        output.store(z);
+    }
 }
 
 use integer_ops_module::_module_asts;
@@ -142,5 +173,62 @@ fn compile_maxi_unsigned() -> () {
         );
 
         println!("\n✓ maxi with unsigned types verified in MLIR output");
+    });
+}
+
+// =========================================================================
+// DefaultValuedAttr bytecode-write regression tests.
+//
+// These tests drive the full DSL → compile → `write_bytecode` path for
+// ops whose TableGen schema declares attrs as `DefaultValuedAttr<...>`
+// (AddI / MulI / SubI / ShLI / TruncI overflow, DivI rounding, FToF
+// rounding_mode). Before the fix, these kernels compiled to MLIR
+// correctly but panicked during bytecode serialization with
+// `BytecodeWrite("missing attribute 'overflow' on op <Opcode>")`
+// because op_writer.rs used `write_inline_attr` instead of
+// `write_inline_attr_or_default`.
+// =========================================================================
+
+fn compile_and_write_bytecode(kernel_name: &str) -> Vec<u8> {
+    let modules = CUDATileModules::new(_module_asts()).expect("Failed to create CUDATileModules");
+    let gpu_name = get_gpu_name(0);
+    let compiler = CUDATileFunctionCompiler::new(
+        &modules,
+        "integer_ops_module",
+        kernel_name,
+        &[128.to_string()],
+        &[("output", &[1])],
+        &[],
+        &[],
+        None,
+        gpu_name,
+        &CompileOptions::default(),
+    )
+    .expect("compiler");
+    let module = compiler.compile().expect("compile");
+    cutile_ir::write_bytecode(&module).expect("write_bytecode failed")
+}
+
+#[test]
+fn trunci_kernel_bytecode_writes_without_panic() {
+    common::with_test_stack(|| {
+        let bc = compile_and_write_bytecode("trunci_kernel");
+        assert!(bc.len() > 12, "bytecode too short");
+    });
+}
+
+#[test]
+fn shli_kernel_bytecode_writes_without_panic() {
+    common::with_test_stack(|| {
+        let bc = compile_and_write_bytecode("shli_kernel");
+        assert!(bc.len() > 12, "bytecode too short");
+    });
+}
+
+#[test]
+fn addi_kernel_bytecode_writes_without_panic() {
+    common::with_test_stack(|| {
+        let bc = compile_and_write_bytecode("addi_kernel");
+        assert!(bc.len() > 12, "bytecode too short");
     });
 }

--- a/cutile/tests/optimization_hints.rs
+++ b/cutile/tests/optimization_hints.rs
@@ -72,6 +72,33 @@ mod opt_hints_module {
         let idx: [i32; 1] = [0i32];
         let _tile: Tile<f32, S> = load_from_view(&partition, idx, Some(L), false);
     }
+
+    /// load_ptr_tko with const-generic latency. This is the exact shape that
+    /// silently dropped the hint before the `extract_optional_i32_hint` fix
+    /// — the special-op handler only matched `Expr::Lit(Int)` and ignored
+    /// `Expr::Path`.
+    #[cutile::entry()]
+    fn load_ptr_const_latency_kernel<const S: [i32; 1], const L: i32>(output: &mut Tensor<f32, S>) {
+        let ptr_seed: Tile<i64, S> = constant(0i64, output.shape());
+        let ptrs_i64: PointerTile<*mut i64, S> = int_to_ptr(ptr_seed);
+        let ptrs: PointerTile<*mut f32, S> = ptr_to_ptr(ptrs_i64);
+        let (loaded, _tok): (Tile<f32, S>, Token) =
+            load_ptr_tko(ptrs, "weak", "tl_blk", None, None, None, Some(L));
+        output.store(loaded);
+    }
+
+    /// Mirror of `load_ptr_const_latency_kernel` for `store_ptr_tko`.
+    #[cutile::entry()]
+    fn store_ptr_const_latency_kernel<const S: [i32; 1], const L: i32>(
+        output: &mut Tensor<f32, S>,
+    ) {
+        let ptr_seed: Tile<i64, S> = constant(0i64, output.shape());
+        let ptrs_i64: PointerTile<*mut i64, S> = int_to_ptr(ptr_seed);
+        let ptrs: PointerTile<*mut f32, S> = ptr_to_ptr(ptrs_i64);
+        let vals: Tile<f32, S> = constant(1.0f32, output.shape());
+        let _tok: Token = store_ptr_tko(ptrs, vals, "weak", "tl_blk", None, None, Some(L));
+        output.store(vals);
+    }
 }
 
 use opt_hints_module::_module_asts;
@@ -256,6 +283,75 @@ fn load_view_const_latency_in_mlir() {
         assert!(
             mlir.contains("latency = 5"),
             "Expected latency=5 from const generic L=5.\nMLIR:\n{mlir}"
+        );
+    });
+}
+
+/// Regression for the `Some(LATENCY)` drop in `compile_load_ptr_tko`. Before
+/// the fix, the special-op handler matched only `Expr::Lit(Int)` and
+/// silently ignored `Expr::Path` (const generics), so this kernel compiled
+/// without any `optimization_hints` attribute at all.
+#[test]
+fn load_ptr_const_latency_in_mlir() {
+    common::with_test_stack(|| {
+        let modules =
+            CUDATileModules::new(_module_asts()).expect("Failed to create CUDATileModules");
+        let gpu_name = get_gpu_name(0);
+        let compiler = CUDATileFunctionCompiler::new(
+            &modules,
+            "opt_hints_module",
+            "load_ptr_const_latency_kernel",
+            &[128.to_string(), 3.to_string()], // S=128, L=3
+            &[("output", &[1])],
+            &[],
+            &[],
+            None,
+            gpu_name,
+            &CompileOptions::default(),
+        )
+        .expect("Failed to create compiler");
+        let module_op = compiler.compile().expect("Failed to compile");
+        let mlir = module_op.to_string();
+        drop(module_op);
+        drop(compiler);
+        println!("{mlir}");
+        assert!(
+            mlir.contains("latency = 3"),
+            "Expected latency=3 from const generic L=3 in load_ptr_tko. \
+             Was previously silently dropped.\nMLIR:\n{mlir}"
+        );
+    });
+}
+
+/// Regression mirror of `load_ptr_const_latency_in_mlir` for the store path.
+#[test]
+fn store_ptr_const_latency_in_mlir() {
+    common::with_test_stack(|| {
+        let modules =
+            CUDATileModules::new(_module_asts()).expect("Failed to create CUDATileModules");
+        let gpu_name = get_gpu_name(0);
+        let compiler = CUDATileFunctionCompiler::new(
+            &modules,
+            "opt_hints_module",
+            "store_ptr_const_latency_kernel",
+            &[128.to_string(), 7.to_string()], // S=128, L=7
+            &[("output", &[1])],
+            &[],
+            &[],
+            None,
+            gpu_name,
+            &CompileOptions::default(),
+        )
+        .expect("Failed to create compiler");
+        let module_op = compiler.compile().expect("Failed to compile");
+        let mlir = module_op.to_string();
+        drop(module_op);
+        drop(compiler);
+        println!("{mlir}");
+        assert!(
+            mlir.contains("latency = 7"),
+            "Expected latency=7 from const generic L=7 in store_ptr_tko. \
+             Was previously silently dropped.\nMLIR:\n{mlir}"
         );
     });
 }

--- a/cutile/tests/reduce_scan_ops.rs
+++ b/cutile/tests/reduce_scan_ops.rs
@@ -91,6 +91,18 @@ mod reduce_scan_ops_module {
         // Store the result
         output.store(prefix_products);
     }
+
+    /// Regression: pre-fix, `reverse = true` was silently defaulted to
+    /// `false` if the arg came through as anything other than a bool
+    /// literal. With the `extract_bool_arg` helper the literal path is
+    /// preserved; this kernel pins the positive `true` case so a future
+    /// refactor can't silently swap it back.
+    #[cutile::entry()]
+    fn scan_reverse_true_kernel<const S: [i32; 1]>(output: &mut Tensor<f32, S>) {
+        let tile: Tile<f32, S> = load_tile_mut(output);
+        let suffix_sums: Tile<f32, S> = scan_sum(tile, 0i32, true, 0.0f32);
+        output.store(suffix_sums);
+    }
 }
 
 use reduce_scan_ops_module::_module_asts;
@@ -330,5 +342,39 @@ fn compile_scan_closure_test() -> () {
         );
 
         println!("\n✓ scan with closure (prefix product) operation verified");
+    });
+}
+
+/// Regression: ensure `scan(..., reverse=true, ...)` actually lowers to
+/// `reverse=true` in the IR. Before the fix, the special-op handler
+/// would silently default to `false` if the arg was anything but a bool
+/// literal, so we specifically pin the literal-`true` path here.
+#[test]
+fn compile_scan_reverse_true() {
+    common::with_test_stack(|| {
+        let modules =
+            CUDATileModules::new(_module_asts()).expect("Failed to create CUDATileModules");
+        let gpu_name = get_gpu_name(0);
+        let compiler = CUDATileFunctionCompiler::new(
+            &modules,
+            "reduce_scan_ops_module",
+            "scan_reverse_true_kernel",
+            &[128.to_string()],
+            &[("output", &[1])],
+            &[],
+            &[],
+            None,
+            gpu_name,
+            &CompileOptions::default(),
+        )
+        .expect("Failed.");
+        let mlir = compiler.compile().expect("Failed.").to_string();
+        println!("\n=== SCAN REVERSE=TRUE MLIR ===\n{mlir}");
+
+        assert!(
+            mlir.contains("reverse=true") || mlir.contains("reverse = true"),
+            "Expected reverse=true in scan op (was silently dropping non-literal bools \
+             before fix; ensure literal `true` still threads through).\nMLIR:\n{mlir}"
+        );
     });
 }


### PR DESCRIPTION
Fixes the `write_bytecode` panic on ops whose TableGen schema declares a `DefaultValuedAttr` (AddI/MulI/SubI/ShLI/TruncI.overflow, DivI.rounding, FToF.rounding_mode, Global.alignment), and the silent drop of `Some(LATENCY)` (const generic) in `compile_{load,store}_ptr_tko` — both blocking kernel generation. Also threads bytecode version through the writer so v13.2-only fields on NegI / TanH / For / Print are version-gated, fixes Print's stubbed `flags = 0` token-flag bug, and converts a handful of adjacent silent drops in the JIT compiler (`unwrap_or(I32)` / `unwrap_or(0)` / `.ok()?` / `.ok()??` on internally-generated strings and types) into loud panics or propagated `JITError`s. Regression tests added at the bytecode, IR-roundtrip, and DSL levels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)