### PR TITLE
Fix scalar divisibility hint lowering

### DIFF
--- a/cutile-compiler/src/compiler/_function.rs
+++ b/cutile-compiler/src/compiler/_function.rs
@@ -64,7 +64,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
         function_generic_args: &[String],
         stride_args: &[(&str, &[i32])],
         spec_args: &[(&str, &crate::specialization::SpecializationBits)],
-        _scalar_hints: &[(&str, &crate::specialization::DivHint)],
+        scalar_hints: &[(&str, &crate::specialization::DivHint)],
         const_grid: Option<(u32, u32, u32)>,
         gpu_name: String,
         compile_options: &crate::hints::CompileOptions,
@@ -131,7 +131,18 @@ impl<'m> CUDATileFunctionCompiler<'m> {
             .iter()
             .map(|(k, v)| (k.to_string(), (*v).clone()))
             .collect();
-        let scalar_hints_map: HashMap<String, crate::specialization::DivHint> = HashMap::new();
+        let scalar_max_divisibility = optimization_hints
+            .target_gpu_name
+            .as_ref()
+            .and_then(|target| optimization_hints.tile_as_hints.get(target))
+            .and_then(|hints| hints.max_divisibility);
+        let scalar_hints_map: HashMap<String, crate::specialization::DivHint> = scalar_hints
+            .iter()
+            .map(|&(name, hint)| {
+                let hint = scalar_max_divisibility.map_or(*hint, |max| hint.with_max(max));
+                (name.to_string(), hint)
+            })
+            .collect();
         let (entry, validator) = generate_entry_point(
             &function,
             &generic_vars,

--- a/cutile-compiler/src/kernel_entry_generator.rs
+++ b/cutile-compiler/src/kernel_entry_generator.rs
@@ -557,6 +557,15 @@ pub fn generate_entry_point(
                         )
                         .unwrap();
                         fn_entry.sig.inputs.push(var_arg);
+                        // Emit assume_div_by for raw pointer params with DivHints.
+                        if let Some(hint) = scalar_hints.get(&var_name) {
+                            if hint.divisor > 1 {
+                                statements.push(TensorInput::get_assume_div_by(
+                                    var_name.clone(),
+                                    hint.divisor,
+                                ));
+                            }
+                        }
                         fn_params_concrete_types.push(ValidParamType::Pointer(PointerParamType {
                             mutable: ptr_type_inst.is_mutable,
                             element_type: var_type,

--- a/cutile-macro/src/kernel_launcher_generator.rs
+++ b/cutile-macro/src/kernel_launcher_generator.rs
@@ -583,6 +583,9 @@ pub fn generate_kernel_launcher(
                 builder_statements.push(parse_stmt(format!(
                     "unsafe {{ kernel_launch.push_device_ptr({var_name}.cu_deviceptr()); }}"
                 )));
+                scalar_hint_exprs.push(format!(
+                    r#"("{var_name}".to_string(), cutile_compiler::specialization::DivHint::from_ptr({var_name}.cu_deviceptr()))"#
+                ));
                 param_element_types.push(None);
             }
             _ => {
@@ -823,7 +826,7 @@ pub fn generate_kernel_launcher(
         spec_args.join(",")
     )));
 
-    // Emit scalar_hints (populated for integer scalar params).
+    // Emit scalar_hints (populated for integer scalar and raw pointer params).
     launcher_method.block.stmts.push(parse_stmt(format!(
         "let scalar_hints: Vec<(String, cutile_compiler::specialization::DivHint)> = vec![{}];",
         scalar_hint_exprs.join(",")

--- a/cutile/tests/specialization_bits.rs
+++ b/cutile/tests/specialization_bits.rs
@@ -4,17 +4,20 @@
  */
 use cutile;
 use cutile::api;
-use cutile::tensor::PartitionMut;
-use cutile::tile_kernel::DeviceOp;
+use cutile::tile_kernel::{DeviceOp, TileKernel};
 use cutile_compiler::compiler::utils::CompileOptions;
 use cutile_compiler::compiler::{CUDATileFunctionCompiler, CUDATileModules};
-use cutile_compiler::cuda_tile_runtime_utils::get_gpu_name;
 use cutile_compiler::specialization::{DivHint, SpecializationBits};
+use std::path::Path;
+use std::sync::{Arc, Mutex};
 
 /// Helper: create a DivHint with the default max (16).
 fn dh(divisor: i32) -> DivHint {
     DivHint { divisor, max: 16 }
 }
+
+static RAW_PTR_DUMP_LOCK: Mutex<()> = Mutex::new(());
+const RAW_PTR_SCALAR_DUMP_DIR: &str = "/tmp/cutile_raw_ptr_scalar_mlir";
 
 mod common;
 
@@ -40,9 +43,14 @@ mod spec_test_module {
         let tile: Tile<f32, S> = constant(1.0f32, output.shape());
         output.store(tile);
     }
+
+    /// Kernel with a raw pointer and scalar integer param — used to test that
+    /// scalar DivHints still lower when pointer args are present.
+    #[cutile::entry(dump_mlir_dir = "/tmp/cutile_raw_ptr_scalar_mlir")]
+    unsafe fn raw_ptr_scalar_kernel(_ptr: *mut f32, _n: i32) {}
 }
 
-use spec_test_module::{__module_ast_self, scalar_kernel};
+use spec_test_module::{__module_ast_self, raw_ptr_scalar_kernel};
 
 fn compile_with_spec(
     name: &str,
@@ -58,17 +66,28 @@ fn compile_with_spec_and_options(
     specs: &[(&str, &SpecializationBits)],
     options: &CompileOptions,
 ) -> String {
+    compile_kernel(name, &[128.to_string()], strides, specs, &[], options)
+}
+
+fn compile_kernel(
+    name: &str,
+    function_generic_args: &[String],
+    strides: &[(&str, &[i32])],
+    specs: &[(&str, &SpecializationBits)],
+    scalar_hints: &[(&str, &DivHint)],
+    options: &CompileOptions,
+) -> String {
     let modules = CUDATileModules::from_kernel(__module_ast_self())
         .expect("Failed to create CUDATileModules");
-    let gpu_name = get_gpu_name(0);
+    let gpu_name = "sm_120".to_string();
     let compiler = CUDATileFunctionCompiler::new(
         &modules,
         "spec_test_module",
         name,
-        &[128.to_string()],
+        function_generic_args,
         strides,
         specs,
-        &[],
+        scalar_hints,
         None,
         gpu_name,
         options,
@@ -300,13 +319,178 @@ fn runtime_max_divisibility_overrides_entry_hint() {
 // -- Scalar integer DivHint --
 
 #[test]
-fn scalar_int_param_gets_div_hint() {
-    // Launch scalar_kernel with n=1024 (divisible by 16).
-    // The MLIR should contain assume_div_by on the scalar param.
+fn scalar_int_hint_emits_assume_div_by_in_entry_wrapper() {
     common::with_test_stack(|| {
-        let mut output = api::zeros::<f32>(&[128]).sync().expect("alloc");
-        scalar_kernel((&mut output).partition([128]), 1024i32)
-            .sync()
-            .expect("kernel launch");
+        let hint = DivHint::from_value(1024);
+        let mlir = compile_kernel(
+            "scalar_kernel",
+            &[128.to_string()],
+            &[("output", &[1])],
+            &[],
+            &[("_n", &hint)],
+            &CompileOptions::default(),
+        );
+        println!("{mlir}");
+        assert!(
+            mlir.contains("div_by<16>"),
+            "Expected scalar hint to emit div_by<16>.\nMLIR:\n{mlir}"
+        );
     });
+}
+
+#[test]
+fn scalar_int_hint_respects_runtime_max_divisibility() {
+    common::with_test_stack(|| {
+        let hint = DivHint::from_value(1024);
+        let options = CompileOptions::default().max_divisibility(4);
+        let mlir = compile_kernel(
+            "scalar_kernel",
+            &[128.to_string()],
+            &[("output", &[1])],
+            &[],
+            &[("_n", &hint)],
+            &options,
+        );
+        println!("{mlir}");
+        assert!(
+            mlir.contains("div_by<4>"),
+            "Expected scalar hint to be capped to div_by<4>.\nMLIR:\n{mlir}"
+        );
+        assert!(
+            !mlir.contains("div_by<16>"),
+            "Should not contain div_by<16> when runtime max_divisibility=4.\nMLIR:\n{mlir}"
+        );
+    });
+}
+
+#[test]
+fn raw_pointer_integer_scalar_hint_emits_assume_div_by() {
+    common::with_test_stack(|| {
+        let ptr_hint = DivHint::from_ptr(0x1000);
+        let scalar_hint = DivHint::from_value(1024);
+        let mlir = compile_kernel(
+            "raw_ptr_scalar_kernel",
+            &[],
+            &[],
+            &[],
+            &[("_ptr", &ptr_hint), ("_n", &scalar_hint)],
+            &CompileOptions::default(),
+        );
+        println!("{mlir}");
+        assert_eq!(
+            mlir.matches("assume div_by<16>").count(),
+            2,
+            "Expected raw pointer and integer scalar hints to both emit div_by<16>.\nMLIR:\n{mlir}"
+        );
+    });
+}
+
+#[test]
+fn raw_pointer_launch_computes_scalar_div_hint() {
+    common::with_test_stack(|| {
+        let mlir =
+            launch_raw_ptr_scalar_kernel_and_read_mlir(12, CompileOptions::default().occupancy(3));
+
+        assert!(
+            mlir.contains("entry @raw_ptr_scalar_kernel_entry"),
+            "Expected dumped MLIR for raw_ptr_scalar_kernel.\nMLIR:\n{mlir}"
+        );
+        assert!(
+            mlir.contains("assume div_by<4>"),
+            "Expected launcher-computed scalar hint for n=12 to emit div_by<4>.\nMLIR:\n{mlir}"
+        );
+        assert!(
+            mlir.contains("assume div_by<16>"),
+            "Expected launcher-computed raw pointer hint to emit div_by<16>.\nMLIR:\n{mlir}"
+        );
+        assert_eq!(
+            mlir.matches("assume div_by<").count(),
+            2,
+            "Expected raw pointer and scalar argument to receive divisibility assumes.\nMLIR:\n{mlir}"
+        );
+    });
+}
+
+#[test]
+fn raw_pointer_launch_scalar_div_hint_covers_powers_of_two_through_16() {
+    common::with_test_stack(|| {
+        let cases = [
+            (1, None, 4),
+            (2, Some(2), 5),
+            (4, Some(4), 6),
+            (8, Some(8), 7),
+            (16, Some(16), 8),
+            (32, Some(16), 9),
+        ];
+
+        for (n, expected_divisor, occupancy) in cases {
+            let mlir = launch_raw_ptr_scalar_kernel_and_read_mlir(
+                n,
+                CompileOptions::default().occupancy(occupancy),
+            );
+            assert!(
+                mlir.contains("assume div_by<16>"),
+                "Expected raw pointer hint for n={n} to emit div_by<16>.\nMLIR:\n{mlir}"
+            );
+            match expected_divisor {
+                Some(divisor) => {
+                    let expected = format!("assume div_by<{divisor}>");
+                    if divisor == 16 {
+                        assert_eq!(
+                            mlir.matches(&expected).count(),
+                            2,
+                            "Expected raw pointer and scalar hints for n={n} to both emit {expected}.\nMLIR:\n{mlir}"
+                        );
+                    } else {
+                        assert!(
+                            mlir.contains(&expected),
+                            "Expected launcher-computed scalar hint for n={n} to emit {expected}.\nMLIR:\n{mlir}"
+                        );
+                    }
+                    assert_eq!(
+                        mlir.matches("assume div_by<").count(),
+                        2,
+                        "Expected raw pointer and scalar arguments to receive divisibility assumes for n={n}.\nMLIR:\n{mlir}"
+                    );
+                }
+                None => {
+                    assert_eq!(
+                        mlir.matches("assume div_by<").count(),
+                        1,
+                        "Expected only the raw pointer argument to receive a divisibility assume for n={n}.\nMLIR:\n{mlir}"
+                    );
+                }
+            }
+        }
+    });
+}
+
+fn launch_raw_ptr_scalar_kernel_and_read_mlir(n: i32, options: CompileOptions) -> String {
+    let _lock = RAW_PTR_DUMP_LOCK.lock().expect("lock raw pointer dump dir");
+    let dump_dir = Path::new(RAW_PTR_SCALAR_DUMP_DIR);
+    let _ = std::fs::remove_dir_all(dump_dir);
+    std::fs::create_dir_all(dump_dir).expect("create MLIR dump dir");
+
+    let backing = api::copy_host_vec_to_device(&Arc::new(vec![0.0f32; 1]))
+        .sync()
+        .expect("alloc backing tensor");
+    let ptr = backing.device_pointer();
+
+    unsafe { raw_ptr_scalar_kernel(ptr, n) }
+        .grid((1, 1, 1))
+        .compile_options(options)
+        .sync()
+        .expect("raw pointer scalar kernel launch");
+
+    let mut mlir = String::new();
+    for entry in std::fs::read_dir(dump_dir).expect("read MLIR dump dir") {
+        let path = entry.expect("read MLIR dump entry").path();
+        if path.extension().is_some_and(|ext| ext == "mlir") {
+            mlir.push_str(
+                &std::fs::read_to_string(&path)
+                    .unwrap_or_else(|err| panic!("read dumped MLIR {path:?}: {err}")),
+            );
+        }
+    }
+    mlir
 }


### PR DESCRIPTION
## Summary
- pass scalar divisibility hints through entry-point generation
- cap scalar divisibility assumptions with max_divisibility
- add MLIR regression coverage for scalar and raw-pointer kernel arguments

## Validation
- cargo test -p cutile --test specialization_bits