### PR TITLE
feat: add MemPool memory accounting (mem_stats, reset watermarks)

### DIFF
--- a/cuda-async/tests/pool_allocation.rs
+++ b/cuda-async/tests/pool_allocation.rs
@@ -337,3 +337,112 @@ fn switch_between_pools() {
         op_default.sync().expect("default op failed");
     });
 }
+
+// ---------------------------------------------------------------------------
+// Memory accounting
+// ---------------------------------------------------------------------------
+
+#[test]
+fn mem_stats_initially_zero() {
+    on_fresh_thread(|| {
+        init_device_contexts(0, 1).expect("init failed (requires GPU)");
+
+        let pool = with_device(0, |device| device.new_mem_pool())
+            .expect("get context failed")
+            .expect("pool creation failed");
+
+        let stats = pool.mem_stats().expect("read stats failed");
+        assert_eq!(stats.used_current, 0, "no allocations yet");
+        assert_eq!(stats.used_high, 0, "no allocations yet");
+    });
+}
+
+
+#[test]
+fn mem_stats_track_alloc_and_free() {
+    on_fresh_thread(|| {
+        init_device_contexts(0, 1).expect("init failed (requires GPU)");
+
+        let pool = with_device(0, |device| device.new_mem_pool())
+            .expect("get context failed")
+            .expect("pool creation failed");
+        pool.set_release_threshold(u64::MAX)
+            .expect("set threshold failed");
+
+        let stream = global_policy(0)
+            .expect("get policy failed")
+            .next_stream()
+            .expect("get stream failed");
+
+        const N: usize = 1 << 20;
+
+        let dptr = unsafe { cuda_core::malloc_from_pool_async(N, &pool, &stream) };
+        assert!(dptr != 0);
+        unsafe { stream.synchronize() }.expect("stream sync failed");
+
+        let stats = pool.mem_stats().expect("read stats failed");
+        assert!(
+            stats.used_current >= N as u64,
+            "used_current should reflect alloc, got {}",
+            stats.used_current
+        );
+        assert!(
+            stats.used_high >= N as u64,
+            "used_high should track peak, got {}",
+            stats.used_high
+        );
+
+        unsafe { cuda_core::free_async(dptr, &stream) };
+        unsafe { stream.synchronize() }.expect("stream sync failed");
+
+        let stats = pool.mem_stats().expect("read stats failed");
+        assert_eq!(
+            stats.used_current, 0,
+            "used_current should return to 0 after free + sync"
+        );
+        assert!(
+            stats.used_high >= N as u64,
+            "used_high is a watermark and must not decrease, got {}",
+            stats.used_high
+        );
+    });
+}
+
+#[test]
+fn reset_used_high_collapses_watermark_to_current() {
+    on_fresh_thread(|| {
+        init_device_contexts(0, 1).expect("init failed (requires GPU)");
+
+        let pool = with_device(0, |device| device.new_mem_pool())
+            .expect("get context failed")
+            .expect("pool creation failed");
+        pool.set_release_threshold(u64::MAX)
+            .expect("set threshold failed");
+
+        let stream = global_policy(0)
+            .expect("get policy failed")
+            .next_stream()
+            .expect("get stream failed");
+
+        const N: usize = 1 << 20;
+
+        let dptr = unsafe { cuda_core::malloc_from_pool_async(N, &pool, &stream) };
+        unsafe { cuda_core::free_async(dptr, &stream) };
+        unsafe { stream.synchronize() }.expect("stream sync failed");
+
+        let before = pool.mem_stats().expect("read stats failed");
+        assert_eq!(before.used_current, 0);
+        assert!(
+            before.used_high >= N as u64,
+            "precondition: high watermark should be > 0"
+        );
+
+        pool.reset_used_high().expect("reset used_high failed");
+
+        let after = pool.mem_stats().expect("read stats failed");
+        assert_eq!(
+            after.used_high, after.used_current,
+            "after reset, used_high should collapse to used_current"
+        );
+    });
+}

--- a/cuda-core/src/cudarc_shim.rs
+++ b/cuda-core/src/cudarc_shim.rs
@@ -508,6 +508,35 @@ pub(crate) mod pool {
         .result()
     }
 
