### PR TITLE
fix: skip nested partition offset metadata for dynamic outer tiles

### DIFF
--- a/cutile-compiler/src/compiler/compile_intrinsic.rs
+++ b/cutile-compiler/src/compiler/compile_intrinsic.rs
@@ -1337,17 +1337,21 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                         ),
                     );
                 }
-                let access_offset = self.compile_nested_mutable_access_offset_metadata(
-                    module,
-                    block_id,
-                    &call_expr.span(),
-                    &partition_value,
-                    &outer_tile,
-                    generic_vars,
-                    ctx,
-                )?;
-                partition_value
-                    .insert_type_meta_field(NESTED_MUTABLE_ACCESS_OFFSET_META, access_offset)?;
+                let outer_shape =
+                    self.static_shape_from_value(&outer_tile, generic_vars, &call_expr.span())?;
+                if outer_shape.iter().all(|d| *d > 0) {
+                    let access_offset = self.compile_nested_mutable_access_offset_metadata(
+                        module,
+                        block_id,
+                        &call_expr.span(),
+                        &partition_value,
+                        &outer_tile,
+                        generic_vars,
+                        ctx,
+                    )?;
+                    partition_value
+                        .insert_type_meta_field(NESTED_MUTABLE_ACCESS_OFFSET_META, access_offset)?;
+                }
                 ctx.vars.insert(var_name, partition_value);
                 Ok(None)
             }


### PR DESCRIPTION
Fixes #130 

### Summary

Gate metadata attachment on whether all outer tile dimensions are statically positive. When the outer shape contains a dynamic `dim (-1)`, no metadata is attached and `store_view_tko_mut` falls back to treating the store index as an absolute tile index — consistent with the pre-fix behavior and symmetric with how the immutable `partition().load()` path works.

### Test
- `cargo run -p cutile-examples --example add_ptr` passes (regression repro)
- `cargo test -p cutile --test nested_partition_mut` passes (nested path unaffected)
-  `cargo run -p cutile-examples --example book_examples` passes
-  `./scripts/run_all.sh` passes