### PR TITLE
fix: resolve pool outside with_default_device_policy closure

### DIFF
--- a/cuda-async/src/device_operation.rs
+++ b/cuda-async/src/device_operation.rs
@@ -331,10 +331,8 @@ pub trait DeviceOp:
     fn graph(
         self,
     ) -> Result<crate::cuda_graph::CudaGraph<<Self as DeviceOp>::Output>, DeviceError> {
-        with_default_device_policy(|policy| {
-            let stream = policy.next_stream()?;
-            self.graph_on(stream)
-        })?
+        let stream = with_default_device_policy(|policy| policy.next_stream())??;
+        self.graph_on(stream)
     }
     /// Capture this operation into a replayable [`CudaGraph`](crate::cuda_graph::CudaGraph)
     /// on an **explicit stream**.
@@ -353,10 +351,8 @@ pub trait DeviceOp:
     /// The policy picks a stream (round-robin by default), submits the work, and blocks
     /// until the GPU finishes. Equivalent to `.await` but blocking.
     fn sync(self) -> Result<<Self as DeviceOp>::Output, DeviceError> {
-        with_default_device_policy(|policy| {
-            let stream = policy.next_stream()?;
-            self.sync_on(&stream)
-        })?
+        let stream = with_default_device_policy(|policy| policy.next_stream())??;
+        self.sync_on(&stream)
     }
     /// Execute on a stream without synchronizing. The GPU may still be
     /// writing to the output when this returns.
@@ -435,17 +431,14 @@ impl<T: Send> IntoFuture for BoxedDeviceOp<T> {
     type Output = Result<T, DeviceError>;
     type IntoFuture = DeviceFuture<T, Self>;
     fn into_future(self) -> Self::IntoFuture {
-        match with_default_device_policy(|policy| {
-            let stream = policy.next_stream()?;
-            let mut f = DeviceFuture::new();
-            f.device_operation = Some(self);
-            f.execution_context = Some(ExecutionContext::new(stream));
-            Ok(f)
-        }) {
-            Ok(Ok(future)) => future,
-            Ok(Err(e)) => DeviceFuture::failed(e),
-            Err(e) => DeviceFuture::failed(e),
-        }
+        let stream = match with_default_device_policy(|policy| policy.next_stream()) {
+            Ok(Ok(stream)) => stream,
+            Ok(Err(e)) | Err(e) => return DeviceFuture::failed(e),
+        };
+        let mut f = DeviceFuture::new();
+        f.device_operation = Some(self);
+        f.execution_context = Some(ExecutionContext::new(stream));
+        f
     }
 }
 
@@ -503,17 +496,14 @@ impl<T: Send + Sync> IntoFuture for SharedDeviceOp<T> {
     type Output = Result<Arc<T>, DeviceError>;
     type IntoFuture = DeviceFuture<Arc<T>, SharedDeviceOp<T>>;
     fn into_future(self) -> Self::IntoFuture {
-        match with_default_device_policy(|policy| {
-            let stream = policy.next_stream()?;
-            let mut f = DeviceFuture::new();
-            f.device_operation = Some(self);
-            f.execution_context = Some(ExecutionContext::new(stream));
-            Ok(f)
-        }) {
-            Ok(Ok(future)) => future,
-            Ok(Err(e)) => DeviceFuture::failed(e),
-            Err(e) => DeviceFuture::failed(e),
-        }
+        let stream = match with_default_device_policy(|policy| policy.next_stream()) {
+            Ok(Ok(stream)) => stream,
+            Ok(Err(e)) | Err(e) => return DeviceFuture::failed(e),
+        };
+        let mut f = DeviceFuture::new();
+        f.device_operation = Some(self);
+        f.execution_context = Some(ExecutionContext::new(stream));
+        f
     }
 }
 
@@ -667,17 +657,14 @@ where
     type Output = Result<O, DeviceError>;
     type IntoFuture = DeviceFuture<O, AndThen<I, DI, O, DO, F>>;
     fn into_future(self) -> Self::IntoFuture {
-        match with_default_device_policy(|policy| {
-            let stream = policy.next_stream()?;
-            let mut f = DeviceFuture::new();
-            f.device_operation = Some(self);
-            f.execution_context = Some(ExecutionContext::new(stream));
-            Ok(f)
-        }) {
-            Ok(Ok(future)) => future,
-            Ok(Err(e)) => DeviceFuture::failed(e),
-            Err(e) => DeviceFuture::failed(e),
-        }
+        let stream = match with_default_device_policy(|policy| policy.next_stream()) {
+            Ok(Ok(stream)) => stream,
+            Ok(Err(e)) | Err(e) => return DeviceFuture::failed(e),
+        };
+        let mut f = DeviceFuture::new();
+        f.device_operation = Some(self);
+        f.execution_context = Some(ExecutionContext::new(stream));
+        f
     }
 }
 
