### PR TITLE
fix: handle nested mutable partition overhang

### DIFF
--- a/cuda-async/src/device_context.rs
+++ b/cuda-async/src/device_context.rs
@@ -7,7 +7,7 @@
 
 use crate::error::{device_assert, device_error, DeviceError};
 use crate::scheduling_policies::{SchedulingPolicy, StreamPoolRoundRobin};
-use cuda_core::{Device, Function, Module, Stream, MemPool};
+use cuda_core::{Device, Function, MemPool, Module, Stream};
 use std::cell::Cell;
 use std::collections::HashMap;
 use std::hash::{DefaultHasher, Hash, Hasher};

--- a/cuda-async/src/device_operation.rs
+++ b/cuda-async/src/device_operation.rs
@@ -9,7 +9,7 @@ use crate::device_context::{pool_for_stream, with_default_device_policy};
 use crate::device_future::DeviceFuture;
 use crate::error::{device_error, DeviceError};
 use crate::scheduling_policies::SchedulingPolicy;
-use cuda_core::{Device, Stream, MemPool};
+use cuda_core::{Device, MemPool, Stream};
 use std::cell::{Cell, UnsafeCell};
 use std::fmt::Debug;
 use std::future::IntoFuture;
@@ -94,9 +94,7 @@ impl ExecutionContext {
     /// The stream must be valid and not destroyed.
     pub unsafe fn alloc_async(&self, num_bytes: usize) -> cuda_core::sys::CUdeviceptr {
         match &self.pool {
-            Some(pool) => {
-                cuda_core::malloc_from_pool_async(num_bytes, pool, &self.cuda_stream)
-            }
+            Some(pool) => cuda_core::malloc_from_pool_async(num_bytes, pool, &self.cuda_stream),
             None => cuda_core::malloc_async(num_bytes, &self.cuda_stream),
         }
     }

--- a/cuda-async/tests/pool_allocation.rs
+++ b/cuda-async/tests/pool_allocation.rs
@@ -120,8 +120,7 @@ fn set_device_pool_rejects_cross_device_pool() {
             .expect("get context failed")
             .expect("pool creation failed");
 
-        let err = set_device_pool(99, pool)
-            .expect_err("expected cross-device pool to be rejected");
+        let err = set_device_pool(99, pool).expect_err("expected cross-device pool to be rejected");
         match err {
             cuda_async::error::DeviceError::Context { device_id, message } => {
                 assert_eq!(device_id, 99, "error should point to target device");
@@ -202,7 +201,11 @@ fn pool_is_frozen_at_scheduling_time() {
         let policy = global_policy(0).expect("get policy failed");
         let future = with_context(move |ctx| {
             let p = ctx.get_pool().expect("pool should be present");
-            assert_eq!(p.cu_pool() as usize, pool_a_ptr, "should use frozen pool_a, not pool_b");
+            assert_eq!(
+                p.cu_pool() as usize,
+                pool_a_ptr,
+                "should use frozen pool_a, not pool_b"
+            );
             value(())
         })
         .schedule(&policy)
@@ -236,7 +239,11 @@ fn schedule_applies_device_pool() {
         let policy = global_policy(0).expect("get policy failed");
         let future = with_context(move |ctx| {
             let p = ctx.get_pool().expect("pool should be present via schedule");
-            assert_eq!(p.cu_pool() as usize, pool_ptr, "schedule must pick up device pool");
+            assert_eq!(
+                p.cu_pool() as usize,
+                pool_ptr,
+                "schedule must pick up device pool"
+            );
             let dptr = unsafe { ctx.alloc_async(512) };
             assert!(dptr != 0, "allocation returned null pointer");
             value(dptr)
@@ -269,7 +276,11 @@ fn sync_on_applies_device_pool() {
 
         let dptr = with_context(move |ctx| {
             let p = ctx.get_pool().expect("pool should be present via sync_on");
-            assert_eq!(p.cu_pool() as usize, pool_ptr, "sync_on must pick up device pool");
+            assert_eq!(
+                p.cu_pool() as usize,
+                pool_ptr,
+                "sync_on must pick up device pool"
+            );
             let dptr = unsafe { ctx.alloc_async(512) };
             assert!(dptr != 0, "allocation returned null pointer");
             value(dptr)

--- a/cuda-core/src/cudarc_shim.rs
+++ b/cuda-core/src/cudarc_shim.rs
@@ -468,8 +468,7 @@ pub(crate) mod pool {
         props: &cuda_bindings::CUmemPoolProps,
     ) -> Result<cuda_bindings::CUmemoryPool, DriverError> {
         let mut pool = MaybeUninit::uninit();
-        cuda_bindings::cuMemPoolCreate(pool.as_mut_ptr(), props as *const _ as *mut _)
-            .result()?;
+        cuda_bindings::cuMemPoolCreate(pool.as_mut_ptr(), props as *const _ as *mut _).result()?;
         Ok(pool.assume_init())
     }
 

--- a/cutile-compiler/src/compiler/compile_binary_op.rs
+++ b/cutile-compiler/src/compiler/compile_binary_op.rs
@@ -72,13 +72,29 @@ impl<'m> CUDATileFunctionCompiler<'m> {
         ctx: &mut CompilerContext,
         return_type: Option<TileRustType>,
     ) -> Result<Option<TileRustValue>, JITError> {
+        let tile_binary_op = get_tile_bop_from_rust_bop(&bin_expr.op)?;
+        let is_comparison = matches!(
+            tile_binary_op,
+            TileBinaryOp::Eq
+                | TileBinaryOp::Ne
+                | TileBinaryOp::Lt
+                | TileBinaryOp::Le
+                | TileBinaryOp::Gt
+                | TileBinaryOp::Ge
+        );
+        let is_logical = matches!(bin_expr.op, syn::BinOp::And(_) | syn::BinOp::Or(_));
+        let lhs_return_type = if is_comparison || is_logical {
+            None
+        } else {
+            return_type.clone()
+        };
         let lhs = self.compile_expression(
             module,
             block_id,
             &bin_expr.left,
             generic_vars,
             ctx,
-            return_type.clone(),
+            lhs_return_type,
         )?;
         if lhs.is_none() {
             return self.jit_error_result(
@@ -87,13 +103,20 @@ impl<'m> CUDATileFunctionCompiler<'m> {
             );
         }
         let lhs = lhs.unwrap();
+        let rhs_return_type = if is_logical {
+            None
+        } else if is_comparison {
+            Some(lhs.ty.clone())
+        } else {
+            return_type.clone().or_else(|| Some(lhs.ty.clone()))
+        };
         let rhs = self.compile_expression(
             module,
             block_id,
             &bin_expr.right,
             generic_vars,
             ctx,
-            return_type.clone(),
+            rhs_return_type,
         )?;
         if rhs.is_none() {
             return self.jit_error_result(
@@ -107,7 +130,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
             block_id,
             lhs,
             rhs,
-            &get_tile_bop_from_rust_bop(&bin_expr.op)?,
+            &tile_binary_op,
             generic_vars,
             ctx,
             return_type,

--- a/cutile-compiler/src/compiler/compile_cuda_tile_op.rs
+++ b/cutile-compiler/src/compiler/compile_cuda_tile_op.rs
@@ -10,7 +10,7 @@
 //! dispatch logic, operand assembly, and attribute handling are identical.
 
 use super::shared_types::Kind::{self, PrimitiveType, StructuredType};
-use super::shared_utils::{get_const_hex, AtomicMode};
+use super::shared_utils::{get_const_hex, AtomicMode, TileBinaryOp};
 use super::tile_rust_type::TileRustType;
 use crate::bounds::Bounds;
 use crate::error::JITError;
@@ -32,6 +32,8 @@ use std::collections::{BTreeMap, HashMap};
 use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
 use syn::{Expr, ExprCall, ExprLit, ItemFn, Lit, Token, Type, UnOp};
+
+const NESTED_MUTABLE_ACCESS_OFFSET_META: &str = "nested_mutable_access_offset";
 
 // ---------------------------------------------------------------------------
 // Helpers ported from old CompilerContext utilities
@@ -210,6 +212,59 @@ fn extract_latency_cycles(expr: &Expr, generic_args: &GenericVars) -> Result<i32
 }
 
 impl<'m> CUDATileFunctionCompiler<'m> {
+    fn offset_nested_mutable_indices(
+        &self,
+        module: &mut Module,
+        block_id: BlockId,
+        span: &proc_macro2::Span,
+        access_offset: &TileRustValue,
+        mut index_values: Vec<TileRustValue>,
+        generic_vars: &GenericVars,
+        ctx: &mut CompilerContext,
+    ) -> Result<Vec<TileRustValue>, JITError> {
+        let Some(offset_values) = access_offset.values.as_ref() else {
+            return self.jit_error_result(
+                span,
+                "nested mutable partition access offset must be an array value",
+            );
+        };
+        if offset_values.len() != index_values.len() {
+            return self.jit_error_result(
+                span,
+                &format!(
+                    "nested mutable partition access offset rank mismatch: offset rank {}, index rank {}",
+                    offset_values.len(),
+                    index_values.len()
+                ),
+            );
+        }
+
+        let mut adjusted = Vec::with_capacity(index_values.len());
+        for (offset, index) in offset_values.iter().cloned().zip(index_values.drain(..)) {
+            let adjusted_index = if index
+                .bounds
+                .as_ref()
+                .is_some_and(|bounds| bounds.is_exact() && bounds.start == 0 && bounds.end == 0)
+            {
+                offset
+            } else {
+                self.compile_binary_op_from_values(
+                    module,
+                    block_id,
+                    offset,
+                    index,
+                    &TileBinaryOp::Add,
+                    generic_vars,
+                    ctx,
+                    None,
+                    span,
+                )?
+            };
+            adjusted.push(adjusted_index);
+        }
+        Ok(adjusted)
+    }
+
     pub fn compile_cuda_tile_op_call(
         &self,
         module: &mut Module,
@@ -1241,7 +1296,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
         let Some(cuda_tile_view_value) = view_value.value else {
             return self.jit_error_result(&call_expr.args[0].span(), "Unable to compile view");
         };
-        let Some(type_meta) = view_value.type_meta else {
+        let Some(type_meta) = view_value.type_meta.as_ref() else {
             return self
                 .jit_error_result(&call_expr.args[0].span(), "Expected some TypeMeta for view");
         };
@@ -1257,6 +1312,10 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                 "Expected token value in TypeMeta for view",
             );
         };
+        let nested_access_offset = type_meta
+            .fields
+            .get(NESTED_MUTABLE_ACCESS_OFFSET_META)
+            .cloned();
 
         let index_arg = &call_expr.args[1];
         let index_arg_str = index_arg.to_token_stream().to_string();
@@ -1266,17 +1325,31 @@ impl<'m> CUDATileFunctionCompiler<'m> {
         if index_value.values.is_none() {
             return self.jit_error_result(&call_expr.args[1].span(), "Expected values for index");
         }
-        let mut index_values_vec = Vec::new();
-        for value in index_value.values.as_ref().unwrap().iter() {
-            let Some(v) = value.value.clone() else {
+        let mut index_value_elems = Vec::new();
+        for value in index_value.values.unwrap().into_iter() {
+            if value.value.is_none() {
                 return self.jit_error_result(
                     &call_expr.args[1].span(),
                     &format!("Unexpected nested array {index_arg_str}"),
                 );
-            };
-            index_values_vec.push(v);
+            }
+            index_value_elems.push(value);
         }
-        let index_values = index_values_vec;
+        if let Some(access_offset) = nested_access_offset.as_ref() {
+            index_value_elems = self.offset_nested_mutable_indices(
+                module,
+                block_id,
+                &call_expr.span(),
+                access_offset,
+                index_value_elems,
+                generic_args,
+                ctx,
+            )?;
+        }
+        let index_values = index_value_elems
+            .iter()
+            .map(|value| value.value.expect("validated index value"))
+            .collect::<Vec<_>>();
 
         let fn_params = get_sig_param_names(&fn_item.sig);
         let (memory_ordering_value, memory_scope_value, memory_ordering) =
@@ -1338,15 +1411,15 @@ impl<'m> CUDATileFunctionCompiler<'m> {
     ) -> Result<Option<TileRustValue>, JITError> {
         let token_result_ir_ty = TileIrType::Token;
         let view_arg = &call_expr.args[0];
-        let Some(mut view_value) =
+        let Some(view_value) =
             self.compile_expression(module, block_id, view_arg, generic_args, ctx, None)?
         else {
             return self.jit_error_result(&call_expr.args[0].span(), "Unable to compile view");
         };
-        let Some(cuda_tile_view_value) = &mut view_value.value else {
+        let Some(cuda_tile_view_value) = view_value.value else {
             return self.jit_error_result(&call_expr.args[0].span(), "Unable to compile view");
         };
-        let Some(type_meta) = &mut view_value.type_meta else {
+        let Some(type_meta) = view_value.type_meta.as_ref() else {
             return self
                 .jit_error_result(&call_expr.args[0].span(), "Expected some TypeMeta for view");
         };
@@ -1356,12 +1429,16 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                 "Expected token value in TypeMeta for view",
             );
         };
-        let Some(cuda_tile_token) = &token_value.value else {
+        let Some(cuda_tile_token) = token_value.value else {
             return self.jit_error_result(
                 &call_expr.args[0].span(),
                 "Expected token value in TypeMeta for view",
             );
         };
+        let nested_access_offset = type_meta
+            .fields
+            .get(NESTED_MUTABLE_ACCESS_OFFSET_META)
+            .cloned();
 
         let tile_value = self
             .compile_expression(
@@ -1389,17 +1466,31 @@ impl<'m> CUDATileFunctionCompiler<'m> {
         if index_value.values.is_none() {
             return self.jit_error_result(&call_expr.args[2].span(), "Expected values for index");
         }
-        let mut index_values_vec = Vec::new();
-        for value in index_value.values.as_ref().unwrap().iter() {
-            let Some(v) = value.value.clone() else {
+        let mut index_value_elems = Vec::new();
+        for value in index_value.values.unwrap().into_iter() {
+            if value.value.is_none() {
                 return self.jit_error_result(
                     &call_expr.args[2].span(),
                     &format!("Unexpected nested array {index_arg_str}"),
                 );
-            };
-            index_values_vec.push(v);
+            }
+            index_value_elems.push(value);
         }
-        let index_values = index_values_vec;
+        if let Some(access_offset) = nested_access_offset.as_ref() {
+            index_value_elems = self.offset_nested_mutable_indices(
+                module,
+                block_id,
+                &call_expr.span(),
+                access_offset,
+                index_value_elems,
+                generic_args,
+                ctx,
+            )?;
+        }
+        let index_values = index_value_elems
+            .iter()
+            .map(|value| value.value.expect("validated index value"))
+            .collect::<Vec<_>>();
 
         let fn_params = get_sig_param_names(&fn_item.sig);
         let (memory_ordering_value, memory_scope_value, memory_ordering) =
@@ -1412,11 +1503,9 @@ impl<'m> CUDATileFunctionCompiler<'m> {
             opt_hint_attrs.push(("optimization_hints".to_string(), load_store_hints_attr));
         }
 
-        let cuda_tile_view_val = *cuda_tile_view_value;
-        let cuda_tile_token_val = *cuda_tile_token;
-        let mut all_operands = vec![tile_value_val, cuda_tile_view_val];
+        let mut all_operands = vec![tile_value_val, cuda_tile_view_value];
         all_operands.extend_from_slice(&index_values);
-        all_operands.push(cuda_tile_token_val);
+        all_operands.push(cuda_tile_token);
         let operand_segments: Vec<i64> = vec![1, 1, index_values.len() as i64, 1];
 
         let mut op_builder =

--- a/cutile-compiler/src/compiler/compile_intrinsic.rs
+++ b/cutile-compiler/src/compiler/compile_intrinsic.rs
@@ -19,7 +19,7 @@ use super::tile_rust_type::TileRustType;
 use super::utils::{int_attr, rounding_mode_attr, signedness_attr};
 use crate::bounds::Bounds;
 use crate::error::JITError;
-use crate::generics::{GenericVars, TypeInstance};
+use crate::generics::{get_cga_from_type, GenericVars, TypeInstance};
 use crate::syn_utils::*;
 use crate::types::*;
 
@@ -32,6 +32,8 @@ use cutile_ir::ir::{
 use quote::ToTokens;
 use std::collections::HashMap;
 use syn::{Expr, ExprCall, ExprPath, GenericArgument, ItemFn, Lit, PathArguments};
+
+const NESTED_MUTABLE_ACCESS_OFFSET_META: &str = "nested_mutable_access_offset";
 
 /// Helper: determine signedness string from a Rust element type name.
 fn get_signedness_str(element_type_str: &str) -> &'static str {
@@ -64,6 +66,138 @@ fn tile_ir_type_from_trt(
 }
 
 impl<'m> CUDATileFunctionCompiler<'m> {
+    fn scalar_i32_type(&self, span: &proc_macro2::Span) -> Result<TileRustType, JITError> {
+        let rust_ty = syn::parse2::<syn::Type>("i32".parse()?).unwrap();
+        self.compile_type(&rust_ty, &GenericVars::empty_unchecked(), &HashMap::new())?
+            .ok_or_else(|| self.jit_error(span, "failed to compile i32 type"))
+    }
+
+    fn array_i32_type(
+        &self,
+        rank: usize,
+        generic_vars: &GenericVars,
+        span: &proc_macro2::Span,
+    ) -> Result<TileRustType, JITError> {
+        let rust_ty = syn::parse_str::<syn::Type>(&format!("[i32; {rank}]")).unwrap();
+        self.compile_type(&rust_ty, generic_vars, &HashMap::new())?
+            .ok_or_else(|| self.jit_error(span, "failed to compile i32 array type"))
+    }
+
+    fn static_shape_from_value(
+        &self,
+        value: &TileRustValue,
+        generic_vars: &GenericVars,
+        span: &proc_macro2::Span,
+    ) -> Result<Vec<i32>, JITError> {
+        if let TypeInstance::StructuredType(instance) = &value.ty.type_instance {
+            Ok(instance.shape.clone())
+        } else if let Some(shape) = get_cga_from_type(&value.ty.rust_ty, generic_vars) {
+            Ok(shape)
+        } else {
+            self.jit_error_result(span, "expected a statically shaped value")
+        }
+    }
+
+    fn partition_tile_shape(
+        &self,
+        value: &TileRustValue,
+        span: &proc_macro2::Span,
+    ) -> Result<Vec<i32>, JITError> {
+        let tile_shape = value.ty.params.iter().find_map(|param| match param {
+            TypeParam::Tile(tile) => match tile.type_instance.as_ref() {
+                Some(TypeInstance::StructuredType(instance)) => Some(instance.shape.clone()),
+                _ => None,
+            },
+            _ => None,
+        });
+        tile_shape.ok_or_else(|| {
+            self.jit_error(
+                span,
+                "nested mutable partition is missing tile-shape metadata",
+            )
+        })
+    }
+
+    fn compile_nested_mutable_access_offset_metadata(
+        &self,
+        module: &mut Module,
+        block_id: BlockId,
+        span: &proc_macro2::Span,
+        partition_value: &TileRustValue,
+        outer_tile: &TileRustValue,
+        generic_vars: &GenericVars,
+        ctx: &mut CompilerContext,
+    ) -> Result<TileRustValue, JITError> {
+        let outer_shape = self.static_shape_from_value(outer_tile, generic_vars, span)?;
+        let nested_shape = self.partition_tile_shape(partition_value, span)?;
+        if outer_shape.len() != nested_shape.len() {
+            return self.jit_error_result(
+                span,
+                &format!(
+                    "nested mutable partition rank mismatch: outer tile rank {}, nested tile rank {}",
+                    outer_shape.len(),
+                    nested_shape.len()
+                ),
+            );
+        }
+        let rank = outer_shape.len();
+        if rank > 3 {
+            return self.jit_error_result(
+                span,
+                "nested mutable partition access offsets are only supported up to rank 3",
+            );
+        }
+
+        let i32_ty = self.scalar_i32_type(span)?;
+        let scalar_i32_ir_ty = Type::Tile(TileType {
+            shape: vec![],
+            element_type: TileElementType::Scalar(ScalarType::I32),
+        });
+        let mut op_builder = OpBuilder::new(Opcode::GetTileBlockId, self.ir_location(span));
+        for _ in 0..3 {
+            op_builder = op_builder.result(scalar_i32_ir_ty.clone());
+        }
+        let (op_id, pid_results) = op_builder.build(module);
+        append_op(module, block_id, op_id);
+
+        let mut offsets = Vec::with_capacity(rank);
+        for i in 0..rank {
+            let outer_dim = outer_shape[i];
+            let nested_dim = nested_shape[i];
+            if outer_dim <= 0 || nested_dim <= 0 {
+                return self.jit_error_result(
+                    span,
+                    &format!(
+                        "nested mutable partition requires static positive tile dimensions, got outer dim {outer_dim} and nested dim {nested_dim} at axis {i}"
+                    ),
+                );
+            }
+            let pid = TileRustValue::new_primitive(pid_results[i], i32_ty.clone(), None);
+            let ratio = ((outer_dim as i64 + nested_dim as i64 - 1) / nested_dim as i64) as i32;
+            let offset = if ratio == 1 {
+                pid
+            } else {
+                let ratio_value =
+                    self.compile_constant(module, block_id, generic_vars, ratio as i32)?;
+                self.compile_binary_op_from_values(
+                    module,
+                    block_id,
+                    pid,
+                    ratio_value,
+                    &TileBinaryOp::Mul,
+                    generic_vars,
+                    ctx,
+                    None,
+                    span,
+                )?
+            };
+            offsets.push(offset);
+        }
+
+        let array_ty = self.array_i32_type(rank, generic_vars, span)?;
+        Ok(TileRustValue::new_compound(offsets, array_ty))
+    }
+
     /// Compiles a `compiler_op` (intrinsic) function call.
     /// The compiler implements Rust-related functionality, such as polymorphism,
     /// for these functions.
@@ -1128,6 +1262,94 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                     );
                 };
                 Ok(Some(return_value.clone()))
+            }
+            "set_nested_mutable_partition_access_offset" => {
+                if call_expr.args.len() != 2 {
+                    return self.jit_error_result(
+                        &call_expr.span(),
+                        &format!(
+                            "set_nested_mutable_partition_access_offset expects 2 arguments, got {}",
+                            call_expr.args.len()
+                        ),
+                    );
+                }
+
+                let var_path = match &call_expr.args[0] {
+                    Expr::Path(var_path) => var_path,
+                    Expr::Reference(reference) => match &*reference.expr {
+                        Expr::Path(var_path) => var_path,
+                        _ => {
+                            return self.jit_error_result(
+                                &call_expr.args[0].span(),
+                                &format!(
+                                    "first argument to `set_nested_mutable_partition_access_offset` must be a mutable partition variable, got `{}`",
+                                    call_expr.args[0].to_token_stream()
+                                ),
+                            )
+                        }
+                    },
+                    _ => {
+                        return self.jit_error_result(
+                            &call_expr.args[0].span(),
+                            &format!(
+                                "first argument to `set_nested_mutable_partition_access_offset` must be a mutable partition variable, got `{}`",
+                                call_expr.args[0].to_token_stream()
+                            ),
+                        )
+                    }
+                };
+                let var_name = get_ident_from_path_expr(var_path)
+                    .to_token_stream()
+                    .to_string();
+
+                let outer_tile = self
+                    .compile_expression(
+                        module,
+                        block_id,
+                        &call_expr.args[1],
+                        generic_vars,
+                        ctx,
+                        None,
+                    )?
+                    .ok_or_else(|| {
+                        self.jit_error(
+                            &call_expr.args[1].span(),
+                            "failed to compile nested mutable outer tile shape",
+                        )
+                    })?;
+                let mut partition_value = ctx.vars.get(var_name.as_str()).cloned().ok_or_else(
+                    || {
+                        self.jit_error(
+                            &call_expr.args[0].span(),
+                            &format!(
+                                "first argument to `set_nested_mutable_partition_access_offset` must be a known variable, got `{}`",
+                                call_expr.args[0].to_token_stream()
+                            ),
+                        )
+                    },
+                )?;
+                if partition_value.mutability != Mutability::Mutable {
+                    return self.jit_error_result(
+                        &call_expr.args[0].span(),
+                        &format!(
+                            "`set_nested_mutable_partition_access_offset` requires a mutable variable, but got {:?}",
+                            partition_value.mutability
+                        ),
+                    );
+                }
+                let access_offset = self.compile_nested_mutable_access_offset_metadata(
+                    module,
+                    block_id,
+                    &call_expr.span(),
+                    &partition_value,
+                    &outer_tile,
+                    generic_vars,
+                    ctx,
+                )?;
+                partition_value
+                    .insert_type_meta_field(NESTED_MUTABLE_ACCESS_OFFSET_META, access_offset)?;
+                ctx.vars.insert(var_name, partition_value);
+                Ok(None)
             }
             "set_type_meta_field" => {
                 let Some(type_meta_field) = compiler_op_attrs.parse_string("type_meta_field")

--- a/cutile/src/_core.rs
+++ b/cutile/src/_core.rs
@@ -543,7 +543,11 @@ pub mod core {
         ) -> PartitionMut<'a, E, R> {
             // TODO (hme): Bounds checks.
             let tensor_token: Token = get_tensor_token(self);
-            unsafe { make_partition_view_mut(self, tile, padding::None, tensor_token) }
+            let outer_tile: Shape<S> = Shape::<S> { dims: &[] };
+            let mut p: PartitionMut<E, R> =
+                unsafe { make_nested_partition_view_mut(self, tile, padding::None, tensor_token) };
+            set_nested_mutable_partition_access_offset(&mut p, outer_tile);
+            p
         }
 
         /// Returns the shape of this tensor.
@@ -1001,6 +1005,21 @@ pub mod core {
     pub fn set_tensor_token<E: ElementType, const S: [i32; N]>(
         tensor: &Tensor<E, S>,
         token: Token,
+    ) {
+        unreachable!()
+    }
+
+    /// Attach CTA-local index offset metadata to a nested mutable partition.
+    #[cuda_tile::variadic_op(N = 6)]
+    #[cuda_tile::compiler_op(name = "set_nested_mutable_partition_access_offset")]
+    pub fn set_nested_mutable_partition_access_offset<
+        'a,
+        E: ElementType,
+        const OUTER_TILE: [i32; N],
+        const NESTED_TILE: [i32; N],
+    >(
+        partition: &mut PartitionMut<'a, E, NESTED_TILE>,
+        outer_tile: Shape<OUTER_TILE>,
     ) {
         unreachable!()
     }
@@ -1929,6 +1948,30 @@ pub mod core {
     )]
     #[cuda_tile::variadic_op(N = 6)]
     pub unsafe fn make_partition_view_mut<
+        'a,
+        E: ElementType,
+        const TENSOR_SHAPE: [i32; N],
+        const TILE_SHAPE: [i32; N],
+        P: padding::Mode,
+    >(
+        tensor_view: &Tensor<E, TENSOR_SHAPE>,
+        shape: Shape<TILE_SHAPE>,
+        padding_value: P,
+        token: Token,
+    ) -> PartitionMut<'a, E, TILE_SHAPE> {
+        unreachable!()
+    }
+
+    /// Build a nested mutable partition view from an already partitioned
+    /// mutable tensor. This still partitions the full tensor view; the compiler
+    /// attaches metadata so tile accesses are offset by the enclosing CTA tile.
+    #[cuda_tile::op(name="cuda_tile.make_partition_view",
+                    params=["tensor_view"],
+                    output_type_params=["tensor_view", "padding_value"],
+                    output_type_meta=["token"]
+    )]
+    #[cuda_tile::variadic_op(N = 6)]
+    pub unsafe fn make_nested_partition_view_mut<
         'a,
         E: ElementType,
         const TENSOR_SHAPE: [i32; N],

--- a/cutile/tests/basics_and_inlining.rs
+++ b/cutile/tests/basics_and_inlining.rs
@@ -36,6 +36,19 @@ mod basics_and_inlining_module {
         other_function(tile_x, shape);
     }
 
+    #[cutile::entry()]
+    fn scalar_bool_condition_kernel<const CAUSAL: i32, const EVEN_K: i32>(
+        output: &mut Tensor<i32, { [1] }>,
+        mask_start: i32,
+    ) {
+        let pid: (i32, i32, i32) = get_tile_block_id();
+        let j = pid.0;
+        if (CAUSAL == 1i32 || EVEN_K == 0i32) && j >= mask_start {
+            let one: Tile<i32, { [1] }> = constant(1i32, const_shape![1]);
+            output.store(one);
+        }
+    }
+
     // Various Rust->TileIR tests.
 
     pub struct SomeStruct {
@@ -312,6 +325,30 @@ fn compile_inlining() -> () {
                 2.to_string(),
             ],
             &[("y", &[1024, 1, 1])],
+            &[],
+            &[],
+            None,
+            gpu_name,
+            &CompileOptions::default(),
+        )
+        .expect("Failed.");
+        let module_op_str = compiler.compile().expect("Failed.").to_string();
+        println!("{module_op_str}");
+    });
+}
+
+#[test]
+fn compile_scalar_bool_condition() -> () {
+    common::with_test_stack(|| {
+        let modules = CUDATileModules::from_kernel(__module_ast_self())
+            .expect("Failed to create CUDATileModules");
+        let gpu_name = get_gpu_name(0);
+        let compiler = CUDATileFunctionCompiler::new(
+            &modules,
+            "basics_and_inlining_module",
+            "scalar_bool_condition_kernel",
+            &[1.to_string(), 0.to_string()],
+            &[("output", &[1])],
             &[],
             &[],
             None,

--- a/cutile/tests/nested_partition_mut.rs
+++ b/cutile/tests/nested_partition_mut.rs
@@ -1,0 +1,222 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Regression repro for nested mutable partition stores.
+//!
+//! The reported pattern is:
+//! - caller passes an already partitioned mutable output tile, e.g. `[1, N]`
+//! - kernel repartitions that `&mut Tensor` with `partition_mut([1, BLOCK])`
+//! - kernel stores subtiles via local indices like `[0, j]`
+//!
+//! Direct stores to CTA-owned `[1, BLOCK]` outputs are used as the control.
+
+use std::sync::Arc;
+
+use cutile::api;
+use cutile::tensor::{IntoPartition, ToHostVec};
+use cutile::tile_kernel::{DeviceOp, TileKernel};
+
+mod common;
+
+#[cutile::module]
+mod nested_partition_mut_module {
+    use cutile::core::*;
+
+    #[cutile::entry()]
+    fn direct_cta_owned_copy<const N: i32, const BLOCK: i32>(
+        out: &mut Tensor<f32, { [1, BLOCK] }>,
+        input: &Tensor<f32, { [-1, N] }>,
+    ) {
+        let pid: (i32, i32, i32) = get_tile_block_id();
+        let row = pid.0;
+        let block = pid.1;
+
+        let input_part: Partition<f32, { [1, BLOCK] }> = input.partition(const_shape![1, BLOCK]);
+        let tile: Tile<f32, { [1, BLOCK] }> = input_part.load([row, block]);
+        out.store(tile);
+    }
+
+    #[cutile::entry()]
+    fn nested_partition_mut_copy<const N: i32, const BLOCK: i32>(
+        out: &mut Tensor<f32, { [1, N] }>,
+        input: &Tensor<f32, { [-1, N] }>,
+    ) {
+        let pid: (i32, i32, i32) = get_tile_block_id();
+        let row = pid.0;
+
+        let input_part: Partition<f32, { [1, BLOCK] }> = input.partition(const_shape![1, BLOCK]);
+        let mut out_part: PartitionMut<f32, { [1, BLOCK] }> =
+            unsafe { out.partition_mut(const_shape![1, BLOCK]) };
+
+        for j in 0i32..((N + BLOCK - 1) / BLOCK) {
+            let tile: Tile<f32, { [1, BLOCK] }> = input_part.load([row, j]);
+            unsafe { out_part.store(tile, [0i32, j]) };
+        }
+    }
+
+    #[cutile::entry()]
+    fn nested_partition_mut_copy_3d<const HEADS: i32, const N: i32, const BLOCK: i32>(
+        out: &mut Tensor<f32, { [1, 1, N] }>,
+        input: &Tensor<f32, { [-1, HEADS, N] }>,
+    ) {
+        let pid: (i32, i32, i32) = get_tile_block_id();
+        let row = pid.0;
+        let head = pid.1;
+
+        let input_part: Partition<f32, { [1, 1, BLOCK] }> =
+            input.partition(const_shape![1, 1, BLOCK]);
+        let mut out_part: PartitionMut<f32, { [1, 1, BLOCK] }> =
+            unsafe { out.partition_mut(const_shape![1, 1, BLOCK]) };
+
+        for j in 0i32..((N + BLOCK - 1) / BLOCK) {
+            let tile: Tile<f32, { [1, 1, BLOCK] }> = input_part.load([row, head, j]);
+            unsafe { out_part.store(tile, [0i32, 0i32, j]) };
+        }
+    }
+}
+
+fn assert_matrix_eq(actual: &[f32], expected: &[f32], rows: usize, cols: usize, label: &str) {
+    assert_eq!(actual.len(), expected.len(), "{label}: length mismatch");
+    for row in 0..rows {
+        for col in 0..cols {
+            let idx = row * cols + col;
+            assert!(
+                (actual[idx] - expected[idx]).abs() < 1e-5,
+                "{label}: element [{row}, {col}] expected {}, got {}\nactual: {actual:?}",
+                expected[idx],
+                actual[idx]
+            );
+        }
+    }
+}
+
+#[test]
+fn nested_partition_mut_store_uses_cta_local_indices() {
+    common::with_test_stack(|| {
+        const ROWS: usize = 4;
+        const N: usize = 8;
+        const BLOCK: usize = 2;
+
+        let expected: Vec<f32> = (0..(ROWS * N)).map(|x| x as f32).collect();
+        let input = api::copy_host_vec_to_device(&Arc::new(expected.clone()))
+            .sync()
+            .expect("input alloc");
+        let input_2d = input.view(&[ROWS, N]).expect("input view");
+
+        let direct_out = api::zeros::<f32>(&[ROWS, N]).sync().expect("direct alloc");
+        let (direct_result, _) = nested_partition_mut_module::direct_cta_owned_copy(
+            direct_out.partition([1, BLOCK]),
+            &input_2d,
+        )
+        .generics(vec![N.to_string(), BLOCK.to_string()])
+        .sync()
+        .expect("direct copy");
+        let direct_host: Vec<f32> = direct_result
+            .unpartition()
+            .to_host_vec()
+            .sync()
+            .expect("direct to_host");
+        assert_matrix_eq(&direct_host, &expected, ROWS, N, "direct control");
+
+        let nested_out = api::zeros::<f32>(&[ROWS, N]).sync().expect("nested alloc");
+        let (nested_result, _) = nested_partition_mut_module::nested_partition_mut_copy(
+            nested_out.partition([1, N]),
+            &input_2d,
+        )
+        .generics(vec![N.to_string(), BLOCK.to_string()])
+        .sync()
+        .expect("nested copy");
+        let nested_host: Vec<f32> = nested_result
+            .unpartition()
+            .to_host_vec()
+            .sync()
+            .expect("nested to_host");
+
+        assert_matrix_eq(
+            &nested_host,
+            &expected,
+            ROWS,
+            N,
+            "nested partition_mut repro",
+        );
+    });
+}
+
+#[test]
+fn nested_partition_mut_3d_store_uses_cta_local_indices() {
+    common::with_test_stack(|| {
+        const ROWS: usize = 2;
+        const HEADS: usize = 3;
+        const N: usize = 10;
+        const BLOCK: usize = 4;
+
+        let expected: Vec<f32> = (0..(ROWS * HEADS * N)).map(|x| x as f32).collect();
+        let input = api::copy_host_vec_to_device(&Arc::new(expected.clone()))
+            .sync()
+            .expect("input alloc");
+        let input_3d = input.view(&[ROWS, HEADS, N]).expect("input view");
+
+        let nested_out = api::zeros::<f32>(&[ROWS, HEADS, N])
+            .sync()
+            .expect("nested alloc");
+        let (nested_result, _) = nested_partition_mut_module::nested_partition_mut_copy_3d(
+            nested_out.partition([1, 1, N]),
+            &input_3d,
+        )
+        .generics(vec![HEADS.to_string(), N.to_string(), BLOCK.to_string()])
+        .sync()
+        .expect("nested 3d copy");
+        let nested_host: Vec<f32> = nested_result
+            .unpartition()
+            .to_host_vec()
+            .sync()
+            .expect("nested to_host");
+
+        assert_eq!(nested_host.len(), expected.len());
+        for (idx, (&actual, &expected)) in nested_host.iter().zip(expected.iter()).enumerate() {
+            assert!(
+                (actual - expected).abs() < 1e-5,
+                "nested partition_mut 3d repro: element {idx} expected {expected}, got {actual}\nactual: {nested_host:?}"
+            );
+        }
+    });
+}
+
+#[test]
+fn nested_partition_mut_allows_nested_tile_overhang() {
+    common::with_test_stack(|| {
+        const ROWS: usize = 3;
+        const N: usize = 10;
+        const BLOCK: usize = 4;
+
+        let expected: Vec<f32> = (0..(ROWS * N)).map(|x| x as f32).collect();
+        let input = api::copy_host_vec_to_device(&Arc::new(expected.clone()))
+            .sync()
+            .expect("input alloc");
+        let input_2d = input.view(&[ROWS, N]).expect("input view");
+        let nested_out = api::zeros::<f32>(&[ROWS, N]).sync().expect("nested alloc");
+
+        let (nested_result, _) = nested_partition_mut_module::nested_partition_mut_copy(
+            nested_out.partition([1, N]),
+            &input_2d,
+        )
+        .generics(vec![N.to_string(), BLOCK.to_string()])
+        .sync()
+        .expect("nested overhang copy");
+        let nested_host: Vec<f32> = nested_result
+            .unpartition()
+            .to_host_vec()
+            .sync()
+            .expect("nested to_host");
+
+        assert_matrix_eq(
+            &nested_host,
+            &expected,
+            ROWS,
+            N,
+            "nested partition_mut overhang",
+        );
+    });
+}


### PR DESCRIPTION
Fix nested mutable partition stores when a kernel repartitions an already partitioned mutable output tile.