+    /// Reads a `u64`-valued pool attribute.
+    ///
+    /// # Safety
+    /// `pool` must be a valid handle. `attr` must be one whose value type is
+    /// `cuuint64_t` — the four `*_MEM_CURRENT` / `*_MEM_HIGH` accounting
+    /// attributes and `RELEASE_THRESHOLD`.
+    pub unsafe fn get_attribute_u64(
+        pool: cuda_bindings::CUmemoryPool,
+        attr: cuda_bindings::CUmemPool_attribute,
+    ) -> Result<u64, DriverError> {
+        let mut value: u64 = 0;
+        cuda_bindings::cuMemPoolGetAttribute(pool, attr, &mut value as *mut _ as *mut _).result()?;
+        Ok(value)
+    }
+
+    /// Resets a high-watermark attribute by writing 0. The driver rejects any
+    /// other value for these attributes.
+    ///
+    /// # Safety
+    /// `pool` must be valid. `attr` must be `USED_MEM_HIGH` or
+    /// `RESERVED_MEM_HIGH`.
+    pub unsafe fn reset_high_watermark(
+        pool: cuda_bindings::CUmemoryPool,
+        attr: cuda_bindings::CUmemPool_attribute,
+    ) -> Result<(), DriverError> {
+        let zero: u64 = 0;
+        cuda_bindings::cuMemPoolSetAttribute(pool, attr, &zero as *const _ as *mut _).result()
+    }
+
     /// Allocates device memory from a specific pool asynchronously.
     ///
     /// # Safety

--- a/cuda-core/src/runtime.rs
+++ b/cuda-core/src/runtime.rs
@@ -282,6 +282,73 @@ impl MemPool {
         self.device.bind_to_thread()?;
         unsafe { pool::set_release_threshold(self.cu_pool, threshold) }
     }
+
+    /// Reads all four memory accounting counters in a single bind-to-thread block.
+    ///
+    /// The four reads happen back-to-back, but the pool is being mutated by
+    /// async allocations on streams — so this is a best-effort snapshot, not
+    /// a synchronously consistent reading. For stable values, sync the streams
+    /// that allocate from this pool first.
+    pub fn mem_stats(&self) -> Result<PoolMemStats, DriverError> {
+        self.device.bind_to_thread()?;
+        unsafe {
+            Ok(PoolMemStats {
+                used_current: pool::get_attribute_u64(
+                    self.cu_pool,
+                    cuda_bindings::CUmemPool_attribute_enum_CU_MEMPOOL_ATTR_USED_MEM_CURRENT,
+                )?,
+                used_high: pool::get_attribute_u64(
+                    self.cu_pool,
+                    cuda_bindings::CUmemPool_attribute_enum_CU_MEMPOOL_ATTR_USED_MEM_HIGH,
+                )?,
+                reserved_current: pool::get_attribute_u64(
+                    self.cu_pool,
+                    cuda_bindings::CUmemPool_attribute_enum_CU_MEMPOOL_ATTR_RESERVED_MEM_CURRENT,
+                )?,
+                reserved_high: pool::get_attribute_u64(
+                    self.cu_pool,
+                    cuda_bindings::CUmemPool_attribute_enum_CU_MEMPOOL_ATTR_RESERVED_MEM_HIGH,
+                )?,
+            })
+        }
+    }
+
+    /// Resets `used_high` to the current `used_current`.
+    pub fn reset_used_high(&self) -> Result<(), DriverError> {
+        self.device.bind_to_thread()?;
+        unsafe {
+            pool::reset_high_watermark(
+                self.cu_pool,
+                cuda_bindings::CUmemPool_attribute_enum_CU_MEMPOOL_ATTR_USED_MEM_HIGH,
+            )
+        }
+    }
+
+    /// Resets `reserved_high` to the current `reserved_current`.
+    pub fn reset_reserved_high(&self) -> Result<(), DriverError> {
+        self.device.bind_to_thread()?;
+        unsafe {
+            pool::reset_high_watermark(
+                self.cu_pool,
+                cuda_bindings::CUmemPool_attribute_enum_CU_MEMPOOL_ATTR_RESERVED_MEM_HIGH,
+            )
+        }
+    }
+}
+
+/// Snapshot of a pool's memory accounting counters at a point in time.
+///
+/// `used_*` tracks memory currently checked out to the application; `reserved_*`
+/// tracks memory the pool holds from the OS (which may exceed `used_*` due to
+/// internal caching). `*_high` are watermarks since the last reset (or pool
+/// creation), readable via [`MemPool::mem_stats`] and resettable via
+/// [`MemPool::reset_used_high`] / [`MemPool::reset_reserved_high`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PoolMemStats {
+    pub used_current: u64,
+    pub used_high: u64,
+    pub reserved_current: u64,
+    pub reserved_high: u64,
 }
 
 /// A CUDA stream handle.


### PR DESCRIPTION
## Summary
Follow-up to #26' comment ("Pool attribute configuration or memory accounting could be a follow-up PR").

Adds `MemPool::mem_stats()`, `reset_used_high()`, `reset_reserved_high()`, and `PoolMemStats`. 
Exposes the four `USED/RESERVED_MEM_CURRENT/HIGH` driver counters; high watermarks reset via the CUDA "write 0" convention.

Not in this PR: reuse policy setters(`REUSE_*`),`cuMemPollTrimTo`-- those belong to the attribute-config follow-up

## Test
`cargo test -p cuda-async --test pool_allocation`  passes 