@@ -709,17 +696,14 @@ impl<T: Send> IntoFuture for Value<T> {
     type Output = Result<T, DeviceError>;
     type IntoFuture = DeviceFuture<T, Value<T>>;
     fn into_future(self) -> Self::IntoFuture {
-        match with_default_device_policy(|policy| {
-            let stream = policy.next_stream()?;
-            let mut f = DeviceFuture::new();
-            f.device_operation = Some(self);
-            f.execution_context = Some(ExecutionContext::new(stream));
-            Ok(f)
-        }) {
-            Ok(Ok(future)) => future,
-            Ok(Err(e)) => DeviceFuture::failed(e),
-            Err(e) => DeviceFuture::failed(e),
-        }
+        let stream = match with_default_device_policy(|policy| policy.next_stream()) {
+            Ok(Ok(stream)) => stream,
+            Ok(Err(e)) | Err(e) => return DeviceFuture::failed(e),
+        };
+        let mut f = DeviceFuture::new();
+        f.device_operation = Some(self);
+        f.execution_context = Some(ExecutionContext::new(stream));
+        f
     }
 }
 
@@ -770,17 +754,14 @@ impl<O: Send, DO: DeviceOp<Output = O>, F: FnOnce() -> DO> IntoFuture for Empty<
     type Output = Result<O, DeviceError>;
     type IntoFuture = DeviceFuture<O, Empty<O, DO, F>>;
     fn into_future(self) -> Self::IntoFuture {
-        match with_default_device_policy(|policy| {
-            let stream = policy.next_stream()?;
-            let mut f = DeviceFuture::new();
-            f.device_operation = Some(self);
-            f.execution_context = Some(ExecutionContext::new(stream));
-            Ok(f)
-        }) {
-            Ok(Ok(future)) => future,
-            Ok(Err(e)) => DeviceFuture::failed(e),
-            Err(e) => DeviceFuture::failed(e),
-        }
+        let stream = match with_default_device_policy(|policy| policy.next_stream()) {
+            Ok(Ok(stream)) => stream,
+            Ok(Err(e)) | Err(e) => return DeviceFuture::failed(e),
+        };
+        let mut f = DeviceFuture::new();
+        f.device_operation = Some(self);
+        f.execution_context = Some(ExecutionContext::new(stream));
+        f
     }
 }
 
@@ -829,17 +810,14 @@ impl<T1: Send, T2: Send, A: DeviceOp<Output = T1>, B: DeviceOp<Output = T2>> Int
     type Output = Result<(T1, T2), DeviceError>;
     type IntoFuture = DeviceFuture<(T1, T2), Zip<T1, T2, A, B>>;
     fn into_future(self) -> Self::IntoFuture {
-        match with_default_device_policy(|policy| {
-            let stream = policy.next_stream()?;
-            let mut f = DeviceFuture::new();
-            f.device_operation = Some(self);
-            f.execution_context = Some(ExecutionContext::new(stream));
-            Ok(f)
-        }) {
-            Ok(Ok(future)) => future,
-            Ok(Err(e)) => DeviceFuture::failed(e),
-            Err(e) => DeviceFuture::failed(e),
-        }
+        let stream = match with_default_device_policy(|policy| policy.next_stream()) {
+            Ok(Ok(stream)) => stream,
+            Ok(Err(e)) | Err(e) => return DeviceFuture::failed(e),
+        };
+        let mut f = DeviceFuture::new();
+        f.device_operation = Some(self);
+        f.execution_context = Some(ExecutionContext::new(stream));
+        f
     }
 }
 
@@ -1045,17 +1023,14 @@ where
     type Output = Result<T1, DeviceError>;
     type IntoFuture = DeviceFuture<T1, SelectLeft<T1, T2, DI>>;
     fn into_future(self) -> Self::IntoFuture {
-        match with_default_device_policy(|policy| {
-            let stream = policy.next_stream()?;
-            let mut f = DeviceFuture::new();
-            f.device_operation = Some(self);
-            f.execution_context = Some(ExecutionContext::new(stream));
-            Ok(f)
-        }) {
-            Ok(Ok(future)) => future,
-            Ok(Err(e)) => DeviceFuture::failed(e),
-            Err(e) => DeviceFuture::failed(e),
-        }
+        let stream = match with_default_device_policy(|policy| policy.next_stream()) {
+            Ok(Ok(stream)) => stream,
+            Ok(Err(e)) | Err(e) => return DeviceFuture::failed(e),
+        };
+        let mut f = DeviceFuture::new();
+        f.device_operation = Some(self);
+        f.execution_context = Some(ExecutionContext::new(stream));
+        f
     }
 }
 
@@ -1092,17 +1067,14 @@ where
     type Output = Result<T2, DeviceError>;
     type IntoFuture = DeviceFuture<T2, SelectRight<T1, T2, DI>>;
     fn into_future(self) -> Self::IntoFuture {
-        match with_default_device_policy(|policy| {
-            let stream = policy.next_stream()?;
-            let mut f = DeviceFuture::new();
-            f.device_operation = Some(self);
-            f.execution_context = Some(ExecutionContext::new(stream));
-            Ok(f)
-        }) {
-            Ok(Ok(future)) => future,
-            Ok(Err(e)) => DeviceFuture::failed(e),
-            Err(e) => DeviceFuture::failed(e),
-        }
+        let stream = match with_default_device_policy(|policy| policy.next_stream()) {
+            Ok(Ok(stream)) => stream,
+            Ok(Err(e)) | Err(e) => return DeviceFuture::failed(e),
+        };
+        let mut f = DeviceFuture::new();
+        f.device_operation = Some(self);
+        f.execution_context = Some(ExecutionContext::new(stream));
+        f
     }
 }
 
@@ -1362,17 +1334,14 @@ impl<O: Send, DO: DeviceOp<Output = O>, F: FnOnce(&ExecutionContext) -> DO + Sen
     type Output = Result<O, DeviceError>;
     type IntoFuture = DeviceFuture<O, StreamOperation<O, DO, F>>;
     fn into_future(self) -> Self::IntoFuture {
-        match with_default_device_policy(|policy| {
-            let stream = policy.next_stream()?;
-            let mut f = DeviceFuture::new();
-            f.device_operation = Some(self);
-            f.execution_context = Some(ExecutionContext::new(stream));
-            Ok(f)
-        }) {
-            Ok(Ok(future)) => future,
-            Ok(Err(e)) => DeviceFuture::failed(e),
-            Err(e) => DeviceFuture::failed(e),
-        }
+        let stream = match with_default_device_policy(|policy| policy.next_stream()) {
+            Ok(Ok(stream)) => stream,
+            Ok(Err(e)) | Err(e) => return DeviceFuture::failed(e),
+        };
+        let mut f = DeviceFuture::new();
+        f.device_operation = Some(self);
+        f.execution_context = Some(ExecutionContext::new(stream));
+        f
     }
 }
 
@@ -1423,17 +1392,14 @@ where
     type Output = Result<O, DeviceError>;
     type IntoFuture = DeviceFuture<O, AndThenWithContext<I, DI, O, DO, F>>;
     fn into_future(self) -> Self::IntoFuture {
-        match with_default_device_policy(|policy| {
-            let stream = policy.next_stream()?;
-            let mut f = DeviceFuture::new();
-            f.device_operation = Some(self);
-            f.execution_context = Some(ExecutionContext::new(stream));
-            Ok(f)
-        }) {
-            Ok(Ok(future)) => future,
-            Ok(Err(e)) => DeviceFuture::failed(e),
-            Err(e) => DeviceFuture::failed(e),
-        }
+        let stream = match with_default_device_policy(|policy| policy.next_stream()) {
+            Ok(Ok(stream)) => stream,
+            Ok(Err(e)) | Err(e) => return DeviceFuture::failed(e),
+        };
+        let mut f = DeviceFuture::new();
+        f.device_operation = Some(self);
+        f.execution_context = Some(ExecutionContext::new(stream));
+        f
     }
 }
 
@@ -1492,17 +1458,14 @@ impl<T: Send> IntoFuture for DeviceOpVec<T> {
     type Output = Result<Vec<T>, DeviceError>;
     type IntoFuture = DeviceFuture<Vec<T>, Self>;
     fn into_future(self) -> Self::IntoFuture {
-        match with_default_device_policy(|policy| {
-            let stream = policy.next_stream()?;
-            let mut f = DeviceFuture::new();
-            f.device_operation = Some(self);
-            f.execution_context = Some(ExecutionContext::new(stream));
-            Ok(f)
-        }) {
-            Ok(Ok(future)) => future,
-            Ok(Err(e)) => DeviceFuture::failed(e),
-            Err(e) => DeviceFuture::failed(e),
-        }
+        let stream = match with_default_device_policy(|policy| policy.next_stream()) {
+            Ok(Ok(stream)) => stream,
+            Ok(Err(e)) | Err(e) => return DeviceFuture::failed(e),
+        };
+        let mut f = DeviceFuture::new();
+        f.device_operation = Some(self);
+        f.execution_context = Some(ExecutionContext::new(stream));
+        f
     }
 }
 

--- a/cuda-async/tests/pool_allocation.rs
+++ b/cuda-async/tests/pool_allocation.rs
@@ -17,6 +17,7 @@ use cuda_async::device_context::{
 };
 use cuda_async::device_operation::{value, DeviceOp};
 use cuda_async::prelude::*;
+use std::future::IntoFuture;
 
 fn on_fresh_thread<F: FnOnce() + Send + 'static>(f: F) {
     std::thread::spawn(f).join().expect("test thread panicked");
@@ -151,9 +152,16 @@ fn alloc_with_custom_pool_via_device_op() {
             .expect("pool creation failed");
         pool.set_release_threshold(u64::MAX)
             .expect("set threshold failed");
+        let pool_ptr = pool.cu_pool() as usize;
         set_device_pool(0, pool).expect("set pool failed");
 
-        let op = with_context(|ctx| {
+        let op = with_context(move |ctx| {
+            let p = ctx.get_pool().expect("pool must be present in ExecutionContext via sync()");
+            assert_eq!(
+                p.cu_pool() as usize,
+                pool_ptr,
+                "sync() must route allocation through the registered pool"
+            );
             let num_bytes = 1024;
             let dptr = unsafe { ctx.alloc_async(num_bytes) };
             assert!(dptr != 0, "allocation returned null pointer");
@@ -161,6 +169,32 @@ fn alloc_with_custom_pool_via_device_op() {
         });
         let dptr = op.sync().expect("device op failed");
         assert!(dptr != 0);
+    });
+}
+
+#[test]
+fn alloc_with_custom_pool_via_into_future() {
+    on_fresh_thread(|| {
+        init_device_contexts(0, 1).expect("init failed (requires GPU)");
+
+        let pool = with_device(0, |device| device.new_mem_pool())
+            .expect("get context failed")
+            .expect("pool creation failed");
+        pool.set_release_threshold(u64::MAX)
+            .expect("set threshold failed");
+        let pool_ptr = pool.cu_pool() as usize;
+        set_device_pool(0, pool).expect("set pool failed");
+
+        let op = with_context(move |ctx| {
+            let p = ctx.get_pool().expect("pool must be present in ExecutionContext via into_future()");
+            assert_eq!(
+                p.cu_pool() as usize,
+                pool_ptr,
+                "into_future() must route allocation through the registered pool"
+            );
+            value(())
+        });
+        futures::executor::block_on(op.into_future()).expect("future failed");
     });
 }
 


### PR DESCRIPTION
Fixes #133

Extract stream selection out of the `with_default_device_policy` closure so `with_global_device_context` releases its borrow before `ExecutionContext::new` is called.

```rust
// Before
with_default_device_policy(|policy| {
    let stream = policy.next_stream()?;
    ExecutionContext::new(stream)   // re-enters Cell → pool lost
})

// After
let stream = with_default_device_policy(|policy| policy.next_stream())??;
ExecutionContext::new(stream)       // Cell already released → pool correct
```
Applied to sync(), graph(), and all into_future() implementations.

### Tests

`cargo test -p cuda-async --test pool_allocation alloc_with_custom_pool_via_device_op` passes
`cargo test -p cuda-async --test pool_allocation alloc_with_custom_pool_via_into_future` passes
`./scripts/run_all.sh` passes

