### PR TITLE
refactor: use typeck-driven lowering

### DIFF
--- a/cuda-async/tests/pool_allocation.rs
+++ b/cuda-async/tests/pool_allocation.rs
@@ -357,7 +357,6 @@ fn mem_stats_initially_zero() {
     });
 }
 
-
 #[test]
 fn mem_stats_track_alloc_and_free() {
     on_fresh_thread(|| {

--- a/cuda-bindings/build.rs
+++ b/cuda-bindings/build.rs
@@ -83,7 +83,7 @@ fn generate_type_bindings(cuda_toolkit: &str, out_dir: &Path) -> Result<(), Box<
     Ok(())
 }
 
-// Detect whether bindgen wrapped `CUmemLocation_st::id` in an anonymous union (e.g. CUDA 13.2+) 
+// Detect whether bindgen wrapped `CUmemLocation_st::id` in an anonymous union (e.g. CUDA 13.2+)
 // or left it as a plain `int` (e.g. 13.0/13.1), so the helper in lib.rs can pick the right access path.
 fn emit_layout_cfgs(generated_source: &str) {
     println!("cargo:rustc-check-cfg=cfg(cu_mem_location_anon_union)");

--- a/cuda-core/src/cudarc_shim.rs
+++ b/cuda-core/src/cudarc_shim.rs
@@ -519,7 +519,8 @@ pub(crate) mod pool {
         attr: cuda_bindings::CUmemPool_attribute,
     ) -> Result<u64, DriverError> {
         let mut value: u64 = 0;
-        cuda_bindings::cuMemPoolGetAttribute(pool, attr, &mut value as *mut _ as *mut _).result()?;
+        cuda_bindings::cuMemPoolGetAttribute(pool, attr, &mut value as *mut _ as *mut _)
+            .result()?;
         Ok(value)
     }
 

--- a/cutile-compiler/src/compiler/_function.rs
+++ b/cutile-compiler/src/compiler/_function.rs
@@ -56,6 +56,11 @@ pub struct CUDATileFunctionCompiler<'m> {
     pub(crate) typeck_results: RefCell<Option<crate::passes::type_inference::TypeckResults>>,
 }
 
+struct FunctionParamTypes {
+    names: Vec<String>,
+    tile_types: Vec<TileRustType>,
+}
+
 impl<'m> CUDATileFunctionCompiler<'m> {
     pub fn new(
         modules: &'m CUDATileModules,
@@ -124,7 +129,9 @@ impl<'m> CUDATileFunctionCompiler<'m> {
             .collect::<HashMap<_, _>>();
 
         // 8. Create GenericVars.
-        let generic_vars = GenericVars::from_flat(&function.sig.generics, function_generic_args)?;
+        let mut generic_vars =
+            GenericVars::from_flat(&function.sig.generics, function_generic_args)?;
+        Self::add_module_const_vars_from_modules(modules, &mut generic_vars);
 
         // 9. generate_entry_point.
         let spec_args_map: HashMap<String, crate::specialization::SpecializationBits> = spec_args
@@ -144,6 +151,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
             })
             .collect();
         let (entry, validator) = generate_entry_point(
+            modules,
             &function,
             &generic_vars,
             &stride_args,
@@ -197,6 +205,26 @@ impl<'m> CUDATileFunctionCompiler<'m> {
     // Error helper methods
     // -----------------------------------------------------------------------
 
+    pub(crate) fn add_module_const_vars(&self, generic_vars: &mut GenericVars) {
+        Self::add_module_const_vars_from_modules(self.modules, generic_vars);
+    }
+
+    fn add_module_const_vars_from_modules(
+        modules: &CUDATileModules,
+        generic_vars: &mut GenericVars,
+    ) {
+        for (name, item) in modules.consts() {
+            if generic_vars.var_type(name).is_some() {
+                continue;
+            }
+            if let Some(value) = crate::type_aliases::const_item_i32_value(item) {
+                generic_vars.inst_i32.insert(name.clone(), value);
+            } else if let Some(value) = crate::type_aliases::const_item_bool_value(item) {
+                generic_vars.inst_bool.insert(name.clone(), value);
+            }
+        }
+    }
+
     pub(crate) fn span_base(&self) -> SpanBase {
         let current_module = &self.module_name_stack[0];
         self.modules
@@ -236,32 +264,72 @@ impl<'m> CUDATileFunctionCompiler<'m> {
     }
 
     // -----------------------------------------------------------------------
+    // Typeck query helper methods
+    // -----------------------------------------------------------------------
+
+    pub(crate) fn typeck_method_selection(
+        &self,
+        method_call_expr: &syn::ExprMethodCall,
+    ) -> Option<crate::passes::type_inference::MethodSelection> {
+        self.typeck_results
+            .borrow()
+            .as_ref()
+            .and_then(|results| results.method_selection(method_call_expr).cloned())
+    }
+
+    pub(crate) fn typeck_expr_syn_type(&self, expr: &syn::Expr) -> Option<syn::Type> {
+        self.typeck_results
+            .borrow()
+            .as_ref()
+            .and_then(|results| results.syn_expr_type(expr))
+    }
+
+    pub(crate) fn typeck_expr_tile_type(
+        &self,
+        expr: &syn::Expr,
+        generic_vars: &GenericVars,
+        type_params: &HashMap<String, crate::types::TypeParam>,
+    ) -> Result<Option<TileRustType>, JITError> {
+        let cached_tile_type = self
+            .typeck_results
+            .borrow()
+            .as_ref()
+            .and_then(|results| results.expr_type(expr).cloned());
+        if cached_tile_type.is_some() {
+            return Ok(cached_tile_type);
+        }
+
+        let Some(syn_type) = self.typeck_expr_syn_type(expr) else {
+            return Ok(None);
+        };
+        self.compile_type(&syn_type, generic_vars, type_params)
+    }
+
+    // -----------------------------------------------------------------------
     // Compile
     // -----------------------------------------------------------------------
 
     /// Compile the kernel function into a `cutile_ir::Module`.
     pub fn compile(&self) -> Result<Module, JITError> {
         let mut module = Module::new(&self.module_name);
+        self.emit_module_globals(&mut module)?;
         let entry_op = self.compile_entry_function(&mut module)?;
         module.functions.push(entry_op);
         Ok(module)
     }
 
-    /// Compile the entry function, returning its OpId.
-    fn compile_entry_function(&self, module: &mut Module) -> Result<cutile_ir::ir::OpId, JITError> {
-        let fn_item = &self.entry;
-        let fn_name = fn_item.sig.ident.to_string();
-        let generic_vars = &self.generic_vars;
-
-        // Compile parameter types via the compiler's type machinery.
-        let var_names = get_sig_param_names(&fn_item.sig);
+    fn compile_function_param_types(
+        &self,
+        fn_item: &syn::ItemFn,
+        generic_vars: &GenericVars,
+    ) -> Result<FunctionParamTypes, JITError> {
+        let names = get_sig_param_names(&fn_item.sig);
         let (r_params, _r_result) = get_sig_types(&fn_item.sig, None);
-        let mut cuda_tile_argument_types: Vec<TileRustType> = vec![];
-        let mut arg_tile_ir_types: Vec<Type> = Vec::new();
+        let mut tile_types = Vec::new();
 
         for (i, r_param_type) in r_params.iter().enumerate() {
             let mut type_params: HashMap<String, crate::types::TypeParam> = HashMap::new();
-            if let Some(strides) = self.stride_args.get(var_names[i].as_str()) {
+            if let Some(strides) = self.stride_args.get(names[i].as_str()) {
                 type_params.insert(
                     "strides".to_string(),
                     crate::types::TypeParam::Strides(crate::types::TypeParamStrides::from(
@@ -281,28 +349,101 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                     )),
                 );
             }
-            match self.compile_type(&r_param_type, generic_vars, &type_params)? {
-                Some(ty) => {
-                    // Convert type string to tile-ir Type.
-                    let tile_ir_ty = super::_type::convert_type(&ty).ok_or_else(|| {
-                        JITError::Generic(format!(
-                            "compiler2: failed to convert parameter type to tile-ir: {}",
-                            r_param_type.to_token_stream().to_string()
-                        ))
-                    })?;
-                    arg_tile_ir_types.push(tile_ir_ty);
-                    cuda_tile_argument_types.push(ty);
-                }
-                None => {
-                    return self.jit_error_result(
-                        &r_param_type.span(),
-                        &format!(
-                            "unable to compile parameter type `{}`",
-                            r_param_type.to_token_stream().to_string()
-                        ),
-                    );
-                }
-            }
+            let Some(ty) = self.compile_type(r_param_type, generic_vars, &type_params)? else {
+                return self.jit_error_result(
+                    &r_param_type.span(),
+                    &format!(
+                        "unable to compile parameter type `{}`",
+                        r_param_type.to_token_stream()
+                    ),
+                );
+            };
+            tile_types.push(ty);
+        }
+
+        Ok(FunctionParamTypes { names, tile_types })
+    }
+
+    fn initial_typeck_types(
+        &self,
+        param_types: &FunctionParamTypes,
+        generic_vars: &GenericVars,
+    ) -> Result<HashMap<String, TileRustType>, JITError> {
+        let mut initial_types = param_types
+            .names
+            .iter()
+            .cloned()
+            .zip(param_types.tile_types.iter().cloned())
+            .collect::<HashMap<_, _>>();
+
+        let i32_ty: syn::Type = syn::parse_quote!(i32);
+        for key in generic_vars.inst_i32.keys() {
+            let Some(ty) = self.compile_type(&i32_ty, generic_vars, &HashMap::new())? else {
+                return SourceLocation::unknown()
+                    .jit_error_result("unable to compile const generic i32 type");
+            };
+            initial_types.insert(key.clone(), ty);
+        }
+
+        let bool_ty: syn::Type = syn::parse_quote!(bool);
+        for key in generic_vars.inst_bool.keys() {
+            let Some(ty) = self.compile_type(&bool_ty, generic_vars, &HashMap::new())? else {
+                return SourceLocation::unknown()
+                    .jit_error_result("unable to compile const generic bool type");
+            };
+            initial_types.insert(key.clone(), ty);
+        }
+
+        for (key, value) in &generic_vars.inst_array {
+            let arr_ty =
+                syn::parse2::<syn::Type>(format!("[i32;{}]", value.len()).parse().unwrap())
+                    .unwrap();
+            let Some(ty) = self.compile_type(&arr_ty, generic_vars, &HashMap::new())? else {
+                return SourceLocation::unknown()
+                    .jit_error_result("unable to compile const generic array type");
+            };
+            initial_types.insert(key.clone(), ty);
+        }
+
+        Ok(initial_types)
+    }
+
+    #[doc(hidden)]
+    pub fn debug_typeck_dump(&self) -> Result<String, JITError> {
+        let fn_item = self._function;
+        let generic_vars = &self.generic_vars;
+        let param_types = self.compile_function_param_types(fn_item, generic_vars)?;
+        let initial_types = self.initial_typeck_types(&param_types, generic_vars)?;
+
+        let mut typed_fn_item = fn_item.clone();
+        crate::passes::node_ids::assign_expr_ids(&mut typed_fn_item);
+        let typeck_results = crate::passes::type_inference::infer_function(
+            self,
+            &typed_fn_item,
+            generic_vars,
+            initial_types,
+        )?;
+        Ok(typeck_results.debug_dump())
+    }
+
+    /// Compile the entry function, returning its OpId.
+    fn compile_entry_function(&self, module: &mut Module) -> Result<cutile_ir::ir::OpId, JITError> {
+        let fn_item = &self.entry;
+        let fn_name = fn_item.sig.ident.to_string();
+        let generic_vars = &self.generic_vars;
+
+        let param_types = self.compile_function_param_types(fn_item, generic_vars)?;
+        let var_names = &param_types.names;
+        let cuda_tile_argument_types = &param_types.tile_types;
+        let mut arg_tile_ir_types = Vec::new();
+        for ty in cuda_tile_argument_types {
+            let tile_ir_ty = super::_type::convert_type(ty).ok_or_else(|| {
+                JITError::Generic(format!(
+                    "compiler2: failed to convert parameter type to tile-ir: {}",
+                    ty.rust_ty.to_token_stream()
+                ))
+            })?;
+            arg_tile_ir_types.push(tile_ir_ty);
         }
 
         let func_type = Type::Func(FuncType {
@@ -329,16 +470,16 @@ impl<'m> CUDATileFunctionCompiler<'m> {
             }
         }
 
-        let mut initial_types = var_names
-            .iter()
-            .cloned()
-            .zip(cuda_tile_argument_types.iter().cloned())
-            .collect::<HashMap<_, _>>();
+        let initial_types = self.initial_typeck_types(&param_types, generic_vars)?;
 
         // Add const generics as variables.
         for (key, value) in &generic_vars.inst_i32 {
             let tr_val = self.compile_constant(module, block_id, generic_vars, *value)?;
-            initial_types.insert(key.clone(), tr_val.ty.clone());
+            ctx.vars.insert(key.clone(), tr_val);
+        }
+
+        for (key, value) in &generic_vars.inst_bool {
+            let tr_val = self.compile_bool_constant(module, block_id, generic_vars, *value)?;
             ctx.vars.insert(key.clone(), tr_val);
         }
 
@@ -352,7 +493,6 @@ impl<'m> CUDATileFunctionCompiler<'m> {
             let tr_val = self
                 .compile_expression(module, block_id, &arr_expr, generic_vars, &mut ctx, ty)?
                 .expect("Failed to compile CGA as var.");
-            initial_types.insert(key.clone(), tr_val.ty.clone());
             ctx.vars.insert(key.clone(), tr_val);
         }
 
@@ -432,8 +572,13 @@ impl<'m> CUDATileFunctionCompiler<'m> {
     ) -> Result<Vec<TileRustValue>, JITError> {
         let mut result = vec![];
         for arg in args {
+            let expected = if matches!(arg, syn::Expr::Lit(_) | syn::Expr::Unary(_)) {
+                self.typeck_expr_tile_type(arg, generic_args, &HashMap::new())?
+            } else {
+                None
+            };
             let value = self
-                .compile_expression(module, block_id, &arg, generic_args, ctx, None)?
+                .compile_expression(module, block_id, &arg, generic_args, ctx, expected)?
                 .ok_or(self.jit_error(
                     &arg.span(),
                     &format!(
@@ -471,6 +616,25 @@ impl<'m> CUDATileFunctionCompiler<'m> {
             .compile_type(&rust_ty, &generic_vars, &HashMap::new())?
             .ok_or(self.jit_error(&rust_ty.span(), "failed to compile constant"))?;
         self.compile_constant_from_exact_bounds(module, block_id, bounds, tr_ty)
+    }
+
+    pub(crate) fn compile_bool_constant(
+        &self,
+        module: &mut Module,
+        block_id: cutile_ir::ir::BlockId,
+        generic_vars: &GenericVars,
+        x: bool,
+    ) -> Result<TileRustValue, JITError> {
+        let rust_ty: syn::Type = syn::parse_quote!(bool);
+        let tr_ty = self
+            .compile_type(&rust_ty, generic_vars, &HashMap::new())?
+            .ok_or(self.jit_error(&rust_ty.span(), "failed to compile bool constant"))?;
+        self.compile_constant_from_exact_bounds(
+            module,
+            block_id,
+            Bounds::exact(if x { 1 } else { 0 }),
+            tr_ty,
+        )
     }
 
     pub(crate) fn compile_constant_from_exact_bounds(
@@ -546,8 +710,13 @@ impl<'m> CUDATileFunctionCompiler<'m> {
         Ok(tr_val)
     }
 
-    /// Derive the return type for an expression based on type parameters.
-    /// Mechanical port of `CUDATileFunctionCompiler::derive_type`.
+    /// Return the typeck side-table type for an expression when possible, then
+    /// fall back to op-signature derivation for types whose Tile IR params are
+    /// completed from call arguments.
+    ///
+    /// The old recursive type derivation path is still available behind
+    /// `CUTILE_DERIVE_TYPE_LEGACY` for debugging, but the compiler should
+    /// normally consume Pass 2 typeck results instead of re-deriving types.
     pub(crate) fn derive_type(
         &self,
         module: &mut Module,
@@ -561,14 +730,32 @@ impl<'m> CUDATileFunctionCompiler<'m> {
         use crate::types::TypeParam;
         use syn::Expr;
 
+        if std::env::var_os("CUTILE_DERIVE_TYPE_LEGACY").is_none() {
+            let typeck_type_params = maybe_type_params
+                .as_ref()
+                .map(|type_params| {
+                    type_params
+                        .iter()
+                        .filter_map(|type_param| {
+                            type_param
+                                .name()
+                                .map(|name| (name.to_string(), type_param.clone()))
+                        })
+                        .collect::<HashMap<_, _>>()
+                })
+                .unwrap_or_default();
+            if let Some(return_type) =
+                self.typeck_expr_tile_type(expr, generic_vars, &typeck_type_params)?
+            {
+                return Ok(Some(return_type));
+            }
+        }
+
         match expr {
             Expr::MethodCall(method_call_expr) => {
                 let ident = &method_call_expr.method;
                 if let Some(return_type) = self
-                    .typeck_results
-                    .borrow()
-                    .as_ref()
-                    .and_then(|results| results.method_selection(method_call_expr).cloned())
+                    .typeck_method_selection(method_call_expr)
                     .and_then(|selection| selection.return_type)
                 {
                     return Ok(Some(return_type));
@@ -651,7 +838,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                         &method_call_expr.method.span(),
                         &format!(
                             "Failed to infer all generic parameters for {}",
-                            method_call_expr.to_token_stream().to_string()
+                            user_method_call_tokens(method_call_expr)
                         ),
                     );
                 }
@@ -717,7 +904,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                         &method_call_expr.method.span(),
                         &format!(
                             "Failed to derive output for {} \ncall_output_type={}",
-                            method_call_expr.to_token_stream().to_string(),
+                            user_method_call_tokens(method_call_expr),
                             call_output_type.to_token_stream().to_string()
                         ),
                     );
@@ -795,7 +982,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                             &call_expr.func.span(),
                             &format!(
                                 "Failed to infer all generic parameters for {}",
-                                call_expr.to_token_stream().to_string()
+                                user_call_tokens(call_expr)
                             ),
                         );
                     }
@@ -863,7 +1050,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                                 &call_expr.func.span(),
                                 &format!(
                                     "Failed to derive output for {} \ngeneric_vars={generic_vars:#?} \ntype_params={type_params:#?}",
-                                    call_expr.to_token_stream().to_string()
+                                    user_call_tokens(call_expr)
                                 ),
                             );
                     }
@@ -876,7 +1063,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                                 "Closure calls are not supported.\n\
                                  Closures can only be used as arguments to operations like reduce() or scan().\n\
                                  Found: {}",
-                                call_expr.to_token_stream().to_string()
+                                user_call_tokens(call_expr)
                             ),
                         );
                 }

--- a/cutile-compiler/src/compiler/_module.rs
+++ b/cutile-compiler/src/compiler/_module.rs
@@ -20,8 +20,8 @@ use quote::ToTokens;
 use std::collections::{HashMap, HashSet};
 use syn::spanned::Spanned;
 use syn::{
-    Expr, ExprMethodCall, GenericArgument, GenericParam, ImplItem, ImplItemFn, ItemFn, ItemImpl,
-    ItemMod, ItemStruct, PathArguments, Type,
+    Expr, ExprMethodCall, GenericArgument, GenericParam, ImplItem, ImplItemFn, ItemConst, ItemFn,
+    ItemImpl, ItemMod, ItemStatic, ItemStruct, ItemTrait, ItemType, PathArguments, Type,
 };
 
 /// Aggregated index of all DSL modules, types, impls, and functions.
@@ -76,16 +76,65 @@ impl CUDATileModules {
         self.name_resolver.structs()
     }
 
+    /// Flat map of all traits: name → ItemTrait.
+    /// Compatibility shim.
+    pub fn traits(&self) -> &HashMap<String, ItemTrait> {
+        self.name_resolver.traits()
+    }
+
+    /// Flat map of all type aliases: name → ItemType.
+    /// Compatibility shim.
+    pub fn type_aliases(&self) -> &HashMap<String, ItemType> {
+        self.name_resolver.type_aliases()
+    }
+
+    /// Flat map of all constants: name → ItemConst.
+    /// Compatibility shim.
+    pub fn consts(&self) -> &HashMap<String, ItemConst> {
+        self.name_resolver.consts()
+    }
+
+    /// Flat map of all static items: name → ItemStatic.
+    /// Compatibility shim.
+    pub fn statics(&self) -> &HashMap<String, ItemStatic> {
+        self.name_resolver.statics()
+    }
+
     /// Flat map of all struct impls: struct_name → [(module, ItemImpl)].
     /// Compatibility shim.
     pub fn struct_impls(&self) -> &HashMap<String, Vec<(String, ItemImpl)>> {
         self.name_resolver.struct_impls()
     }
 
+    /// Flat map of all trait impls: (trait, self_ty) → [(module, ItemImpl)].
+    /// Compatibility shim.
+    pub fn trait_impls(&self) -> &HashMap<(String, String), Vec<(String, ItemImpl)>> {
+        self.name_resolver.trait_impls()
+    }
+
     /// Flat map of all functions: name → (module, ItemFn).
     /// Compatibility shim.
     pub fn functions(&self) -> &HashMap<String, (String, ItemFn)> {
         self.name_resolver.functions()
+    }
+
+    /// Expand DSL-visible type aliases in a Rust type.
+    pub fn normalize_type_aliases(&self, ty: &Type) -> Result<Type, JITError> {
+        let normalized = crate::type_aliases::normalize_type_aliases(ty, self.type_aliases())
+            .map_err(|msg| {
+                SourceLocation::unknown().jit_error(&format!(
+                    "failed to normalize type `{}`: {msg}",
+                    ty.to_token_stream()
+                ))
+            })?;
+        crate::type_aliases::normalize_const_paths_in_type(&normalized, self.consts()).map_err(
+            |msg| {
+                SourceLocation::unknown().jit_error(&format!(
+                    "failed to normalize type `{}`: {msg}",
+                    ty.to_token_stream()
+                ))
+            },
+        )
     }
 
     /// Return the import-catalog hint message for `name` if the name was
@@ -126,7 +175,12 @@ impl CUDATileModules {
             }
 
             module_asts.push((module_name.clone(), module_ast.clone()));
-            span_bases.insert(module_name, module.span_base().clone());
+            let span_base = module.span_base().clone();
+            span_bases.insert(module_name.clone(), span_base.clone());
+            let absolute_path = module.absolute_path();
+            if absolute_path != module_name {
+                span_bases.insert(absolute_path.to_string(), span_base);
+            }
         }
 
         // Pass 1: Build the name resolver (indexes all items, processes imports).
@@ -832,5 +886,80 @@ impl CUDATileModules {
     pub fn get_struct_field_type(&self, struct_name: &str, field_name: &str) -> Option<Type> {
         self.name_resolver
             .get_struct_field_type(struct_name, field_name)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_records_span_base_by_short_name_and_absolute_path() {
+        let ast: ItemMod = syn::parse_quote! {
+            mod my_module {}
+        };
+        let span_base = SpanBase::new("source.rs".to_string(), 12, 4);
+        let mut module = Module::with_span_base("my_module", ast, span_base.clone());
+        module.set_absolute_path("my_crate::my_module".to_string());
+
+        let modules = CUDATileModules::new(vec![module]).expect("module construction");
+
+        assert_eq!(
+            modules
+                .get_span_base("my_module")
+                .map(|base| base.file.as_str()),
+            Some("source.rs")
+        );
+        assert_eq!(
+            modules
+                .get_span_base("my_crate::my_module")
+                .map(|base| base.file.as_str()),
+            Some("source.rs")
+        );
+    }
+
+    #[test]
+    fn method_lookup_prefers_inherent_impl_before_trait_impl() {
+        let ast: ItemMod = syn::parse_quote! {
+            mod my_module {
+                struct Foo;
+
+                trait Pick {
+                    fn pick(&self) -> i32;
+                }
+
+                impl Foo {
+                    fn pick(&self) -> i64 {
+                        0i64
+                    }
+                }
+
+                impl Pick for Foo {
+                    fn pick(&self) -> i32 {
+                        0i32
+                    }
+                }
+            }
+        };
+        let modules =
+            CUDATileModules::new(vec![Module::new("my_module", ast)]).expect("module construction");
+        let method_call: ExprMethodCall = syn::parse_quote!(foo.pick());
+        let receiver_ty: Type = syn::parse_quote!(Foo);
+        let call_arg_rust_tys = vec![receiver_ty.clone()];
+
+        let Some((_module_name, _impl_item, impl_method)) = modules
+            .get_impl_item_fn(
+                &receiver_ty,
+                &method_call,
+                &GenericVars::empty_unchecked(),
+                &call_arg_rust_tys,
+            )
+            .expect("method lookup")
+        else {
+            panic!("expected method lookup to select a method");
+        };
+        let (_inputs, return_ty) = get_sig_types(&impl_method.sig, Some(&receiver_ty));
+
+        assert_eq!(return_ty.to_token_stream().to_string(), "i64");
     }
 }

--- a/cutile-compiler/src/compiler/compile_block.rs
+++ b/cutile-compiler/src/compiler/compile_block.rs
@@ -17,7 +17,7 @@ use super::tile_rust_type::TileRustType;
 use crate::error::{JITError, SpannedJITError};
 use crate::generics::GenericVars;
 use crate::syn_utils::*;
-use crate::types::{get_pat_mutability, get_type_mutability};
+use crate::types::get_type_mutability;
 
 use cutile_ir::builder::{append_op, OpBuilder};
 use cutile_ir::bytecode::Opcode;
@@ -29,6 +29,187 @@ use syn::spanned::Spanned;
 use syn::{Expr, Item, Pat, Stmt};
 
 impl<'m> CUDATileFunctionCompiler<'m> {
+    fn bind_pattern_value(
+        &self,
+        pat: &Pat,
+        value: TileRustValue,
+        inherited_mutability: bool,
+        ctx: &mut CompilerContext,
+    ) -> Result<(), JITError> {
+        match pat {
+            Pat::Ident(ident) => {
+                let mut value = value;
+                value.mutability = if inherited_mutability || ident.mutability.is_some() {
+                    Mutability::Mutable
+                } else {
+                    Mutability::Immutable
+                };
+                ctx.vars.insert(ident.ident.to_string(), value.clone());
+                if let Some((_at, subpat)) = &ident.subpat {
+                    self.bind_pattern_value(subpat, value, inherited_mutability, ctx)?;
+                }
+                Ok(())
+            }
+            Pat::Type(pat_type) => self.bind_pattern_value(
+                &pat_type.pat,
+                value,
+                inherited_mutability || get_type_mutability(&pat_type.ty),
+                ctx,
+            ),
+            Pat::Paren(paren) => {
+                self.bind_pattern_value(&paren.pat, value, inherited_mutability, ctx)
+            }
+            Pat::Reference(reference) => self.bind_pattern_value(
+                &reference.pat,
+                value,
+                inherited_mutability || reference.mutability.is_some(),
+                ctx,
+            ),
+            Pat::Tuple(tuple) => {
+                let Some(elements) = value.values.clone() else {
+                    return self.jit_error_result(
+                        &tuple.span(),
+                        "right-hand side of tuple destructuring must be a tuple expression",
+                    );
+                };
+                if elements.len() != tuple.elems.len() {
+                    return self.jit_error_result(
+                        &tuple.span(),
+                        &format!(
+                            "tuple pattern has {} bindings but the expression produces {} values",
+                            tuple.elems.len(),
+                            elements.len()
+                        ),
+                    );
+                }
+                for (pat, value) in tuple.elems.iter().zip(elements.into_iter()) {
+                    self.bind_pattern_value(pat, value, inherited_mutability, ctx)?;
+                }
+                Ok(())
+            }
+            Pat::Slice(slice) => {
+                let Some(elements) = value.values.clone() else {
+                    return self.jit_error_result(
+                        &slice.span(),
+                        "right-hand side of slice destructuring must be an array expression",
+                    );
+                };
+                let pats = slice.elems.iter().collect::<Vec<_>>();
+                let rest_pos = pats.iter().position(|pat| matches!(pat, Pat::Rest(_)));
+                match rest_pos {
+                    Some(rest_pos) => {
+                        if pats.len().saturating_sub(1) > elements.len() {
+                            return self.jit_error_result(
+                                &slice.span(),
+                                &format!(
+                                    "slice pattern requires at least {} values but the expression produces {} values",
+                                    pats.len() - 1,
+                                    elements.len()
+                                ),
+                            );
+                        }
+                        for idx in 0..rest_pos {
+                            self.bind_pattern_value(
+                                pats[idx],
+                                elements[idx].clone(),
+                                inherited_mutability,
+                                ctx,
+                            )?;
+                        }
+                        let suffix_len = pats.len() - rest_pos - 1;
+                        for suffix_idx in 0..suffix_len {
+                            self.bind_pattern_value(
+                                pats[rest_pos + 1 + suffix_idx],
+                                elements[elements.len() - suffix_len + suffix_idx].clone(),
+                                inherited_mutability,
+                                ctx,
+                            )?;
+                        }
+                    }
+                    None => {
+                        if pats.len() != elements.len() {
+                            return self.jit_error_result(
+                                &slice.span(),
+                                &format!(
+                                    "slice pattern has {} bindings but the expression produces {} values",
+                                    pats.len(),
+                                    elements.len()
+                                ),
+                            );
+                        }
+                        for (pat, value) in pats.into_iter().zip(elements.into_iter()) {
+                            self.bind_pattern_value(pat, value, inherited_mutability, ctx)?;
+                        }
+                    }
+                }
+                Ok(())
+            }
+            Pat::Struct(pat_struct) => {
+                if value.kind != Kind::Struct {
+                    return self.jit_error_result(
+                        &pat_struct.span(),
+                        "right-hand side of struct destructuring must be a struct value",
+                    );
+                }
+                let Some(fields) = value.fields.clone() else {
+                    return self.jit_error_result(
+                        &pat_struct.span(),
+                        "struct value is missing its field data (internal)",
+                    );
+                };
+                for field in &pat_struct.fields {
+                    let syn::Member::Named(field_name) = &field.member else {
+                        return self.jit_error_result(
+                            &field.member.span(),
+                            "tuple struct patterns are not supported in struct destructuring",
+                        );
+                    };
+                    let Some(field_value) = fields.get(&field_name.to_string()).cloned() else {
+                        return self.jit_error_result(
+                            &field.member.span(),
+                            &format!("{} is not a field", field_name),
+                        );
+                    };
+                    self.bind_pattern_value(&field.pat, field_value, inherited_mutability, ctx)?;
+                }
+                Ok(())
+            }
+            Pat::TupleStruct(tuple_struct) => {
+                let Some(elements) = value.values.clone() else {
+                    return self.jit_error_result(
+                        &tuple_struct.span(),
+                        "right-hand side of tuple-struct destructuring must be a compound value",
+                    );
+                };
+                if elements.len() != tuple_struct.elems.len() {
+                    return self.jit_error_result(
+                        &tuple_struct.span(),
+                        &format!(
+                            "tuple-struct pattern has {} bindings but the expression produces {} values",
+                            tuple_struct.elems.len(),
+                            elements.len()
+                        ),
+                    );
+                }
+                for (pat, value) in tuple_struct.elems.iter().zip(elements.into_iter()) {
+                    self.bind_pattern_value(pat, value, inherited_mutability, ctx)?;
+                }
+                Ok(())
+            }
+            Pat::Or(or_pat) => {
+                for case in &or_pat.cases {
+                    self.bind_pattern_value(case, value.clone(), inherited_mutability, ctx)?;
+                }
+                Ok(())
+            }
+            Pat::Wild(_) | Pat::Rest(_) => Ok(()),
+            _ => self.jit_error_result(
+                &pat.span(),
+                "this pattern form is not supported in let bindings",
+            ),
+        }
+    }
+
     pub fn compile_block(
         &self,
         module: &mut Module,
@@ -47,238 +228,38 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                 let is_last = i == num_statements - 1;
                 match statement {
                     Stmt::Local(local) => {
-                        let var_name: Option<String>;
-                        let mut ct_ty: Option<TileRustType> = None;
-                        let mut mutability: bool = false;
-                        match &local.pat {
-                            Pat::Type(pat_type) => {
-                                let pat_mutability = get_pat_mutability(&pat_type.pat);
-                                let ty_mutability = get_type_mutability(&pat_type.ty);
-                                mutability = pat_mutability || ty_mutability;
-                                match &*pat_type.pat {
-                                    Pat::Ident(pat_ident) => {
-                                        var_name = Some(pat_ident.ident.to_string());
-                                    }
-                                    Pat::Tuple(pat_tuple) => {
-                                        ct_ty = self.compile_type(
-                                            &*pat_type.ty,
-                                            generic_args,
-                                            &HashMap::new(),
-                                        )?;
-
-                                        let Some(init) = &local.init else {
-                                            return self.jit_error_result(
-                                                &local.span(),
-                                                "tuple destructuring requires an initializer expression",
-                                            );
-                                        };
-                                        let Some(tuple_value) = self.compile_expression(
-                                            module,
-                                            block_id,
-                                            &*init.expr,
-                                            generic_args,
-                                            ctx,
-                                            ct_ty.clone(),
-                                        )?
-                                        else {
-                                            return self.jit_error_result(
-                                                &init.expr.span(),
-                                                "failed to compile tuple initializer expression",
-                                            );
-                                        };
-
-                                        let mut tuple_var_names = vec![];
-                                        for elem in &pat_tuple.elems {
-                                            match elem {
-                                                Pat::Ident(ident) => {
-                                                    tuple_var_names
-                                                        .push(ident.ident.to_string());
-                                                }
-                                                _ => {
-                                                    return self.jit_error_result(
-                                                        &elem.span(),
-                                                        "only simple variable names are supported in tuple destructuring patterns",
-                                                    )
-                                                }
-                                            }
-                                        }
-
-                                        if tuple_value.kind == Kind::Compound {
-                                            let Some(elements) = &tuple_value.values else {
-                                                return self.jit_error_result(
-                                                    &init.expr.span(),
-                                                    "internal: expected compound value for tuple destructuring",
-                                                );
-                                            };
-                                            if elements.len() != tuple_var_names.len() {
-                                                return self.jit_error_result(
-                                                    &init.expr.span(),
-                                                    &format!(
-                                                        "tuple pattern has {} bindings but the expression produces {} values",
-                                                        tuple_var_names.len(),
-                                                        elements.len()
-                                                    ),
-                                                );
-                                            }
-                                            for (i, var_name) in
-                                                tuple_var_names.iter().enumerate()
-                                            {
-                                                let mut elem_value = elements[i].clone();
-                                                elem_value.mutability = if mutability {
-                                                    Mutability::Mutable
-                                                } else {
-                                                    Mutability::Immutable
-                                                };
-                                                ctx.vars
-                                                    .insert(var_name.clone(), elem_value);
-                                            }
-                                        } else {
-                                            return self.jit_error_result(
-                                                &init.expr.span(),
-                                                "right-hand side of tuple destructuring must be a tuple expression",
-                                            );
-                                        }
-                                        continue;
-                                    }
-                                    _ => {
-                                        return self.jit_error_result(
-                                            &pat_type.pat.span(),
-                                            "this pattern form is not supported on the left side of a let binding",
-                                        )
-                                    }
-                                }
-                                ct_ty = self.compile_type(
-                                    &*pat_type.ty,
-                                    generic_args,
-                                    &HashMap::new(),
-                                )?;
-                            }
-                            Pat::Ident(pat_ident) => {
-                                var_name = Some(pat_ident.ident.to_string());
-                            }
-                            Pat::Tuple(pat_tuple) => {
-                                let Some(init) = &local.init else {
-                                    return self.jit_error_result(
-                                        &local.span(),
-                                        "tuple destructuring requires an initializer expression",
-                                    );
-                                };
-
-                                let Some(tuple_value) = self.compile_expression(
-                                    module,
-                                    block_id,
-                                    &*init.expr,
-                                    generic_args,
-                                    ctx,
-                                    ct_ty.clone(),
-                                )?
-                                else {
-                                    return self.jit_error_result(
-                                        &init.expr.span(),
-                                        "failed to compile tuple initializer expression",
-                                    );
-                                };
-
-                                let mut tuple_var_names = vec![];
-                                for elem in &pat_tuple.elems {
-                                    match elem {
-                                        Pat::Ident(ident) => {
-                                            tuple_var_names.push(ident.ident.to_string());
-                                        }
-                                        _ => {
-                                            return self.jit_error_result(
-                                                &elem.span(),
-                                                "only simple variable names are supported in tuple destructuring patterns",
-                                            )
-                                        }
-                                    }
-                                }
-
-                                if tuple_value.kind == Kind::Compound {
-                                    let Some(elements) = &tuple_value.values else {
-                                        return self.jit_error_result(
-                                            &init.expr.span(),
-                                            "internal: expected compound value for tuple destructuring",
-                                        );
-                                    };
-                                    if elements.len() != tuple_var_names.len() {
-                                        return self.jit_error_result(
-                                            &init.expr.span(),
-                                            &format!(
-                                                "tuple pattern has {} bindings but the expression produces {} values",
-                                                tuple_var_names.len(),
-                                                elements.len()
-                                            ),
-                                        );
-                                    }
-                                    for (i, var_name) in tuple_var_names.iter().enumerate() {
-                                        let mut elem_value = elements[i].clone();
-                                        elem_value.mutability = if mutability {
-                                            Mutability::Mutable
-                                        } else {
-                                            Mutability::Immutable
-                                        };
-                                        ctx.vars.insert(var_name.clone(), elem_value);
-                                    }
-                                } else {
-                                    return self.jit_error_result(
-                                        &init.expr.span(),
-                                        "right-hand side of tuple destructuring must be a tuple expression",
-                                    );
-                                }
-
-                                continue;
-                            }
-                            _ => {
-                                return self.jit_error_result(
-                                    &local.pat.span(),
-                                    "this pattern form is not supported in let bindings",
-                                );
-                            }
-                        }
-                        if var_name.is_none() {
+                        let Some(init) = &local.init else {
                             return self.jit_error_result(
                                 &local.span(),
-                                "unable to determine variable name for let binding",
+                                "let bindings must have an initializer expression",
                             );
-                        }
-                        let var_name = var_name.unwrap();
-                        match &local.init {
-                            Some(init) => {
-                                match self.compile_expression(
-                                    module,
-                                    block_id,
-                                    &*init.expr,
-                                    generic_args,
-                                    ctx,
-                                    ct_ty,
-                                )? {
-                                    Some(mut value) => {
-                                        value.mutability = if mutability {
-                                            Mutability::Mutable
-                                        } else {
-                                            Mutability::Immutable
-                                        };
-                                        ctx.vars.insert(var_name, value);
-                                    }
-                                    None => {
-                                        return self.jit_error_result(
-                                            &init.expr.span(),
-                                            &format!(
-                                                "failed to compile initializer: `{}`",
-                                                init.expr.to_token_stream().to_string()
-                                            ),
-                                        )
-                                    }
-                                }
-                            }
-                            None => {
-                                return self.jit_error_result(
-                                    &local.span(),
-                                    "let bindings must have an initializer expression",
-                                )
-                            }
                         };
+                        let annotated_ty = local_pattern_type(&local.pat);
+                        let annotated_ct_ty = match annotated_ty {
+                            Some(ty) => self.compile_type(ty, generic_args, &HashMap::new())?,
+                            None => None,
+                        };
+                        let init_ty = self
+                            .typeck_expr_tile_type(&init.expr, generic_args, &HashMap::new())?
+                            .or(annotated_ct_ty);
+                        let Some(value) = self.compile_expression(
+                            module,
+                            block_id,
+                            &*init.expr,
+                            generic_args,
+                            ctx,
+                            init_ty,
+                        )?
+                        else {
+                            return self.jit_error_result(
+                                &init.expr.span(),
+                                &format!(
+                                    "failed to compile initializer: `{}`",
+                                    init.expr.to_token_stream()
+                                ),
+                            );
+                        };
+                        self.bind_pattern_value(&local.pat, value, false, ctx)?;
                     }
                     Stmt::Item(item) => {
                         match item {
@@ -370,6 +351,11 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                                         )
                                     }
                                 };
+                            let rhs_ty = self.typeck_expr_tile_type(
+                                &assign_expr.right,
+                                generic_args,
+                                &HashMap::new(),
+                            )?;
                             let mut ct_value: TileRustValue =
                                 match self.compile_expression(
                                     module,
@@ -377,7 +363,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                                     &*assign_expr.right,
                                     generic_args,
                                     ctx,
-                                    None,
+                                    rhs_ty,
                                 )? {
                                     Some(value) => value,
                                     None => return self.jit_error_result(
@@ -494,5 +480,12 @@ impl<'m> CUDATileFunctionCompiler<'m> {
             }
             Ok(return_value)
         }) // stacker::maybe_grow
+    }
+}
+
+fn local_pattern_type(pat: &Pat) -> Option<&syn::Type> {
+    match pat {
+        Pat::Type(pat_type) => Some(pat_type.ty.as_ref()),
+        _ => None,
     }
 }

--- a/cutile-compiler/src/compiler/compile_cuda_tile_op.rs
+++ b/cutile-compiler/src/compiler/compile_cuda_tile_op.rs
@@ -15,6 +15,7 @@ use super::tile_rust_type::TileRustType;
 use crate::bounds::Bounds;
 use crate::error::JITError;
 use crate::generics::{get_cga_from_type, GenericVars};
+use crate::passes::name_resolution::{DefKind, Res};
 use crate::syn_utils::*;
 use crate::types::*;
 
@@ -38,6 +39,21 @@ const NESTED_MUTABLE_ACCESS_OFFSET_META: &str = "nested_mutable_access_offset";
 // ---------------------------------------------------------------------------
 // Helpers ported from old CompilerContext utilities
 // ---------------------------------------------------------------------------
+
+fn dense_const_path_parts(path_expr: &syn::ExprPath) -> Option<(String, String)> {
+    let const_name = path_expr
+        .path
+        .segments
+        .last()
+        .map(|segment| segment.ident.to_string())?;
+    if let Some(qself) = &path_expr.qself {
+        return get_type_ident(&qself.ty).map(|ty| (ty.to_string(), const_name));
+    }
+    if path_expr.path.segments.len() != 2 {
+        return None;
+    }
+    Some((path_expr.path.segments[0].ident.to_string(), const_name))
+}
 
 /// Resolves `static_params` from a `#[cuda_tile::op]` attribute against call-site arguments.
 ///
@@ -212,6 +228,44 @@ fn extract_latency_cycles(expr: &Expr, generic_args: &GenericVars) -> Result<i32
 }
 
 impl<'m> CUDATileFunctionCompiler<'m> {
+    fn dense_module_const_path_value(
+        &self,
+        path_expr: &syn::ExprPath,
+    ) -> Result<Option<String>, JITError> {
+        if path_expr.qself.is_some() || path_expr.path.segments.len() != 1 {
+            return Ok(None);
+        }
+        let res = self
+            .modules
+            .name_resolver
+            .resolve_path(&path_expr.path, &self.module_name);
+        let Res::Def(DefKind::Const, def_id) = res else {
+            return Ok(None);
+        };
+        let Some(item) = self.modules.name_resolver.get_const(&def_id) else {
+            return self.jit_error_result(&path_expr.span(), "failed to resolve constant");
+        };
+        match item.expr.as_ref() {
+            Expr::Lit(lit) => match &lit.lit {
+                Lit::Bool(value) => Ok(Some(value.value.to_string())),
+                Lit::Int(value) => Ok(Some(value.base10_digits().to_string())),
+                Lit::Float(value) => Ok(Some(value.base10_digits().to_string())),
+                _ => Ok(None),
+            },
+            Expr::Unary(unary) if matches!(unary.op, UnOp::Neg(_)) => {
+                let Expr::Lit(lit) = unary.expr.as_ref() else {
+                    return Ok(None);
+                };
+                match &lit.lit {
+                    Lit::Int(value) => Ok(Some(format!("-{}", value.base10_digits()))),
+                    Lit::Float(value) => Ok(Some(format!("-{}", value.base10_digits()))),
+                    _ => Ok(None),
+                }
+            }
+            _ => Ok(None),
+        }
+    }
+
     fn offset_nested_mutable_indices(
         &self,
         module: &mut Module,
@@ -2045,10 +2099,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                 "constant" => {
                     return self.jit_error_result(
                         &call_expr.span(),
-                        &format!(
-                            "Return type required for {}",
-                            call_expr.to_token_stream().to_string()
-                        ),
+                        &format!("Return type required for {}", user_call_tokens(call_expr)),
                     )
                 }
                 _ => {}
@@ -2065,7 +2116,15 @@ impl<'m> CUDATileFunctionCompiler<'m> {
             return_type
         };
         if return_type.is_none() {
-            return self.jit_error_result(&call_expr.span(), "Unable to infer return type for op");
+            return self.jit_error_result(
+                &call_expr.span(),
+                &format!(
+                    "Unable to infer return type for CUDA Tile op `{}` (Tile IR `{}`) from call `{}`",
+                    rust_function_name,
+                    op_name,
+                    user_call_tokens(call_expr)
+                ),
+            );
         }
         let return_type = return_type.unwrap();
 
@@ -2082,7 +2141,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                 for i in 0..param_names.len() {
                     if param_names[i] == field_meta_expr_param {
                         let call_expr_arg = &call_expr.args[i];
-                        let call_expr_arg_str = call_expr_arg.to_token_stream().to_string();
+                        let call_expr_arg_str = user_expr_tokens(call_expr_arg);
                         let final_expr_str =
                             field_meta_expr_str.replace(field_meta_expr_param, &call_expr_arg_str);
                         let final_expr =
@@ -2116,7 +2175,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
         let mut compiled_args: Vec<TileRustValue> = Vec::new();
         for i in 0..cuda_tile_op_params.len() {
             let call_expr_arg = &call_expr.args[i];
-            let call_expr_arg_str = call_expr_arg.to_token_stream().to_string();
+            let call_expr_arg_str = user_expr_tokens(call_expr_arg);
             let op_arg =
                 self.compile_expression(module, block_id, call_expr_arg, generic_args, ctx, None)?;
             if op_arg.is_none() {
@@ -2305,7 +2364,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                     }
                     maybe_next_attr_param = cuda_tile_op_attr_params_iter.next();
                     let call_expr_arg = &call_expr.args[i];
-                    let call_expr_arg_str = call_expr_arg.to_token_stream().to_string();
+                    let call_expr_arg_str = user_expr_tokens(call_expr_arg);
                     let op_arg = self.compile_expression(
                         module,
                         block_id,
@@ -2400,36 +2459,39 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                             }
                         }
                         Expr::Path(path_expr) => {
-                            let path_expr_string = path_expr.to_token_stream().to_string();
-                            let ty_val_split = path_expr_string.split(" :: ").collect::<Vec<_>>();
-                            if ty_val_split.len() != 2 {
-                                return self.jit_error_result(
-                                    &path_expr.span(),
-                                    "Unexpected dense value.",
-                                );
-                            }
-                            let (ty_raw, const_val) =
-                                (ty_val_split[0].to_string(), ty_val_split[1].to_string());
-                            // Resolve generic type parameters (e.g. `T::ZERO` where
-                            // `T` is a kernel generic) to their concrete
-                            // monomorphized type name before dispatching to
-                            // `get_const_hex`.
-                            let ty = generic_args
-                                .inst_types
-                                .get(&ty_raw)
-                                .cloned()
-                                .unwrap_or(ty_raw);
-                            match const_val.as_str() {
-                                "ZERO" => (get_const_hex(ty.as_str(), "zero")?, ty.clone()),
-                                "ONE" => (get_const_hex(ty.as_str(), "one")?, ty.clone()),
-                                "NEG_INFINITY" => (get_const_hex(ty.as_str(), "min")?, ty.clone()),
-                                "INFINITY" => (get_const_hex(ty.as_str(), "max")?, ty.clone()),
-                                "E" => (get_const_hex(ty.as_str(), "e")?, ty.clone()),
-                                _ => {
+                            if let Some(value) = self.dense_module_const_path_value(path_expr)? {
+                                (value, String::new())
+                            } else {
+                                let Some((ty_raw, const_val)) = dense_const_path_parts(path_expr)
+                                else {
                                     return self.jit_error_result(
-                                        &call_expr.args[i].span(),
-                                        "Constant not supported",
-                                    )
+                                        &path_expr.span(),
+                                        "Unexpected dense value.",
+                                    );
+                                };
+                                // Resolve generic type parameters (e.g. `T::ZERO` where
+                                // `T` is a kernel generic) to their concrete
+                                // monomorphized type name before dispatching to
+                                // `get_const_hex`.
+                                let ty = generic_args
+                                    .inst_types
+                                    .get(&ty_raw)
+                                    .cloned()
+                                    .unwrap_or(ty_raw);
+                                match const_val.as_str() {
+                                    "ZERO" => (get_const_hex(ty.as_str(), "zero")?, ty.clone()),
+                                    "ONE" => (get_const_hex(ty.as_str(), "one")?, ty.clone()),
+                                    "NEG_INFINITY" => {
+                                        (get_const_hex(ty.as_str(), "min")?, ty.clone())
+                                    }
+                                    "INFINITY" => (get_const_hex(ty.as_str(), "max")?, ty.clone()),
+                                    "E" => (get_const_hex(ty.as_str(), "e")?, ty.clone()),
+                                    _ => {
+                                        return self.jit_error_result(
+                                            &call_expr.args[i].span(),
+                                            "Constant not supported",
+                                        )
+                                    }
                                 }
                             }
                         }

--- a/cutile-compiler/src/compiler/compile_expression.rs
+++ b/cutile-compiler/src/compiler/compile_expression.rs
@@ -14,8 +14,9 @@ use super::_value::{BlockTerminator, CompilerContext, TileRustValue};
 use super::shared_types::Kind;
 use super::shared_utils::{
     collect_mutated_variables, collect_mutated_variables_from_block,
-    collect_mutated_variables_loop, collect_mutated_variables_while, dedup,
-    update_outer_block_type_meta, STACK_GROW_SIZE, STACK_RED_ZONE,
+    collect_mutated_variables_from_expr, collect_mutated_variables_loop,
+    collect_mutated_variables_while, dedup, update_outer_block_type_meta, STACK_GROW_SIZE,
+    STACK_RED_ZONE,
 };
 use super::tile_rust_type::TileRustType;
 use crate::bounds::Bounds;
@@ -29,11 +30,12 @@ use cutile_ir::builder::{append_op, build_block, OpBuilder};
 use cutile_ir::bytecode::Opcode;
 use cutile_ir::ir::{Attribute, BlockId, Location, Module, Region};
 
-use proc_macro2::TokenTree;
 use quote::ToTokens;
 use std::collections::{BTreeMap, HashMap};
+use syn::parse::Parser;
+use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
-use syn::{parse_quote, Expr, Lit, Member, Pat, UnOp};
+use syn::{parse_quote, Expr, ExprMacro, Lit, Member, Pat, Token, UnOp};
 
 impl<'m> CUDATileFunctionCompiler<'m> {
     /// Construct a ZST marker type placeholder from a path expression.
@@ -53,6 +55,123 @@ impl<'m> CUDATileFunctionCompiler<'m> {
         TileRustValue::new_string(Expr::Path(path_expr.clone()), ty)
     }
 
+    fn const_shape_macro_args(
+        &self,
+        mac_expr: &ExprMacro,
+        generic_vars: &GenericVars,
+        ctx: &CompilerContext,
+    ) -> Result<Vec<String>, JITError> {
+        let parser = Punctuated::<Expr, Token![,]>::parse_terminated;
+        let exprs = parser.parse2(mac_expr.mac.tokens.clone()).map_err(|err| {
+            self.jit_error(
+                &mac_expr.span(),
+                &format!("failed to parse const-shape macro arguments: {err}"),
+            )
+        })?;
+        let expr_count = exprs.len();
+        let mut args = Vec::new();
+        for expr in exprs {
+            match &expr {
+                Expr::Path(path) if path.path.segments.len() == 1 => {
+                    let name = get_ident_from_path_expr(path).to_string();
+                    if let Some(cga) = generic_vars.inst_array.get(&name) {
+                        if expr_count != 1 {
+                            return self.jit_error_result(
+                                &expr.span(),
+                                &format!(
+                                    "`{name}` names a const generic array; use it alone or index it as `{name}[i]`"
+                                ),
+                            );
+                        }
+                        args.extend(cga.iter().map(|dim| dim.to_string()));
+                        continue;
+                    }
+                    self.require_compile_time_shape_expr(&expr, generic_vars, ctx)?;
+                    args.push(expr.to_token_stream().to_string());
+                }
+                Expr::Index(index) => {
+                    if let Expr::Path(path) = index.expr.as_ref() {
+                        let name = get_ident_from_path_expr(path).to_string();
+                        if let Some(cga) = generic_vars.inst_array.get(&name) {
+                            let i = parse_signed_literal_as_i32(&index.index);
+                            let Some(dim) = cga.get(i as usize) else {
+                                return self.jit_error_result(
+                                    &index.index.span(),
+                                    &format!(
+                                        "index {i} out of bounds for const generic array `{name}` of length {}",
+                                        cga.len()
+                                    ),
+                                );
+                            };
+                            args.push(dim.to_string());
+                            continue;
+                        }
+                    }
+                    return self.jit_error_result(
+                        &expr.span(),
+                        "only const generic array indexing like `S[0]` is supported in `const_shape!` and `const_array!`",
+                    );
+                }
+                _ => {
+                    self.require_compile_time_shape_expr(&expr, generic_vars, ctx)?;
+                    args.push(expr.to_token_stream().to_string());
+                }
+            }
+        }
+        Ok(args)
+    }
+
+    fn require_compile_time_shape_expr(
+        &self,
+        expr: &Expr,
+        generic_vars: &GenericVars,
+        ctx: &CompilerContext,
+    ) -> Result<(), JITError> {
+        match expr {
+            Expr::Lit(_) | Expr::Unary(_) => Ok(()),
+            Expr::Path(path) if path.path.segments.len() == 1 => {
+                let name = get_ident_from_path_expr(path).to_string();
+                if generic_vars.get_i32(&name).is_some() {
+                    return Ok(());
+                }
+                if ctx
+                    .vars
+                    .get(&name)
+                    .and_then(|value| value.bounds)
+                    .is_some_and(|bounds| bounds.is_exact())
+                {
+                    return Ok(());
+                }
+                let res = self
+                    .modules
+                    .name_resolver
+                    .resolve_path(&path.path, &self.module_name);
+                if let Res::Def(DefKind::Const, def_id) = res {
+                    if self
+                        .modules
+                        .name_resolver
+                        .get_const(&def_id)
+                        .and_then(crate::type_aliases::const_item_scalar_expr)
+                        .is_some()
+                    {
+                        return Ok(());
+                    }
+                }
+                self.jit_error_result(
+                    &expr.span(),
+                    "all arguments to `const_shape!` must be compile-time constants",
+                )
+            }
+            Expr::Paren(paren) => {
+                self.require_compile_time_shape_expr(&paren.expr, generic_vars, ctx)
+            }
+            _ => self.jit_error_result(
+                &expr.span(),
+                "all arguments to `const_shape!` must be compile-time constants",
+            ),
+        }
+    }
+
     fn make_option_type(rust_ty: syn::Type) -> TileRustType {
         let type_instance = TypeInstance::UserType(TypeInstanceUserType {
             maybe_generic_ty: rust_ty,
@@ -64,6 +183,70 @@ impl<'m> CUDATileFunctionCompiler<'m> {
         let payload_rust_ty = &payload_ty.rust_ty;
         let rust_ty: syn::Type = parse_quote!(Option<#payload_rust_ty>);
         Self::make_option_type(rust_ty)
+    }
+
+    fn path_looks_like_associated_const(
+        &self,
+        path_expr: &syn::ExprPath,
+        generic_vars: &GenericVars,
+    ) -> bool {
+        if path_expr.qself.is_some() {
+            return true;
+        }
+        if path_expr.path.segments.len() != 2 {
+            return false;
+        }
+        let qualifier = path_expr.path.segments[0].ident.to_string();
+        generic_vars.var_type(&qualifier).is_some()
+            || self.modules.structs().contains_key(&qualifier)
+            || self
+                .modules
+                .primitives()
+                .keys()
+                .any(|(_, self_name)| self_name == &qualifier)
+    }
+
+    fn expected_array_element_type(
+        &self,
+        expected: &TileRustType,
+        generic_vars: &GenericVars,
+    ) -> Result<Option<TileRustType>, JITError> {
+        let elem_ty = match &expected.rust_ty {
+            syn::Type::Array(array) => Some(&*array.elem),
+            syn::Type::Slice(slice) => Some(&*slice.elem),
+            _ => None,
+        };
+        let Some(elem_ty) = elem_ty else {
+            return Ok(None);
+        };
+        self.compile_type(elem_ty, generic_vars, &HashMap::new())
+    }
+
+    fn compile_else_branch(
+        &self,
+        module: &mut Module,
+        block_id: BlockId,
+        else_expr: &Expr,
+        generic_vars: &GenericVars,
+        ctx: &mut CompilerContext,
+        return_type: Option<TileRustType>,
+    ) -> Result<Option<TileRustValue>, JITError> {
+        match else_expr {
+            Expr::Block(block_expr) => {
+                self.compile_block(module, block_id, &block_expr.block, generic_vars, ctx, return_type)
+            }
+            Expr::If(_) => {
+                let synthetic_block = syn::Block {
+                    brace_token: Default::default(),
+                    stmts: vec![syn::Stmt::Expr(else_expr.clone(), None)],
+                };
+                self.compile_block(module, block_id, &synthetic_block, generic_vars, ctx, return_type)
+            }
+            _ => self.jit_error_result(
+                &else_expr.span(),
+                "only block expressions (`{ ... }`) and chained `else if` expressions are supported in else branches",
+            ),
+        }
     }
 
     pub fn compile_expression(
@@ -135,13 +318,16 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                             "range expression is missing an end bound (e.g. `0..n`)",
                         );
                     };
+                    let start_return_type = self
+                        .typeck_expr_tile_type(start_expr, generic_vars, &HashMap::new())?
+                        .or(return_type.clone());
                     let Some(start_val) = self.compile_expression(
                         module,
                         block_id,
                         start_expr,
                         generic_vars,
                         ctx,
-                        return_type.clone(),
+                        start_return_type,
                     )?
                     else {
                         return self.jit_error_result(
@@ -149,13 +335,16 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                             "failed to compile range start expression",
                         );
                     };
+                    let end_return_type = self
+                        .typeck_expr_tile_type(end_expr, generic_vars, &HashMap::new())?
+                        .or(return_type.clone());
                     let Some(end_val) = self.compile_expression(
                         module,
                         block_id,
                         end_expr,
                         generic_vars,
                         ctx,
-                        return_type.clone(),
+                        end_return_type,
                     )?
                     else {
                         return self.jit_error_result(
@@ -498,43 +687,48 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                     if let Some(bounds) = conditional_val.bounds {
                         if bounds.is_exact() {
                             // Emit the corresponding conditional, if it's defined.
-                            let branch_block = match (bounds.start, &if_expr.else_branch) {
-                                (1, _) => Some(&if_expr.then_branch),
+                            let mut block_vars = ctx.clone();
+                            // This is inlined, so no need to inject a terminator.
+                            block_vars.default_terminator = None;
+                            let (res, carry_vars) = match (bounds.start, &if_expr.else_branch) {
+                                (1, _) => {
+                                    let res = self.compile_block(
+                                        module,
+                                        block_id,
+                                        &if_expr.then_branch,
+                                        generic_vars,
+                                        &mut block_vars,
+                                        None,
+                                    )?;
+                                    let carry_vars =
+                                        collect_mutated_variables_from_block(&if_expr.then_branch)?
+                                            .into_iter()
+                                            .collect::<Vec<_>>();
+                                    (res, carry_vars)
+                                }
                                 (0, Some((_Else, else_expr))) => {
-                                    let Expr::Block(block_expr) = &**else_expr else {
-                                        return self.jit_error_result(
-                                            &else_expr.span(),
-                                            "only block expressions (`{ ... }`) are supported in else branches",
-                                        );
-                                    };
-                                    Some(&block_expr.block)
+                                    let res = self.compile_else_branch(
+                                        module,
+                                        block_id,
+                                        else_expr,
+                                        generic_vars,
+                                        &mut block_vars,
+                                        None,
+                                    )?;
+                                    let carry_vars =
+                                        collect_mutated_variables_from_expr(else_expr)?
+                                            .into_iter()
+                                            .collect::<Vec<_>>();
+                                    (res, carry_vars)
                                 }
                                 _ => {
                                     // Do nothing since the conditional is false and there is no else branch.
-                                    None
+                                    return Ok(None);
                                 }
                             };
-                            if let Some(branch_block) = branch_block {
-                                let mut block_vars = ctx.clone();
-                                // This is inlined, so no need to inject a terminator.
-                                block_vars.default_terminator = None;
-                                let res = self.compile_block(
-                                    module,
-                                    block_id,
-                                    branch_block,
-                                    generic_vars,
-                                    &mut block_vars,
-                                    None,
-                                )?;
-                                let carry_vars =
-                                    collect_mutated_variables_from_block(branch_block)?
-                                        .into_iter()
-                                        .collect::<Vec<_>>();
-                                let result_values = block_vars.unpack_some_vars(&carry_vars)?;
-                                ctx.repack_some_vars(&carry_vars, &result_values, true)?;
-                                return Ok(res);
-                            }
-                            return Ok(None);
+                            let result_values = block_vars.unpack_some_vars(&carry_vars)?;
+                            ctx.repack_some_vars(&carry_vars, &result_values, true)?;
+                            return Ok(res);
                         }
                     }
 
@@ -545,13 +739,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                             .collect::<Vec<_>>();
                     let else_captured_vars = {
                         if let Some((_Else, else_expr)) = &if_expr.else_branch {
-                            let Expr::Block(block_expr) = &**else_expr else {
-                                return self.jit_error_result(
-                                    &else_expr.span(),
-                                    "only block expressions (`{ ... }`) are supported in else branches",
-                                );
-                            };
-                            collect_mutated_variables_from_block(&block_expr.block)?
+                            collect_mutated_variables_from_expr(else_expr)?
                                 .into_iter()
                                 .collect::<Vec<_>>()
                         } else {
@@ -609,20 +797,14 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                     // We don't need to check return type. Both Rust and Tile IR compiler perform this check.
                     let (else_region_id, _else_return_type) = {
                         if let Some((_Else, else_expr)) = &if_expr.else_branch {
-                            let Expr::Block(block_expr) = &**else_expr else {
-                                return self.jit_error_result(
-                                    &else_expr.span(),
-                                    "only block expressions (`{ ... }`) are supported in else branches",
-                                );
-                            };
                             let mut block_vars = ctx.clone();
                             block_vars.carry_vars = Some(if_captured_var_names.clone());
                             block_vars.default_terminator = Some(BlockTerminator::Yield);
                             let (else_block_id, _else_block_args) = build_block(module, &[]);
-                            let result = self.compile_block(
+                            let result = self.compile_else_branch(
                                 module,
                                 else_block_id,
-                                &block_expr.block,
+                                else_expr,
                                 generic_vars,
                                 &mut block_vars,
                                 then_return_type.clone(),
@@ -776,16 +958,19 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                             .modules
                             .get_struct_field_type(&struct_name, &field_name);
                         let tile_rust_ty = if let Some(field_type) = field_type {
-                            // TODO (hme): Unclear if this works in general for all structs.
+                            // `Shape` and `Array` are compiler-known structs whose field
+                            // expressions often need a concrete expected type during emission.
                             if ["Shape", "Array"].contains(&struct_name.as_str()) {
                                 self.compile_type(&field_type, generic_vars, &HashMap::new())?
                             } else {
-                                // Returning None here is equivalent to asking the programmer to
-                                // specify the field type.
-                                None
+                                self.typeck_expr_tile_type(
+                                    &field.expr,
+                                    generic_vars,
+                                    &HashMap::new(),
+                                )?
                             }
                         } else {
-                            None
+                            self.typeck_expr_tile_type(&field.expr, generic_vars, &HashMap::new())?
                         };
                         let field_value: TileRustValue = match self.compile_expression(
                             module,
@@ -861,16 +1046,42 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                     }
                 }
                 Expr::Tuple(tuple_expr) => {
+                    let expected_elem_types = match return_type.as_ref().map(|ty| &ty.rust_ty) {
+                        Some(syn::Type::Tuple(tuple_ty)) => {
+                            Some(tuple_ty.elems.iter().cloned().collect::<Vec<_>>())
+                        }
+                        _ => None,
+                    };
+                    if let Some(expected_elem_types) = &expected_elem_types {
+                        if expected_elem_types.len() != tuple_expr.elems.len() {
+                            return self.jit_error_result(
+                                &tuple_expr.span(),
+                                &format!(
+                                    "tuple expression has {} elements but expected tuple type has {} elements",
+                                    tuple_expr.elems.len(),
+                                    expected_elem_types.len()
+                                ),
+                            );
+                        }
+                    }
                     let mut rust_types: Vec<syn::Type> = vec![];
                     let mut values: Vec<TileRustValue> = vec![];
-                    for elem in &tuple_expr.elems {
+                    for (idx, elem) in tuple_expr.elems.iter().enumerate() {
+                        let elem_return_type = expected_elem_types
+                            .as_ref()
+                            .and_then(|elem_types| elem_types.get(idx))
+                            .and_then(|elem_ty| {
+                                self.compile_type(elem_ty, generic_vars, &HashMap::new())
+                                    .ok()
+                                    .flatten()
+                            });
                         match self.compile_expression(
                             module,
                             block_id,
                             &elem,
                             generic_vars,
                             ctx,
-                            None,
+                            elem_return_type,
                         )? {
                             Some(value) => {
                                 rust_types.push(value.ty.rust_ty.clone());
@@ -1032,13 +1243,23 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                             len
                         }
                     };
+                    let elem_return_type = match return_type.as_ref() {
+                        Some(return_type) => {
+                            self.expected_array_element_type(return_type, generic_vars)?
+                        }
+                        None => self.typeck_expr_tile_type(
+                            &repeat_expr.expr,
+                            generic_vars,
+                            &HashMap::new(),
+                        )?,
+                    };
                     let Some(value) = self.compile_expression(
                         module,
                         block_id,
                         &repeat_expr.expr,
                         generic_vars,
                         ctx,
-                        None,
+                        elem_return_type,
                     )?
                     else {
                         return self.jit_error_result(
@@ -1117,6 +1338,43 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                             // Known DSL struct — return as ZST marker placeholder.
                             return Ok(Some(Self::make_zst_marker(path_expr)));
                         }
+                        Res::Def(DefKind::Const, def_id) => {
+                            let Some(const_item) = self.modules.name_resolver.get_const(&def_id)
+                            else {
+                                return self.jit_error_result(
+                                    &path_expr.span(),
+                                    &format!("failed to resolve const `{var_name}`"),
+                                );
+                            };
+                            let const_ty =
+                                self.compile_type(&const_item.ty, generic_vars, &HashMap::new())?;
+                            return self.compile_expression(
+                                module,
+                                block_id,
+                                &const_item.expr,
+                                generic_vars,
+                                ctx,
+                                const_ty,
+                            );
+                        }
+                        Res::Def(DefKind::Static, def_id) => {
+                            let Some(static_item) = self.modules.name_resolver.get_static(&def_id)
+                            else {
+                                return self.jit_error_result(
+                                    &path_expr.span(),
+                                    &format!("failed to resolve static `{var_name}`"),
+                                );
+                            };
+                            let Some(static_ty) =
+                                self.compile_type(&static_item.ty, generic_vars, &HashMap::new())?
+                            else {
+                                return self.jit_error_result(
+                                    &path_expr.span(),
+                                    &format!("failed to compile static `{var_name}` type"),
+                                );
+                            };
+                            return Ok(Some(TileRustValue::new_struct(BTreeMap::new(), static_ty)));
+                        }
                         _ => {}
                     }
 
@@ -1127,6 +1385,12 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                     //    in the DSL AST the resolver indexes. They're valid Rust
                     //    type paths consumed by resolve_static_params.
                     if path_expr.path.segments.len() > 1 {
+                        if self.path_looks_like_associated_const(path_expr, generic_vars) {
+                            return self.jit_error_result(
+                                &path_expr.span(),
+                                "associated const values are not supported in expression position; use a literal or pass supported element constants such as `T::ZERO` directly to a DSL operation that accepts them",
+                            );
+                        }
                         return Ok(Some(Self::make_zst_marker(path_expr)));
                     }
 
@@ -1254,14 +1518,26 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                         }
                     }
                 }
-                Expr::MethodCall(method_call_expr) => Ok(self.inline_method_call(
-                    module,
-                    block_id,
-                    &method_call_expr,
-                    &generic_vars,
-                    ctx,
-                    return_type,
-                )?),
+                Expr::MethodCall(method_call_expr) => {
+                    if let Some(value) = self.compile_global_method_call(
+                        module,
+                        block_id,
+                        &method_call_expr,
+                        &generic_vars,
+                        ctx,
+                        return_type.clone(),
+                    )? {
+                        return Ok(Some(value));
+                    }
+                    Ok(self.inline_method_call(
+                        module,
+                        block_id,
+                        &method_call_expr,
+                        &generic_vars,
+                        ctx,
+                        return_type,
+                    )?)
+                }
                 Expr::Field(field_expr) => {
                     let Some(base) = self.compile_expression(
                         module,
@@ -1456,9 +1732,17 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                 }
                 Expr::Lit(lit_expr) => {
                     let return_type = if return_type.is_none() {
-                        match get_lit_type(lit_expr) {
-                            Some(ty) => self.compile_type(&ty, generic_vars, &HashMap::new())?,
-                            None => None,
+                        let typeck_return_type =
+                            self.typeck_expr_tile_type(expr, generic_vars, &HashMap::new())?;
+                        if typeck_return_type.is_some() {
+                            typeck_return_type
+                        } else {
+                            match get_lit_type(lit_expr) {
+                                Some(ty) => {
+                                    self.compile_type(&ty, generic_vars, &HashMap::new())?
+                                }
+                                None => None,
+                            }
                         }
                     } else {
                         return_type
@@ -1569,63 +1853,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                         "const_shape" | "const_array" => {
                             // TODO (hme): Remove special case for const_shape here
                             //  and on the proc-macro side (rank_instantiation.rs).
-                            let mut args = vec![];
-                            let mut is_cga = false;
-                            let mut is_consts = false;
-                            for token in mac_expr.mac.tokens.clone() {
-                                if is_cga && is_consts {
-                                    return self.jit_error_result(
-                                        &mac_expr.span(),
-                                        &format!("inconsistent arguments to `{mac_name}!`: cannot mix CGA and literal arguments"),
-                                    );
-                                }
-                                match token {
-                                    TokenTree::Literal(lit) => {
-                                        args.push(lit.to_string());
-                                    }
-                                    TokenTree::Ident(ident) => {
-                                        let const_var = ident.to_string();
-                                        if let Some(cga) = generic_vars.inst_array.get(&const_var) {
-                                            is_cga = true;
-                                            args = cga
-                                                .iter()
-                                                .map(|x| x.to_string())
-                                                .collect::<Vec<String>>();
-                                        } else {
-                                            is_consts = true;
-                                            let mut is_const =
-                                                generic_vars.get_i32(&const_var).is_some();
-                                            let const_var_value = ctx.vars.get(&const_var).unwrap();
-                                            if let Some(bounds) = const_var_value.bounds {
-                                                is_const = is_const || bounds.is_exact();
-                                            }
-                                            if !is_const {
-                                                return self.jit_error_result(
-                                                    &mac_expr.span(),
-                                                    "all arguments to `const_shape!` must be compile-time constants",
-                                                );
-                                            }
-                                            args.push(const_var);
-                                        }
-                                    }
-                                    TokenTree::Punct(punct) => {
-                                        if punct.as_char() == ',' {
-                                            continue;
-                                        } else {
-                                            return self.jit_error_result(
-                                                &mac_expr.span(),
-                                                &format!("unexpected punctuation `{punct}` in macro arguments"),
-                                            );
-                                        }
-                                    }
-                                    _ => {
-                                        return self.jit_error_result(
-                                            &mac_expr.span(),
-                                            "unexpected token in macro arguments",
-                                        )
-                                    }
-                                }
-                            }
+                            let args = self.const_shape_macro_args(mac_expr, generic_vars, ctx)?;
                             let cga_str = format!("{{[{}]}}", args.join(", "));
                             let ty_str = if mac_name == "const_shape" {
                                 "Shape"

--- a/cutile-compiler/src/compiler/compile_global.rs
+++ b/cutile-compiler/src/compiler/compile_global.rs
@@ -1,0 +1,727 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Module-level `Global` lowering.
+//!
+//! Rust `static NAME: Global<E, { [] }>` items are ordinary Rust statics in the
+//! expanded module, but the JIT treats them as Tile IR globals. The Rust value is
+//! just an immutable descriptor; device-side mutability is expressed by the
+//! load/store/atomic methods lowered here.
+
+use super::_function::CUDATileFunctionCompiler;
+use super::_type;
+use super::_value::{CompilerContext, TileRustValue};
+use super::shared_utils::{AtomicMode, ElementTypePrefix};
+use super::tile_rust_type::TileRustType;
+use crate::error::{JITError, SpannedJITError};
+use crate::generics::GenericVars;
+use crate::passes::name_resolution::{DefKind, Res};
+use crate::syn_utils::get_type_ident;
+use crate::types::TypeParam;
+use cutile_ir::builder::{append_op, OpBuilder};
+use cutile_ir::bytecode::Opcode;
+use cutile_ir::ir::{
+    Attribute, BlockId, DenseElements, Global as IrGlobal, Module, ScalarType, TileElementType,
+    TileType, Type as TileIrType,
+};
+use quote::ToTokens;
+use std::collections::HashMap;
+use syn::spanned::Spanned;
+use syn::{
+    Expr, ExprCall, ExprLit, ExprMethodCall, GenericArgument, ItemStatic, Lit, PathArguments,
+    StaticMutability, Type, UnOp,
+};
+
+#[derive(Clone)]
+struct GlobalInfo {
+    symbol: String,
+    element_ty: Type,
+    element_name: String,
+    shape: Vec<i32>,
+}
+
+impl<'m> CUDATileFunctionCompiler<'m> {
+    pub(crate) fn emit_module_globals(&self, module: &mut Module) -> Result<(), JITError> {
+        for (module_name, item) in self.modules.name_resolver.all_statics() {
+            let Some(info) = self.global_info(module_name, item, &self.generic_vars)? else {
+                return self.modules.resolve_span(module_name, &item.span()).jit_error_result(
+                    "only `static NAME: Global<E, { [] }>` items are supported inside `#[cutile::module]`; use `const` for compile-time constants",
+                );
+            };
+            if !info.shape.is_empty() {
+                return self
+                    .modules
+                    .resolve_span(module_name, &item.span())
+                    .jit_error_result(
+                        "shaped `Global` statics are not supported yet; use `Global<E, { [] }>`",
+                    );
+            }
+
+            let scalar = _type::scalar_from_name(&info.element_name).ok_or_else(|| {
+                JITError::Generic(format!(
+                    "unsupported Global element type `{}`",
+                    info.element_name
+                ))
+            })?;
+            let value_ty = TileIrType::Tile(TileType {
+                shape: vec![1],
+                element_type: TileElementType::Scalar(scalar.clone()),
+            });
+            let init_expr = self.global_static_initializer(item)?;
+            let init_value = self.global_scalar_initializer_value(&init_expr, module_name)?;
+            let data =
+                super::compile_expression::encode_literal_bytes(&init_value, &info.element_name);
+
+            module.globals.push(IrGlobal {
+                sym_name: info.symbol,
+                value: DenseElements {
+                    element_type: value_ty,
+                    shape: vec![1],
+                    data,
+                },
+                alignment: scalar_alignment(scalar),
+            });
+        }
+        Ok(())
+    }
+
+    pub(crate) fn compile_global_method_call(
+        &self,
+        module: &mut Module,
+        block_id: BlockId,
+        method_call: &ExprMethodCall,
+        generic_vars: &GenericVars,
+        ctx: &mut CompilerContext,
+        return_type: Option<TileRustType>,
+    ) -> Result<Option<TileRustValue>, JITError> {
+        let Some(info) = self.resolve_global_receiver(&method_call.receiver, generic_vars, ctx)?
+        else {
+            return Ok(None);
+        };
+        if !info.shape.is_empty() {
+            return self.jit_error_result(
+                &method_call.receiver.span(),
+                "shaped `Global` method calls are not supported yet; use `Global<E, { [] }>`",
+            );
+        }
+
+        match method_call.method.to_string().as_str() {
+            "load" => self.compile_global_load(module, block_id, method_call, generic_vars, info, return_type),
+            "store" => self.compile_global_store(module, block_id, method_call, generic_vars, ctx, info, return_type),
+            "atomic_add" => self.compile_global_atomic_add(module, block_id, method_call, generic_vars, ctx, info, return_type),
+            method => self.jit_error_result(
+                &method_call.method.span(),
+                &format!("unsupported `Global` method `{method}`; supported methods are `load`, `store`, and `atomic_add`"),
+            ),
+        }
+    }
+
+    fn compile_global_load(
+        &self,
+        module: &mut Module,
+        block_id: BlockId,
+        method_call: &ExprMethodCall,
+        generic_vars: &GenericVars,
+        info: GlobalInfo,
+        return_type: Option<TileRustType>,
+    ) -> Result<Option<TileRustValue>, JITError> {
+        if method_call.args.len() != 2 {
+            return self.jit_error_result(
+                &method_call.span(),
+                "`Global::load` expects `(memory_ordering, memory_scope)`",
+            );
+        }
+        let ptr = self.compile_global_ptr(module, block_id, method_call, &info)?;
+        let tile_ty = self.global_tile_type(&info)?;
+        let tile_ir_ty = _type::convert_type(&tile_ty).ok_or_else(|| {
+            self.jit_error(&method_call.span(), "failed to compile Global load type")
+        })?;
+        let token_ty = self.token_type(generic_vars)?;
+
+        let memory_ordering =
+            super::shared_utils::extract_zst_type_name(&method_call.args[0], "memory_ordering")?;
+        let memory_ordering_value = load_ordering_value(&memory_ordering).ok_or_else(|| {
+            self.jit_error(
+                &method_call.args[0].span(),
+                "invalid Global load ordering; valid: Weak, Relaxed, Acquire",
+            )
+        })?;
+        let memory_scope =
+            super::shared_utils::extract_zst_type_name(&method_call.args[1], "memory_scope")?;
+        let memory_scope_value = memory_scope_value(&memory_scope).ok_or_else(|| {
+            self.jit_error(
+                &method_call.args[1].span(),
+                "invalid memory scope; valid: TileBlock, Device, System",
+            )
+        })?;
+
+        let mut builder = OpBuilder::new(Opcode::LoadPtrTko, self.ir_location(&method_call.span()))
+            .result(tile_ir_ty)
+            .result(TileIrType::Token)
+            .operand(ptr)
+            .attr(
+                "memory_ordering_semantics",
+                Attribute::i32(memory_ordering_value),
+            )
+            .attr(
+                "operandSegmentSizes",
+                Attribute::Array(vec![
+                    Attribute::i32(1),
+                    Attribute::i32(0),
+                    Attribute::i32(0),
+                    Attribute::i32(0),
+                ]),
+            );
+        if memory_ordering != "Weak" {
+            builder = builder.attr("memory_scope", Attribute::i32(memory_scope_value));
+        }
+        let (op_id, results) = builder.build(module);
+        append_op(module, block_id, op_id);
+
+        let outer_ty = match return_type {
+            Some(ty) => ty,
+            None => {
+                let tile_rust_ty = &tile_ty.rust_ty;
+                let tuple_ty: Type = syn::parse_quote!((#tile_rust_ty, Token));
+                self.compile_type(&tuple_ty, generic_vars, &HashMap::new())?
+                    .ok_or_else(|| {
+                        self.jit_error(
+                            &method_call.span(),
+                            "failed to compile Global load return type",
+                        )
+                    })?
+            }
+        };
+        Ok(Some(TileRustValue::new_compound(
+            vec![
+                TileRustValue::new_structured_type(results[0], tile_ty, None),
+                TileRustValue::new_primitive(results[1], token_ty, None),
+            ],
+            outer_ty,
+        )))
+    }
+
+    fn compile_global_store(
+        &self,
+        module: &mut Module,
+        block_id: BlockId,
+        method_call: &ExprMethodCall,
+        generic_vars: &GenericVars,
+        ctx: &mut CompilerContext,
+        info: GlobalInfo,
+        return_type: Option<TileRustType>,
+    ) -> Result<Option<TileRustValue>, JITError> {
+        if method_call.args.len() != 3 {
+            return self.jit_error_result(
+                &method_call.span(),
+                "`Global::store` expects `(value, memory_ordering, memory_scope)`",
+            );
+        }
+        let ptr = self.compile_global_ptr(module, block_id, method_call, &info)?;
+        let tile_ty = self.global_tile_type(&info)?;
+        let Some(value) = self.compile_expression(
+            module,
+            block_id,
+            &method_call.args[0],
+            generic_vars,
+            ctx,
+            Some(tile_ty.clone()),
+        )?
+        else {
+            return self.jit_error_result(
+                &method_call.args[0].span(),
+                "failed to compile Global store value",
+            );
+        };
+        let Some(value_ir) = value.value else {
+            return self.jit_error_result(
+                &method_call.args[0].span(),
+                "Global store value did not produce an IR value",
+            );
+        };
+        let token_ty = return_type.unwrap_or(self.token_type(generic_vars)?);
+
+        let memory_ordering =
+            super::shared_utils::extract_zst_type_name(&method_call.args[1], "memory_ordering")?;
+        let memory_ordering_value = store_ordering_value(&memory_ordering).ok_or_else(|| {
+            self.jit_error(
+                &method_call.args[1].span(),
+                "invalid Global store ordering; valid: Weak, Relaxed, Release",
+            )
+        })?;
+        let memory_scope =
+            super::shared_utils::extract_zst_type_name(&method_call.args[2], "memory_scope")?;
+        let memory_scope_value = memory_scope_value(&memory_scope).ok_or_else(|| {
+            self.jit_error(
+                &method_call.args[2].span(),
+                "invalid memory scope; valid: TileBlock, Device, System",
+            )
+        })?;
+
+        let mut builder =
+            OpBuilder::new(Opcode::StorePtrTko, self.ir_location(&method_call.span()))
+                .result(TileIrType::Token)
+                .operand(ptr)
+                .operand(value_ir)
+                .attr(
+                    "memory_ordering_semantics",
+                    Attribute::i32(memory_ordering_value),
+                )
+                .attr(
+                    "operandSegmentSizes",
+                    Attribute::Array(vec![
+                        Attribute::i32(1),
+                        Attribute::i32(1),
+                        Attribute::i32(0),
+                        Attribute::i32(0),
+                    ]),
+                );
+        if memory_ordering != "Weak" {
+            builder = builder.attr("memory_scope", Attribute::i32(memory_scope_value));
+        }
+        let (op_id, results) = builder.build(module);
+        append_op(module, block_id, op_id);
+        Ok(Some(TileRustValue::new_primitive(
+            results[0], token_ty, None,
+        )))
+    }
+
+    fn compile_global_atomic_add(
+        &self,
+        module: &mut Module,
+        block_id: BlockId,
+        method_call: &ExprMethodCall,
+        generic_vars: &GenericVars,
+        ctx: &mut CompilerContext,
+        info: GlobalInfo,
+        return_type: Option<TileRustType>,
+    ) -> Result<Option<TileRustValue>, JITError> {
+        if method_call.args.len() != 3 {
+            return self.jit_error_result(
+                &method_call.span(),
+                "`Global::atomic_add` expects `(value, memory_ordering, memory_scope)`",
+            );
+        }
+        let ptr = self.compile_global_ptr(module, block_id, method_call, &info)?;
+        let tile_ty = self.global_tile_type(&info)?;
+        let Some(value) = self.compile_expression(
+            module,
+            block_id,
+            &method_call.args[0],
+            generic_vars,
+            ctx,
+            Some(tile_ty.clone()),
+        )?
+        else {
+            return self.jit_error_result(
+                &method_call.args[0].span(),
+                "failed to compile Global atomic value",
+            );
+        };
+        let Some(value_ir) = value.value else {
+            return self.jit_error_result(
+                &method_call.args[0].span(),
+                "Global atomic value did not produce an IR value",
+            );
+        };
+        let token_ty = self.token_type(generic_vars)?;
+        let tile_ir_ty = _type::convert_type(&tile_ty).ok_or_else(|| {
+            self.jit_error(
+                &method_call.span(),
+                "failed to compile Global atomic result type",
+            )
+        })?;
+
+        let memory_ordering =
+            super::shared_utils::extract_zst_type_name(&method_call.args[1], "memory_ordering")?;
+        let memory_ordering_value = atomic_ordering_value(&memory_ordering).ok_or_else(|| {
+            self.jit_error(
+                &method_call.args[1].span(),
+                "invalid Global atomic ordering; valid: Relaxed, Acquire, Release, AcqRel",
+            )
+        })?;
+        let memory_scope =
+            super::shared_utils::extract_zst_type_name(&method_call.args[2], "memory_scope")?;
+        let memory_scope_value = memory_scope_value(&memory_scope).ok_or_else(|| {
+            self.jit_error(
+                &method_call.args[2].span(),
+                "invalid memory scope; valid: TileBlock, Device, System",
+            )
+        })?;
+
+        let elem_prefix = ElementTypePrefix::new(&info.element_name)?;
+        let mode = if elem_prefix == ElementTypePrefix::Float {
+            AtomicMode::new("AddF", elem_prefix)?
+        } else {
+            AtomicMode::new("Add", elem_prefix)?
+        } as i64;
+
+        let (op_id, results) =
+            OpBuilder::new(Opcode::AtomicRMW, self.ir_location(&method_call.span()))
+                .result(tile_ir_ty)
+                .result(TileIrType::Token)
+                .operand(ptr)
+                .operand(value_ir)
+                .attr(
+                    "memory_ordering_semantics",
+                    Attribute::i32(memory_ordering_value),
+                )
+                .attr("memory_scope", Attribute::i32(memory_scope_value))
+                .attr("mode", Attribute::i32(mode))
+                .attr(
+                    "operandSegmentSizes",
+                    Attribute::Array(vec![
+                        Attribute::i32(1),
+                        Attribute::i32(1),
+                        Attribute::i32(0),
+                        Attribute::i32(0),
+                    ]),
+                )
+                .build(module);
+        append_op(module, block_id, op_id);
+
+        let outer_ty = match return_type {
+            Some(ty) => ty,
+            None => {
+                let tile_rust_ty = &tile_ty.rust_ty;
+                let tuple_ty: Type = syn::parse_quote!((#tile_rust_ty, Token));
+                self.compile_type(&tuple_ty, generic_vars, &HashMap::new())?
+                    .ok_or_else(|| {
+                        self.jit_error(
+                            &method_call.span(),
+                            "failed to compile Global atomic return type",
+                        )
+                    })?
+            }
+        };
+        Ok(Some(TileRustValue::new_compound(
+            vec![
+                TileRustValue::new_structured_type(results[0], tile_ty, None),
+                TileRustValue::new_primitive(results[1], token_ty, None),
+            ],
+            outer_ty,
+        )))
+    }
+
+    fn compile_global_ptr(
+        &self,
+        module: &mut Module,
+        block_id: BlockId,
+        method_call: &ExprMethodCall,
+        info: &GlobalInfo,
+    ) -> Result<cutile_ir::ir::Value, JITError> {
+        let ptr_ty = TileRustType::from_scalar_ptr(&info.element_name).ok_or_else(|| {
+            self.jit_error(
+                &method_call.receiver.span(),
+                &format!(
+                    "failed to compile Global pointer type for `{}`",
+                    info.element_name
+                ),
+            )
+        })?;
+        let ptr_ir_ty = _type::convert_type(&ptr_ty).ok_or_else(|| {
+            self.jit_error(
+                &method_call.receiver.span(),
+                "failed to convert Global pointer type",
+            )
+        })?;
+        let (op_id, results) = OpBuilder::new(
+            Opcode::GetGlobal,
+            self.ir_location(&method_call.receiver.span()),
+        )
+        .result(ptr_ir_ty)
+        .attr("name", Attribute::String(info.symbol.clone()))
+        .build(module);
+        append_op(module, block_id, op_id);
+        Ok(results[0])
+    }
+
+    fn resolve_global_receiver(
+        &self,
+        receiver: &Expr,
+        generic_vars: &GenericVars,
+        ctx: &CompilerContext,
+    ) -> Result<Option<GlobalInfo>, JITError> {
+        let Expr::Path(path) = receiver else {
+            return Ok(None);
+        };
+        if path.path.segments.len() != 1 {
+            return Ok(None);
+        }
+        let name = path.path.segments[0].ident.to_string();
+        if ctx.vars.contains_key(&name) {
+            return Ok(None);
+        }
+        let res = self
+            .modules
+            .name_resolver
+            .resolve_path(&path.path, &self.module_name);
+        let Res::Def(DefKind::Static, def_id) = res else {
+            return Ok(None);
+        };
+        let Some(static_item) = self.modules.name_resolver.get_static(&def_id) else {
+            return Ok(None);
+        };
+        self.global_info(&def_id.module, static_item, generic_vars)
+    }
+
+    fn global_info(
+        &self,
+        module_name: &str,
+        item: &ItemStatic,
+        generic_vars: &GenericVars,
+    ) -> Result<Option<GlobalInfo>, JITError> {
+        if !matches!(item.mutability, StaticMutability::None) {
+            return self.modules.resolve_span(module_name, &item.span()).jit_error_result(
+                "`Global` declarations should use immutable `static`; mutability is provided by `Global` methods",
+            );
+        }
+        let normalized_ty = self.modules.normalize_type_aliases(&item.ty)?;
+        let Some(type_name) = get_type_ident(&normalized_ty) else {
+            return Ok(None);
+        };
+        if type_name != "Global" {
+            return Ok(None);
+        }
+        let element_ty = global_element_type(&normalized_ty).ok_or_else(|| {
+            self.modules
+                .resolve_span(module_name, &item.ty.span())
+                .jit_error("`Global` requires an element type: `Global<E, { [] }>`")
+        })?;
+        let element_compiled = self
+            .compile_type(
+                &element_ty,
+                generic_vars,
+                &HashMap::<String, TypeParam>::new(),
+            )?
+            .ok_or_else(|| {
+                self.modules
+                    .resolve_span(module_name, &element_ty.span())
+                    .jit_error("failed to compile `Global` element type")
+            })?;
+        let element_name = element_compiled
+            .get_cuda_tile_element_type(self.modules.primitives())?
+            .ok_or_else(|| {
+                self.modules
+                    .resolve_span(module_name, &element_ty.span())
+                    .jit_error("failed to determine `Global` element type")
+            })?;
+        let shape = global_shape(&normalized_ty).ok_or_else(|| {
+            self.modules
+                .resolve_span(module_name, &item.ty.span())
+                .jit_error("`Global` requires a static shape: `Global<E, { [] }>`")
+        })?;
+        Ok(Some(GlobalInfo {
+            symbol: global_symbol_name(module_name, &item.ident.to_string()),
+            element_ty,
+            element_name,
+            shape,
+        }))
+    }
+
+    fn global_static_initializer(&self, item: &ItemStatic) -> Result<Expr, JITError> {
+        let Expr::Call(call) = &*item.expr else {
+            return self.jit_error_result(
+                &item.expr.span(),
+                "`Global` static initializer must be `Global::new(value)`",
+            );
+        };
+        if !call_path_ends_with_new(call) || call.args.len() != 1 {
+            return self.jit_error_result(
+                &call.span(),
+                "`Global` static initializer must be `Global::new(value)`",
+            );
+        }
+        Ok(call.args[0].clone())
+    }
+
+    fn global_scalar_initializer_value(
+        &self,
+        expr: &Expr,
+        module_name: &str,
+    ) -> Result<String, JITError> {
+        if let Some(value) = literal_scalar_value(expr) {
+            return Ok(value);
+        }
+        if let Expr::Path(path) = expr {
+            let res = self
+                .modules
+                .name_resolver
+                .resolve_path(&path.path, module_name);
+            if let Res::Def(DefKind::Const, def_id) = res {
+                if let Some(const_item) = self.modules.name_resolver.get_const(&def_id) {
+                    return self.global_scalar_initializer_value(&const_item.expr, &def_id.module);
+                }
+            }
+        }
+        self.modules.resolve_span(module_name, &expr.span()).jit_error_result(
+            "`Global::new` currently requires a scalar literal or module-level scalar const initializer",
+        )
+    }
+
+    fn global_tile_type(&self, info: &GlobalInfo) -> Result<TileRustType, JITError> {
+        TileRustType::from_tile(&info.element_name, &info.shape).ok_or_else(|| {
+            JITError::Generic(format!(
+                "failed to compile Global tile type for `{}`",
+                info.element_ty.to_token_stream()
+            ))
+        })
+    }
+
+    fn token_type(&self, generic_vars: &GenericVars) -> Result<TileRustType, JITError> {
+        let token_ty: Type = syn::parse_quote!(Token);
+        self.compile_type(&token_ty, generic_vars, &HashMap::new())?
+            .ok_or_else(|| self.jit_error(&token_ty.span(), "failed to compile Token type"))
+    }
+}
+
+fn global_element_type(ty: &Type) -> Option<Type> {
+    let Type::Path(type_path) = ty else {
+        return None;
+    };
+    let segment = type_path.path.segments.last()?;
+    let PathArguments::AngleBracketed(args) = &segment.arguments else {
+        return None;
+    };
+    args.args.iter().find_map(|arg| match arg {
+        GenericArgument::Type(ty) => Some(ty.clone()),
+        _ => None,
+    })
+}
+
+fn global_shape(ty: &Type) -> Option<Vec<i32>> {
+    let Type::Path(type_path) = ty else {
+        return None;
+    };
+    let segment = type_path.path.segments.last()?;
+    let PathArguments::AngleBracketed(args) = &segment.arguments else {
+        return None;
+    };
+    args.args.iter().find_map(|arg| match arg {
+        GenericArgument::Const(expr) => const_shape_expr(expr),
+        _ => None,
+    })
+}
+
+fn const_shape_expr(expr: &Expr) -> Option<Vec<i32>> {
+    match expr {
+        Expr::Block(block) => match block.block.stmts.as_slice() {
+            [syn::Stmt::Expr(expr, _)] => const_shape_expr(expr),
+            _ => None,
+        },
+        Expr::Array(array) => array.elems.iter().map(expr_i32).collect(),
+        Expr::Repeat(repeat) => {
+            let value = expr_i32(&repeat.expr)?;
+            let len = expr_i32(&repeat.len)? as usize;
+            Some(vec![value; len])
+        }
+        Expr::Paren(paren) => const_shape_expr(&paren.expr),
+        _ => None,
+    }
+}
+
+fn expr_i32(expr: &Expr) -> Option<i32> {
+    match expr {
+        Expr::Lit(ExprLit {
+            lit: Lit::Int(value),
+            ..
+        }) => value.base10_parse::<i32>().ok(),
+        Expr::Unary(unary) if matches!(unary.op, UnOp::Neg(_)) => {
+            expr_i32(&unary.expr).map(|value| -value)
+        }
+        Expr::Paren(paren) => expr_i32(&paren.expr),
+        _ => None,
+    }
+}
+
+fn call_path_ends_with_new(call: &ExprCall) -> bool {
+    let Expr::Path(path) = &*call.func else {
+        return false;
+    };
+    path.path
+        .segments
+        .last()
+        .is_some_and(|segment| segment.ident == "new")
+}
+
+fn literal_scalar_value(expr: &Expr) -> Option<String> {
+    match expr {
+        Expr::Lit(ExprLit { lit, .. }) => match lit {
+            Lit::Bool(value) => Some(if value.value() { "1" } else { "0" }.to_string()),
+            Lit::Int(value) => Some(value.base10_digits().to_string()),
+            Lit::Float(value) => Some(value.base10_digits().to_string()),
+            _ => None,
+        },
+        Expr::Unary(unary) if matches!(unary.op, UnOp::Neg(_)) => match &*unary.expr {
+            Expr::Lit(ExprLit { lit, .. }) => match lit {
+                Lit::Int(value) => Some(format!("-{}", value.base10_digits())),
+                Lit::Float(value) => Some(format!("-{}", value.base10_digits())),
+                _ => None,
+            },
+            _ => None,
+        },
+        Expr::Paren(paren) => literal_scalar_value(&paren.expr),
+        _ => None,
+    }
+}
+
+fn global_symbol_name(module_name: &str, name: &str) -> String {
+    let mut symbol = String::new();
+    for ch in module_name.chars().chain(['_']).chain(name.chars()) {
+        if ch.is_ascii_alphanumeric() || ch == '_' {
+            symbol.push(ch);
+        } else {
+            symbol.push('_');
+        }
+    }
+    symbol
+}
+
+fn scalar_alignment(scalar: ScalarType) -> u64 {
+    match scalar {
+        ScalarType::I1 | ScalarType::I8 => 1,
+        ScalarType::I16 | ScalarType::F16 | ScalarType::BF16 => 2,
+        ScalarType::I32 | ScalarType::F32 | ScalarType::TF32 => 4,
+        ScalarType::I64 | ScalarType::F64 => 8,
+        _ => 4,
+    }
+}
+
+fn memory_scope_value(scope: &str) -> Option<i64> {
+    match scope {
+        "TileBlock" => Some(0),
+        "Device" => Some(1),
+        "System" => Some(2),
+        _ => None,
+    }
+}
+
+fn load_ordering_value(ordering: &str) -> Option<i64> {
+    match ordering {
+        "Weak" => Some(0),
+        "Relaxed" => Some(1),
+        "Acquire" => Some(2),
+        _ => None,
+    }
+}
+
+fn store_ordering_value(ordering: &str) -> Option<i64> {
+    match ordering {
+        "Weak" => Some(0),
+        "Relaxed" => Some(1),
+        "Release" => Some(3),
+        _ => None,
+    }
+}
+
+fn atomic_ordering_value(ordering: &str) -> Option<i64> {
+    match ordering {
+        "Relaxed" => Some(1),
+        "Acquire" => Some(2),
+        "Release" => Some(3),
+        "AcqRel" => Some(4),
+        _ => None,
+    }
+}

--- a/cutile-compiler/src/compiler/compile_inline.rs
+++ b/cutile-compiler/src/compiler/compile_inline.rs
@@ -69,6 +69,25 @@ impl VisitMut for CallSiteSpanSetter {
     fn visit_span_mut(&mut self, span: &mut Span) {
         *span = self.target_span;
     }
+
+    fn visit_expr_lit_mut(&mut self, expr: &mut syn::ExprLit) {
+        syn::visit_mut::visit_expr_lit_mut(self, expr);
+        set_lit_span(&mut expr.lit, self.target_span);
+    }
+}
+
+fn set_lit_span(lit: &mut syn::Lit, span: Span) {
+    match lit {
+        syn::Lit::Str(lit) => lit.set_span(span),
+        syn::Lit::ByteStr(lit) => lit.set_span(span),
+        syn::Lit::Byte(lit) => lit.set_span(span),
+        syn::Lit::Char(lit) => lit.set_span(span),
+        syn::Lit::Int(lit) => lit.set_span(span),
+        syn::Lit::Float(lit) => lit.set_span(span),
+        syn::Lit::Bool(lit) => lit.span = span,
+        syn::Lit::Verbatim(_) => {}
+        _ => {}
+    }
 }
 
 impl<'m> CUDATileFunctionCompiler<'m> {
@@ -83,7 +102,13 @@ impl<'m> CUDATileFunctionCompiler<'m> {
         ctx: &mut CompilerContext,
         return_type: Option<TileRustType>,
     ) -> Result<Option<TileRustValue>, JITError> {
+        let normalized_fn_item = crate::type_aliases::normalize_item_fn_param_type_aliases(
+            fn_item,
+            self.modules.type_aliases(),
+        )
+        .map_err(JITError::Generic)?;
         stacker::maybe_grow(STACK_RED_ZONE, STACK_GROW_SIZE, || {
+            let fn_item = &normalized_fn_item;
             let _inline_function_call_debug_str = call_expr.to_token_stream().to_string();
             // println!("enter_function_call: {}", call_expr.to_token_stream().to_string());
 
@@ -127,7 +152,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
             }
             // Remap generic parameters.
             let expr_generic_args = get_call_expression_generics(call_expr);
-            let call_generic_vars = if GenericVars::is_empty(&fn_item.sig.generics) {
+            let mut call_generic_vars = if GenericVars::is_empty(&fn_item.sig.generics) {
                 // If there are no generics, we're done.
                 GenericVars::empty(&fn_item.sig.generics)?
             } else if expr_generic_args.is_some() {
@@ -146,9 +171,15 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                 generic_arg_inference
                     .get_generic_vars_instance(&generic_vars, &self.modules.primitives())
             };
+            self.add_module_const_vars(&mut call_generic_vars);
             // Add function call const generics as variables.
             for (key, value) in &call_generic_vars.inst_i32 {
                 let tr_val = self.compile_constant(module, block_id, &call_generic_vars, *value)?;
+                call_variables.vars.insert(key.clone(), tr_val);
+            }
+            for (key, value) in &call_generic_vars.inst_bool {
+                let tr_val =
+                    self.compile_bool_constant(module, block_id, &call_generic_vars, *value)?;
                 call_variables.vars.insert(key.clone(), tr_val);
             }
             // Add function call CGAs arrays as variables.
@@ -175,6 +206,12 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                 .map(|(name, value)| (name.clone(), value.ty.clone()))
                 .collect::<HashMap<_, _>>();
             let mut typed_fn_item = fn_item.clone();
+            if !same_module_identity(module_name, &self.module_name) {
+                let mut setter = CallSiteSpanSetter {
+                    target_span: call_expr.func.span(),
+                };
+                setter.visit_item_fn_mut(&mut typed_fn_item);
+            }
             crate::passes::node_ids::assign_expr_ids(&mut typed_fn_item);
             let typeck_results = crate::passes::type_inference::infer_function(
                 self,
@@ -223,8 +260,13 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                     ctx,
                 )?
                 else {
-                    return self
-                        .jit_error_result(&call_expr.func.span(), "Failed to derive return type");
+                    return self.jit_error_result(
+                        &call_expr.func.span(),
+                        &format!(
+                            "Failed to determine typeck return type for inlined function call `{}`",
+                            call_expr.to_token_stream()
+                        ),
+                    );
                 };
                 res.ty = derived_ret_ty;
                 Ok(Some(res))
@@ -258,18 +300,14 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                 .iter()
                 .map(|arg| arg.ty.rust_ty.clone())
                 .collect::<Vec<_>>();
-            let selected_method = self
-                .typeck_results
-                .borrow()
-                .as_ref()
-                .and_then(|results| results.method_selection(method_call_expr).cloned());
+            let selected_method = self.typeck_method_selection(method_call_expr);
             let (module_name, impl_item, impl_method, selected_generic_vars) =
                 if let Some(selection) = selected_method {
                     (
                         selection.module_name,
                         selection.impl_item,
                         selection.impl_method,
-                        None,
+                        Some(selection.generic_vars),
                     )
                 } else {
                     let impl_item_fn = self.modules.get_impl_item_fn(
@@ -328,7 +366,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
             // Remap generic parameters.
             // This is different from a function call, because passing generics to a method
             // does not capture all generics available within the method.
-            let call_generic_vars = if let Some(selected_generic_vars) = selected_generic_vars {
+            let mut call_generic_vars = if let Some(selected_generic_vars) = selected_generic_vars {
                 selected_generic_vars
             } else {
                 let generic_arg_inference =
@@ -348,10 +386,15 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                     )?
                 }
             };
+            self.add_module_const_vars(&mut call_generic_vars);
 
             // Add method call const generics as variables.
             for (key, value) in &call_generic_vars.inst_i32 {
                 let tr_val = self.compile_constant(module, block_id, generic_vars, *value)?;
+                call_variables.vars.insert(key.clone(), tr_val);
+            }
+            for (key, value) in &call_generic_vars.inst_bool {
+                let tr_val = self.compile_bool_constant(module, block_id, generic_vars, *value)?;
                 call_variables.vars.insert(key.clone(), tr_val);
             }
             for (key, value) in &call_generic_vars.inst_array {
@@ -381,7 +424,23 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                 target_span: method_call_expr.span(),
             };
             setter.visit_block_mut(&mut compile_block);
-            let previous_typeck_results = self.typeck_results.replace(None);
+            crate::passes::node_ids::assign_block_expr_ids(&mut compile_block);
+            let initial_types = call_variables
+                .vars
+                .iter()
+                .map(|(name, value)| (name.clone(), value.ty.clone()))
+                .collect::<HashMap<_, _>>();
+            let mut typed_method = impl_method.clone();
+            typed_method.block = compile_block.clone();
+            let typeck_results = crate::passes::type_inference::infer_method(
+                self,
+                &impl_item,
+                &typed_method,
+                self_ty,
+                &call_generic_vars,
+                initial_types,
+            )?;
+            let previous_typeck_results = self.typeck_results.replace(Some(typeck_results));
             let result = self.compile_block(
                 module,
                 block_id,
@@ -420,7 +479,10 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                 else {
                     return self.jit_error_result(
                         &method_call_expr.method.span(),
-                        "Failed to derive return type",
+                        &format!(
+                            "Failed to determine typeck return type for inlined method call `{}`",
+                            method_call_expr.to_token_stream()
+                        ),
                     );
                 };
                 res.ty = derived_ret_ty;
@@ -430,4 +492,8 @@ impl<'m> CUDATileFunctionCompiler<'m> {
             }
         }) // stacker::maybe_grow
     }
+}
+
+fn same_module_identity(a: &str, b: &str) -> bool {
+    a == b || a.rsplit("::").next() == b.rsplit("::").next()
 }

--- a/cutile-compiler/src/compiler/compile_intrinsic.rs
+++ b/cutile-compiler/src/compiler/compile_intrinsic.rs
@@ -127,7 +127,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
         outer_tile: &TileRustValue,
         generic_vars: &GenericVars,
         ctx: &mut CompilerContext,
-    ) -> Result<TileRustValue, JITError> {
+    ) -> Result<Option<TileRustValue>, JITError> {
         let outer_shape = self.static_shape_from_value(outer_tile, generic_vars, span)?;
         let nested_shape = self.partition_tile_shape(partition_value, span)?;
         if outer_shape.len() != nested_shape.len() {
@@ -147,6 +147,19 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                 "nested mutable partition access offsets are only supported up to rank 3",
             );
         }
+        for (i, nested_dim) in nested_shape.iter().enumerate() {
+            if *nested_dim <= 0 {
+                return self.jit_error_result(
+                    span,
+                    &format!(
+                        "nested mutable partition requires static positive nested tile dimensions, got nested dim {nested_dim} at axis {i}"
+                    ),
+                );
+            }
+        }
+        if outer_shape.iter().any(|dim| *dim <= 0) {
+            return Ok(None);
+        }
 
         let i32_ty = self.scalar_i32_type(span)?;
         let scalar_i32_ir_ty = Type::Tile(TileType {
@@ -164,14 +177,6 @@ impl<'m> CUDATileFunctionCompiler<'m> {
         for i in 0..rank {
             let outer_dim = outer_shape[i];
             let nested_dim = nested_shape[i];
-            if outer_dim <= 0 || nested_dim <= 0 {
-                return self.jit_error_result(
-                    span,
-                    &format!(
-                        "nested mutable partition requires static positive tile dimensions, got outer dim {outer_dim} and nested dim {nested_dim} at axis {i}"
-                    ),
-                );
-            }
             let pid = TileRustValue::new_primitive(pid_results[i], i32_ty.clone(), None);
             let ratio = ((outer_dim as i64 + nested_dim as i64 - 1) / nested_dim as i64) as i32;
             let offset = if ratio == 1 {
@@ -195,7 +200,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
         }
 
         let array_ty = self.array_i32_type(rank, generic_vars, span)?;
-        Ok(TileRustValue::new_compound(offsets, array_ty))
+        Ok(Some(TileRustValue::new_compound(offsets, array_ty)))
     }
 
     /// Compiles a `compiler_op` (intrinsic) function call.
@@ -1337,18 +1342,16 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                         ),
                     );
                 }
-                let outer_shape =
-                    self.static_shape_from_value(&outer_tile, generic_vars, &call_expr.span())?;
-                if outer_shape.iter().all(|d| *d > 0) {
-                    let access_offset = self.compile_nested_mutable_access_offset_metadata(
-                        module,
-                        block_id,
-                        &call_expr.span(),
-                        &partition_value,
-                        &outer_tile,
-                        generic_vars,
-                        ctx,
-                    )?;
+                let access_offset = self.compile_nested_mutable_access_offset_metadata(
+                    module,
+                    block_id,
+                    &call_expr.span(),
+                    &partition_value,
+                    &outer_tile,
+                    generic_vars,
+                    ctx,
+                )?;
+                if let Some(access_offset) = access_offset {
                     partition_value
                         .insert_type_meta_field(NESTED_MUTABLE_ACCESS_OFFSET_META, access_offset)?;
                 }

--- a/cutile-compiler/src/compiler/compile_type.rs
+++ b/cutile-compiler/src/compiler/compile_type.rs
@@ -26,6 +26,8 @@ impl<'m> CUDATileFunctionCompiler<'m> {
         generic_vars: &GenericVars,
         type_params: &HashMap<String, TypeParam>,
     ) -> Result<Option<TileRustType>, JITError> {
+        let normalized_ty = self.modules.normalize_type_aliases(ty)?;
+        let ty = &normalized_ty;
         let _ty_debug_str = ty.to_token_stream().to_string();
         let mut ty_attrs: Option<SingleMetaList> = None;
         let mut structure: Option<(String, &syn::ItemStruct)> = None;

--- a/cutile-compiler/src/compiler/mod.rs
+++ b/cutile-compiler/src/compiler/mod.rs
@@ -18,6 +18,7 @@ mod compile_binary_op;
 mod compile_block;
 mod compile_cuda_tile_op;
 mod compile_expression;
+mod compile_global;
 mod compile_inline;
 mod compile_intrinsic;
 mod compile_type;

--- a/cutile-compiler/src/compiler/shared_utils.rs
+++ b/cutile-compiler/src/compiler/shared_utils.rs
@@ -22,8 +22,12 @@ use super::_value::{CompilerContext, TileRustValue};
 // Stack management constants
 // ---------------------------------------------------------------------------
 
-/// Minimum remaining stack space before growing (1 MiB).
-pub(crate) const STACK_RED_ZONE: usize = 1 * 1024 * 1024;
+/// Minimum remaining stack space before growing (4 MiB).
+///
+/// Large kernels with nested control flow and inlined DSL helpers can enter
+/// non-trivial work just below a `stacker::maybe_grow` boundary. Growing before
+/// the final MiB avoids finite deep lowering paths exhausting the native stack.
+pub(crate) const STACK_RED_ZONE: usize = 4 * 1024 * 1024;
 /// Size of each new stack segment when growth is needed (10 MiB).
 pub(crate) const STACK_GROW_SIZE: usize = 10 * 1024 * 1024;
 
@@ -439,6 +443,54 @@ pub fn resolve_option_arg(expr: &syn::Expr, ctx: &CompilerContext) -> Option<syn
 // Variable mutation analysis
 // ---------------------------------------------------------------------------
 
+fn collect_pattern_bindings(pat: &Pat, names: &mut Vec<String>) -> Result<(), JITError> {
+    match pat {
+        Pat::Ident(ident) => {
+            names.push(ident.ident.to_string());
+            if let Some((_at, subpat)) = &ident.subpat {
+                collect_pattern_bindings(subpat, names)?;
+            }
+            Ok(())
+        }
+        Pat::Type(pat_type) => collect_pattern_bindings(&pat_type.pat, names),
+        Pat::Paren(paren) => collect_pattern_bindings(&paren.pat, names),
+        Pat::Reference(reference) => collect_pattern_bindings(&reference.pat, names),
+        Pat::Tuple(tuple) => {
+            for elem in &tuple.elems {
+                collect_pattern_bindings(elem, names)?;
+            }
+            Ok(())
+        }
+        Pat::Slice(slice) => {
+            for elem in &slice.elems {
+                collect_pattern_bindings(elem, names)?;
+            }
+            Ok(())
+        }
+        Pat::Struct(pat_struct) => {
+            for field in &pat_struct.fields {
+                collect_pattern_bindings(&field.pat, names)?;
+            }
+            Ok(())
+        }
+        Pat::TupleStruct(tuple_struct) => {
+            for elem in &tuple_struct.elems {
+                collect_pattern_bindings(elem, names)?;
+            }
+            Ok(())
+        }
+        Pat::Or(or_pat) => {
+            for case in &or_pat.cases {
+                collect_pattern_bindings(case, names)?;
+            }
+            Ok(())
+        }
+        Pat::Wild(_) | Pat::Rest(_) => Ok(()),
+        _ => SourceLocation::unknown()
+            .jit_error_result(&format!("Local pattern type not supported {:#?}", pat)),
+    }
+}
+
 /// Collects the names of variables assigned (mutated) in a block that were defined outside it.
 pub fn collect_mutated_variables_from_block(
     block: &syn::Block,
@@ -449,60 +501,7 @@ pub fn collect_mutated_variables_from_block(
         match statement {
             Stmt::Local(local) => {
                 let mut var_names: Vec<String> = vec![];
-                match &local.pat {
-                    Pat::Type(pat_type) => match &*pat_type.pat {
-                        Pat::Ident(pat_ident) => {
-                            var_names.push(pat_ident.ident.to_string());
-                        }
-                        Pat::Tuple(pat_tuple) => {
-                            for elem in &pat_tuple.elems {
-                                match elem {
-                                    Pat::Ident(ident) => {
-                                        var_names.push(ident.ident.to_string());
-                                    }
-                                    _ => {
-                                        return SourceLocation::unknown().jit_error_result(
-                                            "Only identifier patterns supported in tuple destructuring",
-                                        );
-                                    }
-                                }
-                            }
-                        }
-                        _ => {
-                            return SourceLocation::unknown().jit_error_result(&format!(
-                                "let binding LHS not implemented {:#?}.",
-                                pat_type.pat
-                            ));
-                        }
-                    },
-                    Pat::Tuple(pat_tuple) => {
-                        for elem in &pat_tuple.elems {
-                            match elem {
-                                Pat::Ident(ident) => {
-                                    var_names.push(ident.ident.to_string());
-                                }
-                                _ => {
-                                    return SourceLocation::unknown().jit_error_result(
-                                        "Only identifier patterns supported in tuple destructuring",
-                                    );
-                                }
-                            }
-                        }
-                    }
-                    Pat::Ident(pat_ident) => {
-                        var_names.push(pat_ident.ident.to_string());
-                    }
-                    _ => {
-                        return SourceLocation::unknown().jit_error_result(&format!(
-                            "Local pattern type not supported {:#?}",
-                            local.pat
-                        ));
-                    }
-                }
-                if var_names.is_empty() {
-                    return SourceLocation::unknown()
-                        .jit_error_result("failed to parse variable name in let expression");
-                }
+                collect_pattern_bindings(&local.pat, &mut var_names)?;
                 local_vars.extend(var_names);
             }
             Stmt::Expr(Expr::Assign(assign_expr), _) => {
@@ -521,7 +520,7 @@ pub fn collect_mutated_variables_from_block(
             }
             // Recurse into control-flow expressions to find nested mutations.
             Stmt::Expr(Expr::ForLoop(for_expr), _) => {
-                let inner = collect_mutated_variables_from_block(&for_expr.body)?;
+                let inner = collect_mutated_variables(for_expr)?;
                 for name in inner {
                     if !local_vars.contains(&name) {
                         result.insert(name);
@@ -544,21 +543,11 @@ pub fn collect_mutated_variables_from_block(
                     }
                 }
             }
-            Stmt::Expr(Expr::If(if_expr), _) => {
-                let inner = collect_mutated_variables_from_block(&if_expr.then_branch)?;
+            Stmt::Expr(expr, _) => {
+                let inner = collect_mutated_variables_from_expr(expr)?;
                 for name in inner {
                     if !local_vars.contains(&name) {
                         result.insert(name);
-                    }
-                }
-                if let Some((_else, else_expr)) = &if_expr.else_branch {
-                    if let Expr::Block(block_expr) = &**else_expr {
-                        let inner = collect_mutated_variables_from_block(&block_expr.block)?;
-                        for name in inner {
-                            if !local_vars.contains(&name) {
-                                result.insert(name);
-                            }
-                        }
                     }
                 }
             }
@@ -568,11 +557,47 @@ pub fn collect_mutated_variables_from_block(
     Ok(result)
 }
 
+/// Collects mutated outer-scope variables from an expression.
+pub fn collect_mutated_variables_from_expr(expr: &Expr) -> Result<BTreeSet<String>, JITError> {
+    match expr {
+        Expr::Assign(assign_expr) => {
+            let var_name: String = match &*assign_expr.left {
+                Expr::Path(path_expr) => get_ident_from_path_expr(path_expr).to_string(),
+                _ => {
+                    return SourceLocation::unknown().jit_error_result(&format!(
+                        "LHS assign expression not implemented {:#?}.",
+                        assign_expr.left
+                    ));
+                }
+            };
+            Ok(BTreeSet::from([var_name]))
+        }
+        Expr::Block(block_expr) => collect_mutated_variables_from_block(&block_expr.block),
+        Expr::ForLoop(for_expr) => collect_mutated_variables(for_expr),
+        Expr::While(while_expr) => collect_mutated_variables_from_block(&while_expr.body),
+        Expr::Loop(loop_expr) => collect_mutated_variables_from_block(&loop_expr.body),
+        Expr::If(if_expr) => {
+            let mut result = collect_mutated_variables_from_block(&if_expr.then_branch)?;
+            if let Some((_else, else_expr)) = &if_expr.else_branch {
+                result.extend(collect_mutated_variables_from_expr(else_expr)?);
+            }
+            Ok(result)
+        }
+        _ => Ok(BTreeSet::new()),
+    }
+}
+
 /// Collects mutated outer-scope variables from a for-loop body.
 pub fn collect_mutated_variables(
     for_expr: &syn::ExprForLoop,
 ) -> Result<BTreeSet<String>, JITError> {
-    collect_mutated_variables_from_block(&for_expr.body)
+    let mut result = collect_mutated_variables_from_block(&for_expr.body)?;
+    let mut loop_vars = Vec::new();
+    collect_pattern_bindings(&for_expr.pat, &mut loop_vars)?;
+    for loop_var in loop_vars {
+        result.remove(&loop_var);
+    }
+    Ok(result)
 }
 
 /// Collects mutated outer-scope variables from a while-loop body.

--- a/cutile-compiler/src/generics.rs
+++ b/cutile-compiler/src/generics.rs
@@ -76,6 +76,8 @@ pub struct GenericVars {
     pub inst_types: HashMap<String, String>,
     // Generic i32 param name to i32.
     pub inst_i32: HashMap<String, i32>,
+    // Generic bool param name to bool.
+    pub inst_bool: HashMap<String, bool>,
     // Generic array param name to generic array instance.
     pub inst_array: HashMap<String, Vec<i32>>,
     // A map from the length variable of a const generic array to the corresponding key in inst_array.
@@ -90,7 +92,10 @@ impl GenericVars {
             Some(GenericVarType::TypeVariable)
         } else if self.len2array.contains_key(var) {
             Some(GenericVarType::LengthVariable)
-        } else if self.inst_i32.contains_key(var) || self.inst_array.contains_key(var) {
+        } else if self.inst_i32.contains_key(var)
+            || self.inst_bool.contains_key(var)
+            || self.inst_array.contains_key(var)
+        {
             Some(GenericVarType::ConstVariable)
         } else {
             return None;
@@ -111,12 +116,14 @@ impl GenericVars {
     pub fn empty_unchecked() -> Self {
         let inst_types: HashMap<String, String> = HashMap::new();
         let inst_i32: HashMap<String, i32> = HashMap::new();
+        let inst_bool: HashMap<String, bool> = HashMap::new();
         let inst_array: HashMap<String, Vec<i32>> = HashMap::new();
         let len2array: HashMap<String, String> = HashMap::new();
         let ordered_param_vars: Vec<String> = Vec::new();
         GenericVars {
             inst_types,
             inst_i32,
+            inst_bool,
             inst_array,
             len2array,
             ordered_param_vars,
@@ -137,6 +144,7 @@ impl GenericVars {
         // These are kernel entry points and require known length.
         // There are no variable length consts.
         let mut inst_i32: HashMap<String, i32> = HashMap::new();
+        let mut inst_bool: HashMap<String, bool> = HashMap::new();
         let mut inst_array: HashMap<String, Vec<i32>> = HashMap::new();
         let len2array: HashMap<String, String> = HashMap::new();
         let mut ordered_param_vars: Vec<String> = Vec::new();
@@ -172,20 +180,30 @@ impl GenericVars {
                             }
                             let name = const_param.ident.to_string();
                             let ty = type_path.to_token_stream().to_string();
-                            if ty != "i32" {
+                            if ty == "i32" {
+                                let arg = args[pos].parse::<i32>().unwrap();
+                                ordered_param_vars.push(name.clone());
+                                inst_i32.insert(name, arg);
+                            } else if ty == "bool" {
+                                let arg = args[pos].parse::<bool>().map_err(|err| {
+                                    SourceLocation::unknown().jit_error(&format!(
+                                        "failed to parse bool generic argument `{}` for `{}`: {err}",
+                                        args[pos], const_param.ident
+                                    ))
+                                })?;
+                                ordered_param_vars.push(name.clone());
+                                inst_bool.insert(name, arg);
+                            } else {
                                 return SourceLocation::unknown().jit_error_result(&format!(
-                                    "const generic `{}` must be `i32`, got `{ty}`",
+                                    "const generic `{}` must be `i32` or `bool`, got `{ty}`",
                                     const_param.ident
                                 ));
                             }
-                            let arg = args[pos].parse::<i32>().unwrap();
-                            ordered_param_vars.push(name.clone());
-                            inst_i32.insert(name, arg);
                             pos += 1;
                         }
                         _ => {
                             return SourceLocation::unknown().jit_error_result(&format!(
-                                "unsupported type for const generic parameter `{}`; only `i32` and `[i32; N]` are supported",
+                                "unsupported type for const generic parameter `{}`; only `i32`, `bool`, and `[i32; N]` are supported",
                                 const_param.ident
                             ));
                         }
@@ -209,6 +227,7 @@ impl GenericVars {
         Ok(GenericVars {
             inst_types,
             inst_i32,
+            inst_bool,
             inst_array,
             len2array,
             ordered_param_vars,
@@ -227,6 +246,7 @@ impl GenericVars {
         // println!("inlining function with \n generics={generics:#?} \n expr_generic_args={expr_generic_args:#?}");
         let mut inst_types: HashMap<String, String> = HashMap::new();
         let mut inst_i32: HashMap<String, i32> = HashMap::new();
+        let mut inst_bool: HashMap<String, bool> = HashMap::new();
         let mut inst_array: HashMap<String, Vec<i32>> = HashMap::new();
         let mut len2array: HashMap<String, String> = HashMap::new();
         let mut ordered_param_vars: Vec<String> = vec![];
@@ -234,6 +254,7 @@ impl GenericVars {
             return Ok(GenericVars {
                 inst_types,
                 inst_i32,
+                inst_bool,
                 inst_array,
                 len2array,
                 ordered_param_vars,
@@ -289,22 +310,41 @@ impl GenericVars {
                                 }
                             }
                         }
-                        (syn::Expr::Path(arg_path_expr), syn::Type::Path(_param_ty_path)) => {
+                        (syn::Expr::Path(arg_path_expr), syn::Type::Path(param_ty_path)) => {
                             let name = const_param.ident.to_string();
                             let ident_str = get_ident_from_path_expr(arg_path_expr).to_string();
-                            let Some(inst) = self.inst_i32.get(ident_str.as_str()) else {
-                                return SourceLocation::unknown().jit_error_result(&format!(
-                                    "variable `{ident_str}` is not a known const generic scalar"
-                                ));
-                            };
+                            let param_ty = param_ty_path.to_token_stream().to_string();
                             ordered_param_vars.push(name.clone());
-                            inst_i32.insert(name, inst.clone());
+                            if param_ty == "bool" {
+                                let Some(inst) = self.inst_bool.get(ident_str.as_str()) else {
+                                    return SourceLocation::unknown().jit_error_result(&format!(
+                                        "variable `{ident_str}` is not a known bool const generic"
+                                    ));
+                                };
+                                inst_bool.insert(name, *inst);
+                            } else {
+                                let Some(inst) = self.inst_i32.get(ident_str.as_str()) else {
+                                    return SourceLocation::unknown().jit_error_result(&format!(
+                                        "variable `{ident_str}` is not a known const generic scalar"
+                                    ));
+                                };
+                                inst_i32.insert(name, *inst);
+                            }
                         }
-                        (syn::Expr::Lit(_arg_lit_expr), syn::Type::Path(_param_ty_path)) => {
+                        (syn::Expr::Lit(arg_lit_expr), syn::Type::Path(param_ty_path)) => {
                             let name = const_param.ident.to_string();
-                            let literal_i32 = parse_signed_literal_as_i32(const_arg);
                             ordered_param_vars.push(name.clone());
-                            inst_i32.insert(name, literal_i32);
+                            if param_ty_path.to_token_stream().to_string() == "bool" {
+                                let Lit::Bool(bool_lit) = &arg_lit_expr.lit else {
+                                    return SourceLocation::unknown().jit_error_result(&format!(
+                                        "expected bool literal for const generic `{name}`"
+                                    ));
+                                };
+                                inst_bool.insert(name, bool_lit.value);
+                            } else {
+                                let literal_i32 = parse_signed_literal_as_i32(const_arg);
+                                inst_i32.insert(name, literal_i32);
+                            }
                         }
                         (syn::Expr::Block(_), syn::Type::Array(ty_arr)) => {
                             let name = const_param.ident.to_string();
@@ -396,17 +436,30 @@ impl GenericVars {
                                 inst_array.insert(name, inst.clone());
                             }
                         }
-                        syn::Type::Path(_param_ty_path) => {
+                        syn::Type::Path(param_ty_path) => {
                             let name = const_param.ident.to_string();
-                            let Some(inst) = self.inst_i32.get(arg_ident_str.to_string().as_str())
-                            else {
-                                return SourceLocation::unknown().jit_error_result(&format!(
-                                    "variable `{}` is not a known const generic scalar",
-                                    arg_ident_str
-                                ));
-                            };
                             ordered_param_vars.push(name.clone());
-                            inst_i32.insert(name.clone(), inst.clone());
+                            if param_ty_path.to_token_stream().to_string() == "bool" {
+                                let Some(inst) =
+                                    self.inst_bool.get(arg_ident_str.to_string().as_str())
+                                else {
+                                    return SourceLocation::unknown().jit_error_result(&format!(
+                                        "variable `{}` is not a known bool const generic",
+                                        arg_ident_str
+                                    ));
+                                };
+                                inst_bool.insert(name.clone(), *inst);
+                            } else {
+                                let Some(inst) =
+                                    self.inst_i32.get(arg_ident_str.to_string().as_str())
+                                else {
+                                    return SourceLocation::unknown().jit_error_result(&format!(
+                                        "variable `{}` is not a known const generic scalar",
+                                        arg_ident_str
+                                    ));
+                                };
+                                inst_i32.insert(name.clone(), *inst);
+                            }
                         }
                         _ => {
                             return SourceLocation::unknown().jit_error_result(&format!(
@@ -444,6 +497,7 @@ impl GenericVars {
         Ok(GenericVars {
             inst_types,
             inst_i32,
+            inst_bool,
             inst_array,
             len2array,
             ordered_param_vars,
@@ -465,10 +519,16 @@ impl GenericVars {
         None
     }
 
+    /// Looks up a const-generic `bool` value by parameter name.
+    pub fn get_bool(&self, name: &str) -> Option<bool> {
+        self.inst_bool.get(name).copied()
+    }
+
     /// Merges another `GenericVars` into this one, erroring on conflicting entries.
     pub fn merge(mut self, other: GenericVars) -> Result<GenericVars, JITError> {
         self.inst_types = self.inst_types.merge_if_eq(other.inst_types);
         self.inst_i32 = self.inst_i32.merge_if_eq(other.inst_i32);
+        self.inst_bool = self.inst_bool.merge_if_eq(other.inst_bool);
         self.inst_array = self.inst_array.merge_if_eq(other.inst_array);
         self.len2array = self.len2array.merge_if_eq(other.len2array);
         if !self.ordered_param_vars.is_empty() && !other.ordered_param_vars.is_empty() {
@@ -809,7 +869,7 @@ impl Instantiable for TypeInstanceStructuredType {
     ) -> Option<Self> {
         // This is Tile/Tensor/Partition/PartitionMut <T, Shape>.
         // This also handles PointerTile <* mut T, Shape>.
-        let (_type_ident, mut type_generic_args) = get_ident_generic_args(maybe_generic_ty);
+        let mut type_generic_args = maybe_generic_args(maybe_generic_ty)?;
         strip_generic_args_lifetimes(&mut type_generic_args);
         let generic_ty = maybe_generic_ty.clone();
         let mut instance_ty = maybe_generic_ty.clone();
@@ -959,6 +1019,9 @@ impl Instantiable for TypeInstanceStructuredType {
                                                     None => panic!("Undefined generic parameter {ident}")
                                                 }
                                             },
+                                            Expr::Index(_) => {
+                                                _shape.push(parse_expr_as_i32(elem, generic_vars));
+                                            }
                                             _ => unimplemented!("Unexpected array element {elem:#?} in {array_expr:#?}"),
                                         }
                                     }
@@ -1203,6 +1266,9 @@ impl GenericArgInference {
                 // and infer generic parameters in fn f<...>.
                 // Since these are generic arguments as part of a function call expression,
                 // they are either "type" or "const."
+                GenericArgument::Type(syn::Type::Infer(_)) => {
+                    continue;
+                }
                 GenericArgument::Type(arg_ty) => {
                     let Some(arg_type_ident) = get_type_ident(arg_ty) else {
                         panic!("apply_provided_generics_fn_call: Failed to get ident for type {arg_ty:#?}");
@@ -1228,6 +1294,15 @@ impl GenericArgInference {
                                         Some((
                                             GenericArgType::GenericConstExpr,
                                             (*inst_i32).to_string(),
+                                        )),
+                                    );
+                                } else if let Some(inst_bool) = generic_vars.inst_bool.get(var_str)
+                                {
+                                    self.param2arg.insert(
+                                        param.to_string(),
+                                        Some((
+                                            GenericArgType::GenericConstExpr,
+                                            (*inst_bool).to_string(),
                                         )),
                                     );
                                 } else if let Some(inst_arr) = generic_vars.inst_array.get(var_str)
@@ -1302,6 +1377,9 @@ impl GenericArgInference {
                 // and infer generic parameters in fn f<...>.
                 // Since these are generic arguments as part of a function call expression,
                 // they are either "type" or "const."
+                GenericArgument::Type(syn::Type::Infer(_)) => {
+                    continue;
+                }
                 GenericArgument::Type(arg_ty) => {
                     let Some(arg_type_ident) = get_type_ident(arg_ty) else {
                         panic!("apply_provided_generics_fn_call: Failed to get ident for type {arg_ty:#?}");
@@ -1324,14 +1402,26 @@ impl GenericArgInference {
                                 if let Some(inst_i32) = generic_vars.inst_i32.get(var_str) {
                                     self.param2arg.insert(
                                         param.to_string(),
-                                        Some((GenericArgType::Type, (*inst_i32).to_string())),
+                                        Some((
+                                            GenericArgType::GenericConstExpr,
+                                            (*inst_i32).to_string(),
+                                        )),
+                                    );
+                                } else if let Some(inst_bool) = generic_vars.inst_bool.get(var_str)
+                                {
+                                    self.param2arg.insert(
+                                        param.to_string(),
+                                        Some((
+                                            GenericArgType::GenericConstExpr,
+                                            (*inst_bool).to_string(),
+                                        )),
                                     );
                                 } else if let Some(inst_arr) = generic_vars.inst_array.get(var_str)
                                 {
                                     self.param2arg.insert(
                                         param.to_string(),
                                         Some((
-                                            GenericArgType::Type,
+                                            GenericArgType::GenericConstExpr,
                                             format!("{{[{:?}]}}", inst_arr),
                                         )),
                                     );
@@ -1357,7 +1447,10 @@ impl GenericArgInference {
                 GenericArgument::Const(c) => {
                     self.param2arg.insert(
                         param.to_string(),
-                        Some((GenericArgType::Type, c.to_token_stream().to_string())),
+                        Some((
+                            GenericArgType::GenericConstExpr,
+                            c.to_token_stream().to_string(),
+                        )),
                     );
                 }
                 _ => {}
@@ -1397,6 +1490,12 @@ impl GenericArgInference {
                     if let Some(inst_i32_val) = from_generic_args.inst_i32.get(ast_string) {
                         // This is a const generic i32
                         to_generic_vars.inst_i32.insert(name.clone(), *inst_i32_val);
+                    } else if let Some(inst_bool_val) = from_generic_args.inst_bool.get(ast_string)
+                    {
+                        // This is a const generic bool
+                        to_generic_vars
+                            .inst_bool
+                            .insert(name.clone(), *inst_bool_val);
                     } else if let Some(inst_arr_val) = from_generic_args.inst_array.get(ast_string)
                     {
                         // This is a const generic array
@@ -1420,15 +1519,9 @@ impl GenericArgInference {
                     // Check if it's a type parameter.
                     } else if let Some(inst_type_val) = from_generic_args.inst_types.get(ast_string)
                     {
-                        if is_element_type(inst_type_val.as_str(), primitives) {
-                            // This is a GenericParam::Type.
-                            // TODO (hme): Need to support this in more places than here.
-                            to_generic_vars
-                                .inst_types
-                                .insert(name.clone(), inst_type_val.to_string());
-                        } else {
-                            panic!("Failed to get generic arg instances for ({name}, {v:?}).");
-                        }
+                        to_generic_vars
+                            .inst_types
+                            .insert(name.clone(), inst_type_val.to_string());
                     // Check if it's a ptr of generic type param.
                     } else if let Some((is_mutable, element_type)) =
                         get_ptr_type_instance(ast_string, from_generic_args, primitives)
@@ -1453,13 +1546,35 @@ impl GenericArgInference {
                             .inst_types
                             .insert(name.clone(), ast_string.to_string());
                     } else {
-                        panic!("Failed to get generic arg instances for ({name}, {v:?}).");
+                        // ZST marker types (for example `ordering::Acquire`
+                        // and `scope::Device`) are ordinary concrete type
+                        // arguments. They are not ElementType instances, but
+                        // rustc has already accepted them against the method
+                        // bounds, and the JIT only needs to preserve the
+                        // selected type while inferring the return type.
+                        to_generic_vars
+                            .inst_types
+                            .insert(name.clone(), ast_string.to_string());
                     }
                 }
                 GenericArgType::GenericConstExpr => {
-                    let generic_arg =
-                        syn::parse2::<GenericArgument>(ast_string.parse().unwrap()).unwrap();
-                    if let Some(res) =
+                    let generic_arg = match syn::parse_str::<GenericArgument>(ast_string) {
+                        Ok(generic_arg) => generic_arg,
+                        Err(_) => {
+                            let expr = syn::parse_str::<Expr>(ast_string).unwrap_or_else(|err| {
+                                panic!(
+                                    "failed to parse inferred const generic `{ast_string}` for `{name}` as a generic argument or expression: {err}"
+                                )
+                            });
+                            GenericArgument::Const(expr)
+                        }
+                    };
+                    if let Some(res) = try_get_bool_const_generic_from_generic_argument(
+                        &generic_arg,
+                        from_generic_args,
+                    ) {
+                        to_generic_vars.inst_bool.insert(name.clone(), res);
+                    } else if let Some(res) =
                         try_get_const_generic_from_generic_argument(&generic_arg, from_generic_args)
                     {
                         // These are args -> param pairs like:
@@ -1494,6 +1609,10 @@ impl GenericArgInference {
             }
         }
         to_generic_vars
+    }
+
+    pub(crate) fn add_type_constraints(&mut self, type_param: &syn::Type, type_arg: &syn::Type) {
+        self.add_generic_args(type_param, type_arg);
     }
 
     fn add_generic_args(&mut self, type_param: &syn::Type, type_arg: &syn::Type) -> () {
@@ -1903,9 +2022,9 @@ impl GenericArgInference {
                                             .unwrap();
                                 }
                                 Some(Some((GenericArgType::GenericConstExpr, target_ty))) => {
-                                    *arg =
-                                        syn::parse2::<GenericArgument>(target_ty.parse().unwrap())
-                                            .unwrap();
+                                    let target_expr =
+                                        syn::parse2::<Expr>(target_ty.parse().unwrap()).unwrap();
+                                    *arg = GenericArgument::Const(target_expr);
                                 }
                             }
                         }
@@ -2066,6 +2185,28 @@ pub fn try_get_const_generic_from_generic_argument(
     result
 }
 
+/// Attempts to extract a bool const generic expression from a single generic argument.
+pub fn try_get_bool_const_generic_from_generic_argument(
+    generic_arg: &GenericArgument,
+    generic_args: &GenericVars,
+) -> Option<bool> {
+    match generic_arg {
+        GenericArgument::Type(Type::Path(type_path)) => {
+            let last_ident = type_path.path.segments.last()?.ident.to_string();
+            generic_args.inst_bool.get(&last_ident).copied()
+        }
+        GenericArgument::Const(Expr::Path(path)) => {
+            let ident = get_ident_from_path_expr(path).to_string();
+            generic_args.inst_bool.get(&ident).copied()
+        }
+        GenericArgument::Const(Expr::Lit(lit)) => match &lit.lit {
+            Lit::Bool(bool_lit) => Some(bool_lit.value),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
 /// Extracts a const generic array value from a generic argument, resolving variables.
 pub fn get_cga_from_generic_argument(
     generic_arg: &GenericArgument,
@@ -2171,6 +2312,23 @@ pub fn parse_expr_as_i32(expr: &Expr, generic_args: &GenericVars) -> i32 {
                 Some(val) => return *val,
                 None => panic!("Undefined generic parameter {ident}"),
             }
+        }
+        Expr::Index(index) => {
+            let Expr::Path(path) = index.expr.as_ref() else {
+                unimplemented!("Unexpected const generic array base {expr:#?}");
+            };
+            let ident = get_ident_from_path_expr(path);
+            let Some(shape) = generic_args.inst_array.get(ident.to_string().as_str()) else {
+                panic!("Undefined const generic array parameter {ident}");
+            };
+            let i = parse_signed_literal_as_i32(&index.index);
+            let Some(dim) = shape.get(i as usize) else {
+                panic!(
+                    "Index {i} out of bounds for const generic array `{ident}` of length {}",
+                    shape.len()
+                );
+            };
+            *dim
         }
         _ => unimplemented!("Unexpected expression {expr:#?}"),
     }

--- a/cutile-compiler/src/kernel_entry_generator.rs
+++ b/cutile-compiler/src/kernel_entry_generator.rs
@@ -7,6 +7,7 @@
 //! Handles tensor argument unpacking, validation, and shape/stride boilerplate.
 
 use crate::ast::SourceLocation;
+use crate::compiler::_module::CUDATileModules;
 use crate::error::{JITError, SpannedJITError};
 use crate::generics::{GenericVars, TypeInstance};
 use crate::hints::OptimizationHints;
@@ -368,8 +369,18 @@ impl TensorInput {
     }
 }
 
+fn normalized_fn_arg_type(param: &FnArg, ty: syn::Type) -> Result<FnArg, JITError> {
+    let FnArg::Typed(typed_param) = param else {
+        return SourceLocation::unknown().jit_error_result("Unexpected receiver argument.");
+    };
+    let mut typed_param = typed_param.clone();
+    typed_param.ty = Box::new(ty);
+    Ok(FnArg::Typed(typed_param))
+}
+
 /// Generates an MLIR entry-point wrapper for a kernel function, including tensor argument unpacking.
 pub fn generate_entry_point(
+    modules: &CUDATileModules,
     fn_item: &ItemFn,
     generic_vars: &GenericVars,
     stride_args: &HashMap<String, Vec<i32>>,
@@ -397,12 +408,14 @@ pub fn generate_entry_point(
                 return SourceLocation::unknown().jit_error_result("Unexpected receiver argument.");
             }
             FnArg::Typed(typed_param) => {
-                let ty = &*typed_param.ty;
+                let normalized_ty = modules.normalize_type_aliases(&typed_param.ty)?;
+                let normalized_param = normalized_fn_arg_type(param, normalized_ty.clone())?;
+                let ty = &normalized_ty;
                 match ty {
                     syn::Type::Reference(_type_ref) => {
                         let tensor_input = TensorInput::new(
                             fn_name.clone(),
-                            param,
+                            &normalized_param,
                             generic_vars,
                             stride_args,
                             spec_args,
@@ -630,6 +643,36 @@ pub fn get_tensor_shape(
                                                         ));
                                                 }
                                             }
+                                        }
+                                        Expr::Index(index) => {
+                                            let Expr::Path(path) = index.expr.as_ref() else {
+                                                return SourceLocation::unknown().jit_error_result(
+                                                    &format!(
+                                                    "Unexpected const generic array base {elem:#?}"
+                                                ),
+                                                );
+                                            };
+                                            let ident = get_ident_from_path_expr(path);
+                                            let Some(shape) = generic_vars
+                                                .inst_array
+                                                .get(ident.to_string().as_str())
+                                            else {
+                                                return SourceLocation::unknown()
+                                                    .jit_error_result(&format!(
+                                                        "Undefined const generic array parameter {ident}"
+                                                    ));
+                                            };
+                                            let i = crate::types::parse_signed_literal_as_i32(
+                                                &index.index,
+                                            );
+                                            let Some(dim) = shape.get(i as usize) else {
+                                                return SourceLocation::unknown()
+                                                    .jit_error_result(&format!(
+                                                        "Index {i} out of bounds for const generic array `{ident}` of length {}",
+                                                        shape.len()
+                                                    ));
+                                            };
+                                            _shape.push(dim.to_string());
                                         }
                                         _ => {
                                             return SourceLocation::unknown().jit_error_result(

--- a/cutile-compiler/src/lib.rs
+++ b/cutile-compiler/src/lib.rs
@@ -20,6 +20,7 @@ pub mod kernel_naming;
 pub mod registry;
 pub mod syn_utils;
 pub mod train_map;
+pub mod type_aliases;
 pub mod types;
 pub mod use_classifier;
 

--- a/cutile-compiler/src/passes/name_resolution.rs
+++ b/cutile-compiler/src/passes/name_resolution.rs
@@ -18,7 +18,10 @@
 use crate::error::JITError;
 use crate::syn_utils::*;
 use std::collections::HashMap;
-use syn::{ImplItem, ImplItemFn, Item, ItemFn, ItemImpl, ItemMod, ItemStruct, UseTree};
+use syn::{
+    ImplItem, ImplItemFn, Item, ItemConst, ItemFn, ItemImpl, ItemMod, ItemStatic, ItemStruct,
+    ItemTrait, ItemType, UseTree,
+};
 
 // ---------------------------------------------------------------------------
 // Core types (rustc equivalents)
@@ -42,6 +45,12 @@ pub enum DefKind {
     Struct,
     /// A trait definition.
     Trait,
+    /// A type alias definition.
+    TypeAlias,
+    /// A module-level constant.
+    Const,
+    /// A module-level static item.
+    Static,
     /// An associated function (method on a struct).
     AssocFn,
 }
@@ -95,6 +104,10 @@ pub enum Namespace {
 pub struct ModuleItems {
     pub functions: HashMap<String, ItemFn>,
     pub structs: HashMap<String, ItemStruct>,
+    pub traits: HashMap<String, ItemTrait>,
+    pub type_aliases: HashMap<String, ItemType>,
+    pub consts: HashMap<String, ItemConst>,
+    pub statics: HashMap<String, ItemStatic>,
     pub struct_impls: HashMap<String, Vec<ItemImpl>>,
     pub trait_impls: HashMap<(String, String), Vec<ItemImpl>>,
     pub primitives: HashMap<(String, String), ItemImpl>,
@@ -105,6 +118,10 @@ impl ModuleItems {
         Self {
             functions: HashMap::new(),
             structs: HashMap::new(),
+            traits: HashMap::new(),
+            type_aliases: HashMap::new(),
+            consts: HashMap::new(),
+            statics: HashMap::new(),
             struct_impls: HashMap::new(),
             trait_impls: HashMap::new(),
             primitives: HashMap::new(),
@@ -138,6 +155,14 @@ pub struct NameResolver {
     cached_functions: HashMap<String, (String, ItemFn)>,
     /// All structs across all modules: name → ItemStruct.
     cached_structs: HashMap<String, ItemStruct>,
+    /// All traits across all modules: name → ItemTrait.
+    cached_traits: HashMap<String, ItemTrait>,
+    /// All type aliases across all modules: name → ItemType.
+    cached_type_aliases: HashMap<String, ItemType>,
+    /// All constants across all modules: name → ItemConst.
+    cached_consts: HashMap<String, ItemConst>,
+    /// All static items across all modules: name → ItemStatic.
+    cached_statics: HashMap<String, ItemStatic>,
     /// All struct impls across all modules: struct_name → [(module_name, ItemImpl)].
     cached_struct_impls: HashMap<String, Vec<(String, ItemImpl)>>,
     /// All trait impls across all modules: (trait, self_ty) → [(module_name, ItemImpl)].
@@ -173,6 +198,10 @@ impl NameResolver {
         has_cuda_tile_ty: &mut bool,
         cached_functions: &mut HashMap<String, (String, ItemFn)>,
         cached_structs: &mut HashMap<String, ItemStruct>,
+        cached_traits: &mut HashMap<String, ItemTrait>,
+        cached_type_aliases: &mut HashMap<String, ItemType>,
+        cached_consts: &mut HashMap<String, ItemConst>,
+        cached_statics: &mut HashMap<String, ItemStatic>,
         cached_struct_impls: &mut HashMap<String, Vec<(String, ItemImpl)>>,
         cached_trait_impls: &mut HashMap<(String, String), Vec<(String, ItemImpl)>>,
         cached_primitives: &mut HashMap<(String, String), ItemImpl>,
@@ -196,6 +225,26 @@ impl NameResolver {
                     let name = s.ident.to_string();
                     mi.structs.insert(name.clone(), s.clone());
                     cached_structs.insert(name, s.clone());
+                }
+                Item::Trait(t) => {
+                    let name = t.ident.to_string();
+                    mi.traits.insert(name.clone(), t.clone());
+                    cached_traits.insert(name, t.clone());
+                }
+                Item::Type(t) => {
+                    let name = t.ident.to_string();
+                    mi.type_aliases.insert(name.clone(), t.clone());
+                    cached_type_aliases.insert(name, t.clone());
+                }
+                Item::Const(c) => {
+                    let name = c.ident.to_string();
+                    mi.consts.insert(name.clone(), c.clone());
+                    cached_consts.insert(name, c.clone());
+                }
+                Item::Static(s) => {
+                    let name = s.ident.to_string();
+                    mi.statics.insert(name.clone(), s.clone());
+                    cached_statics.insert(name, s.clone());
                 }
                 Item::Impl(impl_item) => {
                     let self_ident = get_type_str(&impl_item.self_ty);
@@ -245,6 +294,10 @@ impl NameResolver {
                             has_cuda_tile_ty,
                             cached_functions,
                             cached_structs,
+                            cached_traits,
+                            cached_type_aliases,
+                            cached_consts,
+                            cached_statics,
                             cached_struct_impls,
                             cached_trait_impls,
                             cached_primitives,
@@ -267,6 +320,10 @@ impl NameResolver {
         let mut cached_primitives: HashMap<(String, String), ItemImpl> = HashMap::new();
         let mut cached_functions: HashMap<String, (String, ItemFn)> = HashMap::new();
         let mut cached_structs: HashMap<String, ItemStruct> = HashMap::new();
+        let mut cached_traits: HashMap<String, ItemTrait> = HashMap::new();
+        let mut cached_type_aliases: HashMap<String, ItemType> = HashMap::new();
+        let mut cached_consts: HashMap<String, ItemConst> = HashMap::new();
+        let mut cached_statics: HashMap<String, ItemStatic> = HashMap::new();
         let mut cached_struct_impls: HashMap<String, Vec<(String, ItemImpl)>> = HashMap::new();
         let mut cached_trait_impls: HashMap<(String, String), Vec<(String, ItemImpl)>> =
             HashMap::new();
@@ -293,6 +350,10 @@ impl NameResolver {
                 &mut has_cuda_tile_ty,
                 &mut cached_functions,
                 &mut cached_structs,
+                &mut cached_traits,
+                &mut cached_type_aliases,
+                &mut cached_consts,
+                &mut cached_statics,
                 &mut cached_struct_impls,
                 &mut cached_trait_impls,
                 &mut cached_primitives,
@@ -323,6 +384,10 @@ impl NameResolver {
             cached_primitives,
             cached_functions,
             cached_structs,
+            cached_traits,
+            cached_type_aliases,
+            cached_consts,
+            cached_statics,
             cached_struct_impls,
             cached_trait_impls,
         })
@@ -450,6 +515,42 @@ impl NameResolver {
                 },
             ));
         }
+        if mi.traits.contains_key(name) {
+            return Some(Res::Def(
+                DefKind::Trait,
+                DefId {
+                    module: module.to_string(),
+                    name: name.to_string(),
+                },
+            ));
+        }
+        if mi.type_aliases.contains_key(name) {
+            return Some(Res::Def(
+                DefKind::TypeAlias,
+                DefId {
+                    module: module.to_string(),
+                    name: name.to_string(),
+                },
+            ));
+        }
+        if mi.consts.contains_key(name) {
+            return Some(Res::Def(
+                DefKind::Const,
+                DefId {
+                    module: module.to_string(),
+                    name: name.to_string(),
+                },
+            ));
+        }
+        if mi.statics.contains_key(name) {
+            return Some(Res::Def(
+                DefKind::Static,
+                DefId {
+                    module: module.to_string(),
+                    name: name.to_string(),
+                },
+            ));
+        }
         None
     }
 
@@ -465,6 +566,39 @@ impl NameResolver {
     /// Get a struct by its DefId.
     pub fn get_struct(&self, def_id: &DefId) -> Option<&ItemStruct> {
         self.items.get(&def_id.module)?.structs.get(&def_id.name)
+    }
+
+    /// Get a trait by its DefId.
+    pub fn get_trait(&self, def_id: &DefId) -> Option<&ItemTrait> {
+        self.items.get(&def_id.module)?.traits.get(&def_id.name)
+    }
+
+    /// Get a type alias by its DefId.
+    pub fn get_type_alias(&self, def_id: &DefId) -> Option<&ItemType> {
+        self.items
+            .get(&def_id.module)?
+            .type_aliases
+            .get(&def_id.name)
+    }
+
+    /// Get a module-level constant by its DefId.
+    pub fn get_const(&self, def_id: &DefId) -> Option<&ItemConst> {
+        self.items.get(&def_id.module)?.consts.get(&def_id.name)
+    }
+
+    /// Get a module-level static by its DefId.
+    pub fn get_static(&self, def_id: &DefId) -> Option<&ItemStatic> {
+        self.items.get(&def_id.module)?.statics.get(&def_id.name)
+    }
+
+    /// Iterate all indexed static items with their defining module.
+    pub fn all_statics(&self) -> impl Iterator<Item = (&str, &ItemStatic)> {
+        self.items.iter().flat_map(|(module_name, items)| {
+            items
+                .statics
+                .values()
+                .map(move |item| (module_name.as_str(), item))
+        })
     }
 
     /// Find a method on a struct. Searches all modules' impls.
@@ -592,6 +726,26 @@ impl NameResolver {
         &self.cached_structs
     }
 
+    /// Flat map of all traits: name → ItemTrait.
+    pub fn traits(&self) -> &HashMap<String, ItemTrait> {
+        &self.cached_traits
+    }
+
+    /// Flat map of all type aliases: name → ItemType.
+    pub fn type_aliases(&self) -> &HashMap<String, ItemType> {
+        &self.cached_type_aliases
+    }
+
+    /// Flat map of all constants: name → ItemConst.
+    pub fn consts(&self) -> &HashMap<String, ItemConst> {
+        &self.cached_consts
+    }
+
+    /// Flat map of all static items: name → ItemStatic.
+    pub fn statics(&self) -> &HashMap<String, ItemStatic> {
+        &self.cached_statics
+    }
+
     /// Flat map of all struct impls: struct_name → [(module_name, ItemImpl)].
     pub fn struct_impls(&self) -> &HashMap<String, Vec<(String, ItemImpl)>> {
         &self.cached_struct_impls
@@ -615,7 +769,13 @@ impl NameResolver {
     pub fn find_all_definitions(&self, name: &str) -> Vec<&str> {
         self.items
             .iter()
-            .filter(|(_, mi)| mi.functions.contains_key(name) || mi.structs.contains_key(name))
+            .filter(|(_, mi)| {
+                mi.functions.contains_key(name)
+                    || mi.structs.contains_key(name)
+                    || mi.traits.contains_key(name)
+                    || mi.type_aliases.contains_key(name)
+                    || mi.consts.contains_key(name)
+            })
             .map(|(module_name, _)| module_name.as_str())
             .collect()
     }
@@ -648,6 +808,15 @@ impl NameResolver {
                             imports.insert(name.clone(), source.clone());
                         }
                         for name in mi.structs.keys() {
+                            imports.insert(name.clone(), source.clone());
+                        }
+                        for name in mi.traits.keys() {
+                            imports.insert(name.clone(), source.clone());
+                        }
+                        for name in mi.type_aliases.keys() {
+                            imports.insert(name.clone(), source.clone());
+                        }
+                        for name in mi.consts.keys() {
                             imports.insert(name.clone(), source.clone());
                         }
                     }

--- a/cutile-compiler/src/passes/node_ids.rs
+++ b/cutile-compiler/src/passes/node_ids.rs
@@ -3,14 +3,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-//! Stable node ids for dispatch-bearing expressions in compiler-owned syn bodies.
+//! Stable node ids for semantic expressions in compiler-owned syn bodies.
 //!
 //! The current compiler still emits from `syn`, so type-check side tables need
-//! a way to refer back to individual call and method-call nodes without relying
-//! on token strings. These ids are stable only within one cloned function body
-//! and pass pipeline. Compiler3 should broaden this to all expressions and
-//! statements.
+//! a way to refer back to individual source nodes without relying on token
+//! strings. These ids are stable only within one cloned function body and pass
+//! pipeline.
+//!
+//! IDs are assigned to source expressions that can produce a value or carry
+//! semantic lowering metadata, such as call results, method selections, and
+//! dispatch-wrapper rewrites. Syntax-only positions are left untagged:
+//! expressions embedded in type syntax, call callees, assignment destinations,
+//! and attribute metadata.
 
+use syn::spanned::Spanned;
 use syn::visit_mut::{self, VisitMut};
 use syn::{Attribute, Expr, ExprLit, ItemFn, Lit, Meta};
 
@@ -21,7 +27,12 @@ pub struct NodeId(pub u32);
 
 pub fn assign_expr_ids(fn_item: &mut ItemFn) {
     let mut assigner = NodeIdAssigner { next: 0 };
-    assigner.visit_item_fn_mut(fn_item);
+    assigner.visit_block_mut(&mut fn_item.block);
+}
+
+pub fn assign_block_expr_ids(block: &mut syn::Block) {
+    let mut assigner = NodeIdAssigner { next: 0 };
+    assigner.visit_block_mut(block);
 }
 
 pub fn expr_id(expr: &Expr) -> Option<NodeId> {
@@ -31,12 +42,13 @@ pub fn expr_id(expr: &Expr) -> Option<NodeId> {
 }
 
 pub fn set_expr_id(expr: &mut Expr, id: NodeId) {
+    let span = expr.span();
     let Some(attrs) = expr_attrs_mut(expr) else {
         return;
     };
     attrs.retain(|attr| !attr.path().is_ident(NODE_ID_ATTR));
-    let raw_id = syn::LitInt::new(&id.0.to_string(), proc_macro2::Span::call_site());
-    attrs.push(syn::parse_quote!(#[__cutile_node_id = #raw_id]));
+    let raw_id = syn::LitInt::new(&id.0.to_string(), span);
+    attrs.push(syn::parse_quote_spanned!(span=> #[__cutile_node_id = #raw_id]));
 }
 
 struct NodeIdAssigner {
@@ -56,12 +68,31 @@ impl VisitMut for NodeIdAssigner {
         // Internal expression ids must not recurse into attribute meta syntax.
     }
 
+    fn visit_type_mut(&mut self, _ty: &mut syn::Type) {
+        // Type syntax can contain expressions in const-generic arguments.
+        // Mutating those expressions changes type token streams used by generic
+        // inference and instantiation.
+    }
+
     fn visit_expr_mut(&mut self, expr: &mut Expr) {
-        if matches!(expr, Expr::Call(_) | Expr::MethodCall(_)) {
+        if semantic_expr_attrs(expr).is_some() {
             let id = self.fresh();
             set_expr_id(expr, id);
         }
-        visit_mut::visit_expr_mut(self, expr);
+
+        match expr {
+            Expr::Assign(assign) => {
+                // The destination is binding syntax, not a value expression.
+                self.visit_expr_mut(&mut *assign.right);
+            }
+            Expr::Call(call) => {
+                // The callee is name-resolution syntax in this DSL.
+                for arg in &mut call.args {
+                    self.visit_expr_mut(arg);
+                }
+            }
+            _ => visit_mut::visit_expr_mut(self, expr),
+        }
     }
 }
 
@@ -80,6 +111,39 @@ fn node_id_from_attr(attr: &Attribute) -> Option<NodeId> {
         return None;
     };
     Some(NodeId(raw_id.base10_parse().ok()?))
+}
+
+fn semantic_expr_attrs(expr: &Expr) -> Option<&Vec<Attribute>> {
+    if !has_semantic_node_id(expr) {
+        return None;
+    }
+    expr_attrs(expr)
+}
+
+fn has_semantic_node_id(expr: &Expr) -> bool {
+    matches!(
+        expr,
+        Expr::Array(_)
+            | Expr::Binary(_)
+            | Expr::Block(_)
+            | Expr::Call(_)
+            | Expr::Cast(_)
+            | Expr::Field(_)
+            | Expr::Group(_)
+            | Expr::If(_)
+            | Expr::Index(_)
+            | Expr::Lit(_)
+            | Expr::Macro(_)
+            | Expr::MethodCall(_)
+            | Expr::Paren(_)
+            | Expr::Path(_)
+            | Expr::Reference(_)
+            | Expr::Repeat(_)
+            | Expr::Struct(_)
+            | Expr::Tuple(_)
+            | Expr::Unary(_)
+            | Expr::Unsafe(_)
+    )
 }
 
 fn expr_attrs(expr: &Expr) -> Option<&Vec<Attribute>> {
@@ -171,5 +235,184 @@ fn expr_attrs_mut(expr: &mut Expr) -> Option<&mut Vec<Attribute>> {
         Expr::Yield(expr) => Some(&mut expr.attrs),
         Expr::Verbatim(_) => None,
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use syn::visit::{self, Visit};
+    use syn::Stmt;
+
+    #[test]
+    fn assign_expr_ids_marks_supported_expressions() {
+        let mut fn_item: ItemFn = syn::parse_quote! {
+            fn kernel() {
+                let x = foo(1) + 2;
+                let y = &x;
+            }
+        };
+
+        assign_expr_ids(&mut fn_item);
+
+        struct Counter {
+            expressions: usize,
+            with_ids: usize,
+        }
+
+        impl<'ast> Visit<'ast> for Counter {
+            fn visit_attribute(&mut self, _attr: &'ast Attribute) {
+                // Internal node-id attributes contain literal expressions; they are
+                // metadata, not source expressions.
+            }
+
+            fn visit_type(&mut self, _ty: &'ast syn::Type) {
+                // Expressions inside type syntax are not lowered source expressions.
+            }
+
+            fn visit_expr(&mut self, expr: &'ast Expr) {
+                self.expressions += 1;
+                if expr_id(expr).is_some() {
+                    self.with_ids += 1;
+                }
+                if let Expr::Call(call) = expr {
+                    for arg in &call.args {
+                        self.visit_expr(arg);
+                    }
+                } else {
+                    visit::visit_expr(self, expr);
+                }
+            }
+        }
+
+        let mut counter = Counter {
+            expressions: 0,
+            with_ids: 0,
+        };
+        counter.visit_item_fn(&fn_item);
+
+        assert!(counter.expressions > 2);
+        assert_eq!(counter.expressions, counter.with_ids);
+    }
+
+    #[test]
+    fn assign_expr_ids_leaves_call_callee_untagged() {
+        let mut fn_item: ItemFn = syn::parse_quote! {
+            fn kernel() {
+                let token = new_token_unordered();
+            }
+        };
+
+        assign_expr_ids(&mut fn_item);
+
+        let Stmt::Local(local) = &fn_item.block.stmts[0] else {
+            panic!("expected local statement");
+        };
+        let Some(init) = &local.init else {
+            panic!("expected local initializer");
+        };
+        let Expr::Call(call) = &*init.expr else {
+            panic!("expected call expression");
+        };
+
+        assert!(expr_id(&init.expr).is_some());
+        assert!(matches!(&*call.func, Expr::Path(_)));
+        assert!(expr_id(&call.func).is_none());
+    }
+
+    #[test]
+    fn assign_expr_ids_leaves_assignment_destination_untagged() {
+        let mut fn_item: ItemFn = syn::parse_quote! {
+            fn kernel() {
+                let mut x = 0i32;
+                x = next_value();
+            }
+        };
+
+        assign_expr_ids(&mut fn_item);
+
+        let Stmt::Expr(Expr::Assign(assign), _) = &fn_item.block.stmts[1] else {
+            panic!("expected assignment statement");
+        };
+        let Expr::Path(_) = &*assign.left else {
+            panic!("expected simple assignment destination");
+        };
+        let Expr::Call(call) = &*assign.right else {
+            panic!("expected call assignment value");
+        };
+
+        assert!(expr_id(&Expr::Assign(assign.clone())).is_none());
+        assert!(expr_id(&assign.left).is_none());
+        assert!(expr_id(&assign.right).is_some());
+        assert!(expr_id(&call.func).is_none());
+    }
+
+    #[test]
+    fn assign_expr_ids_does_not_mutate_type_syntax() {
+        let mut fn_item: ItemFn = syn::parse_quote! {
+            fn kernel<const N: i32>(
+                tensor: Tensor<f32, { [N] }>,
+            ) {
+                let local: Tensor<f32, { [N] }> = make_tensor();
+                consume(local);
+            }
+        };
+        let sig = &fn_item.sig;
+        let rendered_sig_before = quote::quote!(#sig).to_string();
+
+        assign_expr_ids(&mut fn_item);
+
+        let rendered = quote::quote!(#fn_item).to_string();
+        assert!(rendered.contains("__cutile_node_id"));
+
+        let sig = &fn_item.sig;
+        let rendered_sig = quote::quote!(#sig).to_string();
+        assert_eq!(rendered_sig, rendered_sig_before);
+
+        let Stmt::Local(local) = &fn_item.block.stmts[0] else {
+            panic!("expected local statement");
+        };
+        let pat = &local.pat;
+        let rendered_pat = quote::quote!(#pat).to_string();
+        assert!(!rendered_pat.contains("__cutile_node_id"));
+    }
+
+    #[test]
+    fn assign_expr_ids_preserves_literal_span_start() {
+        let source = r#"
+fn kernel() {
+    let _x = 42;
+}
+"#;
+        let mut fn_item: ItemFn = syn::parse_str(source).unwrap();
+
+        fn find_literal(expr: &Expr) -> Option<&ExprLit> {
+            match expr {
+                Expr::Lit(lit) => Some(lit),
+                _ => None,
+            }
+        }
+
+        let Stmt::Local(local) = &fn_item.block.stmts[0] else {
+            panic!("expected local statement");
+        };
+        let Some(init) = &local.init else {
+            panic!("expected local initializer");
+        };
+        let lit_before = find_literal(&init.expr).unwrap();
+        let span_before = lit_before.span().start();
+
+        assign_expr_ids(&mut fn_item);
+
+        let Stmt::Local(local) = &fn_item.block.stmts[0] else {
+            panic!("expected local statement");
+        };
+        let Some(init) = &local.init else {
+            panic!("expected local initializer");
+        };
+        let lit_after = find_literal(&init.expr).unwrap();
+        let span_after = lit_after.span().start();
+
+        assert_eq!(span_after, span_before);
     }
 }

--- a/cutile-compiler/src/passes/type_inference.rs
+++ b/cutile-compiler/src/passes/type_inference.rs
@@ -11,17 +11,196 @@
 //! that should be erased before emission.
 
 use crate::compiler::_function::CUDATileFunctionCompiler;
+use crate::compiler::shared_utils;
 use crate::compiler::tile_rust_type::TileRustType;
 use crate::error::JITError;
-use crate::generics::{GenericArgInference, GenericVars, TypeInstance, TypeInstanceUserType};
+use crate::generics::{
+    GenericArgInference, GenericArgType, GenericVars, TypeInstance, TypeInstanceUserType,
+};
+use crate::passes::name_resolution::{DefKind, Res};
 use crate::passes::node_ids::{self, NodeId};
 use crate::syn_utils::*;
-use crate::types::TypeParam;
-use std::collections::HashMap;
+use crate::types::{get_lit_type, TypeParam};
+use proc_macro2::TokenTree;
+use quote::ToTokens;
+use std::collections::{HashMap, HashSet};
 use syn::{
-    Expr, ExprCall, ExprMethodCall, GenericArgument, ImplItemFn, ItemFn, ItemImpl, Pat,
-    PathArguments, Stmt, Type,
+    Expr, ExprCall, ExprLit, ExprMacro, ExprMethodCall, GenericArgument, Generics, ImplItemFn,
+    ItemFn, ItemImpl, Lit, Pat, PathArguments, Stmt, TraitItem, Type, TypeParamBound,
+    WherePredicate,
 };
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum ResolvedScalarType {
+    Bool,
+    I8,
+    I16,
+    I32,
+    I64,
+    I128,
+    Isize,
+    U8,
+    U16,
+    U32,
+    U64,
+    U128,
+    Usize,
+    F32,
+    F64,
+}
+
+impl ResolvedScalarType {
+    fn from_ident(ident: &str) -> Option<Self> {
+        match ident {
+            "bool" => Some(Self::Bool),
+            "i8" => Some(Self::I8),
+            "i16" => Some(Self::I16),
+            "i32" => Some(Self::I32),
+            "i64" => Some(Self::I64),
+            "i128" => Some(Self::I128),
+            "isize" => Some(Self::Isize),
+            "u8" => Some(Self::U8),
+            "u16" => Some(Self::U16),
+            "u32" => Some(Self::U32),
+            "u64" => Some(Self::U64),
+            "u128" => Some(Self::U128),
+            "usize" => Some(Self::Usize),
+            "f32" => Some(Self::F32),
+            "f64" => Some(Self::F64),
+            _ => None,
+        }
+    }
+
+    fn to_syn_type(&self) -> Type {
+        match self {
+            Self::Bool => syn::parse_quote!(bool),
+            Self::I8 => syn::parse_quote!(i8),
+            Self::I16 => syn::parse_quote!(i16),
+            Self::I32 => syn::parse_quote!(i32),
+            Self::I64 => syn::parse_quote!(i64),
+            Self::I128 => syn::parse_quote!(i128),
+            Self::Isize => syn::parse_quote!(isize),
+            Self::U8 => syn::parse_quote!(u8),
+            Self::U16 => syn::parse_quote!(u16),
+            Self::U32 => syn::parse_quote!(u32),
+            Self::U64 => syn::parse_quote!(u64),
+            Self::U128 => syn::parse_quote!(u128),
+            Self::Usize => syn::parse_quote!(usize),
+            Self::F32 => syn::parse_quote!(f32),
+            Self::F64 => syn::parse_quote!(f64),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum ResolvedType {
+    Scalar(ResolvedScalarType),
+    Adt {
+        path: syn::Path,
+    },
+    Reference {
+        mutable: bool,
+        elem: Box<ResolvedType>,
+    },
+    Pointer {
+        mutable: bool,
+        elem: Box<ResolvedType>,
+    },
+    Tuple(Vec<ResolvedType>),
+    Array {
+        elem: Box<ResolvedType>,
+        len: Expr,
+    },
+    Slice(Box<ResolvedType>),
+    Unit,
+    Never,
+    Surface(Type),
+}
+
+impl ResolvedType {
+    pub fn from_syn_type(ty: &Type) -> Self {
+        match ty {
+            Type::Path(path_ty) if path_ty.qself.is_none() => {
+                if path_ty.path.segments.len() == 1 {
+                    let segment = &path_ty.path.segments[0];
+                    if matches!(segment.arguments, PathArguments::None) {
+                        if let Some(scalar) =
+                            ResolvedScalarType::from_ident(&segment.ident.to_string())
+                        {
+                            return Self::Scalar(scalar);
+                        }
+                    }
+                }
+                Self::Adt {
+                    path: path_ty.path.clone(),
+                }
+            }
+            Type::Reference(reference) => Self::Reference {
+                mutable: reference.mutability.is_some(),
+                elem: Box::new(Self::from_syn_type(&reference.elem)),
+            },
+            Type::Ptr(ptr) => Self::Pointer {
+                mutable: ptr.mutability.is_some(),
+                elem: Box::new(Self::from_syn_type(&ptr.elem)),
+            },
+            Type::Tuple(tuple) if tuple.elems.is_empty() => Self::Unit,
+            Type::Tuple(tuple) => {
+                Self::Tuple(tuple.elems.iter().map(Self::from_syn_type).collect())
+            }
+            Type::Array(array) => Self::Array {
+                elem: Box::new(Self::from_syn_type(&array.elem)),
+                len: array.len.clone(),
+            },
+            Type::Slice(slice) => Self::Slice(Box::new(Self::from_syn_type(&slice.elem))),
+            Type::Never(_) => Self::Never,
+            _ => Self::Surface(ty.clone()),
+        }
+    }
+
+    pub fn to_syn_type(&self) -> Type {
+        match self {
+            Self::Scalar(scalar) => scalar.to_syn_type(),
+            Self::Adt { path } => Type::Path(syn::TypePath {
+                qself: None,
+                path: path.clone(),
+            }),
+            Self::Reference { mutable, elem } => {
+                let elem = elem.to_syn_type();
+                if *mutable {
+                    syn::parse_quote!(&mut #elem)
+                } else {
+                    syn::parse_quote!(&#elem)
+                }
+            }
+            Self::Pointer { mutable, elem } => {
+                let elem = elem.to_syn_type();
+                if *mutable {
+                    syn::parse_quote!(*mut #elem)
+                } else {
+                    syn::parse_quote!(*const #elem)
+                }
+            }
+            Self::Tuple(elems) => {
+                let elems = elems.iter().map(Self::to_syn_type).collect();
+                Type::Tuple(syn::TypeTuple {
+                    paren_token: syn::token::Paren::default(),
+                    elems,
+                })
+            }
+            Self::Array { elem, len } => {
+                let elem = elem.to_syn_type();
+                syn::parse_quote!([#elem; #len])
+            }
+            Self::Slice(elem) => {
+                let elem = elem.to_syn_type();
+                syn::parse_quote!([#elem])
+            }
+            Self::Unit => syn::parse_quote!(()),
+            Self::Never => syn::parse_quote!(!),
+            Self::Surface(ty) => ty.clone(),
+        }
+    }
+}
 
 #[derive(Clone)]
 pub struct MethodSelection {
@@ -32,8 +211,15 @@ pub struct MethodSelection {
     pub return_type: Option<TileRustType>,
 }
 
+#[derive(Clone)]
+struct ClosureSignature {
+    inputs: Vec<Type>,
+    output: Option<Type>,
+}
+
 #[derive(Clone, Default)]
 pub struct TypeckResults {
+    resolved_expr_types: HashMap<NodeId, ResolvedType>,
     expr_types: HashMap<NodeId, TileRustType>,
     method_selections: HashMap<NodeId, MethodSelection>,
     lowered_method_calls: HashMap<NodeId, ExprMethodCall>,
@@ -44,11 +230,91 @@ impl TypeckResults {
         let Some(id) = node_ids::expr_id(expr) else {
             return;
         };
+        self.insert_expr_type_by_id(id, ty);
+    }
+
+    fn insert_expr_type_by_id(&mut self, id: NodeId, ty: TileRustType) {
+        self.resolved_expr_types
+            .insert(id, ResolvedType::from_syn_type(&ty.rust_ty));
         self.expr_types.insert(id, ty);
+    }
+
+    pub fn insert_resolved_expr_type(&mut self, expr: &Expr, ty: ResolvedType) {
+        let Some(id) = node_ids::expr_id(expr) else {
+            return;
+        };
+        self.resolved_expr_types.insert(id, ty);
     }
 
     pub fn expr_type(&self, expr: &Expr) -> Option<&TileRustType> {
         self.expr_types.get(&node_ids::expr_id(expr)?)
+    }
+
+    pub fn resolved_expr_type(&self, expr: &Expr) -> Option<&ResolvedType> {
+        self.resolved_expr_types.get(&node_ids::expr_id(expr)?)
+    }
+
+    pub fn required_resolved_expr_type(&self, expr: &Expr) -> Result<&ResolvedType, JITError> {
+        self.resolved_expr_type(expr)
+            .ok_or_else(|| JITError::generic_err("missing typeck entry for expression"))
+    }
+
+    pub fn syn_expr_type(&self, expr: &Expr) -> Option<Type> {
+        self.resolved_expr_type(expr).map(ResolvedType::to_syn_type)
+    }
+
+    pub fn required_syn_expr_type(&self, expr: &Expr) -> Result<Type, JITError> {
+        self.syn_expr_type(expr)
+            .ok_or_else(|| JITError::generic_err("missing typeck entry for expression"))
+    }
+
+    pub fn required_tile_expr_type(
+        &self,
+        compiler: &CUDATileFunctionCompiler<'_>,
+        expr: &Expr,
+        generic_vars: &GenericVars,
+        type_params: &HashMap<String, TypeParam>,
+    ) -> Result<TileRustType, JITError> {
+        if let Some(ty) = self.expr_type(expr) {
+            return Ok(ty.clone());
+        }
+        let syn_ty = self.required_syn_expr_type(expr)?;
+        compiler
+            .compile_type(&syn_ty, generic_vars, type_params)?
+            .ok_or_else(|| JITError::generic_err("failed to compile typeck expression type"))
+    }
+
+    pub fn debug_dump(&self) -> String {
+        let mut lines = Vec::new();
+        for (id, ty) in &self.resolved_expr_types {
+            let syn_ty = ty.to_syn_type();
+            lines.push((
+                id.0,
+                0u8,
+                format!("expr#{}: {}", id.0, syn_ty.to_token_stream()),
+            ));
+        }
+        for (id, selection) in &self.method_selections {
+            let return_ty = selection
+                .return_type
+                .as_ref()
+                .map(|ty| ty.rust_ty.to_token_stream().to_string())
+                .unwrap_or_else(|| "_".to_string());
+            lines.push((
+                id.0,
+                1u8,
+                format!(
+                    "method#{}: {}::{} -> {}",
+                    id.0, selection.module_name, selection.impl_method.sig.ident, return_ty
+                ),
+            ));
+        }
+        lines.sort_by(|lhs, rhs| (lhs.0, lhs.1, &lhs.2).cmp(&(rhs.0, rhs.1, &rhs.2)));
+        lines
+            .into_iter()
+            .map(|(_, _, line)| line)
+            .collect::<Vec<_>>()
+            .join("\n")
     }
 
     pub fn insert_method_selection(
@@ -84,65 +350,275 @@ impl TypeckResults {
     }
 }
 
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+struct InferVarId(usize);
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+enum InferVarKind {
+    General,
+    Int,
+    Float,
+}
+
+#[derive(Clone, Debug)]
+enum InferredTy {
+    Known(TileRustType),
+    Var(InferVarId),
+    Unknown,
+}
+
+#[derive(Clone, Debug)]
+enum BranchTerm {
+    Value(InferredTy),
+    Diverges,
+    Unknown,
+}
+
+impl BranchTerm {
+    fn from_term(term: InferredTy) -> Self {
+        match term {
+            InferredTy::Unknown => Self::Unknown,
+            term => Self::Value(term),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct InferVar {
+    kind: InferVarKind,
+    parent: Option<InferVarId>,
+    value: Option<TileRustType>,
+    expr_ids: Vec<NodeId>,
+    origins: Vec<Expr>,
+    origin_propagated: bool,
+}
+
+#[derive(Clone, Debug, Default)]
+struct InferenceState {
+    vars: Vec<InferVar>,
+    expr_terms: HashMap<NodeId, InferredTy>,
+}
+
 pub fn infer_function(
     compiler: &CUDATileFunctionCompiler<'_>,
     fn_item: &ItemFn,
     generic_vars: &GenericVars,
     initial_types: HashMap<String, TileRustType>,
 ) -> Result<TypeckResults, JITError> {
+    let (_, return_type) = get_sig_types(&fn_item.sig, None);
+    let expected_return = compiler
+        .compile_type(&return_type, generic_vars, &HashMap::new())
+        .ok()
+        .flatten();
     let mut cx = TypeInferenceCx {
         compiler,
         generic_vars,
-        vars: initial_types,
+        generic_type_bounds: generic_type_bounds(&fn_item.sig.generics),
+        syn_vars: initial_types
+            .iter()
+            .map(|(name, ty)| (name.clone(), ty.rust_ty.clone()))
+            .collect(),
+        mutable_vars: HashSet::new(),
+        vars: HashMap::new(),
+        local_terms: HashMap::new(),
+        inference: InferenceState::default(),
         results: TypeckResults::default(),
     };
-    cx.infer_block(&fn_item.block)?;
+    for (name, ty) in initial_types {
+        cx.bind_tile_var(name, ty);
+    }
+    cx.infer_block(&fn_item.block, expected_return)?;
+    cx.finish_inference()?;
+    Ok(cx.results)
+}
+
+pub fn infer_method(
+    compiler: &CUDATileFunctionCompiler<'_>,
+    impl_item: &ItemImpl,
+    impl_method: &ImplItemFn,
+    self_ty: &Type,
+    generic_vars: &GenericVars,
+    initial_types: HashMap<String, TileRustType>,
+) -> Result<TypeckResults, JITError> {
+    let (_, return_type) = get_sig_types(&impl_method.sig, Some(self_ty));
+    let expected_return = compiler
+        .compile_type(&return_type, generic_vars, &HashMap::new())
+        .ok()
+        .flatten();
+    let mut bounds = generic_type_bounds(&impl_item.generics);
+    merge_generic_type_bounds(&mut bounds, generic_type_bounds(&impl_method.sig.generics));
+    let mut cx = TypeInferenceCx {
+        compiler,
+        generic_vars,
+        generic_type_bounds: bounds,
+        syn_vars: initial_types
+            .iter()
+            .map(|(name, ty)| (name.clone(), ty.rust_ty.clone()))
+            .collect(),
+        mutable_vars: HashSet::new(),
+        vars: HashMap::new(),
+        local_terms: HashMap::new(),
+        inference: InferenceState::default(),
+        results: TypeckResults::default(),
+    };
+    for (name, ty) in initial_types {
+        cx.bind_tile_var(name, ty);
+    }
+    cx.infer_block(&impl_method.block, expected_return)?;
+    cx.finish_inference()?;
     Ok(cx.results)
 }
 
 struct TypeInferenceCx<'a, 'm> {
     compiler: &'a CUDATileFunctionCompiler<'m>,
     generic_vars: &'a GenericVars,
+    generic_type_bounds: HashMap<String, Vec<String>>,
+    syn_vars: HashMap<String, Type>,
+    mutable_vars: HashSet<String>,
     vars: HashMap<String, TileRustType>,
+    local_terms: HashMap<String, InferredTy>,
+    inference: InferenceState,
     results: TypeckResults,
 }
 
-impl TypeInferenceCx<'_, '_> {
-    fn infer_block(&mut self, block: &syn::Block) -> Result<Option<TileRustType>, JITError> {
+enum ArrayLikeExpr {
+    Array(syn::ExprArray),
+    Repeat { len: usize },
+}
+
+impl ArrayLikeExpr {
+    fn len(&self) -> usize {
+        match self {
+            Self::Array(array) => array.elems.len(),
+            Self::Repeat { len } => *len,
+        }
+    }
+}
+
+impl<'a, 'm> TypeInferenceCx<'a, 'm> {
+    fn infer_block(
+        &mut self,
+        block: &syn::Block,
+        expected: Option<TileRustType>,
+    ) -> Result<Option<TileRustType>, JITError> {
+        stacker::maybe_grow(
+            shared_utils::STACK_RED_ZONE,
+            shared_utils::STACK_GROW_SIZE,
+            || self.infer_block_inner(block, expected),
+        )
+    }
+
+    fn infer_block_inner(
+        &mut self,
+        block: &syn::Block,
+        expected: Option<TileRustType>,
+    ) -> Result<Option<TileRustType>, JITError> {
         let mut last_type = None;
-        for stmt in &block.stmts {
-            last_type = self.infer_stmt(stmt)?;
+        for (idx, stmt) in block.stmts.iter().enumerate() {
+            let stmt_expected = if idx + 1 == block.stmts.len() || stmt_is_return(stmt) {
+                expected.clone()
+            } else {
+                None
+            };
+            last_type = self.infer_stmt(stmt, stmt_expected)?;
         }
         Ok(last_type)
     }
 
-    fn infer_stmt(&mut self, stmt: &Stmt) -> Result<Option<TileRustType>, JITError> {
+    fn infer_stmt(
+        &mut self,
+        stmt: &Stmt,
+        expected: Option<TileRustType>,
+    ) -> Result<Option<TileRustType>, JITError> {
+        stacker::maybe_grow(
+            shared_utils::STACK_RED_ZONE,
+            shared_utils::STACK_GROW_SIZE,
+            || self.infer_stmt_inner(stmt, expected),
+        )
+    }
+
+    fn infer_stmt_inner(
+        &mut self,
+        stmt: &Stmt,
+        expected: Option<TileRustType>,
+    ) -> Result<Option<TileRustType>, JITError> {
         match stmt {
             Stmt::Local(local) => {
-                let annotated_type = match &local.pat {
-                    Pat::Type(pat_type) => self.compiler.compile_type(
-                        &pat_type.ty,
-                        self.generic_vars,
-                        &HashMap::new(),
-                    )?,
+                let annotated_syn_type = local_pattern_type(&local.pat).cloned();
+                let annotated_type = match &annotated_syn_type {
+                    Some(ty) => {
+                        self.compiler
+                            .compile_type(ty, self.generic_vars, &HashMap::new())?
+                    }
                     _ => None,
                 };
 
                 let init_type = if let Some(init) = &local.init {
-                    self.infer_expr(&init.expr, annotated_type.clone())?
+                    if annotated_type.is_some() {
+                        self.infer_expr(&init.expr, annotated_type.clone())?
+                    } else {
+                        match self.infer_expr_term(&init.expr, None)? {
+                            InferredTy::Known(ty) => Some(ty),
+                            term @ InferredTy::Var(_) => {
+                                if let Some(name) = local_binding_name(&local.pat) {
+                                    self.bind_inferred_var(name, term);
+                                }
+                                None
+                            }
+                            InferredTy::Unknown => {
+                                if let Some(name) = local_binding_name(&local.pat) {
+                                    let term = self.new_infer_var(
+                                        InferVarKind::General,
+                                        Some(&init.expr),
+                                        Some(*init.expr.clone()),
+                                    );
+                                    self.bind_inferred_var(name, term);
+                                }
+                                None
+                            }
+                        }
+                    }
                 } else {
                     None
                 };
 
                 let binding_type = annotated_type.or(init_type);
                 if let Some(binding_type) = binding_type.clone() {
-                    if let Some(name) = local_binding_name(&local.pat) {
-                        self.vars.insert(name, binding_type);
-                    }
+                    self.bind_pattern_with_tile_type(&local.pat, binding_type)?;
+                } else if let Some(syn_type) = annotated_syn_type.or_else(|| {
+                    local
+                        .init
+                        .as_ref()
+                        .and_then(|init| self.results.syn_expr_type(&init.expr))
+                }) {
+                    self.bind_pattern_with_syn_type(&local.pat, &syn_type)?;
+                } else if let Some(init) = &local.init {
+                    self.bind_pattern_from_expr(&local.pat, &init.expr)?;
                 }
                 Ok(binding_type)
             }
-            Stmt::Expr(expr, _) => self.infer_expr(expr, None),
+            Stmt::Expr(expr, semicolon) => {
+                let expr_expected = if semicolon.is_none() || matches!(expr, Expr::Return(_)) {
+                    expected
+                } else {
+                    None
+                };
+                self.infer_expr(expr, expr_expected)
+            }
+            Stmt::Item(syn::Item::Const(item_const)) => {
+                let expected = self.compiler.compile_type(
+                    &item_const.ty,
+                    self.generic_vars,
+                    &HashMap::new(),
+                )?;
+                let init_ty = self.infer_expr(&item_const.expr, expected.clone())?;
+                if let Some(ty) = expected.or(init_ty) {
+                    self.bind_tile_var(item_const.ident.to_string(), ty);
+                } else {
+                    self.bind_syn_var(item_const.ident.to_string(), item_const.ty.as_ref().clone());
+                }
+                Ok(None)
+            }
             Stmt::Item(_) | Stmt::Macro(_) => Ok(None),
         }
     }
@@ -152,11 +628,41 @@ impl TypeInferenceCx<'_, '_> {
         expr: &Expr,
         expected: Option<TileRustType>,
     ) -> Result<Option<TileRustType>, JITError> {
+        stacker::maybe_grow(
+            shared_utils::STACK_RED_ZONE,
+            shared_utils::STACK_GROW_SIZE,
+            || self.infer_expr_inner(expr, expected),
+        )
+    }
+
+    fn infer_expr_inner(
+        &mut self,
+        expr: &Expr,
+        expected: Option<TileRustType>,
+    ) -> Result<Option<TileRustType>, JITError> {
         let inferred = match expr {
             Expr::Path(path) => {
                 if path.path.segments.len() == 1 {
                     let name = get_ident_from_path_expr(path).to_string();
-                    self.vars.get(&name).cloned()
+                    if name == "None" {
+                        expected.filter(|ty| option_payload_syn_type(&ty.rust_ty).is_some())
+                    } else if let Some(term) = self.local_terms.get(&name).cloned() {
+                        let term = if let Some(expected) = expected.clone() {
+                            self.unify_with_known(term, expected)?
+                        } else {
+                            term
+                        };
+                        self.record_expr_term(expr, term.clone());
+                        self.term_known_type(&term)
+                    } else if let Some(ty) = self.infer_global_const_type(path)? {
+                        Some(ty)
+                    } else if let Some(ty) = self.infer_global_static_type(path)? {
+                        Some(ty)
+                    } else {
+                        self.vars.get(&name).cloned()
+                    }
+                } else if let Some(ty) = self.infer_associated_const_type(path)? {
+                    Some(ty)
                 } else {
                     self.infer_zst_marker_type(expr)
                 }
@@ -174,56 +680,1413 @@ impl TypeInferenceCx<'_, '_> {
                 })
             }
             Expr::Paren(paren) => self.infer_expr(&paren.expr, expected.clone())?,
-            Expr::Block(block) => self.infer_block(&block.block)?,
-            Expr::Tuple(tuple) => self.infer_tuple(tuple)?,
-            Expr::Array(array) => {
-                for elem in &array.elems {
-                    let _ = self.infer_expr(elem, None)?;
+            Expr::Block(block) => {
+                let block_ty = self.infer_block(&block.block, expected.clone())?;
+                if block_ty.is_none() {
+                    if let Some(syn_ty) = self.block_tail_syn_type(&block.block) {
+                        self.results
+                            .insert_resolved_expr_type(expr, ResolvedType::from_syn_type(&syn_ty));
+                    }
                 }
-                expected
+                block_ty
             }
-            Expr::Field(field) => self.infer_field(field)?,
+            Expr::Tuple(tuple) => self.infer_tuple(tuple, expected.clone())?,
+            Expr::Array(array) => {
+                let elem_expected = match expected.as_ref() {
+                    Some(ty) => self.array_element_type(ty)?,
+                    None => None,
+                };
+                let mut elem_types = Vec::new();
+                if let Some(elem_expected) = elem_expected {
+                    for elem in &array.elems {
+                        if let Some(elem_ty) = self.infer_expr(elem, Some(elem_expected.clone()))? {
+                            elem_types.push(elem_ty.rust_ty);
+                        }
+                    }
+                } else {
+                    for elem in array
+                        .elems
+                        .iter()
+                        .filter(|elem| !is_unsuffixed_numeric_literal(elem))
+                    {
+                        if let Some(elem_ty) = self.infer_expr(elem, None)? {
+                            elem_types.push(elem_ty.rust_ty);
+                        }
+                    }
+                    let inferred_elem_expected = elem_types.first().and_then(|ty| {
+                        self.compiler
+                            .compile_type(ty, self.generic_vars, &HashMap::new())
+                            .ok()
+                            .flatten()
+                    });
+                    for elem in array
+                        .elems
+                        .iter()
+                        .filter(|elem| is_unsuffixed_numeric_literal(elem))
+                    {
+                        if let Some(elem_ty) =
+                            self.infer_expr(elem, inferred_elem_expected.clone())?
+                        {
+                            elem_types.push(elem_ty.rust_ty);
+                        }
+                    }
+                }
+                if expected.is_some() {
+                    expected
+                } else if let Some(first_ty) = elem_types.first() {
+                    if elem_types.iter().all(|ty| ty == first_ty) {
+                        let len = array.elems.len();
+                        let array_ty: Type = syn::parse_quote!([#first_ty; #len]);
+                        self.compiler
+                            .compile_type(&array_ty, self.generic_vars, &HashMap::new())?
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
+            }
+            Expr::Repeat(repeat) => {
+                let elem_expected = match expected.as_ref() {
+                    Some(ty) => self.array_element_type(ty)?,
+                    None => None,
+                };
+                let elem_ty = self.infer_expr(&repeat.expr, elem_expected)?;
+                if expected.is_some() {
+                    expected
+                } else if let (Some(elem_ty), Some(len)) =
+                    (elem_ty, repeat_length_value(&repeat.len, self.generic_vars))
+                {
+                    let elem_ty = elem_ty.rust_ty;
+                    let array_ty: Type = syn::parse_quote!([#elem_ty; #len]);
+                    self.compiler
+                        .compile_type(&array_ty, self.generic_vars, &HashMap::new())?
+                } else {
+                    None
+                }
+            }
+            Expr::Range(range) => self.infer_range(range)?,
+            Expr::Field(field) => self.infer_field(field, expected.clone())?,
+            Expr::Index(index) => self.infer_index(index, expected.clone())?,
             Expr::Call(call) => self.infer_call(call, expected.clone())?,
             Expr::MethodCall(method_call) => {
                 self.infer_method_call(method_call, expected.clone())?
             }
-            Expr::Binary(binary) => {
-                let lhs = self.infer_expr(&binary.left, None)?;
-                let _ = self.infer_expr(&binary.right, lhs.clone())?;
-                lhs.or(expected)
+            Expr::Struct(struct_expr) => self.infer_struct(struct_expr, expected.clone())?,
+            Expr::Macro(macro_expr) => self.infer_macro(macro_expr)?,
+            Expr::Cast(cast) => self.infer_cast_target(expr, &cast.expr, &cast.ty)?,
+            Expr::Closure(closure) => {
+                self.infer_closure(closure, &[], None)?;
+                expected
             }
-            Expr::Unary(unary) => self.infer_expr(&unary.expr, expected.clone())?,
-            Expr::Lit(_) => expected,
-            Expr::If(if_expr) => {
-                let _ = self.infer_expr(&if_expr.cond, None)?;
-                let then_ty = self.infer_block(&if_expr.then_branch)?;
-                if let Some((_, else_expr)) = &if_expr.else_branch {
-                    let _ = self.infer_expr(else_expr, then_ty.clone())?;
+            Expr::Assign(assign) => {
+                let lhs_name = match &*assign.left {
+                    Expr::Path(path) if path.path.segments.len() == 1 => {
+                        Some(get_ident_from_path_expr(path).to_string())
+                    }
+                    _ => None,
+                };
+                if let Some(name) = lhs_name {
+                    self.infer_assignment(&name, &assign.right)?;
                 }
-                then_ty.or(expected)
-            }
-            Expr::ForLoop(for_loop) => {
-                let _ = self.infer_expr(&for_loop.expr, None)?;
-                let mut nested = self.fork();
-                let _ = nested.infer_block(&for_loop.body)?;
-                self.results = nested.results;
                 None
             }
-            Expr::Unsafe(unsafe_expr) => self.infer_block(&unsafe_expr.block)?,
+            Expr::Binary(binary) => {
+                if binary_result_is_bool(&binary.op) {
+                    self.infer_bool_binary(binary)?
+                } else if expected.is_none() && binary_result_matches_operands(&binary.op) {
+                    match self.infer_expr_term(expr, None)? {
+                        InferredTy::Known(ty) => Some(ty),
+                        term @ InferredTy::Var(_) => {
+                            self.record_expr_term(expr, term);
+                            None
+                        }
+                        InferredTy::Unknown => None,
+                    }
+                } else if is_unsuffixed_numeric_literal(&binary.left) {
+                    let rhs = self.infer_expr(&binary.right, expected.clone())?;
+                    let lhs = self.infer_expr(&binary.left, rhs.clone().or(expected.clone()))?;
+                    lhs.or(rhs).or(expected)
+                } else {
+                    let lhs = self.infer_expr(&binary.left, expected.clone())?;
+                    let rhs = self.infer_expr(&binary.right, lhs.clone().or(expected.clone()))?;
+                    if lhs.is_none() {
+                        if let Some(rhs_ty) = rhs.clone() {
+                            let _ = self.infer_expr(&binary.left, Some(rhs_ty.clone()))?;
+                            Some(rhs_ty)
+                        } else {
+                            lhs.or(rhs).or(expected)
+                        }
+                    } else {
+                        lhs.or(rhs).or(expected)
+                    }
+                }
+            }
+            Expr::Unary(unary) => {
+                if expected.is_none() && matches!(unary.op, syn::UnOp::Neg(_)) {
+                    match self.infer_expr_term(expr, None)? {
+                        InferredTy::Known(ty) => Some(ty),
+                        term @ InferredTy::Var(_) => {
+                            self.record_expr_term(expr, term);
+                            None
+                        }
+                        InferredTy::Unknown => None,
+                    }
+                } else {
+                    self.infer_expr(&unary.expr, expected.clone())?
+                }
+            }
+            Expr::Lit(lit) => {
+                if expected.is_some() {
+                    expected
+                } else if let Some(ty) = get_lit_type(lit) {
+                    self.compiler
+                        .compile_type(&ty, self.generic_vars, &HashMap::new())?
+                } else {
+                    let term = self.literal_infer_var(expr, lit);
+                    self.record_expr_term(expr, term);
+                    None
+                }
+            }
+            Expr::If(if_expr) => {
+                let _ = self.infer_expr(&if_expr.cond, self.bool_type()?)?;
+                if let Some(expected) = expected.clone() {
+                    let then_ty = self.infer_block(&if_expr.then_branch, Some(expected.clone()))?;
+                    let else_ty = if let Some((_, else_expr)) = &if_expr.else_branch {
+                        self.infer_expr(else_expr, Some(expected.clone()))?
+                    } else {
+                        None
+                    };
+                    then_ty.or(else_ty).or(Some(expected))
+                } else {
+                    match self.infer_if_expr_term(if_expr)? {
+                        InferredTy::Known(ty) => Some(ty),
+                        term @ InferredTy::Var(_) => {
+                            self.record_expr_term(expr, term);
+                            None
+                        }
+                        InferredTy::Unknown => None,
+                    }
+                }
+            }
+            Expr::ForLoop(for_loop) => {
+                let iter_ty = self.infer_for_iter_ty(&for_loop.expr)?;
+                let (results, inference) = {
+                    let mut nested = self.fork();
+                    if let Some(iter_ty) = iter_ty {
+                        nested.bind_pattern_with_tile_type(&for_loop.pat, iter_ty)?;
+                    }
+                    let _ = nested.infer_block(&for_loop.body, None)?;
+                    (nested.results, nested.inference)
+                };
+                self.results = results;
+                self.inference = inference;
+                None
+            }
+            Expr::While(while_expr) => {
+                let _ = self.infer_expr(&while_expr.cond, self.bool_type()?)?;
+                self.infer_scoped_block(&while_expr.body)?;
+                None
+            }
+            Expr::Loop(loop_expr) => {
+                self.infer_scoped_block(&loop_expr.body)?;
+                None
+            }
+            Expr::Return(return_expr) => {
+                if let Some(return_expr) = &return_expr.expr {
+                    let _ = self.infer_expr(return_expr, expected.clone())?;
+                }
+                expected
+            }
+            Expr::Unsafe(unsafe_expr) => {
+                let block_ty = self.infer_block(&unsafe_expr.block, expected.clone())?;
+                if block_ty.is_none() {
+                    if let Some(syn_ty) = self.block_tail_syn_type(&unsafe_expr.block) {
+                        self.results
+                            .insert_resolved_expr_type(expr, ResolvedType::from_syn_type(&syn_ty));
+                    }
+                }
+                block_ty
+            }
             _ => expected,
         };
 
         if let Some(ty) = inferred.clone() {
+            self.record_expr_term(expr, InferredTy::Known(ty.clone()));
             self.results.insert_expr_type(expr, ty);
         }
         Ok(inferred)
     }
 
-    fn fork(&self) -> TypeInferenceCx<'_, '_> {
+    fn bind_tile_var(&mut self, name: String, ty: TileRustType) {
+        self.syn_vars.insert(name.clone(), ty.rust_ty.clone());
+        self.local_terms
+            .insert(name.clone(), InferredTy::Known(ty.clone()));
+        self.vars.insert(name, ty);
+    }
+
+    fn bind_syn_var(&mut self, name: String, ty: Type) {
+        self.syn_vars.insert(name, ty);
+    }
+
+    fn bind_inferred_var(&mut self, name: String, term: InferredTy) {
+        if let Some(ty) = self.term_known_type(&term) {
+            self.bind_tile_var(name, ty);
+        } else {
+            self.local_terms.insert(name, term);
+        }
+    }
+
+    fn infer_assignment(&mut self, lhs_name: &str, rhs: &Expr) -> Result<(), JITError> {
+        if let Some(lhs_term) = self.local_terms.get(lhs_name).cloned() {
+            let rhs_term = if let Some(lhs_ty) = self.term_known_type(&lhs_term) {
+                self.infer_expr_term(rhs, Some(lhs_ty))?
+            } else {
+                self.infer_expr_term(rhs, None)?
+            };
+            let term = self.unify_terms(lhs_term, rhs_term)?;
+            self.bind_inferred_var(lhs_name.to_string(), term);
+            return Ok(());
+        }
+
+        let lhs_ty = self.vars.get(lhs_name).cloned();
+        let rhs_ty = self.infer_expr(rhs, lhs_ty.clone())?;
+        if let Some(ty) = rhs_ty.or(lhs_ty) {
+            self.bind_tile_var(lhs_name.to_string(), ty);
+        }
+        Ok(())
+    }
+
+    fn infer_cast_target(
+        &mut self,
+        cast_expr: &Expr,
+        source_expr: &Expr,
+        target_ty: &Type,
+    ) -> Result<Option<TileRustType>, JITError> {
+        let _ = self.infer_expr(source_expr, None)?;
+        self.results
+            .insert_resolved_expr_type(cast_expr, ResolvedType::from_syn_type(target_ty));
+        match self
+            .compiler
+            .compile_type(target_ty, self.generic_vars, &HashMap::new())
+        {
+            Ok(ty) => Ok(ty),
+            Err(err) if is_surface_only_scalar_type(target_ty) => Ok(None),
+            Err(err) => Err(err),
+        }
+    }
+
+    fn infer_bool_binary(
+        &mut self,
+        binary: &syn::ExprBinary,
+    ) -> Result<Option<TileRustType>, JITError> {
+        let bool_ty = self.bool_type()?;
+        if binary_operands_are_bool(&binary.op) {
+            let _ = self.infer_expr(&binary.left, bool_ty.clone())?;
+            let _ = self.infer_expr(&binary.right, bool_ty.clone())?;
+            return Ok(bool_ty);
+        }
+
+        let lhs = self.infer_expr_term(&binary.left, None)?;
+        let rhs = self.infer_expr_term(&binary.right, None)?;
+        let _ = self.unify_terms(lhs, rhs)?;
+        Ok(bool_ty)
+    }
+
+    fn bool_type(&self) -> Result<Option<TileRustType>, JITError> {
+        let bool_ty: Type = syn::parse_quote!(bool);
+        self.compiler
+            .compile_type(&bool_ty, self.generic_vars, &HashMap::new())
+    }
+
+    fn infer_scoped_block(&mut self, block: &syn::Block) -> Result<(), JITError> {
+        let (results, inference) = {
+            let mut nested = self.fork();
+            let _ = nested.infer_block(block, None)?;
+            (nested.results, nested.inference)
+        };
+        self.results = results;
+        self.inference = inference;
+        Ok(())
+    }
+
+    fn infer_closure(
+        &mut self,
+        closure: &syn::ExprClosure,
+        param_types: &[TileRustType],
+        expected_return: Option<TileRustType>,
+    ) -> Result<(), JITError> {
+        let closure_info = parse_closure(closure);
+        let (results, inference) = {
+            let mut nested = self.fork();
+            for (idx, param) in closure_info.params.iter().enumerate() {
+                if let Some(param_ty) = param_types.get(idx) {
+                    nested.bind_tile_var(param.name.clone(), param_ty.clone());
+                } else if let Some(param_ty) = &param.ty {
+                    if let Some(tile_ty) = nested.compiler.compile_type(
+                        param_ty,
+                        nested.generic_vars,
+                        &HashMap::new(),
+                    )? {
+                        nested.bind_tile_var(param.name.clone(), tile_ty);
+                    } else {
+                        nested.bind_syn_var(param.name.clone(), param_ty.clone());
+                    }
+                } else {
+                    let term = nested.new_infer_var(InferVarKind::General, None, None);
+                    nested.bind_inferred_var(param.name.clone(), term);
+                }
+            }
+            let _ = nested.infer_expr(&closure_info.body, expected_return)?;
+            (nested.results, nested.inference)
+        };
+        self.results = results;
+        self.inference = inference;
+        Ok(())
+    }
+
+    fn bind_pattern_with_tile_type(&mut self, pat: &Pat, ty: TileRustType) -> Result<(), JITError> {
+        self.bind_pattern_with_type(pat, &ty.rust_ty.clone(), Some(ty))
+    }
+
+    fn bind_pattern_with_syn_type(&mut self, pat: &Pat, ty: &Type) -> Result<(), JITError> {
+        let tile_ty = self
+            .compiler
+            .compile_type(ty, self.generic_vars, &HashMap::new())?;
+        self.bind_pattern_with_type(pat, ty, tile_ty)
+    }
+
+    fn bind_pattern_with_type(
+        &mut self,
+        pat: &Pat,
+        ty: &Type,
+        tile_ty: Option<TileRustType>,
+    ) -> Result<(), JITError> {
+        match pat {
+            Pat::Ident(ident) => {
+                let name = ident.ident.to_string();
+                if ident.mutability.is_some() {
+                    self.mutable_vars.insert(name.clone());
+                }
+                if let Some(tile_ty) = tile_ty {
+                    self.bind_tile_var(name, tile_ty);
+                } else {
+                    self.bind_syn_var(name, ty.clone());
+                }
+                if let Some((_at, subpat)) = &ident.subpat {
+                    self.bind_pattern_with_syn_type(subpat, ty)?;
+                }
+            }
+            Pat::Type(pat_type) => {
+                self.bind_pattern_with_syn_type(&pat_type.pat, &pat_type.ty)?;
+            }
+            Pat::Paren(paren) => {
+                self.bind_pattern_with_type(&paren.pat, ty, tile_ty)?;
+            }
+            Pat::Reference(reference) => {
+                if let Type::Reference(reference_ty) = ty {
+                    self.bind_pattern_with_syn_type(&reference.pat, &reference_ty.elem)?;
+                }
+            }
+            Pat::Tuple(tuple) => {
+                if let Some(elem_types) = tuple_element_syn_types(ty) {
+                    for (pat, elem_ty) in tuple.elems.iter().zip(elem_types.iter()) {
+                        self.bind_pattern_with_syn_type(pat, elem_ty)?;
+                    }
+                }
+            }
+            Pat::Slice(slice) => {
+                if let Some(elem_ty) = array_or_slice_element_syn_type(ty) {
+                    for pat in slice
+                        .elems
+                        .iter()
+                        .filter(|pat| !matches!(pat, Pat::Rest(_)))
+                    {
+                        self.bind_pattern_with_syn_type(pat, &elem_ty)?;
+                    }
+                }
+            }
+            Pat::Struct(pat_struct) => {
+                for field in &pat_struct.fields {
+                    if let Some(field_ty) = self.struct_field_syn_type(ty, &field.member) {
+                        self.bind_pattern_with_syn_type(&field.pat, &field_ty)?;
+                    }
+                }
+            }
+            Pat::TupleStruct(tuple_struct) => {
+                if let Some(elem_types) = self.tuple_struct_element_syn_types(ty) {
+                    for (pat, elem_ty) in tuple_struct.elems.iter().zip(elem_types.iter()) {
+                        self.bind_pattern_with_syn_type(pat, elem_ty)?;
+                    }
+                }
+            }
+            Pat::Or(or_pat) => {
+                for case in &or_pat.cases {
+                    self.bind_pattern_with_type(case, ty, tile_ty.clone())?;
+                }
+            }
+            Pat::Wild(_) | Pat::Rest(_) => {}
+            _ => {}
+        }
+        Ok(())
+    }
+
+    fn bind_pattern_from_expr(&mut self, pat: &Pat, expr: &Expr) -> Result<(), JITError> {
+        match pat {
+            Pat::Ident(_) => {
+                let mut term = self.infer_expr_term(expr, None)?;
+                if matches!(term, InferredTy::Unknown) {
+                    term =
+                        self.new_infer_var(InferVarKind::General, Some(expr), Some(expr.clone()));
+                }
+                self.bind_pattern_with_term(pat, term)
+            }
+            Pat::Type(pat_type) => {
+                let expected =
+                    self.compiler
+                        .compile_type(&pat_type.ty, self.generic_vars, &HashMap::new())?;
+                let _ = self.infer_expr(expr, expected)?;
+                self.bind_pattern_with_syn_type(&pat_type.pat, &pat_type.ty)
+            }
+            Pat::Paren(paren) => self.bind_pattern_from_expr(&paren.pat, expr),
+            Pat::Reference(reference) => {
+                let Expr::Reference(expr_reference) = expr else {
+                    if let Some(ty) = self.infer_expr(expr, None)? {
+                        return self.bind_pattern_with_tile_type(pat, ty);
+                    }
+                    return Ok(());
+                };
+                self.bind_pattern_from_expr(&reference.pat, &expr_reference.expr)
+            }
+            Pat::Tuple(tuple_pat) => {
+                if let Expr::Tuple(tuple_expr) = expr {
+                    if tuple_pat.elems.len() == tuple_expr.elems.len() {
+                        for (pat, expr) in tuple_pat.elems.iter().zip(tuple_expr.elems.iter()) {
+                            self.bind_pattern_from_expr(pat, expr)?;
+                        }
+                        return Ok(());
+                    }
+                }
+                if let Some(ty) = self.infer_expr(expr, None)? {
+                    self.bind_pattern_with_tile_type(pat, ty)?;
+                } else if let Some(syn_ty) = self.results.syn_expr_type(expr) {
+                    self.bind_pattern_with_syn_type(pat, &syn_ty)?;
+                }
+                Ok(())
+            }
+            Pat::Slice(slice_pat) => {
+                if let Expr::Array(array_expr) = expr {
+                    self.bind_slice_pattern_from_array_expr(slice_pat, array_expr)?;
+                    return Ok(());
+                }
+                if let Some(ty) = self.infer_expr(expr, None)? {
+                    self.bind_pattern_with_tile_type(pat, ty)?;
+                }
+                Ok(())
+            }
+            Pat::Struct(_) | Pat::TupleStruct(_) => {
+                if let Some(ty) = self.infer_expr(expr, None)? {
+                    self.bind_pattern_with_tile_type(pat, ty)?;
+                }
+                Ok(())
+            }
+            Pat::Or(or_pat) => {
+                for case in &or_pat.cases {
+                    self.bind_pattern_from_expr(case, expr)?;
+                }
+                Ok(())
+            }
+            Pat::Wild(_) | Pat::Rest(_) => Ok(()),
+            _ => {
+                if let Some(ty) = self.infer_expr(expr, None)? {
+                    self.bind_pattern_with_tile_type(pat, ty)?;
+                }
+                Ok(())
+            }
+        }
+    }
+
+    fn bind_pattern_with_term(&mut self, pat: &Pat, term: InferredTy) -> Result<(), JITError> {
+        match pat {
+            Pat::Ident(ident) => {
+                if ident.mutability.is_some() {
+                    self.mutable_vars.insert(ident.ident.to_string());
+                }
+                self.bind_inferred_var(ident.ident.to_string(), term.clone());
+                if let Some((_at, subpat)) = &ident.subpat {
+                    self.bind_pattern_with_term(subpat, term)?;
+                }
+            }
+            Pat::Type(pat_type) => {
+                let expected =
+                    self.compiler
+                        .compile_type(&pat_type.ty, self.generic_vars, &HashMap::new())?;
+                if let Some(expected) = expected {
+                    let _ = self.unify_with_known(term, expected)?;
+                }
+                self.bind_pattern_with_syn_type(&pat_type.pat, &pat_type.ty)?;
+            }
+            Pat::Paren(paren) => self.bind_pattern_with_term(&paren.pat, term)?,
+            Pat::Or(or_pat) => {
+                for case in &or_pat.cases {
+                    self.bind_pattern_with_term(case, term.clone())?;
+                }
+            }
+            Pat::Wild(_) | Pat::Rest(_) => {}
+            _ => {
+                if let Some(ty) = self.term_known_type(&term) {
+                    self.bind_pattern_with_tile_type(pat, ty)?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn bind_slice_pattern_from_array_expr(
+        &mut self,
+        slice_pat: &syn::PatSlice,
+        array_expr: &syn::ExprArray,
+    ) -> Result<(), JITError> {
+        let exprs = array_expr.elems.iter().collect::<Vec<_>>();
+        let pats = slice_pat.elems.iter().collect::<Vec<_>>();
+        let mut elem_terms = Vec::with_capacity(exprs.len());
+        for expr in &exprs {
+            elem_terms.push(self.infer_expr_term(expr, None)?);
+        }
+
+        let mut unified_elem = InferredTy::Unknown;
+        for term in &elem_terms {
+            unified_elem = self.unify_terms(unified_elem, term.clone())?;
+        }
+
+        let rest_pos = pats.iter().position(|pat| matches!(pat, Pat::Rest(_)));
+        let mut pairs = Vec::new();
+        match rest_pos {
+            Some(rest_pos) => {
+                if pats.len().saturating_sub(1) > exprs.len() {
+                    return Ok(());
+                }
+                for idx in 0..rest_pos {
+                    pairs.push((pats[idx], idx));
+                }
+                let suffix_len = pats.len() - rest_pos - 1;
+                for suffix_idx in 0..suffix_len {
+                    pairs.push((
+                        pats[rest_pos + 1 + suffix_idx],
+                        exprs.len() - suffix_len + suffix_idx,
+                    ));
+                }
+            }
+            None => {
+                if pats.len() != exprs.len() {
+                    return Ok(());
+                }
+                for idx in 0..pats.len() {
+                    pairs.push((pats[idx], idx));
+                }
+            }
+        }
+
+        for (pat, expr_idx) in pairs {
+            let term = self.unify_terms(elem_terms[expr_idx].clone(), unified_elem.clone())?;
+            self.bind_pattern_with_term(pat, term)?;
+        }
+        Ok(())
+    }
+
+    fn struct_field_syn_type(&self, ty: &Type, member: &syn::Member) -> Option<Type> {
+        let struct_name = type_path_ident(ty)?;
+        let item_struct = self.compiler.modules.structs().get(&struct_name)?;
+        match (&item_struct.fields, member) {
+            (syn::Fields::Named(fields), syn::Member::Named(field_name)) => fields
+                .named
+                .iter()
+                .find(|field| {
+                    field
+                        .ident
+                        .as_ref()
+                        .is_some_and(|ident| ident == field_name)
+                })
+                .map(|field| field.ty.clone()),
+            (syn::Fields::Unnamed(fields), syn::Member::Unnamed(index)) => fields
+                .unnamed
+                .iter()
+                .nth(index.index as usize)
+                .map(|field| field.ty.clone()),
+            _ => None,
+        }
+    }
+
+    fn tuple_struct_element_syn_types(&self, ty: &Type) -> Option<Vec<Type>> {
+        let struct_name = type_path_ident(ty)?;
+        let item_struct = self.compiler.modules.structs().get(&struct_name)?;
+        let syn::Fields::Unnamed(fields) = &item_struct.fields else {
+            return None;
+        };
+        Some(
+            fields
+                .unnamed
+                .iter()
+                .map(|field| field.ty.clone())
+                .collect(),
+        )
+    }
+
+    fn infer_expr_term(
+        &mut self,
+        expr: &Expr,
+        expected: Option<TileRustType>,
+    ) -> Result<InferredTy, JITError> {
+        stacker::maybe_grow(
+            shared_utils::STACK_RED_ZONE,
+            shared_utils::STACK_GROW_SIZE,
+            || self.infer_expr_term_inner(expr, expected),
+        )
+    }
+
+    fn infer_expr_term_inner(
+        &mut self,
+        expr: &Expr,
+        expected: Option<TileRustType>,
+    ) -> Result<InferredTy, JITError> {
+        if let Some(expected) = expected {
+            if let Some(existing) = self.expr_term(expr) {
+                let term = self.unify_with_known(existing, expected)?;
+                self.record_expr_term(expr, term.clone());
+                return Ok(term);
+            }
+            if let Some(ty) = self.infer_expr(expr, Some(expected.clone()))? {
+                return Ok(InferredTy::Known(ty));
+            }
+            return Ok(InferredTy::Known(expected));
+        }
+
+        if let Some(existing) = self.expr_term(expr) {
+            return Ok(existing);
+        }
+
+        match expr {
+            Expr::Path(path) if path.path.segments.len() == 1 => {
+                let name = get_ident_from_path_expr(path).to_string();
+                if let Some(term) = self.local_terms.get(&name).cloned() {
+                    self.record_expr_term(expr, term.clone());
+                    Ok(term)
+                } else if let Some(ty) = self.vars.get(&name).cloned() {
+                    Ok(InferredTy::Known(ty))
+                } else if let Some(ty) = self.infer_global_const_type(path)? {
+                    Ok(InferredTy::Known(ty))
+                } else {
+                    Ok(InferredTy::Unknown)
+                }
+            }
+            Expr::Path(path) => {
+                if let Some(ty) = self.infer_associated_const_type(path)? {
+                    Ok(InferredTy::Known(ty))
+                } else {
+                    Ok(InferredTy::Unknown)
+                }
+            }
+            Expr::Lit(lit) => {
+                if let Some(ty) = get_lit_type(lit) {
+                    let Some(ty) =
+                        self.compiler
+                            .compile_type(&ty, self.generic_vars, &HashMap::new())?
+                    else {
+                        return Ok(InferredTy::Unknown);
+                    };
+                    Ok(InferredTy::Known(ty))
+                } else {
+                    Ok(self.literal_infer_var(expr, lit))
+                }
+            }
+            Expr::Unary(unary) if matches!(unary.op, syn::UnOp::Neg(_)) => {
+                let term = self.infer_expr_term(&unary.expr, None)?;
+                self.record_expr_term(expr, term.clone());
+                Ok(term)
+            }
+            Expr::Paren(paren) => {
+                let term = self.infer_expr_term(&paren.expr, None)?;
+                self.record_expr_term(expr, term.clone());
+                Ok(term)
+            }
+            Expr::Block(block) => {
+                let term = self.infer_block_term(&block.block)?;
+                if matches!(term, InferredTy::Unknown) {
+                    if let Some(ty) = self.infer_expr(expr, None)? {
+                        return Ok(InferredTy::Known(ty));
+                    }
+                }
+                self.record_expr_term(expr, term.clone());
+                Ok(term)
+            }
+            Expr::Unsafe(unsafe_expr) => {
+                let term = self.infer_block_term(&unsafe_expr.block)?;
+                if matches!(term, InferredTy::Unknown) {
+                    if let Some(ty) = self.infer_expr(expr, None)? {
+                        return Ok(InferredTy::Known(ty));
+                    }
+                }
+                self.record_expr_term(expr, term.clone());
+                Ok(term)
+            }
+            Expr::Binary(binary) if binary_result_matches_operands(&binary.op) => {
+                let lhs = self.infer_expr_term(&binary.left, None)?;
+                let rhs = self.infer_expr_term(&binary.right, None)?;
+                let term = self.unify_terms(lhs, rhs)?;
+                self.record_expr_term(expr, term.clone());
+                Ok(term)
+            }
+            Expr::Binary(binary) if binary_result_is_bool(&binary.op) => {
+                let Some(bool_ty) = self.bool_type()? else {
+                    return Ok(InferredTy::Unknown);
+                };
+                let _ = self.infer_bool_binary(binary)?;
+                let term = InferredTy::Known(bool_ty);
+                self.record_expr_term(expr, term.clone());
+                Ok(term)
+            }
+            Expr::Cast(cast) => {
+                let Some(ty) = self.infer_cast_target(expr, &cast.expr, &cast.ty)? else {
+                    return Ok(InferredTy::Unknown);
+                };
+                let term = InferredTy::Known(ty);
+                self.record_expr_term(expr, term.clone());
+                Ok(term)
+            }
+            Expr::If(if_expr) => {
+                let _ = self.infer_expr(&if_expr.cond, self.bool_type()?)?;
+                let term = self.infer_if_expr_term(if_expr)?;
+                self.record_expr_term(expr, term.clone());
+                Ok(term)
+            }
+            _ => match self.infer_expr(expr, None)? {
+                Some(ty) => Ok(InferredTy::Known(ty)),
+                None => Ok(InferredTy::Unknown),
+            },
+        }
+    }
+
+    fn infer_if_expr_term(&mut self, if_expr: &syn::ExprIf) -> Result<InferredTy, JITError> {
+        let then_term = self.infer_block_branch_term(&if_expr.then_branch)?;
+        let else_term = if let Some((_, else_expr)) = &if_expr.else_branch {
+            self.infer_expr_branch_term(else_expr)?
+        } else {
+            BranchTerm::Unknown
+        };
+        self.join_branch_terms(then_term, else_term)
+    }
+
+    fn infer_expr_branch_term(&mut self, expr: &Expr) -> Result<BranchTerm, JITError> {
+        if expr_diverges(expr) {
+            let _ = self.infer_expr(expr, None)?;
+            return Ok(BranchTerm::Diverges);
+        }
+        self.infer_expr_term(expr, None).map(BranchTerm::from_term)
+    }
+
+    fn infer_block_branch_term(&mut self, block: &syn::Block) -> Result<BranchTerm, JITError> {
+        if block_diverges(block) {
+            let _ = self.infer_block(block, None)?;
+            return Ok(BranchTerm::Diverges);
+        }
+        self.infer_block_term(block).map(BranchTerm::from_term)
+    }
+
+    fn join_branch_terms(
+        &mut self,
+        lhs: BranchTerm,
+        rhs: BranchTerm,
+    ) -> Result<InferredTy, JITError> {
+        match (lhs, rhs) {
+            (BranchTerm::Diverges, BranchTerm::Diverges) => Ok(InferredTy::Unknown),
+            (BranchTerm::Diverges, BranchTerm::Value(term))
+            | (BranchTerm::Value(term), BranchTerm::Diverges)
+            | (BranchTerm::Unknown, BranchTerm::Value(term))
+            | (BranchTerm::Value(term), BranchTerm::Unknown) => Ok(term),
+            (BranchTerm::Value(lhs), BranchTerm::Value(rhs)) => self.unify_terms(lhs, rhs),
+            (BranchTerm::Diverges, BranchTerm::Unknown)
+            | (BranchTerm::Unknown, BranchTerm::Diverges)
+            | (BranchTerm::Unknown, BranchTerm::Unknown) => Ok(InferredTy::Unknown),
+        }
+    }
+
+    fn infer_block_term(&mut self, block: &syn::Block) -> Result<InferredTy, JITError> {
+        let Some((last, prefix)) = block.stmts.split_last() else {
+            return Ok(InferredTy::Unknown);
+        };
+        for stmt in prefix {
+            let _ = self.infer_stmt(stmt, None)?;
+        }
+        match last {
+            Stmt::Expr(expr, None) => self.infer_expr_term(expr, None),
+            Stmt::Expr(expr, _) => {
+                let _ = self.infer_expr(expr, None)?;
+                Ok(InferredTy::Unknown)
+            }
+            Stmt::Local(_) | Stmt::Item(_) | Stmt::Macro(_) => {
+                let _ = self.infer_stmt(last, None)?;
+                Ok(InferredTy::Unknown)
+            }
+        }
+    }
+
+    fn literal_infer_var(&mut self, expr: &Expr, lit: &ExprLit) -> InferredTy {
+        if let Some(existing) = self.expr_term(expr) {
+            return existing;
+        }
+        let kind = match &lit.lit {
+            Lit::Int(raw) if raw.suffix().is_empty() => InferVarKind::Int,
+            Lit::Float(raw) if raw.suffix().is_empty() => InferVarKind::Float,
+            _ => return InferredTy::Unknown,
+        };
+        self.new_infer_var(kind, Some(expr), Some(expr.clone()))
+    }
+
+    fn new_infer_var(
+        &mut self,
+        kind: InferVarKind,
+        expr: Option<&Expr>,
+        origin: Option<Expr>,
+    ) -> InferredTy {
+        let id = InferVarId(self.inference.vars.len());
+        let expr_ids = expr
+            .and_then(node_ids::expr_id)
+            .map(|id| vec![id])
+            .unwrap_or_default();
+        self.inference.vars.push(InferVar {
+            kind,
+            parent: None,
+            value: None,
+            expr_ids,
+            origins: origin.into_iter().collect(),
+            origin_propagated: false,
+        });
+        let term = InferredTy::Var(id);
+        if let Some(expr) = expr {
+            self.record_expr_term(expr, term.clone());
+        }
+        term
+    }
+
+    fn expr_term(&self, expr: &Expr) -> Option<InferredTy> {
+        self.inference
+            .expr_terms
+            .get(&node_ids::expr_id(expr)?)
+            .cloned()
+    }
+
+    fn expr_or_local_term(&self, expr: &Expr) -> Option<InferredTy> {
+        if let Some(term) = self.expr_term(expr) {
+            return Some(term);
+        }
+        let Expr::Path(path) = expr else {
+            return None;
+        };
+        if path.path.segments.len() != 1 {
+            return None;
+        }
+        let name = get_ident_from_path_expr(path).to_string();
+        self.local_terms.get(&name).cloned()
+    }
+
+    fn term_origin(&self, term: &InferredTy) -> Option<Expr> {
+        let InferredTy::Var(id) = self.normalize_term(term.clone()) else {
+            return None;
+        };
+        self.inference
+            .vars
+            .get(id.0)
+            .and_then(|var| var.origins.first().cloned())
+    }
+
+    fn record_expr_term(&mut self, expr: &Expr, term: InferredTy) {
+        let Some(id) = node_ids::expr_id(expr) else {
+            return;
+        };
+        let term = self.normalize_term(term);
+        self.inference.expr_terms.insert(id, term.clone());
+        if let InferredTy::Var(var_id) = term {
+            let Some(root_id) = self.find_var_id(var_id) else {
+                return;
+            };
+            let Some(var) = self.inference.vars.get_mut(root_id.0) else {
+                return;
+            };
+            if !var.expr_ids.contains(&id) {
+                var.expr_ids.push(id);
+            }
+        }
+    }
+
+    fn term_known_type(&self, term: &InferredTy) -> Option<TileRustType> {
+        match self.normalize_term(term.clone()) {
+            InferredTy::Known(ty) => Some(ty.clone()),
+            InferredTy::Var(id) => {
+                let root_id = self.find_var_id(id)?;
+                self.inference
+                    .vars
+                    .get(root_id.0)
+                    .and_then(|var| var.value.clone())
+            }
+            InferredTy::Unknown => None,
+        }
+    }
+
+    fn normalize_term(&self, term: InferredTy) -> InferredTy {
+        match term {
+            InferredTy::Var(id) => self
+                .find_var_id(id)
+                .map(InferredTy::Var)
+                .unwrap_or(InferredTy::Unknown),
+            _ => term,
+        }
+    }
+
+    fn find_var_id(&self, mut id: InferVarId) -> Option<InferVarId> {
+        let mut seen = 0usize;
+        loop {
+            let var = self.inference.vars.get(id.0)?;
+            let Some(parent) = var.parent else {
+                return Some(id);
+            };
+            id = parent;
+            seen += 1;
+            if seen > self.inference.vars.len() {
+                return None;
+            }
+        }
+    }
+
+    fn unify_terms(&mut self, lhs: InferredTy, rhs: InferredTy) -> Result<InferredTy, JITError> {
+        let lhs = self.normalize_term(lhs);
+        let rhs = self.normalize_term(rhs);
+        match (lhs, rhs) {
+            (InferredTy::Unknown, term) | (term, InferredTy::Unknown) => Ok(term),
+            (InferredTy::Known(lhs), InferredTy::Known(rhs)) => {
+                if lhs.rust_ty == rhs.rust_ty {
+                    Ok(InferredTy::Known(lhs))
+                } else {
+                    Ok(InferredTy::Unknown)
+                }
+            }
+            (InferredTy::Known(known), term @ InferredTy::Var(_))
+            | (term @ InferredTy::Var(_), InferredTy::Known(known)) => {
+                self.unify_with_known(term, known)
+            }
+            (InferredTy::Var(lhs), InferredTy::Var(rhs)) => self.unify_vars(lhs, rhs),
+        }
+    }
+
+    fn unify_vars(&mut self, lhs: InferVarId, rhs: InferVarId) -> Result<InferredTy, JITError> {
+        let Some(lhs_root) = self.find_var_id(lhs) else {
+            return Ok(InferredTy::Unknown);
+        };
+        let Some(rhs_root) = self.find_var_id(rhs) else {
+            return Ok(InferredTy::Unknown);
+        };
+        if lhs_root == rhs_root {
+            return Ok(InferredTy::Var(lhs_root));
+        }
+
+        let lhs_value = self.inference.vars[lhs_root.0].value.clone();
+        let rhs_value = self.inference.vars[rhs_root.0].value.clone();
+        let root_value = match (&lhs_value, &rhs_value) {
+            (Some(lhs), Some(rhs)) if lhs.rust_ty == rhs.rust_ty => Some(lhs.clone()),
+            (Some(lhs), None) if self.var_accepts_type(rhs_root, &lhs.rust_ty) => Some(lhs.clone()),
+            (None, Some(rhs)) if self.var_accepts_type(lhs_root, &rhs.rust_ty) => Some(rhs.clone()),
+            (None, None) => None,
+            _ => return Ok(InferredTy::Unknown),
+        };
+        let Some(root_kind) = merge_infer_var_kinds(
+            self.inference.vars[lhs_root.0].kind,
+            self.inference.vars[rhs_root.0].kind,
+        ) else {
+            return Ok(InferredTy::Unknown);
+        };
+
+        let (root, child) = if lhs_value.is_some() && rhs_value.is_none() {
+            (lhs_root, rhs_root)
+        } else if rhs_value.is_some() && lhs_value.is_none() {
+            (rhs_root, lhs_root)
+        } else if lhs_root.0 <= rhs_root.0 {
+            (lhs_root, rhs_root)
+        } else {
+            (rhs_root, lhs_root)
+        };
+
+        let child_var = self.inference.vars[child.0].clone();
+        {
+            let root_var = &mut self.inference.vars[root.0];
+            root_var.kind = root_kind;
+            if let Some(value) = root_value {
+                root_var.value = Some(value);
+            }
+            for expr_id in child_var.expr_ids {
+                if !root_var.expr_ids.contains(&expr_id) {
+                    root_var.expr_ids.push(expr_id);
+                }
+            }
+            for origin in child_var.origins {
+                root_var.origins.push(origin);
+            }
+            root_var.origin_propagated = false;
+        }
+        self.inference.vars[child.0].parent = Some(root);
+        Ok(InferredTy::Var(root))
+    }
+
+    fn var_accepts_type(&self, id: InferVarId, ty: &Type) -> bool {
+        let Some(root) = self.find_var_id(id) else {
+            return false;
+        };
+        literal_kind_accepts_type(self.inference.vars[root.0].kind, ty)
+    }
+
+    fn unify_with_known(
+        &mut self,
+        term: InferredTy,
+        expected: TileRustType,
+    ) -> Result<InferredTy, JITError> {
+        match self.normalize_term(term) {
+            InferredTy::Known(known) => Ok(InferredTy::Known(known)),
+            InferredTy::Unknown => Ok(InferredTy::Known(expected)),
+            InferredTy::Var(id) => {
+                let Some(root_id) = self.find_var_id(id) else {
+                    return Ok(InferredTy::Unknown);
+                };
+                let Some(var) = self.inference.vars.get_mut(root_id.0) else {
+                    return Ok(InferredTy::Unknown);
+                };
+                if let Some(known) = &var.value {
+                    return Ok(InferredTy::Known(known.clone()));
+                }
+                if literal_kind_accepts_type(var.kind, &expected.rust_ty) {
+                    var.value = Some(expected.clone());
+                    var.origin_propagated = false;
+                    Ok(InferredTy::Known(expected))
+                } else {
+                    Ok(InferredTy::Var(id))
+                }
+            }
+        }
+    }
+
+    fn finish_inference(&mut self) -> Result<(), JITError> {
+        self.propagate_resolved_origins()?;
+        self.fallback_unresolved_literals()?;
+        self.propagate_resolved_origins()?;
+        self.writeback_inferred_expr_types();
+        Ok(())
+    }
+
+    fn propagate_resolved_origins(&mut self) -> Result<(), JITError> {
+        loop {
+            let mut work = Vec::new();
+            for (idx, var) in self.inference.vars.iter().enumerate() {
+                if var.parent.is_some() {
+                    continue;
+                }
+                if var.origin_propagated {
+                    continue;
+                }
+                let Some(value) = &var.value else {
+                    continue;
+                };
+                if var.origins.is_empty() {
+                    continue;
+                }
+                work.push((InferVarId(idx), var.origins.clone(), value.clone()));
+            }
+            if work.is_empty() {
+                return Ok(());
+            }
+            for (id, origins, value) in work {
+                if let Some(var) = self.inference.vars.get_mut(id.0) {
+                    var.origin_propagated = true;
+                }
+                for origin in origins {
+                    let _ = self.infer_expr(&origin, Some(value.clone()))?;
+                }
+            }
+        }
+    }
+
+    fn fallback_unresolved_literals(&mut self) -> Result<(), JITError> {
+        let fallbacks = self
+            .inference
+            .vars
+            .iter()
+            .map(|var| {
+                if var.parent.is_some() || var.value.is_some() {
+                    None
+                } else {
+                    match var.kind {
+                        InferVarKind::Int => Some(syn::parse_quote!(i32)),
+                        InferVarKind::Float => Some(syn::parse_quote!(f64)),
+                        InferVarKind::General => None,
+                    }
+                }
+            })
+            .collect::<Vec<Option<Type>>>();
+        for (idx, fallback) in fallbacks.into_iter().enumerate() {
+            let Some(fallback) = fallback else {
+                continue;
+            };
+            let Some(ty) =
+                self.compiler
+                    .compile_type(&fallback, self.generic_vars, &HashMap::new())?
+            else {
+                continue;
+            };
+            if let Some(var) = self.inference.vars.get_mut(idx) {
+                var.value = Some(ty);
+                var.origin_propagated = false;
+            }
+        }
+        Ok(())
+    }
+
+    fn writeback_inferred_expr_types(&mut self) {
+        let expr_terms = self.inference.expr_terms.clone();
+        for (id, term) in expr_terms {
+            if let Some(ty) = self.term_known_type(&term) {
+                self.results.insert_expr_type_by_id(id, ty);
+            }
+        }
+    }
+
+    fn infer_expr_syn_type(
+        &mut self,
+        expr: &Expr,
+        expected: Option<TileRustType>,
+    ) -> Result<Option<Type>, JITError> {
+        if let Some(inferred) = self.infer_expr(expr, expected)? {
+            return Ok(Some(inferred.rust_ty));
+        }
+        if let Some(syn_type) = self.results.syn_expr_type(expr) {
+            return Ok(Some(syn_type));
+        }
+        match expr {
+            Expr::Path(path) if path.path.segments.len() == 1 => {
+                let name = get_ident_from_path_expr(path).to_string();
+                Ok(self.syn_vars.get(&name).cloned())
+            }
+            Expr::Paren(paren) => self.infer_expr_syn_type(&paren.expr, None),
+            Expr::Reference(reference) => {
+                let Some(elem_ty) = self.infer_expr_syn_type(&reference.expr, None)? else {
+                    return Ok(None);
+                };
+                Ok(Some(Type::Reference(syn::TypeReference {
+                    and_token: reference.and_token,
+                    lifetime: None,
+                    mutability: reference.mutability,
+                    elem: Box::new(elem_ty),
+                })))
+            }
+            _ => Ok(None),
+        }
+    }
+
+    fn array_element_type(
+        &self,
+        expected: &TileRustType,
+    ) -> Result<Option<TileRustType>, JITError> {
+        let elem_ty = match &expected.rust_ty {
+            Type::Array(array) => Some(&*array.elem),
+            Type::Slice(slice) => Some(&*slice.elem),
+            _ => None,
+        };
+        let Some(elem_ty) = elem_ty else {
+            return Ok(None);
+        };
+        self.compiler
+            .compile_type(elem_ty, self.generic_vars, &HashMap::new())
+    }
+
+    fn infer_index(
+        &mut self,
+        index: &syn::ExprIndex,
+        expected: Option<TileRustType>,
+    ) -> Result<Option<TileRustType>, JITError> {
+        let Some(base_ty) = self.infer_expr(&index.expr, None)? else {
+            if let Some(expected_elem_ty) = expected.clone() {
+                if let Some(array_ty) =
+                    self.expected_array_type_from_index_base(&index.expr, &expected_elem_ty)?
+                {
+                    let _ = self.infer_expr(&index.expr, Some(array_ty))?;
+                    return Ok(Some(expected_elem_ty));
+                }
+            }
+            return Ok(None);
+        };
+        match &base_ty.rust_ty {
+            Type::Array(array) => {
+                self.compiler
+                    .compile_type(&array.elem, self.generic_vars, &HashMap::new())
+            }
+            Type::Slice(slice) => {
+                self.compiler
+                    .compile_type(&slice.elem, self.generic_vars, &HashMap::new())
+            }
+            Type::Tuple(tuple) => {
+                let Some(idx) = static_usize_index(&index.index) else {
+                    return Ok(None);
+                };
+                let Some(elem_ty) = tuple.elems.iter().nth(idx) else {
+                    return Ok(None);
+                };
+                self.compiler
+                    .compile_type(elem_ty, self.generic_vars, &HashMap::new())
+            }
+            _ => Ok(None),
+        }
+    }
+
+    fn expected_array_type_from_index_base(
+        &mut self,
+        base: &Expr,
+        expected_elem_ty: &TileRustType,
+    ) -> Result<Option<TileRustType>, JITError> {
+        let Some(array_like) = self.array_like_expr_or_origin(base) else {
+            return Ok(None);
+        };
+        let elem_ty = &expected_elem_ty.rust_ty;
+        let len = array_like.len();
+        let array_syn_ty: Type = syn::parse_quote!([#elem_ty; #len]);
+        let Some(array_ty) =
+            self.compiler
+                .compile_type(&array_syn_ty, self.generic_vars, &HashMap::new())?
+        else {
+            return Ok(None);
+        };
+        if let Some(term) = self.expr_or_local_term(base) {
+            let term = self.unify_with_known(term, array_ty.clone())?;
+            self.record_expr_term(base, term);
+        }
+        Ok(Some(array_ty))
+    }
+
+    fn array_like_expr_or_origin(&self, expr: &Expr) -> Option<ArrayLikeExpr> {
+        match expr {
+            Expr::Array(array) => Some(ArrayLikeExpr::Array(array.clone())),
+            Expr::Repeat(repeat) => repeat_length_value(&repeat.len, self.generic_vars)
+                .map(|len| ArrayLikeExpr::Repeat { len }),
+            Expr::Paren(paren) => self.array_like_expr_or_origin(&paren.expr),
+            _ => self
+                .expr_or_local_term(expr)
+                .and_then(|term| match self.term_origin(&term) {
+                    Some(Expr::Array(array)) => Some(ArrayLikeExpr::Array(array)),
+                    Some(Expr::Repeat(repeat)) => {
+                        repeat_length_value(&repeat.len, self.generic_vars)
+                            .map(|len| ArrayLikeExpr::Repeat { len })
+                    }
+                    _ => None,
+                }),
+        }
+    }
+
+    fn infer_struct(
+        &mut self,
+        struct_expr: &syn::ExprStruct,
+        expected: Option<TileRustType>,
+    ) -> Result<Option<TileRustType>, JITError> {
+        let struct_ty = Type::Path(syn::TypePath {
+            qself: None,
+            path: struct_expr.path.clone(),
+        });
+        let struct_name = match struct_expr.path.segments.last() {
+            Some(segment) => segment.ident.to_string(),
+            None => return Ok(expected),
+        };
+
+        for field in &struct_expr.fields {
+            let syn::Member::Named(field_name) = &field.member else {
+                let _ = self.infer_expr(&field.expr, None)?;
+                continue;
+            };
+            let field_expected = self
+                .compiler
+                .modules
+                .get_struct_field_type(&struct_name, &field_name.to_string())
+                .and_then(|field_ty| {
+                    self.compiler
+                        .compile_type(&field_ty, self.generic_vars, &HashMap::new())
+                        .ok()
+                        .flatten()
+                });
+            let _ = self.infer_expr(&field.expr, field_expected)?;
+        }
+
+        self.compiler
+            .compile_type(&struct_ty, self.generic_vars, &HashMap::new())
+            .map(|ty| ty.or(expected))
+    }
+
+    fn infer_for_iter_ty(&mut self, iter_expr: &Expr) -> Result<Option<TileRustType>, JITError> {
+        if let Expr::MethodCall(method_call) = iter_expr {
+            if method_call.method == "step_by" {
+                let receiver = match &*method_call.receiver {
+                    Expr::Paren(paren) => &*paren.expr,
+                    receiver => receiver,
+                };
+                if let Expr::Range(range) = receiver {
+                    let _ = method_call
+                        .args
+                        .iter()
+                        .map(|arg| self.infer_expr(arg, None))
+                        .collect::<Result<Vec<_>, _>>()?;
+                    return self.infer_range(range);
+                }
+            }
+        }
+        self.infer_expr(iter_expr, None)
+    }
+
+    fn block_tail_syn_type(&self, block: &syn::Block) -> Option<Type> {
+        match block.stmts.last()? {
+            Stmt::Expr(Expr::Return(return_expr), _) => return_expr
+                .expr
+                .as_ref()
+                .and_then(|expr| self.results.syn_expr_type(expr)),
+            Stmt::Expr(expr, None) => self.results.syn_expr_type(expr),
+            _ => None,
+        }
+    }
+
+    fn infer_range(&mut self, range: &syn::ExprRange) -> Result<Option<TileRustType>, JITError> {
+        if let (Some(start), Some(end)) = (&range.start, &range.end) {
+            if is_unsuffixed_numeric_literal(start) {
+                let end_ty = self.infer_expr(end, None)?;
+                let start_ty = self.infer_expr(start, end_ty.clone())?;
+                return Ok(start_ty.or(end_ty));
+            }
+        }
+        let start_ty = match &range.start {
+            Some(start) => self.infer_expr(start, None)?,
+            None => None,
+        };
+        let end_ty = match &range.end {
+            Some(end) => self.infer_expr(end, start_ty.clone())?,
+            None => None,
+        };
+        if start_ty.is_none() {
+            if let (Some(start), Some(end_ty)) = (&range.start, end_ty.clone()) {
+                let _ = self.infer_expr(start, Some(end_ty))?;
+            }
+        }
+        Ok(start_ty.or(end_ty))
+    }
+
+    fn fork(&self) -> TypeInferenceCx<'a, 'm> {
         TypeInferenceCx {
             compiler: self.compiler,
             generic_vars: self.generic_vars,
+            generic_type_bounds: self.generic_type_bounds.clone(),
+            syn_vars: self.syn_vars.clone(),
+            mutable_vars: self.mutable_vars.clone(),
             vars: self.vars.clone(),
+            local_terms: self.local_terms.clone(),
+            inference: self.inference.clone(),
             results: self.results.clone(),
         }
     }
@@ -242,7 +2105,28 @@ impl TypeInferenceCx<'_, '_> {
         Some(TileRustType::new_string(type_instance))
     }
 
-    fn infer_tuple(&mut self, tuple: &syn::ExprTuple) -> Result<Option<TileRustType>, JITError> {
+    fn infer_tuple(
+        &mut self,
+        tuple: &syn::ExprTuple,
+        expected: Option<TileRustType>,
+    ) -> Result<Option<TileRustType>, JITError> {
+        if let Some(expected) = expected {
+            if let Some(elem_types) = tuple_element_syn_types(&expected.rust_ty) {
+                if elem_types.len() == tuple.elems.len() {
+                    for (elem, elem_ty) in tuple.elems.iter().zip(elem_types.iter()) {
+                        let expected_elem = self.compiler.compile_type(
+                            elem_ty,
+                            self.generic_vars,
+                            &HashMap::new(),
+                        )?;
+                        let _ = self.infer_expr(elem, expected_elem)?;
+                    }
+                    return Ok(Some(expected));
+                }
+            }
+            return Ok(Some(expected));
+        }
+
         let mut elem_types = Vec::new();
         for elem in &tuple.elems {
             if let Some(elem_ty) = self.infer_expr(elem, None)? {
@@ -260,8 +2144,58 @@ impl TypeInferenceCx<'_, '_> {
             .compile_type(&tuple_ty, self.generic_vars, &HashMap::new())
     }
 
-    fn infer_field(&mut self, field: &syn::ExprField) -> Result<Option<TileRustType>, JITError> {
+    fn infer_macro(&self, macro_expr: &ExprMacro) -> Result<Option<TileRustType>, JITError> {
+        let Some(name) = macro_expr
+            .mac
+            .path
+            .segments
+            .last()
+            .map(|segment| segment.ident.to_string())
+        else {
+            return Ok(None);
+        };
+        let ty_name = match name.as_str() {
+            "const_shape" => "Shape",
+            "const_array" => "Array",
+            _ => return Ok(None),
+        };
+        let mut dims = Vec::new();
+        for token in macro_expr.mac.tokens.clone() {
+            match token {
+                TokenTree::Literal(lit) => dims.push(lit.to_string()),
+                TokenTree::Ident(ident) => {
+                    let name = ident.to_string();
+                    if let Some(array) = self.generic_vars.inst_array.get(&name) {
+                        dims.extend(array.iter().map(i32::to_string));
+                    } else {
+                        dims.push(name);
+                    }
+                }
+                TokenTree::Punct(punct) if punct.as_char() == ',' => {}
+                _ => return Ok(None),
+            }
+        }
+        let dims = dims.join(", ");
+        let ty: Type = syn::parse_str(&format!("{ty_name}<{{ [{dims}] }}>"))
+            .map_err(|err| JITError::Generic(err.to_string()))?;
+        self.compiler
+            .compile_type(&ty, self.generic_vars, &HashMap::new())
+    }
+
+    fn infer_field(
+        &mut self,
+        field: &syn::ExprField,
+        expected: Option<TileRustType>,
+    ) -> Result<Option<TileRustType>, JITError> {
         let Some(base_ty) = self.infer_expr(&field.base, None)? else {
+            if let Some(expected) = expected {
+                if self
+                    .expected_tuple_type_from_field_base(&field.base, &field.member, &expected)?
+                    .is_some()
+                {
+                    return Ok(Some(expected));
+                }
+            }
             return Ok(None);
         };
         match (&base_ty.rust_ty, &field.member) {
@@ -272,7 +2206,87 @@ impl TypeInferenceCx<'_, '_> {
                 self.compiler
                     .compile_type(elem_ty, self.generic_vars, &HashMap::new())
             }
+            (Type::Path(path), syn::Member::Named(field_name)) if path.qself.is_none() => {
+                let Some(struct_name) = path.path.segments.last().map(|segment| &segment.ident)
+                else {
+                    return Ok(None);
+                };
+                let Some(item_struct) = self
+                    .compiler
+                    .modules
+                    .structs()
+                    .get(&struct_name.to_string())
+                else {
+                    return Ok(None);
+                };
+                let syn::Fields::Named(fields) = &item_struct.fields else {
+                    return Ok(None);
+                };
+                let Some(field) = fields.named.iter().find(|field| {
+                    field
+                        .ident
+                        .as_ref()
+                        .is_some_and(|ident| ident == field_name)
+                }) else {
+                    return Ok(None);
+                };
+                self.compiler
+                    .compile_type(&field.ty, self.generic_vars, &HashMap::new())
+            }
             _ => Ok(None),
+        }
+    }
+
+    fn expected_tuple_type_from_field_base(
+        &mut self,
+        base: &Expr,
+        member: &syn::Member,
+        expected_elem_ty: &TileRustType,
+    ) -> Result<Option<TileRustType>, JITError> {
+        let syn::Member::Unnamed(index) = member else {
+            return Ok(None);
+        };
+        let Some(tuple) = self.tuple_expr_or_origin(base) else {
+            return Ok(None);
+        };
+        let target_idx = index.index as usize;
+        if target_idx >= tuple.elems.len() {
+            return Ok(None);
+        }
+        let mut elem_types = Vec::new();
+        for (idx, elem) in tuple.elems.iter().enumerate() {
+            if idx == target_idx {
+                elem_types.push(expected_elem_ty.rust_ty.clone());
+            } else if let Some(elem_ty) = self.infer_expr_syn_type(elem, None)? {
+                elem_types.push(elem_ty);
+            } else {
+                return Ok(None);
+            }
+        }
+        let tuple_ty = Type::Tuple(syn::TypeTuple {
+            paren_token: syn::token::Paren::default(),
+            elems: elem_types.into_iter().collect(),
+        });
+        let Some(tuple_ty) =
+            self.compiler
+                .compile_type(&tuple_ty, self.generic_vars, &HashMap::new())?
+        else {
+            return Ok(None);
+        };
+        let _ = self.infer_expr(base, Some(tuple_ty.clone()))?;
+        Ok(Some(tuple_ty))
+    }
+
+    fn tuple_expr_or_origin(&self, expr: &Expr) -> Option<syn::ExprTuple> {
+        match expr {
+            Expr::Tuple(tuple) => Some(tuple.clone()),
+            Expr::Paren(paren) => self.tuple_expr_or_origin(&paren.expr),
+            _ => self
+                .expr_or_local_term(expr)
+                .and_then(|term| match self.term_origin(&term) {
+                    Some(Expr::Tuple(tuple)) => Some(tuple),
+                    _ => None,
+                }),
         }
     }
 
@@ -286,21 +2300,39 @@ impl TypeInferenceCx<'_, '_> {
         };
         let ident = get_ident_from_path_expr(path).to_string();
         if ident == "Some" && call.args.len() == 1 {
-            return self.infer_expr(&call.args[0], expected);
+            if let Some(expected) = expected {
+                let payload_expected =
+                    option_payload_syn_type(&expected.rust_ty).and_then(|payload_ty| {
+                        self.compiler
+                            .compile_type(&payload_ty, self.generic_vars, &HashMap::new())
+                            .ok()
+                            .flatten()
+                    });
+                let _ = self.infer_expr(&call.args[0], payload_expected)?;
+                return Ok(Some(expected));
+            }
+            let Some(payload_ty) = self.infer_expr(&call.args[0], None)? else {
+                return Ok(None);
+            };
+            let payload_ty = payload_ty.rust_ty;
+            let option_ty: Type = syn::parse_quote!(Option<#payload_ty>);
+            return self
+                .compiler
+                .compile_type(&option_ty, self.generic_vars, &HashMap::new());
         }
 
-        let arg_types = self.infer_call_arg_types(call.args.iter())?;
         let Some((_, fn_item)) = self.compiler.modules.get_function_by_name(&ident) else {
+            let _ = self.infer_call_arg_types(call.args.iter())?;
             return Ok(expected);
         };
 
+        self.infer_signature_closure_args(fn_item, call, expected.as_ref())?;
+
+        let arg_types = self.infer_function_call_arg_types(fn_item, call, expected.as_ref())?;
         if let Some(lowered_method_call) =
             crate::passes::typed_dispatch_lowering::lower_dispatch_wrapper_call(fn_item, call)
         {
-            let method_arg_types = self.method_call_arg_types(&lowered_method_call)?;
-            if let Some(selection) =
-                self.select_method_call(&lowered_method_call, &method_arg_types)?
-            {
+            if let Some(selection) = self.infer_method_call_selection(&lowered_method_call)? {
                 self.results
                     .insert_lowered_method_call(call, lowered_method_call.clone());
                 self.results
@@ -312,13 +2344,115 @@ impl TypeInferenceCx<'_, '_> {
         self.infer_function_return(fn_item, call, &arg_types, expected)
     }
 
+    fn infer_signature_closure_args(
+        &mut self,
+        fn_item: &ItemFn,
+        call: &ExprCall,
+        expected_return: Option<&TileRustType>,
+    ) -> Result<(), JITError> {
+        let (param_types, return_type) = get_sig_types(&fn_item.sig, None);
+        let closure_signatures = call
+            .args
+            .iter()
+            .zip(param_types.iter())
+            .map(|(arg, param_type)| match arg {
+                Expr::Closure(_) => closure_signature_for_param(&fn_item.sig, param_type),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        if closure_signatures.iter().all(Option::is_none) {
+            return Ok(());
+        }
+        let closure_generics =
+            closure_signature_generic_names(&fn_item.sig, closure_signatures.iter().flatten());
+
+        let mut generic_arg_inf = GenericArgInference::new_function(fn_item.sig.clone());
+        if let Some(expected_return) = expected_return {
+            generic_arg_inf.add_type_constraints(&return_type, &expected_return.rust_ty);
+        }
+        generic_arg_inf.apply_provided_generics_fn_call(call, self.generic_vars);
+
+        for ((arg, param_type), signature) in call
+            .args
+            .iter()
+            .zip(param_types.iter())
+            .zip(closure_signatures.iter())
+        {
+            if let Expr::Closure(closure) = arg {
+                if let Some(signature) = signature {
+                    if let Some((param_types, return_type)) =
+                        self.instantiate_closure_signature(&signature, &generic_arg_inf)
+                    {
+                        self.infer_closure(closure, &param_types, return_type)?;
+                    } else {
+                        self.infer_closure(closure, &[], None)?;
+                    }
+                } else {
+                    self.infer_closure(closure, &[], None)?;
+                }
+                continue;
+            }
+
+            let expected = substitute_resolved_generics(param_type, &generic_arg_inf)
+                .as_ref()
+                .and_then(|ty| self.compile_expected_param_type(ty))
+                .or_else(|| {
+                    concrete_scalar_param_type(param_type).and_then(|param_type| {
+                        self.compiler
+                            .compile_type(param_type, self.generic_vars, &HashMap::new())
+                            .ok()
+                            .flatten()
+                    })
+                });
+            if let Some(arg_ty) = self.infer_expr_syn_type(arg, expected)? {
+                if type_mentions_any_name(param_type, &closure_generics)
+                    && can_add_type_constraint(param_type, &arg_ty)
+                {
+                    generic_arg_inf.add_type_constraints(param_type, &arg_ty);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn instantiate_closure_signature(
+        &self,
+        signature: &ClosureSignature,
+        inference: &GenericArgInference,
+    ) -> Option<(Vec<TileRustType>, Option<TileRustType>)> {
+        let mut param_types = Vec::with_capacity(signature.inputs.len());
+        for param_type in &signature.inputs {
+            let param_type = substitute_resolved_generics(param_type, inference)?;
+            param_types.push(self.compile_closure_value_type(&param_type)?);
+        }
+        let return_type = signature
+            .output
+            .as_ref()
+            .and_then(|return_type| substitute_resolved_generics(return_type, inference))
+            .and_then(|return_type| self.compile_closure_value_type(&return_type));
+        Some((param_types, return_type))
+    }
+
+    fn compile_closure_value_type(&self, ty: &Type) -> Option<TileRustType> {
+        if let Some(name) = scalar_type_name(ty) {
+            if name == "bool" || is_integer_scalar_name(&name) || is_float_scalar_name(&name) {
+                if let Some(scalar_tile) = TileRustType::from_scalar_tile(&name) {
+                    return Some(scalar_tile);
+                }
+            }
+        }
+        self.compile_expected_param_type(ty)
+    }
+
     fn infer_method_call(
         &mut self,
         method_call: &ExprMethodCall,
         expected: Option<TileRustType>,
     ) -> Result<Option<TileRustType>, JITError> {
-        let call_arg_types = self.method_call_arg_types(method_call)?;
-        if let Some(selection) = self.select_method_call(method_call, &call_arg_types)? {
+        if let Some(global_return) = self.infer_global_method_call(method_call)? {
+            return Ok(Some(global_return));
+        }
+        if let Some(selection) = self.infer_method_call_selection(method_call)? {
             self.results
                 .insert_method_selection(method_call, selection.clone());
             Ok(selection.return_type.or(expected))
@@ -327,9 +2461,100 @@ impl TypeInferenceCx<'_, '_> {
         }
     }
 
-    fn infer_call_arg_types<'a>(
+    fn infer_global_method_call(
         &mut self,
-        args: impl Iterator<Item = &'a Expr>,
+        method_call: &ExprMethodCall,
+    ) -> Result<Option<TileRustType>, JITError> {
+        let Some((element_ty, shape)) =
+            self.global_receiver_element_and_shape(&method_call.receiver)?
+        else {
+            return Ok(None);
+        };
+        let tile_ty = global_tile_syn_type(&element_ty, &shape)?;
+        let return_syn_ty = match method_call.method.to_string().as_str() {
+            "load" | "atomic_add" => {
+                for (idx, arg) in method_call.args.iter().enumerate() {
+                    if method_call.method == "atomic_add" && idx == 0 {
+                        let expected = self.compiler.compile_type(
+                            &tile_ty,
+                            self.generic_vars,
+                            &HashMap::new(),
+                        )?;
+                        let _ = self.infer_expr(arg, expected)?;
+                    } else {
+                        let _ = self.infer_expr(arg, None)?;
+                    }
+                }
+                syn::parse_quote!((#tile_ty, Token))
+            }
+            "store" => {
+                for (idx, arg) in method_call.args.iter().enumerate() {
+                    if idx == 0 {
+                        let expected = self.compiler.compile_type(
+                            &tile_ty,
+                            self.generic_vars,
+                            &HashMap::new(),
+                        )?;
+                        let _ = self.infer_expr(arg, expected)?;
+                    } else {
+                        let _ = self.infer_expr(arg, None)?;
+                    }
+                }
+                syn::parse_quote!(Token)
+            }
+            _ => return Ok(None),
+        };
+        self.results.insert_resolved_expr_type(
+            &Expr::MethodCall(method_call.clone()),
+            ResolvedType::from_syn_type(&return_syn_ty),
+        );
+        self.compiler
+            .compile_type(&return_syn_ty, self.generic_vars, &HashMap::new())
+    }
+
+    fn global_receiver_element_and_shape(
+        &self,
+        receiver: &Expr,
+    ) -> Result<Option<(Type, Vec<i32>)>, JITError> {
+        let Expr::Path(path) = receiver else {
+            return Ok(None);
+        };
+        if path.path.segments.len() != 1 {
+            return Ok(None);
+        }
+        let res = self
+            .compiler
+            .modules
+            .name_resolver
+            .resolve_path(&path.path, &self.compiler.module_name);
+        let Res::Def(DefKind::Static, def_id) = res else {
+            return Ok(None);
+        };
+        let Some(static_item) = self.compiler.modules.name_resolver.get_static(&def_id) else {
+            return Ok(None);
+        };
+        let ty = self
+            .compiler
+            .modules
+            .normalize_type_aliases(&static_item.ty)?;
+        let Some(type_name) = get_type_ident(&ty) else {
+            return Ok(None);
+        };
+        if type_name != "Global" {
+            return Ok(None);
+        }
+        let Some(element_ty) = global_element_type(&ty) else {
+            return Ok(None);
+        };
+        let Some(shape) = global_shape(&ty) else {
+            return Ok(None);
+        };
+        Ok(Some((element_ty, shape)))
+    }
+
+    fn infer_call_arg_types<'expr>(
+        &mut self,
+        args: impl Iterator<Item = &'expr Expr>,
     ) -> Result<Vec<TileRustType>, JITError> {
         let mut arg_types = Vec::new();
         for arg in args {
@@ -341,17 +2566,29 @@ impl TypeInferenceCx<'_, '_> {
         Ok(arg_types)
     }
 
-    fn method_call_arg_types(
+    fn infer_function_call_arg_types(
         &mut self,
-        method_call: &ExprMethodCall,
+        fn_item: &ItemFn,
+        call: &ExprCall,
+        expected_return: Option<&TileRustType>,
     ) -> Result<Vec<TileRustType>, JITError> {
-        let receiver = self.infer_expr(&method_call.receiver, None)?;
-        let Some(receiver) = receiver else {
-            return Ok(Vec::new());
-        };
-        let mut arg_types = vec![receiver];
-        for arg in &method_call.args {
-            let Some(arg_ty) = self.infer_expr(arg, None)? else {
+        let (param_types, _) = get_sig_types(&fn_item.sig, None);
+        let expected_arg_types =
+            self.expected_function_arg_types(fn_item, call, expected_return)?;
+        let mut arg_types = Vec::new();
+        for (idx, arg) in call.args.iter().enumerate() {
+            let expected = expected_arg_types.get(idx).cloned().flatten().or_else(|| {
+                param_types
+                    .get(idx)
+                    .and_then(concrete_scalar_param_type)
+                    .and_then(|param_type| {
+                        self.compiler
+                            .compile_type(param_type, self.generic_vars, &HashMap::new())
+                            .ok()
+                            .flatten()
+                    })
+            });
+            let Some(arg_ty) = self.infer_expr(arg, expected)? else {
                 return Ok(Vec::new());
             };
             arg_types.push(arg_ty);
@@ -359,24 +2596,309 @@ impl TypeInferenceCx<'_, '_> {
         Ok(arg_types)
     }
 
-    fn select_method_call(
+    fn expected_function_arg_types(
         &self,
+        fn_item: &ItemFn,
+        call: &ExprCall,
+        expected_return: Option<&TileRustType>,
+    ) -> Result<Vec<Option<TileRustType>>, JITError> {
+        let (param_types, return_type) = get_sig_types(&fn_item.sig, None);
+        let mut generic_arg_inf = GenericArgInference::new_function(fn_item.sig.clone());
+        if let Some(expected_return) = expected_return {
+            generic_arg_inf.add_type_constraints(&return_type, &expected_return.rust_ty);
+        }
+        generic_arg_inf.apply_provided_generics_fn_call(call, self.generic_vars);
+
+        let mut expected_arg_types = Vec::new();
+        for param_type in param_types {
+            let expected = substitute_resolved_generics(&param_type, &generic_arg_inf)
+                .as_ref()
+                .and_then(|ty| self.compile_expected_param_type(ty))
+                .or_else(|| self.compile_expected_param_type(&param_type));
+            expected_arg_types.push(expected);
+        }
+        Ok(expected_arg_types)
+    }
+
+    fn compile_expected_param_type(&self, ty: &Type) -> Option<TileRustType> {
+        if type_has_impl_trait(ty)
+            || !type_is_fully_known(self.compiler, ty, self.generic_vars)
+            || !type_is_resolvable(self.compiler, ty, self.generic_vars)
+        {
+            return None;
+        }
+        self.compiler
+            .compile_type(ty, self.generic_vars, &HashMap::new())
+            .ok()
+            .flatten()
+    }
+
+    fn infer_global_const_type(
+        &self,
+        path: &syn::ExprPath,
+    ) -> Result<Option<TileRustType>, JITError> {
+        let res = self
+            .compiler
+            .modules
+            .name_resolver
+            .resolve_path(&path.path, &self.compiler.module_name);
+        let Res::Def(DefKind::Const, def_id) = res else {
+            return Ok(None);
+        };
+        let Some(const_item) = self.compiler.modules.name_resolver.get_const(&def_id) else {
+            return Ok(None);
+        };
+        self.compiler
+            .compile_type(&const_item.ty, self.generic_vars, &HashMap::new())
+    }
+
+    fn infer_global_static_type(
+        &self,
+        path: &syn::ExprPath,
+    ) -> Result<Option<TileRustType>, JITError> {
+        let res = self
+            .compiler
+            .modules
+            .name_resolver
+            .resolve_path(&path.path, &self.compiler.module_name);
+        let Res::Def(DefKind::Static, def_id) = res else {
+            return Ok(None);
+        };
+        let Some(static_item) = self.compiler.modules.name_resolver.get_static(&def_id) else {
+            return Ok(None);
+        };
+        self.compiler
+            .compile_type(&static_item.ty, self.generic_vars, &HashMap::new())
+    }
+
+    fn infer_associated_const_type(
+        &self,
+        path: &syn::ExprPath,
+    ) -> Result<Option<TileRustType>, JITError> {
+        let candidates = self.associated_const_syn_type_candidates(path);
+        let Some(ty) = single_syn_type(candidates) else {
+            return Ok(None);
+        };
+        self.compiler
+            .compile_type(&ty, self.generic_vars, &HashMap::new())
+    }
+
+    fn associated_const_syn_type_candidates(&self, path: &syn::ExprPath) -> Vec<Type> {
+        if let Some(qself) = &path.qself {
+            let Some(const_name) = path
+                .path
+                .segments
+                .last()
+                .map(|segment| segment.ident.to_string())
+            else {
+                return Vec::new();
+            };
+            let Some(trait_name) = qself
+                .position
+                .checked_sub(1)
+                .and_then(|idx| path.path.segments.iter().nth(idx))
+                .map(|segment| segment.ident.to_string())
+            else {
+                return Vec::new();
+            };
+            return self
+                .trait_associated_const_syn_type(&trait_name, &const_name, &qself.ty)
+                .into_iter()
+                .collect();
+        }
+
+        if path.path.segments.len() != 2 {
+            return Vec::new();
+        }
+        let qualifier = &path.path.segments[0];
+        let qualifier_name = qualifier.ident.to_string();
+        let const_name = path.path.segments[1].ident.to_string();
+        let self_ty = type_from_path_segment(qualifier);
+
+        let mut candidates = Vec::new();
+        if let Some(bounds) = self.generic_type_bounds.get(&qualifier_name) {
+            for trait_name in bounds {
+                if let Some(ty) =
+                    self.trait_associated_const_syn_type(trait_name, &const_name, &self_ty)
+                {
+                    candidates.push(ty);
+                }
+            }
+        }
+
+        for ((trait_name, self_name), _impls) in self.compiler.modules.trait_impls() {
+            if self_name == &qualifier_name {
+                if let Some(ty) =
+                    self.trait_associated_const_syn_type(trait_name, &const_name, &self_ty)
+                {
+                    candidates.push(ty);
+                }
+            }
+        }
+        for ((trait_name, self_name), _impl_item) in self.compiler.modules.primitives() {
+            if self_name == &qualifier_name {
+                if let Some(ty) =
+                    self.trait_associated_const_syn_type(trait_name, &const_name, &self_ty)
+                {
+                    candidates.push(ty);
+                }
+            }
+        }
+        candidates
+    }
+
+    fn trait_associated_const_syn_type(
+        &self,
+        trait_name: &str,
+        const_name: &str,
+        self_ty: &Type,
+    ) -> Option<Type> {
+        let item_trait = self.compiler.modules.traits().get(trait_name)?;
+        item_trait.items.iter().find_map(|item| {
+            let TraitItem::Const(item_const) = item else {
+                return None;
+            };
+            if item_const.ident != const_name {
+                return None;
+            }
+            Some(substitute_self_type(&item_const.ty, self_ty))
+        })
+    }
+
+    fn method_call_arg_rust_types_with_receiver(
+        &mut self,
         method_call: &ExprMethodCall,
-        call_arg_types: &[TileRustType],
+        receiver: Type,
+    ) -> Result<Option<Vec<Type>>, JITError> {
+        let expected_arg_types = self.unique_inherent_method_arg_types(&receiver, method_call);
+        let mut arg_types = vec![receiver];
+        for (idx, arg) in method_call.args.iter().enumerate() {
+            let expected = expected_arg_types
+                .as_ref()
+                .and_then(|arg_types| arg_types.get(idx))
+                .and_then(|param_type| self.compile_expected_param_type(param_type));
+            let Some(arg_ty) = self.infer_expr_syn_type(arg, expected)? else {
+                return Ok(None);
+            };
+            arg_types.push(arg_ty);
+        }
+        Ok(Some(arg_types))
+    }
+
+    fn infer_method_call_selection(
+        &mut self,
+        method_call: &ExprMethodCall,
     ) -> Result<Option<MethodSelection>, JITError> {
-        if call_arg_types.is_empty() {
+        let Some(receiver) = self.infer_expr_syn_type(&method_call.receiver, None)? else {
+            let _ = self.infer_call_arg_types(method_call.args.iter())?;
+            return Ok(None);
+        };
+
+        let allow_mut_borrow = self.receiver_allows_mut_borrow(&method_call.receiver, &receiver);
+        for receiver in receiver_adjustment_candidates(&receiver, allow_mut_borrow) {
+            let mut probe = self.fork();
+            let Some(call_arg_types) =
+                probe.method_call_arg_rust_types_with_receiver(method_call, receiver)?
+            else {
+                continue;
+            };
+            let Some(selection) = probe.select_method_call(method_call, &call_arg_types)? else {
+                continue;
+            };
+            self.commit_typeck_probe(probe);
+            return Ok(Some(selection));
+        }
+
+        let _ = self.infer_call_arg_types(method_call.args.iter())?;
+        Ok(None)
+    }
+
+    fn receiver_allows_mut_borrow(&self, receiver_expr: &Expr, receiver_ty: &Type) -> bool {
+        if type_is_mut_reference(receiver_ty) {
+            return true;
+        }
+        let Expr::Path(path) = receiver_expr else {
+            return false;
+        };
+        if path.path.segments.len() != 1 {
+            return false;
+        }
+        let name = get_ident_from_path_expr(path).to_string();
+        self.mutable_vars.contains(&name)
+    }
+
+    fn commit_typeck_probe(&mut self, probe: TypeInferenceCx<'_, '_>) {
+        self.syn_vars = probe.syn_vars;
+        self.mutable_vars = probe.mutable_vars;
+        self.vars = probe.vars;
+        self.local_terms = probe.local_terms;
+        self.inference = probe.inference;
+        self.results = probe.results;
+    }
+
+    fn unique_inherent_method_arg_types(
+        &self,
+        receiver_ty: &Type,
+        method_call: &ExprMethodCall,
+    ) -> Option<Vec<Type>> {
+        let receiver_type = get_type_ident(receiver_ty)?.to_string();
+        let method_name = method_call.method.to_string();
+        let mut matches = Vec::new();
+
+        for (_module_name, item_impl) in self
+            .compiler
+            .modules
+            .struct_impls()
+            .get(&receiver_type)?
+            .iter()
+        {
+            for item in &item_impl.items {
+                let syn::ImplItem::Fn(method) = item else {
+                    continue;
+                };
+                if method.sig.ident == method_name {
+                    matches.push((item_impl, method));
+                }
+            }
+        }
+
+        let [(item_impl, method)] = matches.as_slice() else {
+            return None;
+        };
+        let self_ty = &*item_impl.self_ty;
+        let (param_types, _return_type) = get_sig_types(&method.sig, Some(self_ty));
+        let mut generic_arg_inf = GenericArgInference::new_method(item_impl, method);
+        generic_arg_inf.add_type_constraints(self_ty, receiver_ty);
+        let receiver_rank = rank_from_type_shape_arg(receiver_ty, self.generic_vars);
+        Some(
+            param_types
+                .into_iter()
+                .skip(1)
+                .map(|param_type| {
+                    let resolved = substitute_resolved_generics(&param_type, &generic_arg_inf)
+                        .unwrap_or(param_type);
+                    receiver_rank
+                        .map(|rank| replace_array_len_with_rank(resolved.clone(), rank))
+                        .unwrap_or(resolved)
+                })
+                .collect(),
+        )
+    }
+
+    fn select_method_call(
+        &mut self,
+        method_call: &ExprMethodCall,
+        call_arg_rust_tys: &[Type],
+    ) -> Result<Option<MethodSelection>, JITError> {
+        if call_arg_rust_tys.is_empty() {
             return Ok(None);
         }
-        let call_arg_rust_tys = call_arg_types
-            .iter()
-            .map(|arg| arg.rust_ty.clone())
-            .collect::<Vec<_>>();
         let receiver_ty = &call_arg_rust_tys[0];
         let Some((module_name, impl_item, impl_method)) = self.compiler.modules.get_impl_item_fn(
             receiver_ty,
             method_call,
             self.generic_vars,
-            &call_arg_rust_tys,
+            call_arg_rust_tys,
         )?
         else {
             return Ok(None);
@@ -386,7 +2908,7 @@ impl TypeInferenceCx<'_, '_> {
             &impl_item,
             &impl_method,
             method_call,
-            &call_arg_rust_tys,
+            call_arg_rust_tys,
             self_ty,
             self.generic_vars,
             self.compiler.modules.primitives(),
@@ -394,7 +2916,7 @@ impl TypeInferenceCx<'_, '_> {
         let return_type = self.infer_method_return_type(
             &impl_item,
             &impl_method,
-            &call_arg_rust_tys,
+            call_arg_rust_tys,
             self_ty,
             &call_generic_vars,
             method_call,
@@ -409,12 +2931,12 @@ impl TypeInferenceCx<'_, '_> {
     }
 
     fn infer_method_return_type(
-        &self,
+        &mut self,
         impl_item: &ItemImpl,
         impl_method: &ImplItemFn,
         call_arg_rust_tys: &[Type],
         self_ty: &Type,
-        call_generic_vars: &GenericVars,
+        _call_generic_vars: &GenericVars,
         method_call: &ExprMethodCall,
     ) -> Result<Option<TileRustType>, JITError> {
         let (arg_types, return_type) = get_sig_types(&impl_method.sig, Some(self_ty));
@@ -428,20 +2950,37 @@ impl TypeInferenceCx<'_, '_> {
             return Ok(None);
         }
         let call_output_type = generic_arg_inf.infer_type(&return_type, self.generic_vars);
-        if !type_is_resolvable(self.compiler, &call_output_type, call_generic_vars) {
+        if !type_is_resolvable(self.compiler, &call_output_type, self.generic_vars) {
+            self.results.insert_resolved_expr_type(
+                &Expr::MethodCall(method_call.clone()),
+                ResolvedType::from_syn_type(&call_output_type),
+            );
             return Ok(None);
         }
         match self
             .compiler
-            .compile_type(&call_output_type, call_generic_vars, &HashMap::new())
+            .compile_type(&call_output_type, self.generic_vars, &HashMap::new())
         {
-            Ok(ty) => Ok(ty),
-            Err(_) => Ok(None),
+            Ok(Some(ty)) => Ok(Some(ty)),
+            Ok(None) => {
+                self.results.insert_resolved_expr_type(
+                    &Expr::MethodCall(method_call.clone()),
+                    ResolvedType::from_syn_type(&call_output_type),
+                );
+                Ok(None)
+            }
+            Err(_) => {
+                self.results.insert_resolved_expr_type(
+                    &Expr::MethodCall(method_call.clone()),
+                    ResolvedType::from_syn_type(&call_output_type),
+                );
+                Ok(None)
+            }
         }
     }
 
     fn infer_function_return(
-        &self,
+        &mut self,
         fn_item: &ItemFn,
         call: &ExprCall,
         arg_types: &[TileRustType],
@@ -472,6 +3011,27 @@ impl TypeInferenceCx<'_, '_> {
             .as_ref()
             .map(type_params_by_name)
             .unwrap_or_default();
+        let param_names = get_sig_param_names(&fn_item.sig);
+        let mut arg_string_values: HashMap<String, String> = HashMap::new();
+        let mut arg_zst_values: HashMap<String, String> = HashMap::new();
+
+        for (idx, param_name) in param_names.iter().enumerate() {
+            let Some(arg_expr) = call.args.get(idx) else {
+                continue;
+            };
+            if let Some(value) = shared_utils::zst_type_name(arg_expr) {
+                arg_zst_values.insert(param_name.clone(), value);
+            }
+            if let Expr::Lit(lit_expr) = arg_expr {
+                if let syn::Lit::Str(s) = &lit_expr.lit {
+                    arg_string_values.insert(param_name.clone(), s.value());
+                }
+            } else if param_name == "padding_value" {
+                if let Some(value) = shared_utils::padding_zst_value(arg_expr) {
+                    arg_string_values.insert(param_name.clone(), value);
+                }
+            }
+        }
 
         if let Some(op_attrs) = self
             .compiler
@@ -479,30 +3039,28 @@ impl TypeInferenceCx<'_, '_> {
             .get_cuda_tile_op_attrs(fn_item.sig.ident.to_string().as_str())
         {
             if let Some(output_type_params) = op_attrs.parse_string_arr("output_type_params") {
-                let param_names = get_sig_param_names(&fn_item.sig);
                 let arg_types_by_name = param_names
                     .iter()
                     .zip(arg_types.iter())
                     .map(|(name, ty)| (name.clone(), ty.clone()))
                     .collect::<HashMap<_, _>>();
                 for type_param_name in output_type_params {
+                    if should_skip_optional_output_type_param(&type_param_name, &arg_zst_values) {
+                        continue;
+                    }
                     if let Some(arg_type) = arg_types_by_name.get(&type_param_name) {
-                        if should_skip_optional_output_type_param(
-                            &type_param_name,
-                            &arg_type.rust_ty,
-                        ) {
-                            continue;
-                        }
                         let cuda_tile_type_str = arg_type.get_cuda_tile_type_str();
-                        type_params.insert(
+                        let mut type_param = TypeParam::derive_param_from_type(
                             type_param_name.clone(),
-                            TypeParam::derive_param_from_type(
-                                type_param_name,
-                                arg_type.rust_ty.clone(),
-                                cuda_tile_type_str,
-                                Some(arg_type.type_instance.clone()),
-                            ),
+                            arg_type.rust_ty.clone(),
+                            cuda_tile_type_str,
+                            Some(arg_type.type_instance.clone()),
                         );
+                        if let TypeParam::Padding(ref mut padding) = type_param {
+                            padding.padding_value =
+                                arg_string_values.get(&type_param_name).cloned();
+                        }
+                        type_params.insert(type_param_name.clone(), type_param);
                     }
                 }
             }
@@ -512,9 +3070,284 @@ impl TypeInferenceCx<'_, '_> {
             .compiler
             .compile_type(&call_output_type, self.generic_vars, &type_params)
         {
-            Ok(ty) => Ok(ty),
-            Err(_) => Ok(expected),
+            Ok(Some(ty)) => Ok(Some(ty)),
+            Ok(None) => {
+                self.results.insert_resolved_expr_type(
+                    &Expr::Call(call.clone()),
+                    ResolvedType::from_syn_type(&call_output_type),
+                );
+                Ok(expected)
+            }
+            Err(_) => {
+                self.results.insert_resolved_expr_type(
+                    &Expr::Call(call.clone()),
+                    ResolvedType::from_syn_type(&call_output_type),
+                );
+                Ok(expected)
+            }
         }
+    }
+}
+
+fn local_pattern_type(pat: &Pat) -> Option<&Type> {
+    match pat {
+        Pat::Type(pat_type) => Some(pat_type.ty.as_ref()),
+        _ => None,
+    }
+}
+
+fn generic_type_bounds(generics: &Generics) -> HashMap<String, Vec<String>> {
+    let mut bounds: HashMap<String, Vec<String>> = HashMap::new();
+
+    for param in &generics.params {
+        let syn::GenericParam::Type(type_param) = param else {
+            continue;
+        };
+        let type_name = type_param.ident.to_string();
+        for bound in &type_param.bounds {
+            if let Some(trait_name) = trait_bound_name(bound) {
+                insert_unique_bound(&mut bounds, &type_name, trait_name);
+            }
+        }
+    }
+
+    if let Some(where_clause) = &generics.where_clause {
+        for predicate in &where_clause.predicates {
+            let WherePredicate::Type(predicate_ty) = predicate else {
+                continue;
+            };
+            let Some(type_name) = type_path_ident(&predicate_ty.bounded_ty) else {
+                continue;
+            };
+            for bound in &predicate_ty.bounds {
+                if let Some(trait_name) = trait_bound_name(bound) {
+                    insert_unique_bound(&mut bounds, &type_name, trait_name);
+                }
+            }
+        }
+    }
+
+    bounds
+}
+
+fn merge_generic_type_bounds(
+    bounds: &mut HashMap<String, Vec<String>>,
+    extra: HashMap<String, Vec<String>>,
+) {
+    for (type_name, trait_names) in extra {
+        for trait_name in trait_names {
+            insert_unique_bound(bounds, &type_name, trait_name);
+        }
+    }
+}
+
+fn trait_bound_name(bound: &TypeParamBound) -> Option<String> {
+    match bound {
+        TypeParamBound::Trait(trait_bound) => trait_bound
+            .path
+            .segments
+            .last()
+            .map(|segment| segment.ident.to_string()),
+        _ => None,
+    }
+}
+
+fn insert_unique_bound(
+    bounds: &mut HashMap<String, Vec<String>>,
+    type_name: &str,
+    trait_name: String,
+) {
+    let entry = bounds.entry(type_name.to_string()).or_default();
+    if !entry.iter().any(|existing| existing == &trait_name) {
+        entry.push(trait_name);
+    }
+}
+
+fn type_from_path_segment(segment: &syn::PathSegment) -> Type {
+    let segment = segment.clone();
+    syn::parse_quote!(#segment)
+}
+
+fn single_syn_type(types: Vec<Type>) -> Option<Type> {
+    match types.as_slice() {
+        [ty] => Some(ty.clone()),
+        _ => None,
+    }
+}
+
+fn global_tile_syn_type(element_ty: &Type, shape: &[i32]) -> Result<Type, JITError> {
+    let elem = element_ty.to_token_stream().to_string();
+    let shape = shape
+        .iter()
+        .map(|dim| dim.to_string())
+        .collect::<Vec<_>>()
+        .join(", ");
+    let ty = if shape.is_empty() {
+        format!("Tile<{elem}, {{ [] }}>")
+    } else {
+        format!("Tile<{elem}, {{ [{shape}] }}>")
+    };
+    syn::parse_str::<Type>(&ty)
+        .map_err(|err| JITError::Generic(format!("failed to parse Global tile type `{ty}`: {err}")))
+}
+
+fn global_element_type(ty: &Type) -> Option<Type> {
+    let Type::Path(type_path) = ty else {
+        return None;
+    };
+    let segment = type_path.path.segments.last()?;
+    let PathArguments::AngleBracketed(args) = &segment.arguments else {
+        return None;
+    };
+    args.args.iter().find_map(|arg| match arg {
+        GenericArgument::Type(ty) => Some(ty.clone()),
+        _ => None,
+    })
+}
+
+fn global_shape(ty: &Type) -> Option<Vec<i32>> {
+    let Type::Path(type_path) = ty else {
+        return None;
+    };
+    let segment = type_path.path.segments.last()?;
+    let PathArguments::AngleBracketed(args) = &segment.arguments else {
+        return None;
+    };
+    args.args.iter().find_map(|arg| match arg {
+        GenericArgument::Const(expr) => global_const_shape_expr(expr),
+        _ => None,
+    })
+}
+
+fn global_const_shape_expr(expr: &Expr) -> Option<Vec<i32>> {
+    match expr {
+        Expr::Block(block) => match block.block.stmts.as_slice() {
+            [Stmt::Expr(expr, _)] => global_const_shape_expr(expr),
+            _ => None,
+        },
+        Expr::Array(array) => array.elems.iter().map(global_expr_i32).collect(),
+        Expr::Repeat(repeat) => {
+            let value = global_expr_i32(&repeat.expr)?;
+            let len = global_expr_i32(&repeat.len)? as usize;
+            Some(vec![value; len])
+        }
+        Expr::Paren(paren) => global_const_shape_expr(&paren.expr),
+        _ => None,
+    }
+}
+
+fn global_expr_i32(expr: &Expr) -> Option<i32> {
+    match expr {
+        Expr::Lit(ExprLit {
+            lit: Lit::Int(value),
+            ..
+        }) => value.base10_parse::<i32>().ok(),
+        Expr::Unary(unary) if matches!(unary.op, syn::UnOp::Neg(_)) => {
+            global_expr_i32(&unary.expr).map(|value| -value)
+        }
+        Expr::Paren(paren) => global_expr_i32(&paren.expr),
+        _ => None,
+    }
+}
+
+fn substitute_self_type(ty: &Type, self_ty: &Type) -> Type {
+    match ty {
+        Type::Path(path)
+            if path.qself.is_none()
+                && path.path.segments.len() == 1
+                && path.path.segments[0].ident == "Self" =>
+        {
+            self_ty.clone()
+        }
+        Type::Reference(reference) => {
+            let mut reference = reference.clone();
+            reference.elem = Box::new(substitute_self_type(&reference.elem, self_ty));
+            Type::Reference(reference)
+        }
+        Type::Ptr(ptr) => {
+            let mut ptr = ptr.clone();
+            ptr.elem = Box::new(substitute_self_type(&ptr.elem, self_ty));
+            Type::Ptr(ptr)
+        }
+        Type::Tuple(tuple) => {
+            let mut tuple = tuple.clone();
+            tuple.elems = tuple
+                .elems
+                .iter()
+                .map(|elem| substitute_self_type(elem, self_ty))
+                .collect();
+            Type::Tuple(tuple)
+        }
+        Type::Array(array) => {
+            let mut array = array.clone();
+            array.elem = Box::new(substitute_self_type(&array.elem, self_ty));
+            Type::Array(array)
+        }
+        Type::Slice(slice) => {
+            let mut slice = slice.clone();
+            slice.elem = Box::new(substitute_self_type(&slice.elem, self_ty));
+            Type::Slice(slice)
+        }
+        Type::Paren(paren) => {
+            let mut paren = paren.clone();
+            paren.elem = Box::new(substitute_self_type(&paren.elem, self_ty));
+            Type::Paren(paren)
+        }
+        Type::Group(group) => {
+            let mut group = group.clone();
+            group.elem = Box::new(substitute_self_type(&group.elem, self_ty));
+            Type::Group(group)
+        }
+        _ => ty.clone(),
+    }
+}
+
+fn receiver_adjustment_candidates(receiver_ty: &Type, allow_mut_borrow: bool) -> Vec<Type> {
+    let mut candidates = Vec::new();
+    let mut seen = HashSet::new();
+
+    for base in autoderef_type_chain(receiver_ty) {
+        push_unique_type(&mut candidates, &mut seen, base.clone());
+        if !matches!(base, Type::Reference(_)) {
+            let shared: Type = syn::parse_quote!(&#base);
+            push_unique_type(&mut candidates, &mut seen, shared);
+            if allow_mut_borrow {
+                let mutable: Type = syn::parse_quote!(&mut #base);
+                push_unique_type(&mut candidates, &mut seen, mutable);
+            }
+        }
+    }
+
+    candidates
+}
+
+fn autoderef_type_chain(ty: &Type) -> Vec<Type> {
+    let mut chain = Vec::new();
+    let mut current = ty.clone();
+    loop {
+        chain.push(current.clone());
+        current = match current {
+            Type::Reference(reference) => (*reference.elem).clone(),
+            Type::Paren(paren) => (*paren.elem).clone(),
+            Type::Group(group) => (*group.elem).clone(),
+            _ => break,
+        };
+    }
+    chain
+}
+
+fn push_unique_type(candidates: &mut Vec<Type>, seen: &mut HashSet<String>, ty: Type) {
+    if seen.insert(ty.to_token_stream().to_string()) {
+        candidates.push(ty);
+    }
+}
+
+fn type_is_mut_reference(ty: &Type) -> bool {
+    match ty {
+        Type::Reference(reference) => reference.mutability.is_some(),
+        Type::Paren(paren) => type_is_mut_reference(&paren.elem),
+        Type::Group(group) => type_is_mut_reference(&group.elem),
+        _ => false,
     }
 }
 
@@ -526,11 +3359,638 @@ fn local_binding_name(pat: &Pat) -> Option<String> {
     }
 }
 
+fn tuple_element_syn_types(ty: &Type) -> Option<Vec<Type>> {
+    match ty {
+        Type::Tuple(tuple) => Some(tuple.elems.iter().cloned().collect()),
+        Type::Paren(paren) => tuple_element_syn_types(&paren.elem),
+        _ => None,
+    }
+}
+
+fn array_or_slice_element_syn_type(ty: &Type) -> Option<Type> {
+    match ty {
+        Type::Array(array) => Some((*array.elem).clone()),
+        Type::Slice(slice) => Some((*slice.elem).clone()),
+        Type::Reference(reference) => array_or_slice_element_syn_type(&reference.elem),
+        Type::Paren(paren) => array_or_slice_element_syn_type(&paren.elem),
+        _ => None,
+    }
+}
+
+fn option_payload_syn_type(ty: &Type) -> Option<Type> {
+    let Type::Path(path) = ty else {
+        return None;
+    };
+    if path.qself.is_some() {
+        return None;
+    }
+    let segment = path.path.segments.last()?;
+    if segment.ident != "Option" {
+        return None;
+    }
+    let PathArguments::AngleBracketed(args) = &segment.arguments else {
+        return None;
+    };
+    let mut payload_types = args.args.iter().filter_map(|arg| match arg {
+        GenericArgument::Type(ty) => Some(ty.clone()),
+        _ => None,
+    });
+    let payload_ty = payload_types.next()?;
+    if payload_types.next().is_some() {
+        return None;
+    }
+    Some(payload_ty)
+}
+
+fn repeat_length_value(len: &Expr, generic_vars: &GenericVars) -> Option<usize> {
+    match len {
+        Expr::Lit(lit) => match &lit.lit {
+            Lit::Int(raw) => raw.base10_parse::<usize>().ok(),
+            _ => None,
+        },
+        Expr::Path(path) if path.path.segments.len() == 1 => {
+            let ident = path.path.segments[0].ident.to_string();
+            generic_vars.get_i32(&ident).and_then(|value| {
+                if value >= 0 {
+                    Some(value as usize)
+                } else {
+                    None
+                }
+            })
+        }
+        Expr::Paren(paren) => repeat_length_value(&paren.expr, generic_vars),
+        _ => None,
+    }
+}
+
+fn type_path_ident(ty: &Type) -> Option<String> {
+    match ty {
+        Type::Path(path) if path.qself.is_none() => path
+            .path
+            .segments
+            .last()
+            .map(|segment| segment.ident.to_string()),
+        Type::Paren(paren) => type_path_ident(&paren.elem),
+        Type::Reference(reference) => type_path_ident(&reference.elem),
+        _ => None,
+    }
+}
+
+fn stmt_is_return(stmt: &Stmt) -> bool {
+    matches!(stmt, Stmt::Expr(Expr::Return(_), _))
+}
+
+fn stmt_diverges(stmt: &Stmt) -> bool {
+    match stmt {
+        Stmt::Expr(expr, _) => expr_diverges(expr),
+        Stmt::Local(_) | Stmt::Item(_) | Stmt::Macro(_) => false,
+    }
+}
+
+fn block_diverges(block: &syn::Block) -> bool {
+    block.stmts.iter().any(stmt_diverges)
+}
+
+fn expr_diverges(expr: &Expr) -> bool {
+    match expr {
+        Expr::Return(_) => true,
+        Expr::Block(block) => block_diverges(&block.block),
+        Expr::Unsafe(unsafe_expr) => block_diverges(&unsafe_expr.block),
+        Expr::Paren(paren) => expr_diverges(&paren.expr),
+        Expr::If(if_expr) => {
+            let Some((_, else_expr)) = &if_expr.else_branch else {
+                return false;
+            };
+            block_diverges(&if_expr.then_branch) && expr_diverges(else_expr)
+        }
+        _ => false,
+    }
+}
+
 fn type_params_by_name(ty: &TileRustType) -> HashMap<String, TypeParam> {
     ty.params
         .iter()
         .filter_map(|param| param.name().map(|name| (name.to_string(), param.clone())))
         .collect()
+}
+
+fn concrete_scalar_param_type(ty: &Type) -> Option<&Type> {
+    let Type::Path(path) = ty else {
+        return None;
+    };
+    if path.qself.is_some() || path.path.segments.len() != 1 {
+        return None;
+    }
+    let segment = &path.path.segments[0];
+    if !matches!(segment.arguments, PathArguments::None) {
+        return None;
+    }
+    ResolvedScalarType::from_ident(&segment.ident.to_string()).map(|_| ty)
+}
+
+fn is_unsuffixed_numeric_literal(expr: &Expr) -> bool {
+    match expr {
+        Expr::Lit(lit) => match &lit.lit {
+            Lit::Int(lit) => lit.suffix().is_empty(),
+            Lit::Float(lit) => lit.suffix().is_empty(),
+            _ => false,
+        },
+        Expr::Paren(paren) => is_unsuffixed_numeric_literal(&paren.expr),
+        Expr::Unary(unary) if matches!(unary.op, syn::UnOp::Neg(_)) => {
+            is_unsuffixed_numeric_literal(&unary.expr)
+        }
+        _ => false,
+    }
+}
+
+fn literal_kind_accepts_type(kind: InferVarKind, ty: &Type) -> bool {
+    match kind {
+        InferVarKind::General => true,
+        InferVarKind::Int => scalar_type_name(ty)
+            .as_deref()
+            .is_some_and(is_integer_scalar_name),
+        InferVarKind::Float => scalar_type_name(ty)
+            .as_deref()
+            .is_some_and(is_float_scalar_name),
+    }
+}
+
+fn merge_infer_var_kinds(lhs: InferVarKind, rhs: InferVarKind) -> Option<InferVarKind> {
+    match (lhs, rhs) {
+        (InferVarKind::General, kind) | (kind, InferVarKind::General) => Some(kind),
+        (lhs, rhs) if lhs == rhs => Some(lhs),
+        _ => None,
+    }
+}
+
+fn binary_result_matches_operands(op: &syn::BinOp) -> bool {
+    matches!(
+        op,
+        syn::BinOp::Add(_)
+            | syn::BinOp::Sub(_)
+            | syn::BinOp::Mul(_)
+            | syn::BinOp::Div(_)
+            | syn::BinOp::Rem(_)
+            | syn::BinOp::BitAnd(_)
+            | syn::BinOp::BitOr(_)
+            | syn::BinOp::BitXor(_)
+    )
+}
+
+fn binary_result_is_bool(op: &syn::BinOp) -> bool {
+    matches!(
+        op,
+        syn::BinOp::Eq(_)
+            | syn::BinOp::Ne(_)
+            | syn::BinOp::Lt(_)
+            | syn::BinOp::Le(_)
+            | syn::BinOp::Gt(_)
+            | syn::BinOp::Ge(_)
+            | syn::BinOp::And(_)
+            | syn::BinOp::Or(_)
+    )
+}
+
+fn binary_operands_are_bool(op: &syn::BinOp) -> bool {
+    matches!(op, syn::BinOp::And(_) | syn::BinOp::Or(_))
+}
+
+fn closure_signature_for_param(sig: &syn::Signature, param_ty: &Type) -> Option<ClosureSignature> {
+    let param_name = bare_type_path_name(param_ty)?;
+    for generic_param in &sig.generics.params {
+        let syn::GenericParam::Type(type_param) = generic_param else {
+            continue;
+        };
+        if type_param.ident == param_name {
+            if let Some(signature) = closure_signature_from_bounds(&type_param.bounds) {
+                return Some(signature);
+            }
+        }
+    }
+    let where_clause = sig.generics.where_clause.as_ref()?;
+    for predicate in &where_clause.predicates {
+        let syn::WherePredicate::Type(predicate) = predicate else {
+            continue;
+        };
+        if bare_type_path_name(&predicate.bounded_ty).as_deref() == Some(param_name.as_str()) {
+            if let Some(signature) = closure_signature_from_bounds(&predicate.bounds) {
+                return Some(signature);
+            }
+        }
+    }
+    None
+}
+
+fn closure_signature_from_bounds(
+    bounds: &syn::punctuated::Punctuated<syn::TypeParamBound, syn::Token![+]>,
+) -> Option<ClosureSignature> {
+    for bound in bounds {
+        let syn::TypeParamBound::Trait(trait_bound) = bound else {
+            continue;
+        };
+        let segment = trait_bound.path.segments.last()?;
+        if !matches!(
+            segment.ident.to_string().as_str(),
+            "Fn" | "FnMut" | "FnOnce"
+        ) {
+            continue;
+        }
+        let syn::PathArguments::Parenthesized(args) = &segment.arguments else {
+            continue;
+        };
+        let output = match &args.output {
+            syn::ReturnType::Default => None,
+            syn::ReturnType::Type(_, ty) => Some(*ty.clone()),
+        };
+        return Some(ClosureSignature {
+            inputs: args.inputs.iter().cloned().collect(),
+            output,
+        });
+    }
+    None
+}
+
+fn closure_signature_generic_names<'a>(
+    sig: &syn::Signature,
+    signatures: impl Iterator<Item = &'a ClosureSignature>,
+) -> HashSet<String> {
+    let function_generics = get_supported_generic_params(&sig.generics)
+        .into_iter()
+        .map(|(name, _)| name)
+        .collect::<HashSet<_>>();
+    let mut names = HashSet::new();
+    for signature in signatures {
+        for input in &signature.inputs {
+            collect_type_names(input, &function_generics, &mut names);
+        }
+        if let Some(output) = &signature.output {
+            collect_type_names(output, &function_generics, &mut names);
+        }
+    }
+    names
+}
+
+fn collect_type_names(ty: &Type, allowed: &HashSet<String>, names: &mut HashSet<String>) {
+    match ty {
+        Type::Path(path) => {
+            if path.qself.is_some() {
+                return;
+            }
+            for segment in &path.path.segments {
+                let name = segment.ident.to_string();
+                if allowed.contains(&name) {
+                    names.insert(name);
+                }
+                if let PathArguments::AngleBracketed(args) = &segment.arguments {
+                    for arg in &args.args {
+                        match arg {
+                            GenericArgument::Type(ty) => collect_type_names(ty, allowed, names),
+                            GenericArgument::Const(expr) => {
+                                collect_const_expr_names(expr, allowed, names)
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+            }
+        }
+        Type::Reference(reference) => collect_type_names(&reference.elem, allowed, names),
+        Type::Ptr(ptr) => collect_type_names(&ptr.elem, allowed, names),
+        Type::Tuple(tuple) => {
+            for elem in &tuple.elems {
+                collect_type_names(elem, allowed, names);
+            }
+        }
+        Type::Array(array) => {
+            collect_type_names(&array.elem, allowed, names);
+            collect_const_expr_names(&array.len, allowed, names);
+        }
+        Type::Slice(slice) => collect_type_names(&slice.elem, allowed, names),
+        _ => {}
+    }
+}
+
+fn collect_const_expr_names(expr: &Expr, allowed: &HashSet<String>, names: &mut HashSet<String>) {
+    match expr {
+        Expr::Path(path) if path.path.segments.len() == 1 => {
+            let name = path.path.segments[0].ident.to_string();
+            if allowed.contains(&name) {
+                names.insert(name);
+            }
+        }
+        Expr::Block(block) => {
+            for stmt in &block.block.stmts {
+                if let Stmt::Expr(expr, _) = stmt {
+                    collect_const_expr_names(expr, allowed, names);
+                }
+            }
+        }
+        Expr::Array(array) => {
+            for elem in &array.elems {
+                collect_const_expr_names(elem, allowed, names);
+            }
+        }
+        Expr::Repeat(repeat) => {
+            collect_const_expr_names(&repeat.expr, allowed, names);
+            collect_const_expr_names(&repeat.len, allowed, names);
+        }
+        Expr::Unary(unary) => collect_const_expr_names(&unary.expr, allowed, names),
+        Expr::Paren(paren) => collect_const_expr_names(&paren.expr, allowed, names),
+        _ => {}
+    }
+}
+
+fn type_mentions_any_name(ty: &Type, names: &HashSet<String>) -> bool {
+    if names.is_empty() {
+        return false;
+    }
+    let mut seen = HashSet::new();
+    collect_type_names(ty, names, &mut seen);
+    !seen.is_empty()
+}
+
+fn bare_type_path_name(ty: &Type) -> Option<String> {
+    let Type::Path(path) = ty else {
+        return None;
+    };
+    if path.qself.is_some() || path.path.segments.len() != 1 {
+        return None;
+    }
+    let segment = &path.path.segments[0];
+    if !matches!(segment.arguments, PathArguments::None) {
+        return None;
+    }
+    Some(segment.ident.to_string())
+}
+
+fn scalar_type_name(ty: &Type) -> Option<String> {
+    let Type::Path(path) = ty else {
+        return None;
+    };
+    if path.qself.is_some() || path.path.segments.len() != 1 {
+        return None;
+    }
+    let segment = &path.path.segments[0];
+    if !matches!(segment.arguments, PathArguments::None) {
+        return None;
+    }
+    Some(segment.ident.to_string())
+}
+
+fn is_integer_scalar_name(name: &str) -> bool {
+    matches!(
+        name,
+        "i8" | "i16"
+            | "i32"
+            | "i64"
+            | "i128"
+            | "isize"
+            | "u8"
+            | "u16"
+            | "u32"
+            | "u64"
+            | "u128"
+            | "usize"
+    )
+}
+
+fn is_float_scalar_name(name: &str) -> bool {
+    matches!(
+        name,
+        "f16" | "bf16" | "f32" | "f64" | "tf32" | "f8e4m3fn" | "f8e5m2"
+    )
+}
+
+fn is_builtin_scalar_name(name: &str) -> bool {
+    name == "bool" || is_integer_scalar_name(name) || is_float_scalar_name(name)
+}
+
+fn is_surface_only_scalar_type(ty: &Type) -> bool {
+    matches!(scalar_type_name(ty).as_deref(), Some("isize" | "usize"))
+}
+
+fn is_likely_unresolved_type_param(name: &str) -> bool {
+    name.chars()
+        .next()
+        .is_some_and(|ch| ch == '_' || ch.is_ascii_uppercase())
+}
+
+fn replace_array_len_with_rank(mut ty: Type, rank: usize) -> Type {
+    match &mut ty {
+        Type::Array(array) => {
+            if matches!(array.len, Expr::Path(_)) {
+                let rank_lit = rank;
+                array.len = syn::parse_quote!(#rank_lit);
+            }
+        }
+        Type::Reference(reference) => {
+            *reference.elem = replace_array_len_with_rank(*reference.elem.clone(), rank);
+        }
+        Type::Tuple(tuple) => {
+            for elem in &mut tuple.elems {
+                *elem = replace_array_len_with_rank(elem.clone(), rank);
+            }
+        }
+        _ => {}
+    }
+    ty
+}
+
+fn rank_from_type_shape_arg(ty: &Type, generic_vars: &GenericVars) -> Option<usize> {
+    let Type::Path(path) = ty else {
+        return None;
+    };
+    let segment = path.path.segments.last()?;
+    let PathArguments::AngleBracketed(args) = &segment.arguments else {
+        return None;
+    };
+    for arg in &args.args {
+        match arg {
+            GenericArgument::Const(expr) => {
+                if let Some(rank) = rank_from_const_shape_expr(expr, generic_vars) {
+                    return Some(rank);
+                }
+            }
+            GenericArgument::Type(Type::Path(path)) if path.qself.is_none() => {
+                let ident = path.path.segments.last()?.ident.to_string();
+                if let Some(shape) = generic_vars.inst_array.get(&ident) {
+                    return Some(shape.len());
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+fn rank_from_const_shape_expr(expr: &Expr, generic_vars: &GenericVars) -> Option<usize> {
+    match expr {
+        Expr::Block(block) => match block.block.stmts.as_slice() {
+            [Stmt::Expr(inner, _)] => rank_from_const_shape_expr(inner, generic_vars),
+            _ => None,
+        },
+        Expr::Array(array) => Some(array.elems.len()),
+        Expr::Repeat(repeat) => match &*repeat.len {
+            Expr::Lit(lit) => match &lit.lit {
+                Lit::Int(raw) => raw.base10_parse::<usize>().ok(),
+                _ => None,
+            },
+            Expr::Path(path) => {
+                let ident = get_ident_from_path_expr(path).to_string();
+                generic_vars.get_i32(&ident).map(|value| value as usize)
+            }
+            _ => None,
+        },
+        Expr::Path(path) => {
+            let ident = get_ident_from_path_expr(path).to_string();
+            generic_vars.inst_array.get(&ident).map(Vec::len)
+        }
+        _ => None,
+    }
+}
+
+fn substitute_resolved_generics(ty: &Type, inference: &GenericArgInference) -> Option<Type> {
+    match ty {
+        Type::Path(path_ty) if path_ty.qself.is_none() => {
+            if let Some((kind, target)) = resolved_bare_type_path_arg(ty, inference)? {
+                return match kind {
+                    GenericArgType::Type => syn::parse_str::<Type>(target).ok(),
+                    GenericArgType::GenericConstExpr => None,
+                };
+            }
+
+            let mut result = path_ty.clone();
+            for segment in &mut result.path.segments {
+                let PathArguments::AngleBracketed(args) = &mut segment.arguments else {
+                    continue;
+                };
+                for arg in &mut args.args {
+                    *arg = substitute_generic_argument(arg, inference)?;
+                }
+            }
+            Some(Type::Path(result))
+        }
+        Type::Reference(reference) => {
+            let mut result = reference.clone();
+            result.elem = Box::new(substitute_resolved_generics(&reference.elem, inference)?);
+            Some(Type::Reference(result))
+        }
+        Type::Ptr(ptr) => {
+            let mut result = ptr.clone();
+            result.elem = Box::new(substitute_resolved_generics(&ptr.elem, inference)?);
+            Some(Type::Ptr(result))
+        }
+        Type::Tuple(tuple) => {
+            let mut result = tuple.clone();
+            for elem in &mut result.elems {
+                *elem = substitute_resolved_generics(elem, inference)?;
+            }
+            Some(Type::Tuple(result))
+        }
+        Type::Array(array) => {
+            let mut result = array.clone();
+            result.elem = Box::new(substitute_resolved_generics(&array.elem, inference)?);
+            result.len = substitute_resolved_const_expr(&array.len, inference)?;
+            Some(Type::Array(result))
+        }
+        Type::Slice(slice) => {
+            let mut result = slice.clone();
+            result.elem = Box::new(substitute_resolved_generics(&slice.elem, inference)?);
+            Some(Type::Slice(result))
+        }
+        Type::ImplTrait(_) => None,
+        _ => Some(ty.clone()),
+    }
+}
+
+fn substitute_generic_argument(
+    arg: &GenericArgument,
+    inference: &GenericArgInference,
+) -> Option<GenericArgument> {
+    match arg {
+        GenericArgument::Type(ty) => {
+            if let Some((_kind, target)) = resolved_bare_type_path_arg(ty, inference)? {
+                return syn::parse_str::<GenericArgument>(target).ok();
+            }
+            Some(GenericArgument::Type(substitute_resolved_generics(
+                ty, inference,
+            )?))
+        }
+        GenericArgument::Const(expr) => Some(GenericArgument::Const(
+            substitute_resolved_const_expr(expr, inference)?,
+        )),
+        GenericArgument::Lifetime(lifetime) => Some(GenericArgument::Lifetime(lifetime.clone())),
+        _ => None,
+    }
+}
+
+fn substitute_resolved_const_expr(expr: &Expr, inference: &GenericArgInference) -> Option<Expr> {
+    match expr {
+        Expr::Path(path) if path.path.segments.len() == 1 => {
+            let name = path.path.segments[0].ident.to_string();
+            let Some(mapping) = inference.param2arg.get(&name) else {
+                return Some(expr.clone());
+            };
+            let Some((_kind, target)) = mapping else {
+                return None;
+            };
+            syn::parse_str::<Expr>(target).ok()
+        }
+        Expr::Block(block) => {
+            let mut result = block.clone();
+            let [Stmt::Expr(inner, semi)] = result.block.stmts.as_mut_slice() else {
+                return Some(Expr::Block(result));
+            };
+            *inner = substitute_resolved_const_expr(inner, inference)?;
+            *semi = None;
+            Some(Expr::Block(result))
+        }
+        Expr::Array(array) => {
+            let mut result = array.clone();
+            for elem in &mut result.elems {
+                *elem = substitute_resolved_const_expr(elem, inference)?;
+            }
+            Some(Expr::Array(result))
+        }
+        Expr::Repeat(repeat) => {
+            let mut result = repeat.clone();
+            result.expr = Box::new(substitute_resolved_const_expr(&repeat.expr, inference)?);
+            result.len = Box::new(substitute_resolved_const_expr(&repeat.len, inference)?);
+            Some(Expr::Repeat(result))
+        }
+        Expr::Unary(unary) => {
+            let mut result = unary.clone();
+            result.expr = Box::new(substitute_resolved_const_expr(&unary.expr, inference)?);
+            Some(Expr::Unary(result))
+        }
+        Expr::Paren(paren) => {
+            let mut result = paren.clone();
+            result.expr = Box::new(substitute_resolved_const_expr(&paren.expr, inference)?);
+            Some(Expr::Paren(result))
+        }
+        _ => Some(expr.clone()),
+    }
+}
+
+fn resolved_bare_type_path_arg<'a>(
+    ty: &Type,
+    inference: &'a GenericArgInference,
+) -> Option<Option<&'a (GenericArgType, String)>> {
+    let Type::Path(path_ty) = ty else {
+        return Some(None);
+    };
+    if path_ty.qself.is_some() || path_ty.path.segments.len() != 1 {
+        return Some(None);
+    }
+    let segment = &path_ty.path.segments[0];
+    if !matches!(segment.arguments, PathArguments::None) {
+        return Some(None);
+    }
+    match inference.param2arg.get(&segment.ident.to_string()) {
+        Some(Some(mapping)) => Some(Some(mapping)),
+        Some(None) => None,
+        None => Some(None),
+    }
 }
 
 fn type_has_impl_trait(ty: &Type) -> bool {
@@ -555,11 +4015,87 @@ fn type_has_impl_trait(ty: &Type) -> bool {
     }
 }
 
+fn can_add_type_constraint(param_ty: &Type, arg_ty: &Type) -> bool {
+    if type_has_impl_trait(param_ty) {
+        return false;
+    }
+    match (param_ty, arg_ty) {
+        (Type::Path(param_path), Type::Path(arg_path)) => {
+            if param_path.qself.is_some() || arg_path.qself.is_some() {
+                return false;
+            }
+            let Some(param_segment) = param_path.path.segments.last() else {
+                return false;
+            };
+            let Some(arg_segment) = arg_path.path.segments.last() else {
+                return false;
+            };
+            match (&param_segment.arguments, &arg_segment.arguments) {
+                (PathArguments::None, _) => true,
+                (
+                    PathArguments::AngleBracketed(param_args),
+                    PathArguments::AngleBracketed(arg_args),
+                ) => generic_arguments_are_compatible(param_args, arg_args),
+                (PathArguments::AngleBracketed(_), _) => false,
+                _ => true,
+            }
+        }
+        (Type::Reference(param_ref), Type::Reference(arg_ref)) => {
+            can_add_type_constraint(&param_ref.elem, &arg_ref.elem)
+        }
+        (Type::Ptr(param_ptr), Type::Ptr(arg_ptr)) => {
+            can_add_type_constraint(&param_ptr.elem, &arg_ptr.elem)
+        }
+        (Type::Tuple(param_tuple), Type::Tuple(arg_tuple)) => {
+            param_tuple.elems.len() == arg_tuple.elems.len()
+                && param_tuple
+                    .elems
+                    .iter()
+                    .zip(arg_tuple.elems.iter())
+                    .all(|(param, arg)| can_add_type_constraint(param, arg))
+        }
+        (Type::Array(param_array), Type::Array(arg_array)) => {
+            can_add_type_constraint(&param_array.elem, &arg_array.elem)
+        }
+        (Type::Slice(param_slice), Type::Slice(arg_slice)) => {
+            can_add_type_constraint(&param_slice.elem, &arg_slice.elem)
+        }
+        (Type::ImplTrait(_), _) => false,
+        _ => true,
+    }
+}
+
+fn generic_arguments_are_compatible(
+    param_args: &syn::AngleBracketedGenericArguments,
+    arg_args: &syn::AngleBracketedGenericArguments,
+) -> bool {
+    if param_args.args.len() != arg_args.args.len() {
+        return false;
+    }
+    param_args
+        .args
+        .iter()
+        .zip(arg_args.args.iter())
+        .all(|(param, arg)| match (param, arg) {
+            (GenericArgument::Type(param_ty), GenericArgument::Type(arg_ty)) => {
+                can_add_type_constraint(param_ty, arg_ty)
+            }
+            (GenericArgument::Const(_), GenericArgument::Const(_)) => true,
+            (GenericArgument::Lifetime(_), GenericArgument::Lifetime(_)) => true,
+            _ => false,
+        })
+}
+
 fn type_is_resolvable(
     compiler: &CUDATileFunctionCompiler<'_>,
     ty: &Type,
     generic_vars: &GenericVars,
 ) -> bool {
+    let normalized_ty = compiler
+        .modules
+        .normalize_type_aliases(ty)
+        .unwrap_or_else(|_| ty.clone());
+    let ty = &normalized_ty;
     match ty {
         Type::Reference(reference) => type_is_resolvable(compiler, &reference.elem, generic_vars),
         Type::Tuple(tuple) => tuple
@@ -591,10 +4127,7 @@ fn type_is_resolvable(
                             .modules
                             .primitives()
                             .contains_key(&("Scalar".to_string(), ident.clone()))
-                        || matches!(
-                            ident.as_str(),
-                            "i32" | "u32" | "i64" | "u64" | "f32" | "f64" | "bool"
-                        )
+                        || is_builtin_scalar_name(&ident)
                 }
                 PathArguments::AngleBracketed(args) => args.args.iter().all(|arg| match arg {
                     GenericArgument::Type(arg_ty) => {
@@ -611,12 +4144,89 @@ fn type_is_resolvable(
     }
 }
 
+fn type_is_fully_known(
+    compiler: &CUDATileFunctionCompiler<'_>,
+    ty: &Type,
+    generic_vars: &GenericVars,
+) -> bool {
+    let normalized_ty = compiler
+        .modules
+        .normalize_type_aliases(ty)
+        .unwrap_or_else(|_| ty.clone());
+    let ty = &normalized_ty;
+    match ty {
+        Type::Reference(reference) => type_is_fully_known(compiler, &reference.elem, generic_vars),
+        Type::Tuple(tuple) => tuple
+            .elems
+            .iter()
+            .all(|elem| type_is_fully_known(compiler, elem, generic_vars)),
+        Type::Array(array) => {
+            type_is_fully_known(compiler, &array.elem, generic_vars)
+                && const_expr_is_fully_known(&array.len, generic_vars)
+        }
+        Type::Slice(slice) => type_is_fully_known(compiler, &slice.elem, generic_vars),
+        Type::Ptr(ptr) => type_is_fully_known(compiler, &ptr.elem, generic_vars),
+        Type::Path(path) => {
+            if path.qself.is_some() {
+                return false;
+            }
+            let Some(segment) = path.path.segments.last() else {
+                return false;
+            };
+            let ident = segment.ident.to_string();
+            if generic_vars.var_type(&ident).is_some() {
+                return generic_vars.inst_types.contains_key(&ident)
+                    || generic_vars.inst_i32.contains_key(&ident)
+                    || generic_vars.inst_bool.contains_key(&ident)
+                    || generic_vars.inst_array.contains_key(&ident)
+                    || generic_vars.len2array.contains_key(&ident);
+            }
+            if is_likely_unresolved_type_param(&ident)
+                && !generic_vars.inst_types.contains_key(&ident)
+                && !compiler.modules.structs().contains_key(&ident)
+            {
+                return false;
+            }
+            let base_known = generic_vars.inst_types.contains_key(&ident)
+                || compiler.modules.structs().contains_key(&ident)
+                || compiler
+                    .modules
+                    .primitives()
+                    .contains_key(&("ElementType".to_string(), ident.clone()))
+                || compiler
+                    .modules
+                    .primitives()
+                    .contains_key(&("Scalar".to_string(), ident.clone()))
+                || is_builtin_scalar_name(&ident);
+            if !base_known {
+                return false;
+            }
+            match &segment.arguments {
+                PathArguments::None => true,
+                PathArguments::AngleBracketed(args) => args.args.iter().all(|arg| match arg {
+                    GenericArgument::Type(arg_ty) => {
+                        type_is_fully_known(compiler, arg_ty, generic_vars)
+                    }
+                    GenericArgument::Const(expr) => const_expr_is_fully_known(expr, generic_vars),
+                    GenericArgument::Lifetime(_) => true,
+                    _ => false,
+                }),
+                _ => false,
+            }
+        }
+        Type::Never(_) => true,
+        Type::Infer(_) | Type::ImplTrait(_) => false,
+        _ => true,
+    }
+}
+
 fn const_expr_is_resolvable(expr: &Expr, generic_vars: &GenericVars) -> bool {
     match expr {
         Expr::Path(path) => {
             let ident = get_ident_from_path_expr(path).to_string();
             generic_vars.var_type(&ident).is_some()
         }
+        Expr::Index(index) => const_cga_index_is_resolvable(index, generic_vars),
         Expr::Block(block) => match block.block.stmts.as_slice() {
             [Stmt::Expr(inner, _)] => const_expr_is_resolvable(inner, generic_vars),
             _ => false,
@@ -624,7 +4234,7 @@ fn const_expr_is_resolvable(expr: &Expr, generic_vars: &GenericVars) -> bool {
         Expr::Array(array) => array
             .elems
             .iter()
-            .all(|elem| const_expr_is_resolvable(elem, generic_vars)),
+            .all(|elem| const_array_elem_is_resolvable(elem, generic_vars)),
         Expr::Repeat(repeat) => {
             const_expr_is_resolvable(&repeat.expr, generic_vars)
                 && const_expr_is_resolvable(&repeat.len, generic_vars)
@@ -633,6 +4243,98 @@ fn const_expr_is_resolvable(expr: &Expr, generic_vars: &GenericVars) -> bool {
         Expr::Unary(unary) => const_expr_is_resolvable(&unary.expr, generic_vars),
         Expr::Paren(paren) => const_expr_is_resolvable(&paren.expr, generic_vars),
         _ => false,
+    }
+}
+
+fn const_expr_is_fully_known(expr: &Expr, generic_vars: &GenericVars) -> bool {
+    match expr {
+        Expr::Path(path) => {
+            let ident = get_ident_from_path_expr(path).to_string();
+            generic_vars.inst_i32.contains_key(&ident)
+                || generic_vars.inst_bool.contains_key(&ident)
+                || generic_vars.inst_array.contains_key(&ident)
+                || generic_vars.len2array.contains_key(&ident)
+        }
+        Expr::Index(index) => const_cga_index_is_resolvable(index, generic_vars),
+        Expr::Block(block) => match block.block.stmts.as_slice() {
+            [Stmt::Expr(inner, _)] => const_expr_is_fully_known(inner, generic_vars),
+            _ => false,
+        },
+        Expr::Array(array) => array
+            .elems
+            .iter()
+            .all(|elem| const_array_elem_is_fully_known(elem, generic_vars)),
+        Expr::Repeat(repeat) => {
+            const_expr_is_fully_known(&repeat.expr, generic_vars)
+                && const_expr_is_fully_known(&repeat.len, generic_vars)
+        }
+        Expr::Lit(_) => true,
+        Expr::Unary(unary) => const_expr_is_fully_known(&unary.expr, generic_vars),
+        Expr::Paren(paren) => const_expr_is_fully_known(&paren.expr, generic_vars),
+        _ => false,
+    }
+}
+
+fn const_array_elem_is_resolvable(expr: &Expr, generic_vars: &GenericVars) -> bool {
+    match expr {
+        Expr::Lit(_) => true,
+        Expr::Path(path) => {
+            let ident = get_ident_from_path_expr(path).to_string();
+            generic_vars.var_type(&ident).is_some()
+        }
+        Expr::Index(index) => const_cga_index_is_resolvable(index, generic_vars),
+        Expr::Unary(unary) => const_array_elem_is_resolvable(&unary.expr, generic_vars),
+        Expr::Paren(paren) => const_array_elem_is_resolvable(&paren.expr, generic_vars),
+        _ => false,
+    }
+}
+
+fn const_array_elem_is_fully_known(expr: &Expr, generic_vars: &GenericVars) -> bool {
+    match expr {
+        Expr::Lit(_) => true,
+        Expr::Path(path) => {
+            let ident = get_ident_from_path_expr(path).to_string();
+            generic_vars.inst_i32.contains_key(&ident)
+                || generic_vars.inst_bool.contains_key(&ident)
+                || generic_vars.inst_array.contains_key(&ident)
+                || generic_vars.len2array.contains_key(&ident)
+        }
+        Expr::Index(index) => const_cga_index_is_resolvable(index, generic_vars),
+        Expr::Unary(unary) => const_array_elem_is_fully_known(&unary.expr, generic_vars),
+        Expr::Paren(paren) => const_array_elem_is_fully_known(&paren.expr, generic_vars),
+        _ => false,
+    }
+}
+
+fn const_cga_index_is_resolvable(index: &syn::ExprIndex, generic_vars: &GenericVars) -> bool {
+    let Expr::Path(path) = index.expr.as_ref() else {
+        return false;
+    };
+    let ident = get_ident_from_path_expr(path).to_string();
+    let Some(shape) = generic_vars.inst_array.get(&ident) else {
+        return false;
+    };
+    let Some(i) = static_usize_index(&index.index) else {
+        return false;
+    };
+    i < shape.len()
+}
+
+fn static_usize_index(expr: &Expr) -> Option<usize> {
+    match expr {
+        Expr::Lit(lit) => match &lit.lit {
+            syn::Lit::Int(raw) => raw.base10_parse::<usize>().ok(),
+            _ => None,
+        },
+        Expr::Unary(unary) => {
+            if matches!(unary.op, syn::UnOp::Neg(_)) {
+                None
+            } else {
+                static_usize_index(&unary.expr)
+            }
+        }
+        Expr::Paren(paren) => static_usize_index(&paren.expr),
+        _ => None,
     }
 }
 
@@ -663,12 +4365,70 @@ pub fn infer_method_generics(
     }
 }
 
-fn should_skip_optional_output_type_param(type_param_name: &str, rust_ty: &Type) -> bool {
-    let Some(ident) = get_type_ident(rust_ty).map(|ident| ident.to_string()) else {
-        return false;
-    };
+fn should_skip_optional_output_type_param(
+    type_param_name: &str,
+    arg_zst_values: &HashMap<String, String>,
+) -> bool {
     matches!(
-        (type_param_name, ident.as_str()),
-        ("padding_value", "None") | ("dim_map", "Identity")
+        (
+            type_param_name,
+            arg_zst_values.get(type_param_name).map(String::as_str)
+        ),
+        ("padding_value", Some("None")) | ("dim_map", Some("Identity"))
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolved_type_round_trips_common_syn_types() {
+        let cases: Vec<Type> = vec![
+            syn::parse_quote!(i32),
+            syn::parse_quote!(bool),
+            syn::parse_quote!(&mut Tensor<f32, { [16, 32] }>),
+            syn::parse_quote!((i32, f32)),
+            syn::parse_quote!([i32; 4]),
+            syn::parse_quote!(*mut f32),
+            syn::parse_quote!(!),
+        ];
+
+        for ty in cases {
+            let resolved = ResolvedType::from_syn_type(&ty);
+            assert_eq!(resolved.to_syn_type(), ty);
+        }
+    }
+
+    #[test]
+    fn builtin_scalar_names_include_pointer_sized_integers() {
+        assert!(is_builtin_scalar_name("usize"));
+        assert!(is_builtin_scalar_name("isize"));
+    }
+
+    #[test]
+    fn receiver_adjustments_include_autoref_and_autoderef_candidates() {
+        let receiver: Type = syn::parse_quote!(&mut Tensor<f32, { [4] }>);
+        let candidates = receiver_adjustment_candidates(&receiver, true)
+            .into_iter()
+            .map(|ty| ty.to_token_stream().to_string())
+            .collect::<Vec<_>>();
+
+        assert!(candidates.contains(&"& mut Tensor < f32 , { [4] } >".to_string()));
+        assert!(candidates.contains(&"Tensor < f32 , { [4] } >".to_string()));
+        assert!(candidates.contains(&"& Tensor < f32 , { [4] } >".to_string()));
+    }
+
+    #[test]
+    fn receiver_adjustments_do_not_add_mut_borrow_for_immutable_receivers() {
+        let receiver: Type = syn::parse_quote!(Tensor<f32, { [4] }>);
+        let candidates = receiver_adjustment_candidates(&receiver, false)
+            .into_iter()
+            .map(|ty| ty.to_token_stream().to_string())
+            .collect::<Vec<_>>();
+
+        assert!(candidates.contains(&"Tensor < f32 , { [4] } >".to_string()));
+        assert!(candidates.contains(&"& Tensor < f32 , { [4] } >".to_string()));
+        assert!(!candidates.contains(&"& mut Tensor < f32 , { [4] } >".to_string()));
+    }
 }

--- a/cutile-compiler/src/syn_utils.rs
+++ b/cutile-compiler/src/syn_utils.rs
@@ -14,11 +14,14 @@ use std::fmt::Display;
 use std::str::FromStr;
 use syn::parse::{Parse, ParseStream};
 use syn::punctuated::Punctuated;
+use syn::visit_mut::{self, VisitMut};
 use syn::{
     parse_quote, AngleBracketedGenericArguments, Attribute, ConstParam, Expr, ExprCall,
-    ExprClosure, ExprPath, FnArg, GenericArgument, GenericParam, Generics, Item, ItemFn, Lit, Meta,
-    MetaList, Pat, PathArguments, ReturnType, Signature, Token, Type,
+    ExprClosure, ExprMethodCall, ExprPath, FnArg, GenericArgument, GenericParam, Generics, Item,
+    ItemFn, Lit, Meta, MetaList, Pat, PathArguments, ReturnType, Signature, Token, Type,
 };
+
+const CUTILE_INTERNAL_NODE_ID_ATTR: &str = "__cutile_node_id";
 
 /// A parsed attribute meta list (e.g. `#[cuda_tile::ty(name = "f32")]`).
 #[derive(Debug)]
@@ -26,6 +29,91 @@ pub struct SingleMetaList {
     name: Option<String>,
     meta_list: Option<MetaList>,
     variables: Vec<Meta>,
+}
+
+/// Render an expression for user-facing diagnostics.
+///
+/// Compiler-owned `syn` trees carry internal node-id attributes used by
+/// typeck/lowering side tables. Those attributes are intentionally retained in
+/// the AST but should not leak into source-facing error messages.
+pub fn user_expr_tokens(expr: &Expr) -> String {
+    let mut expr = expr.clone();
+    strip_user_hidden_expr_attrs(&mut expr);
+    expr.to_token_stream().to_string()
+}
+
+pub fn user_call_tokens(call_expr: &ExprCall) -> String {
+    user_expr_tokens(&Expr::Call(call_expr.clone()))
+}
+
+pub fn user_method_call_tokens(method_call_expr: &ExprMethodCall) -> String {
+    user_expr_tokens(&Expr::MethodCall(method_call_expr.clone()))
+}
+
+fn strip_user_hidden_expr_attrs(expr: &mut Expr) {
+    let mut stripper = UserHiddenAttrStripper;
+    stripper.visit_expr_mut(expr);
+}
+
+struct UserHiddenAttrStripper;
+
+impl VisitMut for UserHiddenAttrStripper {
+    fn visit_attribute_mut(&mut self, _attr: &mut Attribute) {
+        // Do not recurse into attribute metadata.
+    }
+
+    fn visit_expr_mut(&mut self, expr: &mut Expr) {
+        if let Some(attrs) = expr_attrs_mut(expr) {
+            attrs.retain(|attr| !attr.path().is_ident(CUTILE_INTERNAL_NODE_ID_ATTR));
+        }
+        visit_mut::visit_expr_mut(self, expr);
+    }
+}
+
+fn expr_attrs_mut(expr: &mut Expr) -> Option<&mut Vec<Attribute>> {
+    match expr {
+        Expr::Array(expr) => Some(&mut expr.attrs),
+        Expr::Assign(expr) => Some(&mut expr.attrs),
+        Expr::Async(expr) => Some(&mut expr.attrs),
+        Expr::Await(expr) => Some(&mut expr.attrs),
+        Expr::Binary(expr) => Some(&mut expr.attrs),
+        Expr::Block(expr) => Some(&mut expr.attrs),
+        Expr::Break(expr) => Some(&mut expr.attrs),
+        Expr::Call(expr) => Some(&mut expr.attrs),
+        Expr::Cast(expr) => Some(&mut expr.attrs),
+        Expr::Closure(expr) => Some(&mut expr.attrs),
+        Expr::Const(expr) => Some(&mut expr.attrs),
+        Expr::Continue(expr) => Some(&mut expr.attrs),
+        Expr::Field(expr) => Some(&mut expr.attrs),
+        Expr::ForLoop(expr) => Some(&mut expr.attrs),
+        Expr::Group(expr) => Some(&mut expr.attrs),
+        Expr::If(expr) => Some(&mut expr.attrs),
+        Expr::Index(expr) => Some(&mut expr.attrs),
+        Expr::Infer(expr) => Some(&mut expr.attrs),
+        Expr::Let(expr) => Some(&mut expr.attrs),
+        Expr::Lit(expr) => Some(&mut expr.attrs),
+        Expr::Loop(expr) => Some(&mut expr.attrs),
+        Expr::Macro(expr) => Some(&mut expr.attrs),
+        Expr::Match(expr) => Some(&mut expr.attrs),
+        Expr::MethodCall(expr) => Some(&mut expr.attrs),
+        Expr::Paren(expr) => Some(&mut expr.attrs),
+        Expr::Path(expr) => Some(&mut expr.attrs),
+        Expr::Range(expr) => Some(&mut expr.attrs),
+        Expr::RawAddr(expr) => Some(&mut expr.attrs),
+        Expr::Reference(expr) => Some(&mut expr.attrs),
+        Expr::Repeat(expr) => Some(&mut expr.attrs),
+        Expr::Return(expr) => Some(&mut expr.attrs),
+        Expr::Struct(expr) => Some(&mut expr.attrs),
+        Expr::Try(expr) => Some(&mut expr.attrs),
+        Expr::TryBlock(expr) => Some(&mut expr.attrs),
+        Expr::Tuple(expr) => Some(&mut expr.attrs),
+        Expr::Unary(expr) => Some(&mut expr.attrs),
+        Expr::Unsafe(expr) => Some(&mut expr.attrs),
+        Expr::While(expr) => Some(&mut expr.attrs),
+        Expr::Yield(expr) => Some(&mut expr.attrs),
+        Expr::Verbatim(_) => None,
+        _ => None,
+    }
 }
 
 impl SingleMetaList {
@@ -966,4 +1054,36 @@ pub fn get_closure_captures(
 /// Check if an expression is a closure
 pub fn is_closure(expr: &Expr) -> bool {
     matches!(expr, Expr::Closure(_))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn user_expr_tokens_strips_internal_node_id_attrs() {
+        let expr: Expr = syn::parse_quote! {
+            #[__cutile_node_id = 28]
+            make_partition_view_mut(
+                #[__cutile_node_id = 29] & #[__cutile_node_id = 30] z,
+                #[__cutile_node_id = 31] const_shape![BM, BN],
+                #[__cutile_node_id = 32] padding::None,
+                #[__cutile_node_id = 33] z_token,
+            )
+        };
+
+        assert!(expr
+            .to_token_stream()
+            .to_string()
+            .contains("__cutile_node_id"));
+
+        let rendered = user_expr_tokens(&expr);
+        assert!(!rendered.contains("__cutile_node_id"));
+        assert!(rendered.contains("make_partition_view_mut"));
+        assert!(rendered.contains("const_shape"));
+        assert!(expr
+            .to_token_stream()
+            .to_string()
+            .contains("__cutile_node_id"));
+    }
 }

--- a/cutile-compiler/src/type_aliases.rs
+++ b/cutile-compiler/src/type_aliases.rs
@@ -1,0 +1,484 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Type-alias normalization for the DSL front-end.
+//!
+//! This is intentionally syntax-local: Pass 1 indexes `type` items, and
+//! consumers that need the underlying DSL type ask this module to expand those
+//! aliases before doing Tensor/scalar/pointer classification.
+
+use quote::ToTokens;
+use std::collections::HashMap;
+use syn::visit_mut::{self, VisitMut};
+use syn::{
+    Expr, ExprPath, FnArg, GenericArgument, GenericParam, Item, ItemConst, ItemFn, ItemType, Lit,
+    PatType, PathArguments, Type, TypePath,
+};
+
+const MAX_ALIAS_EXPANSION_DEPTH: usize = 64;
+
+#[derive(Default)]
+struct AliasSubstitution {
+    types: HashMap<String, Type>,
+    consts: HashMap<String, Expr>,
+}
+
+/// Collect type aliases from an inline module item list.
+///
+/// Nested inline modules are intentionally not merged into the parent scope.
+/// Callers that process a submodule should call this again for that submodule's
+/// own item list.
+pub fn collect_type_aliases(items: &[Item]) -> HashMap<String, ItemType> {
+    items
+        .iter()
+        .filter_map(|item| {
+            let Item::Type(alias) = item else {
+                return None;
+            };
+            Some((alias.ident.to_string(), alias.clone()))
+        })
+        .collect()
+}
+
+/// Expand all known type aliases in a type.
+pub fn normalize_type_aliases(
+    ty: &Type,
+    aliases: &HashMap<String, ItemType>,
+) -> Result<Type, String> {
+    normalize_type_aliases_inner(ty, aliases, &mut Vec::new())
+}
+
+/// Replace paths to module-level scalar consts inside a type with their
+/// literal expression. This keeps type-level shapes such as
+/// `Tensor<f32, {[BLOCK]}>` consumable by the existing generic machinery.
+pub fn normalize_const_paths_in_type(
+    ty: &Type,
+    consts: &HashMap<String, ItemConst>,
+) -> Result<Type, String> {
+    let mut out = ty.clone();
+    ConstPathNormalizer { consts }.visit_type_mut(&mut out);
+    Ok(out)
+}
+
+/// Return a supported scalar const expression suitable for substituting into
+/// a type-level const expression.
+pub fn const_item_scalar_expr(item: &ItemConst) -> Option<Expr> {
+    let Type::Path(type_path) = item.ty.as_ref() else {
+        return None;
+    };
+    let ty_name = type_path.path.segments.last()?.ident.to_string();
+    match ty_name.as_str() {
+        "bool" => match item.expr.as_ref() {
+            Expr::Lit(lit) if matches!(lit.lit, Lit::Bool(_)) => Some(item.expr.as_ref().clone()),
+            _ => None,
+        },
+        "i32" | "i64" | "u32" | "u64" => match item.expr.as_ref() {
+            Expr::Lit(lit) if matches!(lit.lit, Lit::Int(_)) => Some(item.expr.as_ref().clone()),
+            Expr::Unary(unary) => match unary.expr.as_ref() {
+                Expr::Lit(lit) if matches!(lit.lit, Lit::Int(_)) => {
+                    Some(item.expr.as_ref().clone())
+                }
+                _ => None,
+            },
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+pub fn const_item_i32_value(item: &ItemConst) -> Option<i32> {
+    let Type::Path(type_path) = item.ty.as_ref() else {
+        return None;
+    };
+    if type_path.path.segments.last()?.ident != "i32" {
+        return None;
+    }
+    match item.expr.as_ref() {
+        Expr::Lit(lit) => match &lit.lit {
+            Lit::Int(int_lit) => int_lit.base10_parse::<i32>().ok(),
+            _ => None,
+        },
+        Expr::Unary(unary) => {
+            if !matches!(unary.op, syn::UnOp::Neg(_)) {
+                return None;
+            }
+            let Expr::Lit(lit) = unary.expr.as_ref() else {
+                return None;
+            };
+            let Lit::Int(int_lit) = &lit.lit else {
+                return None;
+            };
+            int_lit.base10_parse::<i32>().ok().map(|value| -value)
+        }
+        _ => None,
+    }
+}
+
+pub fn const_item_bool_value(item: &ItemConst) -> Option<bool> {
+    let Type::Path(type_path) = item.ty.as_ref() else {
+        return None;
+    };
+    if type_path.path.segments.last()?.ident != "bool" {
+        return None;
+    }
+    let Expr::Lit(lit) = item.expr.as_ref() else {
+        return None;
+    };
+    let Lit::Bool(bool_lit) = &lit.lit else {
+        return None;
+    };
+    Some(bool_lit.value)
+}
+
+/// Return a copy of `item` whose parameter types have aliases expanded.
+pub fn normalize_item_fn_param_type_aliases(
+    item: &ItemFn,
+    aliases: &HashMap<String, ItemType>,
+) -> Result<ItemFn, String> {
+    let mut item = item.clone();
+    for arg in &mut item.sig.inputs {
+        let FnArg::Typed(PatType { ty, .. }) = arg else {
+            continue;
+        };
+        *ty = Box::new(normalize_type_aliases(ty, aliases)?);
+    }
+    Ok(item)
+}
+
+struct ConstPathNormalizer<'a> {
+    consts: &'a HashMap<String, ItemConst>,
+}
+
+impl VisitMut for ConstPathNormalizer<'_> {
+    fn visit_generic_argument_mut(&mut self, arg: &mut GenericArgument) {
+        if let GenericArgument::Const(expr) = arg {
+            self.visit_expr_mut(expr);
+        } else {
+            visit_mut::visit_generic_argument_mut(self, arg);
+        }
+    }
+
+    fn visit_expr_mut(&mut self, expr: &mut Expr) {
+        if let Expr::Path(path) = expr {
+            if let Some(name) = single_segment_expr_ident(path) {
+                if let Some(replacement) = self.consts.get(&name).and_then(const_item_scalar_expr) {
+                    *expr = replacement;
+                    return;
+                }
+            }
+        }
+        visit_mut::visit_expr_mut(self, expr);
+    }
+}
+
+fn normalize_type_aliases_inner(
+    ty: &Type,
+    aliases: &HashMap<String, ItemType>,
+    stack: &mut Vec<String>,
+) -> Result<Type, String> {
+    if stack.len() > MAX_ALIAS_EXPANSION_DEPTH {
+        return Err("type alias expansion exceeded recursion limit".to_string());
+    }
+
+    match ty {
+        Type::Path(type_path) => normalize_path_type(type_path, aliases, stack),
+        Type::Reference(type_ref) => {
+            let mut out = type_ref.clone();
+            out.elem = Box::new(normalize_type_aliases_inner(&out.elem, aliases, stack)?);
+            Ok(Type::Reference(out))
+        }
+        Type::Ptr(type_ptr) => {
+            let mut out = type_ptr.clone();
+            out.elem = Box::new(normalize_type_aliases_inner(&out.elem, aliases, stack)?);
+            Ok(Type::Ptr(out))
+        }
+        Type::Tuple(tuple) => {
+            let mut out = tuple.clone();
+            for elem in &mut out.elems {
+                *elem = normalize_type_aliases_inner(elem, aliases, stack)?;
+            }
+            Ok(Type::Tuple(out))
+        }
+        Type::Array(array) => {
+            let mut out = array.clone();
+            out.elem = Box::new(normalize_type_aliases_inner(&out.elem, aliases, stack)?);
+            Ok(Type::Array(out))
+        }
+        Type::Slice(slice) => {
+            let mut out = slice.clone();
+            out.elem = Box::new(normalize_type_aliases_inner(&out.elem, aliases, stack)?);
+            Ok(Type::Slice(out))
+        }
+        Type::Paren(paren) => {
+            let mut out = paren.clone();
+            out.elem = Box::new(normalize_type_aliases_inner(&out.elem, aliases, stack)?);
+            Ok(Type::Paren(out))
+        }
+        Type::Group(group) => {
+            let mut out = group.clone();
+            out.elem = Box::new(normalize_type_aliases_inner(&out.elem, aliases, stack)?);
+            Ok(Type::Group(out))
+        }
+        _ => Ok(ty.clone()),
+    }
+}
+
+fn normalize_path_type(
+    type_path: &TypePath,
+    aliases: &HashMap<String, ItemType>,
+    stack: &mut Vec<String>,
+) -> Result<Type, String> {
+    let Some(last_segment) = type_path.path.segments.last() else {
+        return Ok(Type::Path(type_path.clone()));
+    };
+    let alias_name = last_segment.ident.to_string();
+
+    if let Some(alias) = aliases.get(&alias_name) {
+        if stack.contains(&alias_name) {
+            return Err(format!(
+                "recursive type alias expansion involving `{}`",
+                alias_name
+            ));
+        }
+        stack.push(alias_name.clone());
+        let subst = build_alias_substitution(alias, &last_segment.arguments)?;
+        let substituted = substitute_type(&alias.ty, &subst, aliases, stack)?;
+        let expanded = normalize_type_aliases_inner(&substituted, aliases, stack)?;
+        stack.pop();
+        return Ok(expanded);
+    }
+
+    let mut out = type_path.clone();
+    if let Some(last_segment) = out.path.segments.last_mut() {
+        if let PathArguments::AngleBracketed(args) = &mut last_segment.arguments {
+            for arg in &mut args.args {
+                *arg = substitute_generic_arg(arg, &AliasSubstitution::default(), aliases, stack)?;
+            }
+        }
+    }
+    Ok(Type::Path(out))
+}
+
+fn build_alias_substitution(
+    alias: &ItemType,
+    args: &PathArguments,
+) -> Result<AliasSubstitution, String> {
+    let actual_args: Vec<GenericArgument> = match args {
+        PathArguments::AngleBracketed(args) => args.args.iter().cloned().collect(),
+        PathArguments::None => Vec::new(),
+        PathArguments::Parenthesized(_) => {
+            return Err(format!(
+                "type alias `{}` uses unsupported parenthesized generic arguments",
+                alias.ident
+            ));
+        }
+    };
+    let formals: Vec<&GenericParam> = alias
+        .generics
+        .params
+        .iter()
+        .filter(|param| !matches!(param, GenericParam::Lifetime(_)))
+        .collect();
+
+    if formals.len() != actual_args.len() {
+        return Err(format!(
+            "type alias `{}` expects {} generic argument(s), got {}",
+            alias.ident,
+            formals.len(),
+            actual_args.len()
+        ));
+    }
+
+    let mut subst = AliasSubstitution::default();
+    for (formal, actual) in formals.into_iter().zip(actual_args.into_iter()) {
+        match (formal, actual) {
+            (GenericParam::Type(param), GenericArgument::Type(ty)) => {
+                subst.types.insert(param.ident.to_string(), ty);
+            }
+            (GenericParam::Const(param), GenericArgument::Const(expr)) => {
+                subst.consts.insert(param.ident.to_string(), expr);
+            }
+            (GenericParam::Const(param), GenericArgument::Type(Type::Path(path))) => {
+                subst
+                    .consts
+                    .insert(param.ident.to_string(), expr_path_from_type_path(&path));
+            }
+            (GenericParam::Type(param), other) => {
+                return Err(format!(
+                    "type alias `{}` expected type argument for `{}`, got `{}`",
+                    alias.ident,
+                    param.ident,
+                    other.to_token_stream()
+                ));
+            }
+            (GenericParam::Const(param), other) => {
+                return Err(format!(
+                    "type alias `{}` expected const argument for `{}`, got `{}`",
+                    alias.ident,
+                    param.ident,
+                    other.to_token_stream()
+                ));
+            }
+            (GenericParam::Lifetime(_), _) => {}
+        }
+    }
+    Ok(subst)
+}
+
+fn substitute_type(
+    ty: &Type,
+    subst: &AliasSubstitution,
+    aliases: &HashMap<String, ItemType>,
+    stack: &mut Vec<String>,
+) -> Result<Type, String> {
+    match ty {
+        Type::Path(type_path) => {
+            if let Some(name) = single_segment_ident(type_path) {
+                if let Some(replacement) = subst.types.get(&name) {
+                    return normalize_type_aliases_inner(replacement, aliases, stack);
+                }
+            }
+            let mut out = type_path.clone();
+            if let Some(last_segment) = out.path.segments.last_mut() {
+                if let PathArguments::AngleBracketed(args) = &mut last_segment.arguments {
+                    for arg in &mut args.args {
+                        *arg = substitute_generic_arg(arg, subst, aliases, stack)?;
+                    }
+                }
+            }
+            normalize_type_aliases_inner(&Type::Path(out), aliases, stack)
+        }
+        Type::Reference(type_ref) => {
+            let mut out = type_ref.clone();
+            out.elem = Box::new(substitute_type(&out.elem, subst, aliases, stack)?);
+            Ok(Type::Reference(out))
+        }
+        Type::Ptr(type_ptr) => {
+            let mut out = type_ptr.clone();
+            out.elem = Box::new(substitute_type(&out.elem, subst, aliases, stack)?);
+            Ok(Type::Ptr(out))
+        }
+        Type::Tuple(tuple) => {
+            let mut out = tuple.clone();
+            for elem in &mut out.elems {
+                *elem = substitute_type(elem, subst, aliases, stack)?;
+            }
+            Ok(Type::Tuple(out))
+        }
+        Type::Array(array) => {
+            let mut out = array.clone();
+            out.elem = Box::new(substitute_type(&out.elem, subst, aliases, stack)?);
+            substitute_expr_in_place(&mut out.len, subst);
+            Ok(Type::Array(out))
+        }
+        Type::Slice(slice) => {
+            let mut out = slice.clone();
+            out.elem = Box::new(substitute_type(&out.elem, subst, aliases, stack)?);
+            Ok(Type::Slice(out))
+        }
+        Type::Paren(paren) => {
+            let mut out = paren.clone();
+            out.elem = Box::new(substitute_type(&out.elem, subst, aliases, stack)?);
+            Ok(Type::Paren(out))
+        }
+        Type::Group(group) => {
+            let mut out = group.clone();
+            out.elem = Box::new(substitute_type(&out.elem, subst, aliases, stack)?);
+            Ok(Type::Group(out))
+        }
+        _ => Ok(ty.clone()),
+    }
+}
+
+fn substitute_generic_arg(
+    arg: &GenericArgument,
+    subst: &AliasSubstitution,
+    aliases: &HashMap<String, ItemType>,
+    stack: &mut Vec<String>,
+) -> Result<GenericArgument, String> {
+    match arg {
+        GenericArgument::Type(Type::Path(path)) => {
+            if let Some(name) = single_segment_ident(path) {
+                if let Some(expr) = subst.consts.get(&name) {
+                    return Ok(generic_arg_from_const_expr(expr));
+                }
+            }
+            Ok(GenericArgument::Type(substitute_type(
+                &Type::Path(path.clone()),
+                subst,
+                aliases,
+                stack,
+            )?))
+        }
+        GenericArgument::Type(ty) => Ok(GenericArgument::Type(substitute_type(
+            ty, subst, aliases, stack,
+        )?)),
+        GenericArgument::Const(expr) => {
+            let mut expr = expr.clone();
+            substitute_expr_in_place(&mut expr, subst);
+            Ok(GenericArgument::Const(expr))
+        }
+        _ => Ok(arg.clone()),
+    }
+}
+
+fn substitute_expr_in_place(expr: &mut Expr, subst: &AliasSubstitution) {
+    struct Substituter<'a> {
+        consts: &'a HashMap<String, Expr>,
+    }
+
+    impl VisitMut for Substituter<'_> {
+        fn visit_expr_mut(&mut self, expr: &mut Expr) {
+            if let Expr::Path(path) = expr {
+                if let Some(name) = single_segment_expr_ident(path) {
+                    if let Some(replacement) = self.consts.get(&name) {
+                        *expr = replacement.clone();
+                        return;
+                    }
+                }
+            }
+            visit_mut::visit_expr_mut(self, expr);
+        }
+    }
+
+    Substituter {
+        consts: &subst.consts,
+    }
+    .visit_expr_mut(expr);
+}
+
+fn single_segment_ident(type_path: &TypePath) -> Option<String> {
+    if type_path.qself.is_some() || type_path.path.segments.len() != 1 {
+        return None;
+    }
+    Some(type_path.path.segments.first()?.ident.to_string())
+}
+
+fn single_segment_expr_ident(expr_path: &ExprPath) -> Option<String> {
+    if expr_path.qself.is_some() || expr_path.path.segments.len() != 1 {
+        return None;
+    }
+    Some(expr_path.path.segments.first()?.ident.to_string())
+}
+
+fn expr_path_from_type_path(type_path: &TypePath) -> Expr {
+    let qself = type_path.qself.clone();
+    let path = type_path.path.clone();
+    Expr::Path(ExprPath {
+        attrs: Vec::new(),
+        qself,
+        path,
+    })
+}
+
+fn generic_arg_from_const_expr(expr: &Expr) -> GenericArgument {
+    if let Expr::Path(path) = expr {
+        return GenericArgument::Type(Type::Path(TypePath {
+            qself: path.qself.clone(),
+            path: path.path.clone(),
+        }));
+    }
+    GenericArgument::Const(expr.clone())
+}

--- a/cutile-compiler/src/types.rs
+++ b/cutile-compiler/src/types.rs
@@ -823,6 +823,30 @@ pub fn try_extract_cga(ty: &Type, generic_vars: &GenericVars) -> Option<Vec<i32>
                                                 }
                                             }
                                         }
+                                        Expr::Index(index) => {
+                                            let Expr::Path(path) = index.expr.as_ref() else {
+                                                unimplemented!(
+                                                    "Unexpected const generic array base {elem:#?}"
+                                                );
+                                            };
+                                            let ident = get_ident_from_path_expr(path);
+                                            let Some(shape) = generic_vars
+                                                .inst_array
+                                                .get(ident.to_string().as_str())
+                                            else {
+                                                panic!(
+                                                    "Undefined const generic array parameter {ident}"
+                                                )
+                                            };
+                                            let i = parse_signed_literal_as_i32(&index.index);
+                                            let Some(dim) = shape.get(i as usize) else {
+                                                panic!(
+                                                    "Index {i} out of bounds for const generic array `{ident}` of length {}",
+                                                    shape.len()
+                                                )
+                                            };
+                                            _result.push(*dim);
+                                        }
                                         _ => unimplemented!(
                                             "Unexpected array element {elem:#?} in {array_expr:#?}"
                                         ),
@@ -854,6 +878,23 @@ pub fn try_extract_cga(ty: &Type, generic_vars: &GenericVars) -> Option<Vec<i32>
                                             Some(val) => *val,
                                             None => panic!("Undefined generic parameter {ident}")
                                         }
+                                    },
+                                    Expr::Index(index) => {
+                                        let Expr::Path(path) = index.expr.as_ref() else {
+                                            unimplemented!("Unexpected const generic array base {repeat_expr_expr:#?}");
+                                        };
+                                        let ident = get_ident_from_path_expr(path);
+                                        let Some(shape) = generic_vars.inst_array.get(ident.to_string().as_str()) else {
+                                            panic!("Undefined const generic array parameter {ident}")
+                                        };
+                                        let i = parse_signed_literal_as_i32(&index.index);
+                                        let Some(dim) = shape.get(i as usize) else {
+                                            panic!(
+                                                "Index {i} out of bounds for const generic array `{ident}` of length {}",
+                                                shape.len()
+                                            )
+                                        };
+                                        *dim
                                     },
                                     _ => unimplemented!("Unexpected unary expression {repeat_expr_expr:#?} in {repeat_expr:#?}"),
                                 };

--- a/cutile-examples/README.md
+++ b/cutile-examples/README.md
@@ -6,4 +6,5 @@ This crate contains runnable examples for the user-facing API and kernel DSL.
 
 - Start with `cargo run -p cutile-examples --example hello_world` to verify the toolchain.
 - Run `cargo run -p cutile-examples --example add_basic` for a small kernel launch example.
+- Run `cargo run -p cutile-examples --example global_memory` for a compile-only device global example.
 - Run `cargo run -p cutile-examples --example async_gemm` for a larger async example.

--- a/cutile-examples/examples/global_memory.rs
+++ b/cutile-examples/examples/global_memory.rs
@@ -1,0 +1,52 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Example: module-level device global memory.
+ *
+ * The load/store sequence below demonstrates ordered memory operations. It is
+ * not an atomic counter increment under concurrent writers.
+ *
+ * Run with: cargo run -p cutile-examples --example global_memory
+ */
+
+use cutile::prelude::*;
+
+#[cutile::module]
+mod global_kernels {
+    use cutile::core::*;
+
+    static COUNTER: Global<i32, { [] }> = Global::new(0i32);
+
+    #[cutile::entry()]
+    fn update_counter_ordered(out: &mut Tensor<i32, { [1] }>) {
+        let (old_value, _load_token) = COUNTER.load(ordering::Acquire, scope::Device);
+        let next_value = old_value + constant(1i32, const_shape![]);
+        let _store_token = COUNTER.store(next_value, ordering::Release, scope::Device);
+        out.store(old_value.reshape(const_shape![1]));
+    }
+}
+
+use global_kernels::update_counter_ordered;
+
+fn main() -> Result<(), Error> {
+    let device = Device::new(0)?;
+    let stream = device.new_stream()?;
+
+    let mut first = api::zeros::<i32>(&[1]).sync_on(&stream)?;
+    update_counter_ordered((&mut first).partition([1]))
+        .grid((1, 1, 1))
+        .sync_on(&stream)?;
+    let first_host: Vec<i32> = first.dup().to_host_vec().sync_on(&stream)?;
+    assert_eq!(first_host, vec![0]);
+
+    let mut second = api::zeros::<i32>(&[1]).sync_on(&stream)?;
+    update_counter_ordered((&mut second).partition([1]))
+        .grid((1, 1, 1))
+        .sync_on(&stream)?;
+    let second_host: Vec<i32> = second.dup().to_host_vec().sync_on(&stream)?;
+    assert_eq!(second_host, vec![1]);
+
+    println!("Global counter old values from two launches: {first_host:?}, {second_host:?}");
+    Ok(())
+}

--- a/cutile-macro/src/_module.rs
+++ b/cutile-macro/src/_module.rs
@@ -57,13 +57,13 @@ use proc_macro::TokenStream;
 use proc_macro2::Ident;
 use proc_macro2::{LineColumn, Span, TokenStream as TokenStream2};
 use quote::{format_ident, quote, ToTokens};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::{env, fs};
 
 use syn::{
     parse_file, parse_macro_input, parse_quote, AngleBracketedGenericArguments, GenericArgument,
-    GenericParam, ItemFn, ItemImpl, ItemMod, ItemStruct, ItemTrait, Path,
+    GenericParam, ItemFn, ItemImpl, ItemMod, ItemStruct, ItemTrait, ItemType, Path,
 };
 
 use crate::error::{Error, SpannedError};
@@ -244,6 +244,7 @@ fn process_items(
 ) -> Result<(Vec<TokenStream2>, Vec<TokenStream2>), Error> {
     let mut concrete_items: Vec<TokenStream2> = vec![];
     let mut entry_functions: Vec<TokenStream2> = vec![];
+    let type_aliases = cutile_compiler::type_aliases::collect_type_aliases(items);
 
     for item in items {
         match item {
@@ -256,9 +257,17 @@ fn process_items(
                     &function_item.attrs,
                 );
                 if entry_attrs.is_some() {
-                    entry_functions.push(kernel_launcher(parent_name, function_item)?);
+                    entry_functions.push(kernel_launcher(
+                        parent_name,
+                        function_item,
+                        &type_aliases,
+                    )?);
                 };
-                concrete_items.push(function(function_item.clone(), tile_rust_crate_root)?);
+                concrete_items.push(function(
+                    function_item.clone(),
+                    tile_rust_crate_root,
+                    &type_aliases,
+                )?);
             }
             syn::Item::Struct(struct_item) => {
                 let item_clone = struct_item.clone();
@@ -269,7 +278,7 @@ fn process_items(
                 concrete_items.push(trait_(item_clone)?.into());
             }
             syn::Item::Type(type_item) => {
-                concrete_items.push(type_item.to_token_stream());
+                concrete_items.push(instantiate_type_alias_for_rank(type_item)?.to_token_stream());
             }
             syn::Item::Impl(impl_item) => {
                 let item_clone = impl_item.clone();
@@ -283,7 +292,7 @@ fn process_items(
                 concrete_items.push(const_item.to_token_stream());
             }
             syn::Item::Static(static_item) => {
-                concrete_items.push(static_item.to_token_stream());
+                concrete_items.push(instantiate_static_for_rank(static_item)?.to_token_stream());
             }
             syn::Item::Mod(submod) => {
                 let Some(sub_content) = &submod.content else {
@@ -590,10 +599,19 @@ pub fn structure(mut item: ItemStruct) -> Result<TokenStream, Error> {
 /// ## Entry Points
 ///
 /// Functions marked with `#[entry]` are validated and have launchers generated.
-pub fn function(mut item: ItemFn, tile_rust_crate_root: &Ident) -> Result<TokenStream2, Error> {
+pub fn function(
+    mut item: ItemFn,
+    tile_rust_crate_root: &Ident,
+    type_aliases: &HashMap<String, ItemType>,
+) -> Result<TokenStream2, Error> {
     let is_entry = get_meta_list_by_last_segment("entry", &item.attrs).is_some();
     if is_entry {
-        validate_entry_point_parameters(&item)?
+        let validation_item = cutile_compiler::type_aliases::normalize_item_fn_param_type_aliases(
+            &item,
+            type_aliases,
+        )
+        .map_err(|msg| crate::error::syn_err(item.sig.ident.span(), &msg))?;
+        validate_entry_point_parameters(&validation_item)?
     }
     let attributes = get_meta_list("cuda_tile :: variadic_op", &item.attrs);
     // Any function annotated with `#[cuda_tile::variadic_op(...)]` is
@@ -687,7 +705,11 @@ pub fn function(mut item: ItemFn, tile_rust_crate_root: &Ident) -> Result<TokenS
 /// ## Entry Attributes
 ///
 /// Respects `#[entry(print_ir = true)]` to print the generated launcher code.
-pub fn kernel_launcher(module_ident: &Ident, item: &ItemFn) -> Result<TokenStream2, Error> {
+pub fn kernel_launcher(
+    module_ident: &Ident,
+    item: &ItemFn,
+    type_aliases: &HashMap<String, ItemType>,
+) -> Result<TokenStream2, Error> {
     let module_name = module_ident.to_string();
     let function_name = item.sig.ident.to_string();
     let kernel_naming = KernelNaming::new(function_name.as_str());
@@ -695,6 +717,9 @@ pub fn kernel_launcher(module_ident: &Ident, item: &ItemFn) -> Result<TokenStrea
     let launcher_name = function_name.to_case(Case::UpperCamel).to_string();
     let launcher_args_name = format!("{}Args", launcher_name);
     let unsafety = item.sig.unsafety;
+    let launcher_item =
+        cutile_compiler::type_aliases::normalize_item_fn_param_type_aliases(item, type_aliases)
+            .map_err(|msg| crate::error::syn_err(item.sig.ident.span(), &msg))?;
 
     let (
         required_generics,
@@ -702,7 +727,7 @@ pub fn kernel_launcher(module_ident: &Ident, item: &ItemFn) -> Result<TokenStrea
         device_op_impl,
         kernel_input_info,
     ) = generate_kernel_launcher(
-        item,
+        &launcher_item,
         &module_name,
         &function_name,
         function_entry_name.as_str(),

--- a/cutile-macro/src/kernel_launcher_generator.rs
+++ b/cutile-macro/src/kernel_launcher_generator.rs
@@ -1452,6 +1452,28 @@ pub fn infer_shape_params_from_tensor_type(
                                         SupportedGenericType::Unknown => {}
                                     }
                                 }
+                                Expr::Index(index) => {
+                                    let Expr::Path(path) = index.expr.as_ref() else {
+                                        return elem.err(
+                                            "Unsupported array element in tensor shape expression.",
+                                        );
+                                    };
+                                    let ident = get_ident_from_path_expr(path).to_string();
+                                    match required_generics.get_ty(&ident) {
+                                        SupportedGenericType::ConstArray => {
+                                            // A projection like `S[0]` does not determine the
+                                            // whole `S`; keep it explicit instead of rejecting the
+                                            // entry signature.
+                                            continue;
+                                        }
+                                        SupportedGenericType::Unknown => {}
+                                        _ => {
+                                            return elem.err(
+                                                "Only const generic array projections like `S[0]` are supported in tensor shape index expressions.",
+                                            );
+                                        }
+                                    }
+                                }
                                 _ => {
                                     return elem.err(
                                         "Unsupported array element in tensor shape expression.",

--- a/cutile-macro/src/rank_instantiation.rs
+++ b/cutile-macro/src/rank_instantiation.rs
@@ -65,17 +65,19 @@
 use crate::error::{syn_err, Error};
 use cutile_compiler::syn_utils::*;
 use cutile_compiler::types::parse_signed_literal_as_i32;
-use proc_macro2::{Ident, Span, TokenTree};
+use proc_macro2::{Ident, Span};
 use quote::{format_ident, ToTokens};
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 use syn::{
+    parse::Parser,
     parse_quote,
+    punctuated::Punctuated,
     spanned::Spanned,
     visit_mut::{self, VisitMut},
     AngleBracketedGenericArguments, Expr, ExprPath, ExprStruct, FnArg, GenericArgument,
-    GenericParam, Generics, ImplItem, ImplItemFn, ItemFn, ItemImpl, ItemStruct, Macro, Path,
-    PathArguments, PathSegment, ReturnType, Signature, Stmt, Type,
+    GenericParam, Generics, ImplItem, ImplItemFn, ItemFn, ItemImpl, ItemStatic, ItemStruct,
+    ItemType, Macro, Path, PathArguments, PathSegment, ReturnType, Signature, Stmt, Token, Type,
 };
 
 /// Rank suffix string from a list of dimension counts:
@@ -948,8 +950,8 @@ fn instantiate_cga_args(
                                 // This is something like Tensor<E, {[1, 2, -1]}>
                                 let rank = array_expr.elems.len();
                                 for elem in &array_expr.elems {
-                                    let val = elem.to_token_stream().to_string();
-                                    generic_args_result.push(val);
+                                    generic_args_result
+                                        .push(format_rank_const_expr(elem, instances)?);
                                 }
                                 instantiated_param_name = if skip_suffix {
                                     type_ident.to_string()
@@ -960,7 +962,7 @@ fn instantiate_cga_args(
                             Expr::Repeat(repeat_expr) => {
                                 // println!("Expr::Repeat: {:?}", repeat_expr.expr);
                                 let thing_to_repeat =
-                                    repeat_expr.expr.to_token_stream().to_string();
+                                    format_rank_const_expr(&repeat_expr.expr, instances)?;
                                 let num_repetitions = match &*repeat_expr.len {
                                     Expr::Path(len_path) => {
                                         // This is something like Tensor<E, {[-1; N]}>
@@ -1051,6 +1053,33 @@ fn instantiate_cga_args(
             )
         })?,
     ))
+}
+
+fn format_rank_const_expr(expr: &Expr, instances: &RankBindings) -> Result<String, Error> {
+    if let Expr::Index(index) = expr {
+        if let Expr::Path(path) = index.expr.as_ref() {
+            let name = path
+                .path
+                .segments
+                .last()
+                .map(|segment| segment.ident.to_string())
+                .unwrap_or_default();
+            if let Some(cga) = instances.inst_array.get(&name) {
+                let i = parse_signed_literal_as_i32(&index.index);
+                if !(0 <= i && (i as u32) < cga.length) {
+                    return Err(syn_err(
+                        index.index.span(),
+                        &format!(
+                            "Index {i} out of bounds for CGA `{}` of length {}",
+                            cga.name, cga.length
+                        ),
+                    ));
+                }
+                return Ok(format!("{}{}", cga.name, i as u32));
+            }
+        }
+    }
+    Ok(expr.to_token_stream().to_string())
 }
 
 // ---------------------------------------------------------------------------
@@ -1201,29 +1230,58 @@ impl RankInstantiator {
     /// macro that name an in-scope CGA expand to rank-instance dim refs.
     fn expand_shape_macro(&self, mac: &Macro, kind: &str) -> Result<Expr, Error> {
         let mut args: Vec<String> = Vec::new();
-        for token in mac.tokens.clone() {
-            match token {
-                TokenTree::Literal(lit) => args.push(lit.to_string()),
-                TokenTree::Ident(ident) => {
+        let parser = Punctuated::<Expr, Token![,]>::parse_terminated;
+        let exprs = parser
+            .parse2(mac.tokens.clone())
+            .map_err(|e| syn_err(mac.span(), &format!("Failed to parse {kind}! args: {e}")))?;
+        let expr_count = exprs.len();
+        for expr in exprs {
+            match &expr {
+                Expr::Path(path) if path.path.segments.len() == 1 => {
+                    let ident = &path.path.segments[0].ident;
                     let name = ident.to_string();
-                    if self.bindings.inst_array.contains_key(&name) {
-                        let path: Path = parse_quote! { #ident };
-                        let expanded = instantiate_cga(&path, &self.bindings)?;
-                        for arg in &expanded.args {
-                            args.push(arg.to_token_stream().to_string());
+                    if let Some(cga) = self.bindings.inst_array.get(&name) {
+                        if expr_count != 1 {
+                            return Err(syn_err(
+                                expr.span(),
+                                &format!(
+                                    "`{name}` names a const generic array; use it alone or index it as `{name}[i]`"
+                                ),
+                            ));
                         }
-                    } else {
-                        args.push(name);
+                        for i in 0..cga.length {
+                            args.push(format!("{}{}", cga.name, i));
+                        }
+                        continue;
                     }
                 }
-                TokenTree::Punct(p) if p.as_char() == ',' => continue,
-                other => {
-                    return Err(syn_err(
-                        mac.span(),
-                        &format!("Unexpected token in {kind}!: {:?}", other),
-                    ));
+                Expr::Index(index) => {
+                    if let Expr::Path(path) = index.expr.as_ref() {
+                        let name = path
+                            .path
+                            .segments
+                            .last()
+                            .map(|segment| segment.ident.to_string())
+                            .unwrap_or_default();
+                        if let Some(cga) = self.bindings.inst_array.get(&name) {
+                            let i = parse_signed_literal_as_i32(&index.index);
+                            if !(0 <= i && (i as u32) < cga.length) {
+                                return Err(syn_err(
+                                    index.index.span(),
+                                    &format!(
+                                        "Index {i} out of bounds for CGA `{}` of length {}",
+                                        cga.name, cga.length
+                                    ),
+                                ));
+                            }
+                            args.push(format!("{}{}", cga.name, i as u32));
+                            continue;
+                        }
+                    }
                 }
+                _ => {}
             }
+            args.push(expr.to_token_stream().to_string());
         }
         let cga_str = format!("{{[{}]}}", args.join(", "));
         let ty_str = if kind == "const_shape" {
@@ -1384,6 +1442,69 @@ pub fn instantiate_struct_for_rank(item: &ItemStruct) -> Result<ItemStruct, Erro
 pub fn instantiate_function_for_rank(item: &ItemFn) -> Result<ItemFn, Error> {
     let bindings = RankBindings::from_generics(&item.sig.generics)?;
     RankInstantiator::new(bindings).rewrite_function(item)
+}
+
+/// Desugars const generic array syntax in a type alias.
+///
+/// This keeps same-module concrete aliases usable in rustc-visible expanded
+/// code, e.g. `type Block = Tensor<f32, {[4]}>`.
+pub fn instantiate_type_alias_for_rank(item: &ItemType) -> Result<ItemType, Error> {
+    let bindings = RankBindings::from_generics(&item.generics)?;
+    let mut item = item.clone();
+    rewrite_generics_for_rank(&mut item.generics, &bindings)?;
+    item.ty = Box::new(rewrite_type_for_rank(&item.ty, &bindings)?);
+    Ok(item)
+}
+
+/// Desugars const generic array syntax in a static item.
+///
+/// This keeps `static COUNTER: Global<i32, { [] }> = Global::new(0i32);`
+/// valid in rustc-visible expanded code while preserving the original source
+/// text for the JIT.
+pub fn instantiate_static_for_rank(item: &ItemStatic) -> Result<ItemStatic, Error> {
+    let bindings = RankBindings::new();
+    let mut item = item.clone();
+    item.ty = Box::new(rewrite_type_for_rank(&item.ty, &bindings)?);
+    let concrete_type_ident = concrete_type_ident(&item.ty);
+    let mut instantiator = RankInstantiator::new(bindings);
+    instantiator.visit_expr_mut(&mut item.expr);
+    let mut item = instantiator.into_result(item)?;
+    if let Some(concrete_type_ident) = concrete_type_ident {
+        rewrite_static_constructor_path(&mut item.expr, &concrete_type_ident);
+    }
+    Ok(item)
+}
+
+fn concrete_type_ident(ty: &Type) -> Option<Ident> {
+    let Type::Path(type_path) = ty else {
+        return None;
+    };
+    type_path
+        .path
+        .segments
+        .last()
+        .map(|segment| segment.ident.clone())
+}
+
+fn rewrite_static_constructor_path(expr: &mut Expr, concrete_type_ident: &Ident) {
+    let Expr::Call(call) = expr else {
+        return;
+    };
+    let Expr::Path(path) = &mut *call.func else {
+        return;
+    };
+    if path.path.segments.len() < 2 {
+        return;
+    }
+    let Some(last) = path.path.segments.last() else {
+        return;
+    };
+    if last.ident != "new" {
+        return;
+    }
+    if let Some(first) = path.path.segments.first_mut() {
+        first.ident = concrete_type_ident.clone();
+    }
 }
 
 /// Desugars const generic array syntax in an impl block.

--- a/cutile-macro/src/validate_dsl_syntax.rs
+++ b/cutile-macro/src/validate_dsl_syntax.rs
@@ -113,7 +113,10 @@ pub fn validate_entry_point_parameters(item: &ItemFn) -> Result<(), Error> {
                 let type_name = ident.to_string();
                 if type_name != "Tensor" {
                     ty.err(&format!(
-                        "References to {} as parameters are not supported.",
+                        "References to `{}` as parameters are not supported. \
+                         If this is a type alias for `Tensor`, define the alias in the same \
+                         `#[cutile::module]` as the entry function; imported Tensor aliases are \
+                         not supported by launcher generation.",
                         type_name
                     ))?;
                 }
@@ -142,6 +145,25 @@ pub fn validate_entry_point_parameters(item: &ItemFn) -> Result<(), Error> {
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn imported_tensor_alias_parameter_error_mentions_same_module_aliases() {
+        let item: ItemFn = syn::parse_quote! {
+            fn kernel(x: &ImportedTensorAlias) {}
+        };
+        let err = validate_entry_point_parameters(&item).expect_err("expected alias rejection");
+        let message = err.to_string();
+        assert!(
+            message.contains("define the alias in the same `#[cutile::module]`")
+                && message.contains("imported Tensor aliases are not supported"),
+            "{message}"
+        );
+    }
 }
 
 // TODO (hme): Implement a comprehensive validation pass on entire module.

--- a/cutile/src/_core.rs
+++ b/cutile/src/_core.rs
@@ -416,6 +416,60 @@ pub mod core {
         }
     }
 
+    /// Module-scope mutable global memory.
+    ///
+    /// `Global` is declared as a Rust `static` inside a `#[cutile::module]`.
+    /// The Rust value is an immutable descriptor; mutability lives in the
+    /// device storage and is exposed through ordered memory operations.
+    #[cuda_tile::variadic_struct(N = 6)]
+    #[derive(Copy, Clone)]
+    pub struct Global<E: ElementType, const D: [i32; N]> {
+        _type: PhantomData<E>,
+    }
+
+    #[cuda_tile::variadic_impl(N = 6)]
+    unsafe impl<E: ElementType, const D: [i32; N]> Sync for Global<E, D> {}
+
+    #[cuda_tile::variadic_impl(N = 6)]
+    impl<E: ElementType, const D: [i32; N]> Global<E, D> {
+        /// Declare a global with a scalar initializer.
+        ///
+        /// Today the JIT compiler only lowers scalar globals
+        /// (`Global<E, { [] }>`). Shaped globals are reserved for a follow-up pass.
+        pub const fn new(_value: E) -> Self {
+            Self { _type: PhantomData }
+        }
+
+        /// Load the scalar global. Returns the loaded value and completion token.
+        pub fn load<O: ordering::LoadMode, Sc: scope::Mode>(
+            &self,
+            memory_ordering: O,
+            memory_scope: Sc,
+        ) -> (Tile<E, D>, Token) {
+            unreachable!()
+        }
+
+        /// Store to the scalar global. Returns the completion token.
+        pub fn store<O: ordering::StoreMode, Sc: scope::Mode>(
+            &self,
+            value: Tile<E, D>,
+            memory_ordering: O,
+            memory_scope: Sc,
+        ) -> Token {
+            unreachable!()
+        }
+
+        /// Atomic add on the scalar global. Returns the old value and token.
+        pub fn atomic_add<O: ordering::AtomicMode, Sc: scope::Mode>(
+            &self,
+            value: Tile<E, D>,
+            memory_ordering: O,
+            memory_scope: Sc,
+        ) -> (Tile<E, D>, Token) {
+            unreachable!()
+        }
+    }
+
     // ---- §5.3 TENSOR TYPES (Tile, Tensor, Partition, PartitionMut) ---------
 
     /// Multi-dimensional array stored in registers / shared memory. The unit

--- a/cutile/tests/basics_and_inlining.rs
+++ b/cutile/tests/basics_and_inlining.rs
@@ -61,7 +61,86 @@ mod basics_and_inlining_module {
     }
 
     fn ones_shape<const N: usize>() -> [i32; N] {
-        [1i32; N]
+        [1; N]
+    }
+
+    fn expects_i32(value: i32) -> i32 {
+        value
+    }
+
+    fn expects_f32(value: f32) -> f32 {
+        value
+    }
+
+    unsafe fn tensor_from_ptr<T: ElementType>(ptr: *mut T, len: i32) -> Tensor<T, { [-1] }> {
+        let shape: Shape<{ [-1] }> = Shape::<{ [-1] }> { dims: &[len] };
+        let strides: Array<{ [-1] }> = Array::<{ [-1] }> { dims: &[1i32] };
+        let ptr_tile: PointerTile<*mut T, { [] }> = pointer_to_tile(ptr);
+        make_tensor_view(ptr_tile, shape, strides, new_token_unordered())
+    }
+
+    #[cutile::entry()]
+    unsafe fn inline_tensor_from_ptr_kernel<T: ElementType>(ptr: *mut T, len: i32) {
+        let _tensor: Tensor<T, { [-1] }> = tensor_from_ptr(ptr, len);
+    }
+
+    #[cutile::entry()]
+    unsafe fn ptr_partition_load_kernel<T: ElementType>(ptr: *mut T, len: i32) {
+        let tensor: Tensor<T, { [-1] }> = tensor_from_ptr(ptr, len);
+        let pid: (i32, i32, i32) = get_tile_block_id();
+        let tile_shape = const_shape![4i32];
+        let _tile = tensor.partition(tile_shape).load([pid.0]);
+    }
+
+    #[cutile::entry()]
+    unsafe fn ptr_partition_mut_store_kernel(ptr: *mut f32, len: i32) {
+        let mut tensor: Tensor<f32, { [-1] }> = tensor_from_ptr(ptr, len);
+        let pid: (i32, i32, i32) = get_tile_block_id();
+        let tile_shape = const_shape![4i32];
+        let tile: Tile<f32, { [4] }> = constant(1.0, tile_shape);
+        tensor.partition_mut(tile_shape).store(tile, [pid.0]);
+    }
+
+    #[cutile::entry()]
+    unsafe fn partition_mut_store_rank3_loop_kernel<const S: [i32; 3]>(out: &mut Tensor<f32, S>) {
+        let tile_shape = const_shape![1i32, 4i32, 8i32];
+        let mut out_part: PartitionMut<f32, { [1, 4, 8] }> =
+            unsafe { out.partition_mut(tile_shape) };
+        for s_local in 0i32..4i32 {
+            let tile: Tile<f32, { [1, 4, 8] }> = constant(1.0, tile_shape);
+            unsafe { out_part.store(tile, [0i32, s_local, 0i32]) };
+        }
+    }
+
+    #[cutile::entry()]
+    unsafe fn partition_mut_store_loaded_rank3_loop_kernel<
+        const BLOCK_SIZE: i32,
+        const BM_S: i32,
+    >(
+        source: &Tensor<f32, { [-1, -1, BLOCK_SIZE] }>,
+        out: &mut Tensor<f32, { [1, BM_S, BLOCK_SIZE] }>,
+        seq_len: i32,
+    ) {
+        let pid: (i32, i32, i32) = get_tile_block_id();
+        let head = pid.0;
+        let s_tile_idx = pid.1;
+        let d_block = pid.2;
+
+        let source_part = source.partition(const_shape![1, 1, BLOCK_SIZE]);
+        let mut out_part = unsafe { out.partition_mut(const_shape![1, 1, BLOCK_SIZE]) };
+
+        let s_start: i32 = s_tile_idx * BM_S;
+        if s_start < seq_len {
+            for s_local in 0i32..BM_S {
+                let s_global: i32 = s_start + s_local;
+                if s_global < seq_len {
+                    let tile = source_part
+                        .load([s_global, head, d_block])
+                        .reshape(const_shape![1, 1, BLOCK_SIZE]);
+                    unsafe { out_part.store(tile, [0i32, s_local, 0i32]) };
+                }
+            }
+        }
     }
 
     #[cutile::entry()]
@@ -190,6 +269,27 @@ mod basics_and_inlining_module {
         let _b: bool = an_f32 < another_f32;
         let _b: bool = an_f32 <= another_f32;
 
+        let inferred_i32 = 7i32;
+        let _inferred_i32_tile: Tile<i32, { [] }> = scalar_to_tile(inferred_i32);
+        let inferred_f32 = 7.0f32;
+        let _inferred_f32_tile: Tile<f32, { [] }> = scalar_to_tile(inferred_f32);
+        let mut assigned_i32: i32 = 0i32;
+        let _assigned_i32_initial_tile: Tile<i32, { [] }> = scalar_to_tile(assigned_i32);
+        assigned_i32 = 9;
+        let _assigned_i32_tile: Tile<i32, { [] }> = scalar_to_tile(assigned_i32);
+        let mut assigned_f32: f32 = 0.0f32;
+        let _assigned_f32_initial_tile: Tile<f32, { [] }> = scalar_to_tile(assigned_f32);
+        assigned_f32 = 9.0;
+        let _assigned_f32_tile: Tile<f32, { [] }> = scalar_to_tile(assigned_f32);
+        let contextual_i32 = expects_i32(11);
+        let _contextual_i32_tile: Tile<i32, { [] }> = scalar_to_tile(contextual_i32);
+        let contextual_f32 = expects_f32(11.0);
+        let _contextual_f32_tile: Tile<f32, { [] }> = scalar_to_tile(contextual_f32);
+        let annotated_call_i32: i32 = expects_i32(13);
+        let _annotated_call_i32_tile: Tile<i32, { [] }> = scalar_to_tile(annotated_call_i32);
+        let annotated_call_f32: f32 = expects_f32(13.0);
+        let _annotated_call_f32_tile: Tile<f32, { [] }> = scalar_to_tile(annotated_call_f32);
+
         // Convert things.
         let x: f32 = 0.0;
         let x: i32 = convert_scalar::<i32>(x);
@@ -244,7 +344,8 @@ mod basics_and_inlining_module {
                 None,
                 tma::Enabled,
             );
-            for _i in 0i32..10i32 {
+            let loop_end: i32 = 10;
+            for _i in 0..loop_end {
                 let some_tile_2: Tile<f32, { [128, 256] }> = constant(2.0, shape);
                 some_tile = some_tile + some_tile_2;
                 store_view_tko_mut(
@@ -274,6 +375,8 @@ mod basics_and_inlining_module {
 
         let x: [i32; 2] = [1i32, 2i32];
         let _x_val: i32 = x[0];
+        let repeat_x: [i32; 2] = [0; 2];
+        let _repeat_x_val: i32 = repeat_x[0];
         let x: &[i32] = &[1i32, 2i32];
         let _x_val: i32 = x[0];
 
@@ -291,7 +394,10 @@ mod basics_and_inlining_module {
     #[cutile::entry()]
     unsafe fn ptr_tile_reshape_kernel(ptr: *mut f32) {
         let ptr_tile: PointerTile<*mut f32, { [] }> = pointer_to_tile(ptr);
+        let offset_ptr_tile: PointerTile<*mut f32, { [] }> = pointer_to_tile(ptr).offset(1);
         let reshaped: PointerTile<*mut f32, { [1] }> = ptr_tile.reshape(const_shape![1]);
+        let _reshaped_offset: PointerTile<*mut f32, { [1] }> =
+            offset_ptr_tile.reshape(const_shape![1]);
         let _broadcast: PointerTile<*mut f32, { [128] }> = reshaped.broadcast(const_shape![128]);
     }
 
@@ -307,11 +413,149 @@ mod basics_and_inlining_module {
 use basics_and_inlining_module::__module_ast_self;
 
 #[test]
+fn compile_inline_tensor_from_ptr_helper() -> () {
+    common::with_test_stack(|| {
+        let modules = CUDATileModules::from_kernel(__module_ast_self())
+            .expect("Failed to create CUDATileModules");
+        let compiler = CUDATileFunctionCompiler::new(
+            &modules,
+            "basics_and_inlining_module",
+            "inline_tensor_from_ptr_kernel",
+            &["f32".to_string()],
+            &[],
+            &[],
+            &[],
+            None,
+            "sm_120".to_string(),
+            &CompileOptions::default(),
+        )
+        .expect("Failed.");
+        let module_op_str = compiler.compile().expect("Failed.").to_string();
+        assert!(
+            module_op_str.contains("make_tensor_view"),
+            "Expected inlined pointer helper to emit make_tensor_view.\n{module_op_str}"
+        );
+        println!("{module_op_str}");
+    });
+}
+
+#[test]
+fn compile_ptr_partition_load_helper() -> () {
+    common::with_test_stack(|| {
+        let modules = CUDATileModules::from_kernel(__module_ast_self())
+            .expect("Failed to create CUDATileModules");
+        let compiler = CUDATileFunctionCompiler::new(
+            &modules,
+            "basics_and_inlining_module",
+            "ptr_partition_load_kernel",
+            &["f32".to_string()],
+            &[],
+            &[],
+            &[],
+            None,
+            "sm_120".to_string(),
+            &CompileOptions::default(),
+        )
+        .expect("Failed.");
+        let module_op_str = compiler.compile().expect("Failed.").to_string();
+        assert!(
+            module_op_str.contains("make_partition_view"),
+            "Expected partition helper to emit make_partition_view.\n{module_op_str}"
+        );
+        assert!(
+            module_op_str.contains("load_view_tko"),
+            "Expected partition load helper to emit load_view_tko.\n{module_op_str}"
+        );
+    });
+}
+
+#[test]
+fn compile_ptr_partition_mut_store_helper() -> () {
+    common::with_test_stack(|| {
+        let modules = CUDATileModules::from_kernel(__module_ast_self())
+            .expect("Failed to create CUDATileModules");
+        let compiler = CUDATileFunctionCompiler::new(
+            &modules,
+            "basics_and_inlining_module",
+            "ptr_partition_mut_store_kernel",
+            &[],
+            &[],
+            &[],
+            &[],
+            None,
+            "sm_120".to_string(),
+            &CompileOptions::default(),
+        )
+        .expect("Failed.");
+        let module_op_str = compiler.compile().expect("Failed.").to_string();
+        assert!(
+            module_op_str.contains("make_partition_view"),
+            "Expected mutable partition helper to emit make_partition_view.\n{module_op_str}"
+        );
+        assert!(
+            module_op_str.contains("store_view_tko"),
+            "Expected mutable partition helper to emit store_view_tko.\n{module_op_str}"
+        );
+    });
+}
+
+#[test]
+fn compile_partition_mut_store_rank3_loop() -> () {
+    common::with_test_stack(|| {
+        let modules = CUDATileModules::from_kernel(__module_ast_self())
+            .expect("Failed to create CUDATileModules");
+        let compiler = CUDATileFunctionCompiler::new(
+            &modules,
+            "basics_and_inlining_module",
+            "partition_mut_store_rank3_loop_kernel",
+            &[1.to_string(), 4.to_string(), 8.to_string()],
+            &[("out", &[1, 4, 8])],
+            &[],
+            &[],
+            None,
+            "sm_120".to_string(),
+            &CompileOptions::default(),
+        )
+        .expect("Failed.");
+        let module_op_str = compiler.compile().expect("Failed.").to_string();
+        assert!(
+            module_op_str.contains("store_view_tko"),
+            "Expected partition store helper to emit store_view_tko.\n{module_op_str}"
+        );
+    });
+}
+
+#[test]
+fn compile_partition_mut_store_loaded_rank3_loop() -> () {
+    common::with_test_stack(|| {
+        let modules = CUDATileModules::from_kernel(__module_ast_self())
+            .expect("Failed to create CUDATileModules");
+        let compiler = CUDATileFunctionCompiler::new(
+            &modules,
+            "basics_and_inlining_module",
+            "partition_mut_store_loaded_rank3_loop_kernel",
+            &[8.to_string(), 4.to_string()],
+            &[("source", &[16, 16, 8]), ("out", &[1, 4, 8])],
+            &[],
+            &[],
+            None,
+            "sm_120".to_string(),
+            &CompileOptions::default(),
+        )
+        .expect("Failed.");
+        let module_op_str = compiler.compile().expect("Failed.").to_string();
+        assert!(
+            module_op_str.contains("store_view_tko"),
+            "Expected partition store helper to emit store_view_tko.\n{module_op_str}"
+        );
+    });
+}
+
+#[test]
 fn compile_inlining() -> () {
     common::with_test_stack(|| {
         let modules = CUDATileModules::from_kernel(__module_ast_self())
             .expect("Failed to create CUDATileModules");
-        let gpu_name = get_gpu_name(0);
         let compiler = CUDATileFunctionCompiler::new(
             &modules,
             "basics_and_inlining_module",
@@ -328,7 +572,7 @@ fn compile_inlining() -> () {
             &[],
             &[],
             None,
-            gpu_name,
+            "sm_120".to_string(),
             &CompileOptions::default(),
         )
         .expect("Failed.");

--- a/cutile/tests/control_flow_ops.rs
+++ b/cutile/tests/control_flow_ops.rs
@@ -199,6 +199,36 @@ mod control_flow_ops_module {
         output.store(result);
     }
 
+    /// else-if as a tile expression: nested ifs in Rust source syntax.
+    #[cutile::entry()]
+    fn else_if_tile_expr_kernel<const S: [i32; 1]>(output: &mut Tensor<f32, S>, flag: i32) {
+        let ones: Tile<f32, S> = constant(1.0f32, output.shape());
+        let twos: Tile<f32, S> = constant(2.0f32, output.shape());
+        let threes: Tile<f32, S> = constant(3.0f32, output.shape());
+        let result: Tile<f32, S> = if flag < 0i32 {
+            ones
+        } else if flag < 1i32 {
+            twos
+        } else {
+            threes
+        };
+        output.store(result);
+    }
+
+    /// else-if carrying a mutable variable through every branch.
+    #[cutile::entry()]
+    fn else_if_carry_kernel<const S: [i32; 1]>(output: &mut Tensor<f32, S>, flag: i32) {
+        let mut acc: Tile<f32, S> = constant(0.0f32, output.shape());
+        if flag < 0i32 {
+            acc = acc + constant(1.0f32, output.shape());
+        } else if flag < 1i32 {
+            acc = acc + constant(2.0f32, output.shape());
+        } else {
+            acc = acc + constant(3.0f32, output.shape());
+        }
+        output.store(acc);
+    }
+
     /// Nested mutation: for-in-if with runtime condition.
     /// The for loop mutates `acc` inside a dynamic if branch.
     #[cutile::entry()]
@@ -259,9 +289,10 @@ mod control_flow_ops_module {
 }
 
 use control_flow_ops_module::{
-    __module_ast_self, break_test_kernel, if_else_tile_expr_kernel, if_for_carry_const_kernel,
-    if_for_carry_kernel, if_return_test_kernel, nested_for_in_if_const_kernel,
-    nested_for_in_if_kernel, nested_if_for_if_kernel,
+    __module_ast_self, break_test_kernel, else_if_carry_kernel, else_if_tile_expr_kernel,
+    if_else_tile_expr_kernel, if_for_carry_const_kernel, if_for_carry_kernel,
+    if_return_test_kernel, nested_for_in_if_const_kernel, nested_for_in_if_kernel,
+    nested_if_for_if_kernel,
 };
 
 #[test]
@@ -689,6 +720,42 @@ fn if_else_tile_expr_returns_value() {
             host[0]
         );
     });
+}
+
+#[test]
+fn else_if_tile_expr_returns_value() {
+    for (flag, expected) in [(-1i32, 1.0f32), (0i32, 2.0f32), (1i32, 3.0f32)] {
+        common::with_test_stack(move || {
+            let mut output = cutile::api::zeros::<f32>(&[128]).sync().expect("alloc");
+            else_if_tile_expr_kernel((&mut output).partition([128]), flag)
+                .sync()
+                .expect("kernel");
+            let host: Vec<f32> = output.dup().to_host_vec().sync().expect("to_host");
+            assert!(
+                (host[0] - expected).abs() < 1e-3,
+                "flag={flag}: expected {expected}, got {}",
+                host[0]
+            );
+        });
+    }
+}
+
+#[test]
+fn else_if_carries_mutable_values() {
+    for (flag, expected) in [(-1i32, 1.0f32), (0i32, 2.0f32), (1i32, 3.0f32)] {
+        common::with_test_stack(move || {
+            let mut output = cutile::api::zeros::<f32>(&[128]).sync().expect("alloc");
+            else_if_carry_kernel((&mut output).partition([128]), flag)
+                .sync()
+                .expect("kernel");
+            let host: Vec<f32> = output.dup().to_host_vec().sync().expect("to_host");
+            assert!(
+                (host[0] - expected).abs() < 1e-3,
+                "flag={flag}: expected {expected}, got {}",
+                host[0]
+            );
+        });
+    }
 }
 
 // ---- Nested mutation tests ------------------------------------------------

--- a/cutile/tests/flash_attention_compile.rs
+++ b/cutile/tests/flash_attention_compile.rs
@@ -1,0 +1,181 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Compile-only coverage for the example flash-attention kernels.
+
+use cutile;
+use cutile::compile_api::KernelCompiler;
+
+mod common;
+
+#[cutile::module]
+mod flash_attention_compile_module {
+    use cutile::core::*;
+
+    #[cutile::entry(
+        unchecked_accesses = false,
+        optimization_hints = (
+            sm_120 = (num_cta_in_cga = 1, max_divisibility = 16,),
+        )
+    )]
+    fn fmha<
+        const BM: i32,
+        const BN: i32,
+        const D: i32,
+        const H: i32,
+        const CAUSAL: i32,
+        const EVEN_K: i32,
+    >(
+        out: &mut Tensor<f32, { [1, BM, D] }>,
+        q: &Tensor<f32, { [-1, -1, -1, -1] }>,
+        k: &Tensor<f32, { [-1, -1, -1, -1] }>,
+        v: &Tensor<f32, { [-1, -1, -1, -1] }>,
+        qk_scale: f32,
+        input_pos: i32,
+        query_group_size: i32,
+    ) {
+        let pid: (i32, i32, i32) = get_tile_block_id();
+        let batch_idx = pid.0 / H;
+        let q_head_idx = pid.0 % H;
+        let q_m_idx = pid.1;
+        let kv_head_idx = q_head_idx / query_group_size;
+
+        let two: Tile<f32, { [] }> = constant(2.0f32, const_shape![]);
+        let log2: f32 = tile_to_scalar(log(two));
+        let qk_scale: Tile<f32, { [BM, BN] }> =
+            broadcast_scalar(qk_scale / log2, const_shape![BM, BN]);
+
+        let mut m_i: Tile<f32, { [BM, 1] }> = constant(f32::NEG_INFINITY, const_shape![BM, 1]);
+        let mut l_i: Tile<f32, { [BM, 1] }> = constant(0.0f32, const_shape![BM, 1]);
+        let mut acc: Tile<f32, { [BM, D] }> = constant(0.0f32, const_shape![BM, D]);
+
+        let q_part: Partition<f32, { [1, 1, BM, D] }> = q.partition(const_shape![1, 1, BM, D]);
+        let tq: Tile<f32, { [BM, D] }> = q_part
+            .load([batch_idx, q_head_idx, q_m_idx, 0i32])
+            .reshape(const_shape![BM, D]);
+
+        let k_seqlen: i32 = get_shape_dim(k.shape(), 2i32);
+        let m_end: i32 = input_pos + (q_m_idx + 1i32) * BM;
+        let mut mask_start: i32 = k_seqlen / BN;
+        let mut tc: i32 = ceil_div(k_seqlen, BN);
+        if CAUSAL == 1i32 {
+            mask_start = (input_pos + q_m_idx * BM) / BN;
+            let k_seqlen_tiles = k_seqlen / BN;
+            mask_start = min(mask_start, k_seqlen_tiles);
+            tc = ceil_div(min(m_end, k_seqlen), BN);
+        }
+
+        let k_part = k.partition(const_shape![1, 1, BN, D]);
+        let v_part = v.partition(const_shape![1, 1, BN, D]);
+        let transpose: Array<{ [1, 0] }> = Array::<{ [1, 0] }> {
+            dims: &[1i32, 0i32],
+        };
+
+        let offs_n_tile: Tile<i32, { [BN] }> = iota(const_shape![BN]);
+        let offs_n_tile: Tile<i32, { [BM, BN] }> = offs_n_tile
+            .reshape(const_shape![1, BN])
+            .broadcast(const_shape![BM, BN]);
+
+        let offs_m_iota: Tile<i32, { [BM] }> = iota(const_shape![BM]);
+        let offs_m_iota = offs_m_iota.reshape(const_shape![BM, 1]);
+        let offs_m: Tile<i32, { [BM, 1] }> =
+            broadcast_scalar(q_m_idx * BM + input_pos, const_shape![BM, 1]) + offs_m_iota;
+        let offs_m: Tile<i32, { [BM, BN] }> = offs_m.broadcast(const_shape![BM, BN]);
+        let k_seqlen_tile: Tile<i32, { [BM, BN] }> = k_seqlen.broadcast(const_shape![BM, BN]);
+        let mask_true: Tile<f32, { [BM, BN] }> = constant(0.0f32, const_shape![BM, BN]);
+        let mask_false: Tile<f32, { [BM, BN] }> = constant(f32::NEG_INFINITY, const_shape![BM, BN]);
+
+        for j in 0i32..tc {
+            let k_tile: Tile<f32, { [BN, D] }> = k_part
+                .load([batch_idx, kv_head_idx, j, 0i32])
+                .reshape(const_shape![BN, D]);
+            let k_tile_trans: Tile<f32, { [D, BN] }> = permute(k_tile, transpose);
+            let mut qk: Tile<f32, { [BM, BN] }> = constant(0.0f32, const_shape![BM, BN]);
+            qk = mma(tq, k_tile_trans, qk);
+
+            if (CAUSAL == 1i32 || EVEN_K == 0i32) && j >= mask_start {
+                let offs_n: Tile<i32, { [BM, BN] }> =
+                    broadcast_scalar(j * BN, const_shape![BM, BN]) + offs_n_tile;
+                let mut mask: Tile<bool, { [BM, BN] }> = constant(true, const_shape![BM, BN]);
+                if EVEN_K == 0i32 {
+                    let lt_res: Tile<bool, { [BM, BN] }> = lt_tile(offs_n, k_seqlen_tile);
+                    mask = mask & lt_res;
+                }
+                if CAUSAL == 1i32 {
+                    let ge_res: Tile<bool, { [BM, BN] }> = ge_tile(offs_m, offs_n);
+                    mask = mask & ge_res;
+                }
+                qk = qk + select(mask, mask_true, mask_false);
+            }
+
+            qk = qk * qk_scale;
+            let qk_max: Tile<f32, { [BM] }> = reduce_max(qk, 1);
+            let qk_max: Tile<f32, { [BM, 1] }> = qk_max.reshape(const_shape![BM, 1]);
+            let m_ij: Tile<f32, { [BM, 1] }> = max_tile(m_i, qk_max);
+            let qk = qk - m_ij.broadcast(const_shape![BM, BN]);
+
+            let p: Tile<f32, { [BM, BN] }> = exp2(qk, ftz::Disabled);
+            let l_ij: Tile<f32, { [BM] }> = reduce_sum(p, 1);
+            let l_ij: Tile<f32, { [BM, 1] }> = l_ij.reshape(const_shape![BM, 1]);
+            let alpha: Tile<f32, { [BM, 1] }> = exp2(m_i - m_ij, ftz::Disabled);
+            l_i = l_i * alpha + l_ij;
+            acc = acc * alpha.broadcast(const_shape![BM, D]);
+
+            let v_tile: Tile<f32, { [BN, D] }> = v_part
+                .load([batch_idx, kv_head_idx, j, 0i32])
+                .reshape(const_shape![BN, D]);
+            acc = mma(p, v_tile, acc);
+            m_i = m_ij;
+        }
+
+        out.store(
+            true_div(acc, l_i.broadcast(const_shape![BM, D])).reshape(const_shape![1, BM, D]),
+        );
+    }
+}
+
+use flash_attention_compile_module::__module_ast_self;
+
+#[test]
+fn compile_flash_attention_causal_example() {
+    common::with_test_stack(|| {
+        let artifacts =
+            KernelCompiler::new(__module_ast_self, "flash_attention_compile_module", "fmha")
+                .generics(vec![
+                    "32".to_string(),
+                    "32".to_string(),
+                    "32".to_string(),
+                    "8".to_string(),
+                    "1".to_string(),
+                    "1".to_string(),
+                ])
+                .strides(&[
+                    ("out", &[1024, 32, 1]),
+                    ("q", &[16384, 2048, 32, 1]),
+                    ("k", &[16384, 2048, 32, 1]),
+                    ("v", &[16384, 2048, 32, 1]),
+                ])
+                .target("sm_120")
+                .compile()
+                .expect("Failed to compile");
+
+        let ir = artifacts.ir_text();
+        assert!(ir.contains("mma"), "expected MMA op in IR.\nIR:\n{ir}");
+        assert!(
+            ir.contains("store_view_tko"),
+            "expected output store op in IR.\nIR:\n{ir}"
+        );
+
+        let bytecode = artifacts
+            .bytecode()
+            .expect("bytecode serialization should succeed");
+        assert!(!bytecode.is_empty(), "expected non-empty bytecode");
+        assert_eq!(
+            &bytecode[..8],
+            &[0x7F, b'T', b'i', b'l', b'e', b'I', b'R', 0x00],
+            "expected TileIR bytecode magic"
+        );
+    });
+}

--- a/cutile/tests/global_memory.rs
+++ b/cutile/tests/global_memory.rs
@@ -1,0 +1,134 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+use cutile;
+use cutile_compiler::compiler::utils::CompileOptions;
+use cutile_compiler::compiler::{CUDATileFunctionCompiler, CUDATileModules};
+
+mod common;
+
+#[cutile::module]
+mod global_memory_module {
+    use cutile::core::*;
+
+    const INITIAL_COUNTER: i32 = 7;
+
+    static COUNTER: Global<i32, { [] }> = Global::new(INITIAL_COUNTER);
+    static FLOAT_ACCUM: Global<f32, { [] }> = Global::new(0.0f32);
+
+    #[cutile::entry()]
+    fn load_global_kernel(out: &mut Tensor<i32, { [1] }>) {
+        let (value, _token) = COUNTER.load(ordering::Acquire, scope::Device);
+        out.store(value.reshape(const_shape![1]));
+    }
+
+    #[cutile::entry()]
+    fn store_global_kernel(out: &mut Tensor<i32, { [1] }>) {
+        let value = constant(3i32, const_shape![]);
+        let _token = COUNTER.store(value, ordering::Release, scope::Device);
+        out.store(value.reshape(const_shape![1]));
+    }
+
+    #[cutile::entry()]
+    fn atomic_add_global_kernel(out: &mut Tensor<f32, { [1] }>) {
+        let increment = constant(1.0f32, const_shape![]);
+        let (old, _token) = FLOAT_ACCUM.atomic_add(increment, ordering::AcqRel, scope::Device);
+        out.store(old.reshape(const_shape![1]));
+    }
+}
+
+#[cutile::module]
+mod bad_static_module {
+    use cutile::core::*;
+
+    static BAD_STATIC: i32 = 0;
+
+    #[cutile::entry()]
+    fn kernel(out: &mut Tensor<i32, { [1] }>) {
+        let value = constant(1i32, const_shape![1]);
+        out.store(value);
+    }
+}
+
+use bad_static_module::__module_ast_self as bad_static_module_ast;
+use global_memory_module::__module_ast_self as global_memory_module_ast;
+
+fn compile_global_kernel(name: &str) -> String {
+    let modules = CUDATileModules::from_kernel(global_memory_module_ast())
+        .expect("Failed to create CUDATileModules");
+    let compiler = CUDATileFunctionCompiler::new(
+        &modules,
+        "global_memory_module",
+        name,
+        &[],
+        &[("out", &[1])],
+        &[],
+        &[],
+        None,
+        "sm_120".to_string(),
+        &CompileOptions::default(),
+    )
+    .expect("Failed to create compiler.");
+    compiler.compile().expect("Failed to compile.").to_string()
+}
+
+#[test]
+fn global_load_lowers_to_get_global_and_load_ptr() {
+    common::with_test_stack(|| {
+        let mlir = compile_global_kernel("load_global_kernel");
+        assert!(mlir.contains("cuda_tile.global @global_memory_module_COUNTER"));
+        assert!(mlir.contains("tile<1xi32>"));
+        assert!(mlir.contains("get_global @global_memory_module_COUNTER"));
+        assert!(mlir.contains("load_ptr_tko"));
+        assert!(mlir.contains("load_ptr_tko acquire device"));
+    });
+}
+
+#[test]
+fn global_store_lowers_to_get_global_and_store_ptr() {
+    common::with_test_stack(|| {
+        let mlir = compile_global_kernel("store_global_kernel");
+        assert!(mlir.contains("cuda_tile.global @global_memory_module_COUNTER"));
+        assert!(mlir.contains("tile<1xi32>"));
+        assert!(mlir.contains("get_global @global_memory_module_COUNTER"));
+        assert!(mlir.contains("store_ptr_tko"));
+        assert!(mlir.contains("store_ptr_tko release device"));
+    });
+}
+
+#[test]
+fn global_atomic_add_lowers_to_atomic_rmw() {
+    common::with_test_stack(|| {
+        let mlir = compile_global_kernel("atomic_add_global_kernel");
+        assert!(mlir.contains("cuda_tile.global @global_memory_module_FLOAT_ACCUM"));
+        assert!(mlir.contains("tile<1xf32>"));
+        assert!(mlir.contains("get_global @global_memory_module_FLOAT_ACCUM"));
+        assert!(mlir.contains("atomic_rmw_tko"));
+        assert!(mlir.contains("atomic_rmw_tko acq_rel device"));
+    });
+}
+
+#[test]
+fn non_global_static_is_rejected() {
+    common::with_test_stack(|| {
+        let modules = CUDATileModules::from_kernel(bad_static_module_ast())
+            .expect("Failed to create CUDATileModules");
+        let compiler = CUDATileFunctionCompiler::new(
+            &modules,
+            "bad_static_module",
+            "kernel",
+            &[],
+            &[("out", &[1])],
+            &[],
+            &[],
+            None,
+            "sm_120".to_string(),
+            &CompileOptions::default(),
+        )
+        .expect("Failed to create compiler.");
+        let err = compiler.compile().expect_err("expected static rejection");
+        let msg = err.to_string();
+        assert!(msg.contains("only `static NAME: Global<E, { [] }>` items are supported"));
+    });
+}

--- a/cutile/tests/gpu/error_quality.rs
+++ b/cutile/tests/gpu/error_quality.rs
@@ -11,6 +11,8 @@ use cutile_compiler::compiler::utils::CompileOptions;
 use cutile_compiler::compiler::{CUDATileFunctionCompiler, CUDATileModules};
 use cutile_compiler::cuda_tile_runtime_utils::get_gpu_name;
 use cutile_compiler::error::JITError;
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
 
 use crate::common;
 
@@ -64,13 +66,53 @@ fn assert_display_eq_debug_jit(err: &JITError, context: &str) {
     );
 }
 
+fn unsupported_dsl_call() -> i32 {
+    0
+}
+
 #[cutile::module]
 mod error_quality_untyped_literal {
     use cutile::core::*;
 
     #[cutile::entry()]
     fn untyped_kernel<const S: [i32; 1]>(output: &mut Tensor<f32, S>) {
-        let _x = 42;
+        let _x = super::unsupported_dsl_call();
+        let tile = load_tile_mut(output);
+        output.store(tile);
+    }
+}
+
+#[cutile::module]
+mod error_quality_same_module_inline {
+    use cutile::core::*;
+
+    fn same_module_bad_helper() {
+        let _same_module_literal = super::unsupported_dsl_call();
+    }
+
+    #[cutile::entry()]
+    fn caller<const S: [i32; 1]>(output: &mut Tensor<f32, S>) {
+        same_module_bad_helper();
+        let tile = load_tile_mut(output);
+        output.store(tile);
+    }
+}
+
+#[cutile::module]
+mod error_quality_linked_helper {
+    pub fn linked_bad_helper() {
+        let _linked_module_literal = super::unsupported_dsl_call();
+    }
+}
+
+#[cutile::module]
+mod error_quality_linked_caller {
+    use crate::error_quality::error_quality_linked_helper::linked_bad_helper;
+    use cutile::core::*;
+
+    #[cutile::entry()]
+    fn caller<const S: [i32; 1]>(output: &mut Tensor<f32, S>) {
+        linked_bad_helper();
         let tile = load_tile_mut(output);
         output.store(tile);
     }
@@ -103,6 +145,62 @@ fn compile_and_get_error(kernel: Module, module_name: &str, function_name: &str)
     })
 }
 
+fn line_containing(needle: &str) -> usize {
+    include_str!("error_quality.rs")
+        .lines()
+        .enumerate()
+        .find(|(_, line)| line.contains(needle))
+        .map(|(idx, _)| idx + 1)
+        .unwrap_or_else(|| panic!("could not find `{needle}` in error_quality.rs"))
+}
+
+fn assert_located_line(err: &JITError, expected_line: usize, context: &str) {
+    match err {
+        JITError::Located(_msg, loc) => {
+            assert!(
+                loc.is_known(),
+                "{context}: expected a known source location"
+            );
+            assert!(
+                loc.file.ends_with("gpu/error_quality.rs"),
+                "{context}: expected gpu/error_quality.rs, got {}",
+                loc.file
+            );
+            assert_eq!(loc.line, expected_line, "{context}: {err}");
+            assert!(loc.column > 0, "{context}: expected non-zero column");
+        }
+        _ => panic!("{context}: expected a Located JIT error, got: {err}"),
+    }
+}
+
+fn call_line_in_module(kernel: &Module, call_name: &str) -> Option<usize> {
+    struct CallFinder<'a> {
+        call_name: &'a str,
+        line: Option<usize>,
+        kernel: &'a Module,
+    }
+
+    impl<'ast> Visit<'ast> for CallFinder<'_> {
+        fn visit_expr_call(&mut self, call: &'ast syn::ExprCall) {
+            if let syn::Expr::Path(path) = &*call.func {
+                if path.path.is_ident(self.call_name) {
+                    self.line = Some(self.kernel.resolve_span(&call.span()).line);
+                    return;
+                }
+            }
+            visit::visit_expr_call(self, call);
+        }
+    }
+
+    let mut finder = CallFinder {
+        call_name,
+        line: None,
+        kernel,
+    };
+    finder.visit_item_mod(kernel.ast());
+    finder.line
+}
+
 #[test]
 fn untyped_literal_error_message_quality() {
     common::with_test_stack(|| {
@@ -124,6 +222,7 @@ fn untyped_literal_error_message_quality() {
                 || display.contains("type")
                 || display.contains("annotation")
                 || display.contains("literal")
+                || display.contains("unsupported")
         );
 
         match &err {
@@ -144,6 +243,49 @@ fn untyped_literal_error_message_quality() {
         let outer: cutile::error::Error = err.into();
         let outer_display = format!("{outer}");
         assert_single_error_prefix(&outer_display, "untyped literal (outer)");
+    });
+}
+
+#[test]
+fn linked_caller_ast_call_span_points_to_call_line() {
+    let kernel = error_quality_linked_caller::__module_ast_self();
+    assert_eq!(
+        call_line_in_module(&kernel, "linked_bad_helper"),
+        Some(line_containing("linked_bad_helper();"))
+    );
+}
+
+#[test]
+fn same_module_inline_error_location_points_to_helper_body() {
+    common::with_test_stack(|| {
+        let err = compile_and_get_error(
+            error_quality_same_module_inline::__module_ast_self(),
+            "error_quality_same_module_inline",
+            "caller",
+        );
+
+        assert_located_line(
+            &err,
+            line_containing("let _same_module_literal = super::unsupported_dsl_call();"),
+            "same-module inline helper",
+        );
+    });
+}
+
+#[test]
+fn linked_inline_error_location_points_to_call_site() {
+    common::with_test_stack(|| {
+        let err = compile_and_get_error(
+            error_quality_linked_caller::__module_ast_self(),
+            "error_quality_linked_caller",
+            "caller",
+        );
+
+        assert_located_line(
+            &err,
+            line_containing("linked_bad_helper();"),
+            "linked inline helper",
+        );
     });
 }
 
@@ -171,7 +313,7 @@ fn untyped_literal_error_location_points_to_this_file() {
                     .enumerate()
                     .find(|(_, line)| {
                         let trimmed = line.trim_start();
-                        trimmed.starts_with("let _x = 42;")
+                        trimmed.starts_with("let _x = super::unsupported_dsl_call();")
                     })
                     .map(|(idx, _)| idx + 1);
 

--- a/cutile/tests/span_source_location.rs
+++ b/cutile/tests/span_source_location.rs
@@ -40,8 +40,12 @@ use cutile_compiler::error::JITError;
 
 mod common;
 
+fn unsupported_dsl_call() -> i32 {
+    0
+}
+
 // ---------------------------------------------------------------------------
-// Test 1 – Comment-free module: untyped numeric literal produces a Located
+// Test 1 – Comment-free module: unsupported DSL expression produces a Located
 //           error with the EXACT source file, line number, and column number.
 // ---------------------------------------------------------------------------
 //
@@ -54,7 +58,7 @@ mod span_error_module {
     use cutile::core::*;
     #[cutile::entry()]
     fn untyped_literal_kernel<const S: [i32; 1]>(output: &mut Tensor<f32, S>) {
-        let _x = 42;
+        let _x = super::unsupported_dsl_call();
         let tile = load_tile_mut(output);
         output.store(tile);
     }
@@ -87,12 +91,14 @@ fn untyped_literal_error_has_correct_source_location() {
         let err = match compile_result {
             Err(e) => e,
             Ok(_) => {
-                panic!("Expected compilation to fail for an untyped literal, but it succeeded.")
+                panic!(
+                    "Expected compilation to fail for an unsupported DSL call, but it succeeded."
+                )
             }
         };
 
         let err_string = format!("{err}");
-        println!("\n=== UNTYPED LITERAL ERROR ===\n{err_string}");
+        println!("\n=== UNSUPPORTED DSL CALL ERROR ===\n{err_string}");
 
         // The error must be a Located variant carrying a real source location.
         match &err {
@@ -109,7 +115,7 @@ fn untyped_literal_error_has_correct_source_location() {
                     loc.file
                 );
 
-                // Find the expected line for `let _x = 42;` by scanning this
+                // Find the expected line for the unsupported helper call by scanning this
                 // file's own source text.  This avoids hard-coding a line
                 // number that would break whenever the file is edited.
                 let source = include_str!("span_source_location.rs");
@@ -121,33 +127,33 @@ fn untyped_literal_error_has_correct_source_location() {
                     // comments contain `//` or `///` before it.
                     .find(|(_, line)| {
                         let trimmed = line.trim_start();
-                        trimmed.starts_with("let _x = 42;")
+                        trimmed.starts_with("let _x = super::unsupported_dsl_call();")
                     })
                     .map(|(idx, _)| idx + 1) // 1-indexed
-                    .expect("Could not find 'let _x = 42;' marker in test source");
+                    .expect("Could not find unsupported helper call marker in test source");
 
                 assert_eq!(
                     loc.line, expected_line,
-                    "Expected error on line {expected_line} ('let _x = 42;'), got line {}",
+                    "Expected error on line {expected_line} ('let _x = super::unsupported_dsl_call();'), got line {}",
                     loc.line
                 );
 
-                // Column: should point to `42`, which comes after `let _x = `.
+                // Column: should point into the unsupported call.
                 // We verify it is non-zero and plausible.
                 assert!(
                     loc.column > 0,
-                    "Expected a non-zero column for the literal, got {}",
+                    "Expected a non-zero column for the unsupported call, got {}",
                     loc.column
                 );
 
-                // The error message should mention the literal.
+                // The error message should mention the unsupported call.
                 assert!(
-                    msg.contains("42"),
-                    "Expected error message to mention the literal '42', got: {msg}"
+                    msg.contains("unsupported_dsl_call") || msg.contains("not supported"),
+                    "Expected error message to mention the unsupported call, got: {msg}"
                 );
 
                 println!(
-                    "\n✓ Untyped literal error correctly located at {}:{}:{}\n  message: {msg}",
+                    "\n✓ Unsupported DSL call error correctly located at {}:{}:{}\n  message: {msg}",
                     loc.file, loc.line, loc.column
                 );
             }
@@ -167,7 +173,7 @@ fn untyped_literal_error_has_correct_source_location() {
 // should be exact even with comments everywhere.  We verify:
 //   a) The error is a Located variant with a known source location.
 //   b) The file path is correct.
-//   c) The reported line matches the EXACT line of `let _y = 99;`.
+//   c) The reported line matches the EXACT line of the unsupported helper call.
 //   d) The column is non-zero.
 
 // A comment OUTSIDE the macro — shifts the module's base_line but must not
@@ -196,7 +202,7 @@ mod span_comments_module {
     ) {
         // Comment inside body.
         // Yet another comment.
-        let _y = 99;
+        let _y = super::unsupported_dsl_call();
         let tile = load_tile_mut(output);
         output.store(tile);
     }
@@ -227,7 +233,7 @@ fn comments_do_not_break_span_tracking() {
         let err = match compile_result {
             Err(e) => e,
             Ok(_) => panic!(
-                "Expected compilation to fail for an untyped literal inside \
+                "Expected compilation to fail for an unsupported DSL call inside \
                  commented module, but it succeeded."
             ),
         };
@@ -252,7 +258,7 @@ fn comments_do_not_break_span_tracking() {
                 );
 
                 // (c) The reported line must EXACTLY match the line containing
-                //     `let _y = 99;`.  Because `Span::source_text()` preserves
+                //     the unsupported helper call. Because `Span::source_text()` preserves
                 //     comments in the captured text, the span-base arithmetic
                 //     produces the correct absolute line even when comments
                 //     appear inside the module body.
@@ -263,14 +269,14 @@ fn comments_do_not_break_span_tracking() {
                     // Match the actual code line, not comments that mention it.
                     .find(|(_, line)| {
                         let trimmed = line.trim_start();
-                        trimmed.starts_with("let _y = 99;")
+                        trimmed.starts_with("let _y = super::unsupported_dsl_call();")
                     })
                     .map(|(idx, _)| idx + 1)
-                    .expect("Could not find 'let _y = 99;' marker in test source");
+                    .expect("Could not find unsupported helper call marker in test source");
 
                 assert_eq!(
                     loc.line, expected_line,
-                    "Expected error on line {expected_line} ('let _y = 99;'), got line {}.\n\
+                    "Expected error on line {expected_line} ('let _y = super::unsupported_dsl_call();'), got line {}.\n\
                      Comments should NOT affect line numbers when source_text() is used.",
                     loc.line
                 );
@@ -282,10 +288,10 @@ fn comments_do_not_break_span_tracking() {
                     loc.column
                 );
 
-                // The error message should reference the literal value.
+                // The error message should reference the unsupported call.
                 assert!(
-                    msg.contains("99"),
-                    "Expected error message to reference '99', got: {msg}"
+                    msg.contains("unsupported_dsl_call") || msg.contains("not supported"),
+                    "Expected error message to reference the unsupported call, got: {msg}"
                 );
 
                 println!(

--- a/cutile/tests/type_inference_sanity.rs
+++ b/cutile/tests/type_inference_sanity.rs
@@ -1,0 +1,1365 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+use cutile;
+use cutile_compiler::compiler::utils::CompileOptions;
+use cutile_compiler::compiler::{CUDATileFunctionCompiler, CUDATileModules};
+
+mod common;
+
+#[cutile::module]
+mod type_inference_sanity_module {
+    use cutile::core::*;
+
+    const GLOBAL_DIM: i32 = 4;
+    const GLOBAL_FLAG: bool = true;
+    const GLOBAL_SCALE: f32 = 1.0;
+
+    struct TileCarrier {
+        tile: Tile<f32, { [4] }>,
+    }
+
+    trait AutorefTrait {
+        fn trait_by_ref(&self) -> i64;
+        fn trait_by_mut(&mut self) -> i64;
+    }
+
+    impl AutorefTrait for Tensor<f32, { [4] }> {
+        fn trait_by_ref(&self) -> i64 {
+            0i64
+        }
+
+        fn trait_by_mut(&mut self) -> i64 {
+            0i64
+        }
+    }
+
+    trait HasI64Const {
+        const VALUE: i64;
+    }
+
+    struct AssocConstHost;
+
+    impl HasI64Const for AssocConstHost {
+        const VALUE: i64 = 7;
+    }
+
+    fn expect_i64(value: i64) -> i64 {
+        value
+    }
+
+    fn expect_u32(value: u32) -> u32 {
+        value
+    }
+
+    fn expect_f32(value: f32) -> f32 {
+        value
+    }
+
+    fn expect_tile_f32x4(tile: Tile<f32, { [4] }>) -> Tile<f32, { [4] }> {
+        tile
+    }
+
+    fn expect_option_tile_f32x4(value: Option<Tile<f32, { [4] }>>) -> Option<Tile<f32, { [4] }>> {
+        value
+    }
+
+    type TensorAlias = Tensor<f32, { [4] }>;
+    type DynamicTensorAlias = Tensor<f32, { [-1] }>;
+    type ScalarAlias = i32;
+    type PtrAlias = *mut f32;
+
+    fn signature_closure_probe<E: ElementType, F>(tile: Tile<E, { [4] }>, _f: F) -> Tile<E, { [4] }>
+    where
+        F: Fn(E, E) -> E,
+    {
+        tile
+    }
+
+    #[cutile::entry()]
+    fn unsafe_block_tail_store_kernel(
+        source: &Tensor<f32, { [-1, -1, 8] }>,
+        out: &mut Tensor<f32, { [1, 4, 8] }>,
+        seq_len: i32,
+    ) {
+        let pid: (i32, i32, i32) = get_tile_block_id();
+        let source_part = source.partition(const_shape![1, 1, 8]);
+        let mut out_part = unsafe { out.partition_mut(const_shape![1, 1, 8]) };
+        let s_start: i32 = pid.1 * 4i32;
+        if s_start < seq_len {
+            for s_local in 0i32..4i32 {
+                let s_global: i32 = s_start + s_local;
+                if s_global < seq_len {
+                    let tile = source_part
+                        .load([s_global, pid.0, pid.2])
+                        .reshape(const_shape![1, 1, 8]);
+                    unsafe { out_part.store(tile, [0i32, s_local, 0i32]) };
+                }
+            }
+        }
+    }
+
+    #[cutile::entry()]
+    fn if_tail_method_chain_kernel(
+        source: &Tensor<f32, { [-1, -1, 8] }>,
+        out: &mut Tensor<f32, { [1, 1, 8] }>,
+        flag: i32,
+    ) {
+        let pid: (i32, i32, i32) = get_tile_block_id();
+        let source_part = source.partition(const_shape![1, 1, 8]);
+        let tile = if flag > 0i32 {
+            source_part
+                .load([pid.0, pid.1, pid.2])
+                .reshape(const_shape![1, 1, 8])
+        } else {
+            source_part
+                .load([pid.0, pid.1, pid.2])
+                .reshape(const_shape![1, 1, 8])
+        };
+        out.store(tile);
+    }
+
+    #[cutile::entry()]
+    fn struct_literal_field_kernel(out: &mut Tensor<f32, { [4] }>) {
+        let carrier = TileCarrier {
+            tile: constant(1.0f32, const_shape![4]),
+        };
+        out.store(carrier.tile);
+    }
+
+    #[cutile::entry()]
+    fn tuple_destructure_method_chain_kernel(
+        source: &Tensor<f32, { [-1] }>,
+        out: &mut Tensor<f32, { [4] }>,
+    ) {
+        let part = source.partition(const_shape![4]);
+        let pair = (
+            part.load([0i32]).reshape(const_shape![4]),
+            part.load([1i32]).reshape(const_shape![4]),
+        );
+        let (first, _second) = pair;
+        out.store(first);
+    }
+
+    #[cutile::entry()]
+    fn index_result_method_arg_kernel(out: &mut Tensor<f32, { [4] }>) {
+        let values = [0i32, 1i32, 2i32];
+        let idx = values[1];
+        let tile = constant(1.0f32, const_shape![4]);
+        let mut out_part = unsafe { out.partition_mut(const_shape![4]) };
+        unsafe { out_part.store(tile, [idx]) };
+    }
+
+    #[cutile::entry()]
+    fn step_by_loop_local_kernel(out: &mut Tensor<f32, { [4] }>) {
+        let mut out_part = unsafe { out.partition_mut(const_shape![4]) };
+        for i in (0i32..4i32).step_by(1) {
+            let tile = constant(1.0f32, const_shape![4]);
+            unsafe { out_part.store(tile, [i]) };
+        }
+    }
+
+    #[cutile::entry()]
+    fn step_by_cast_usize_kernel(out: &mut Tensor<f32, { [4] }>) {
+        let mut out_part = unsafe { out.partition_mut(const_shape![4]) };
+        let step = 1i32;
+        for i in (0i32..4i32).step_by(step as usize) {
+            let tile = constant(1.0f32, const_shape![4]);
+            unsafe { out_part.store(tile, [i]) };
+        }
+    }
+
+    #[cutile::entry()]
+    fn if_else_never_join_kernel(out: &mut Tensor<f32, { [4] }>, flag: i32) {
+        let tile = if flag > 0i32 {
+            return;
+        } else {
+            constant(1.0f32, const_shape![4])
+        };
+        out.store(tile);
+    }
+
+    #[cutile::entry()]
+    fn unsuffixed_literal_context_kernel(
+        source: &Tensor<f32, { [-1] }>,
+        out: &mut Tensor<f32, { [4] }>,
+        flag: i32,
+    ) {
+        let part = source.partition(const_shape![4]);
+        let mut out_part = unsafe { out.partition_mut(const_shape![4]) };
+        let default_int = 7;
+        let default_float = 3.0;
+        let _default_int_tile: Tile<i32, { [] }> = scalar_to_tile(default_int);
+        let _default_float_tile: Tile<f64, { [] }> = scalar_to_tile(default_float);
+        for i in 0..4 {
+            let indices = [0, i, 2];
+            let idx = indices[1];
+            let tile: Tile<f32, { [4] }> = if 0 < flag {
+                constant(1.0, const_shape![4])
+            } else {
+                part.load([idx])
+            };
+            unsafe { out_part.store(tile, [idx]) };
+        }
+    }
+
+    #[cutile::entry()]
+    fn backward_literal_constraints_kernel(out: &mut Tensor<f32, { [4] }>) {
+        let int_lit = 0;
+        let int_alias = int_lit;
+        let _resolved_i64 = expect_i64(int_alias);
+
+        let float_lit = 1.0;
+        let float_alias = float_lit;
+        let resolved_f32 = expect_f32(float_alias);
+        let _resolved_f32_tile: Tile<f32, { [] }> = scalar_to_tile(resolved_f32);
+
+        let tile = constant(1.0, const_shape![4]);
+        let tile = expect_tile_f32x4(tile);
+        out.store(tile);
+    }
+
+    #[cutile::entry()]
+    fn var_to_var_binary_constraints_kernel(out: &mut Tensor<f32, { [4] }>) {
+        let lhs = 0;
+        let rhs = 1;
+        let _sum = lhs + rhs;
+        let _resolved_lhs = expect_i64(lhs);
+
+        let tile = constant(1.0f32, const_shape![4]);
+        out.store(tile);
+    }
+
+    #[cutile::entry()]
+    fn var_to_var_branch_constraints_kernel(out: &mut Tensor<f32, { [4] }>, flag: bool) {
+        let lhs = 0;
+        let rhs = 1;
+        let _joined = if flag { lhs } else { rhs };
+        let _resolved_lhs = expect_i64(lhs);
+
+        let tile = constant(1.0f32, const_shape![4]);
+        out.store(tile);
+    }
+
+    #[cutile::entry()]
+    fn if_join_direct_expr_constraints_kernel(out: &mut Tensor<f32, { [4] }>, flag: bool) {
+        let lhs = 0;
+        let _pair = (if flag { lhs } else { 1i64 }, 2i64);
+
+        let tile = constant(1.0f32, const_shape![4]);
+        out.store(tile);
+    }
+
+    #[cutile::entry()]
+    fn if_join_diverging_branch_constraints_kernel(out: &mut Tensor<f32, { [4] }>, flag: bool) {
+        let _pair = (
+            if flag {
+                return;
+            } else {
+                1i64
+            },
+            2i64,
+        );
+
+        let tile = constant(1.0f32, const_shape![4]);
+        out.store(tile);
+    }
+
+    #[cutile::entry()]
+    fn inline_array_index_backward_constraints_kernel(out: &mut Tensor<f32, { [4] }>) {
+        let idx = [0, 1][0];
+        let _resolved_idx = expect_i64(idx);
+
+        let tile = constant(1.0f32, const_shape![4]);
+        out.store(tile);
+    }
+
+    #[cutile::entry()]
+    fn local_array_index_backward_constraints_kernel(out: &mut Tensor<f32, { [4] }>) {
+        let values = [0, 1];
+        let idx = values[0];
+        let _resolved_idx = expect_i64(idx);
+
+        let tile = constant(1.0f32, const_shape![4]);
+        out.store(tile);
+    }
+
+    #[cutile::entry()]
+    fn repeat_array_index_backward_constraints_kernel(out: &mut Tensor<f32, { [4] }>) {
+        let values = [0; 2];
+        let idx = values[0];
+        let _resolved_idx = expect_i64(idx);
+
+        let tile = constant(1.0f32, const_shape![4]);
+        out.store(tile);
+    }
+
+    #[cutile::entry()]
+    fn inline_tuple_field_backward_constraints_kernel(out: &mut Tensor<f32, { [4] }>) {
+        let idx = (0,).0;
+        let _resolved_idx = expect_i64(idx);
+
+        let tile = constant(1.0f32, const_shape![4]);
+        out.store(tile);
+    }
+
+    #[cutile::entry()]
+    fn local_tuple_field_backward_constraints_kernel(out: &mut Tensor<f32, { [4] }>) {
+        let pair = (0,);
+        let idx = pair.0;
+        let _resolved_idx = expect_i64(idx);
+
+        let tile = constant(1.0f32, const_shape![4]);
+        out.store(tile);
+    }
+
+    #[allow(unused_assignments)]
+    #[cutile::entry()]
+    fn assignment_backward_constraints_kernel(out: &mut Tensor<f32, { [4] }>) {
+        let mut idx = 0;
+        idx = 1i64;
+        let _resolved_idx = expect_i64(idx);
+
+        let tile = constant(1.0f32, const_shape![4]);
+        out.store(tile);
+    }
+
+    #[cutile::entry()]
+    fn assignment_accumulator_constraints_kernel(out: &mut Tensor<f32, { [4] }>) {
+        let mut acc = 0.0;
+        let update = expect_f32(1.0);
+        acc = acc + update;
+        let resolved_acc = expect_f32(acc);
+        let _acc_tile: Tile<f32, { [] }> = scalar_to_tile(resolved_acc);
+
+        let tile = constant(1.0f32, const_shape![4]);
+        out.store(tile);
+    }
+
+    #[cutile::entry()]
+    fn cast_result_type_kernel(out: &mut Tensor<f32, { [4] }>) {
+        let idx = 0i32 as u32;
+        let _resolved_idx = expect_u32(idx);
+
+        let tile = constant(1.0f32, const_shape![4]);
+        out.store(tile);
+    }
+
+    #[cutile::entry()]
+    fn bool_condition_context_kernel(out: &mut Tensor<f32, { [4] }>) {
+        let idx = 0;
+        let flag = idx < 1i64;
+        if flag && true {
+            let _resolved_idx = expect_i64(idx);
+        }
+
+        let tile = constant(1.0f32, const_shape![4]);
+        out.store(tile);
+    }
+
+    #[cutile::entry()]
+    fn reduce_closure_body_typeck_kernel(out: &mut Tensor<f32, { [4] }>) {
+        let tile = constant(1.0f32, const_shape![4]);
+        let _sum = reduce(tile, 0i32, 0.0f32, |acc, x| {
+            let y = acc + x;
+            y
+        });
+        out.store(tile);
+    }
+
+    #[cutile::entry()]
+    fn signature_driven_closure_typeck_kernel(out: &mut Tensor<f32, { [4] }>) {
+        let tile = constant(1.0f32, const_shape![4]);
+        let _same = signature_closure_probe(tile, |acc, x| {
+            let y = acc + x;
+            y
+        });
+        out.store(tile);
+    }
+
+    #[cutile::entry()]
+    fn while_loop_body_method_selection_kernel(
+        source: &Tensor<f32, { [-1] }>,
+        out: &mut Tensor<f32, { [4] }>,
+    ) {
+        let part = source.partition(const_shape![4]);
+        let mut out_part = unsafe { out.partition_mut(const_shape![4]) };
+        let mut i = 0;
+        while i < 1i32 {
+            let tile = part.load([i]);
+            unsafe { out_part.store(tile, [i]) };
+            i = i + 1i32;
+        }
+    }
+
+    #[cutile::entry()]
+    fn loop_body_method_selection_kernel(
+        source: &Tensor<f32, { [-1] }>,
+        out: &mut Tensor<f32, { [4] }>,
+    ) {
+        let part = source.partition(const_shape![4]);
+        let mut out_part = unsafe { out.partition_mut(const_shape![4]) };
+        let mut i = 0;
+        loop {
+            let tile = part.load([i]);
+            unsafe { out_part.store(tile, [i]) };
+            i = i + 1i32;
+            if i >= 1i32 {
+                break;
+            }
+        }
+    }
+
+    #[cutile::entry()]
+    fn tuple_pattern_backward_constraints_kernel(out: &mut Tensor<f32, { [4] }>) {
+        let (idx, scale) = (0, 1.0);
+        let _resolved_idx = expect_i64(idx);
+        let resolved_scale = expect_f32(scale);
+        let _scale_tile: Tile<f32, { [] }> = scalar_to_tile(resolved_scale);
+
+        let tile = constant(1.0f32, const_shape![4]);
+        out.store(tile);
+    }
+
+    #[cutile::entry()]
+    fn annotated_tuple_pattern_context_kernel(out: &mut Tensor<f32, { [4] }>) {
+        let (idx, scale): (i64, f32) = (0, 1.0);
+        let _resolved_idx = expect_i64(idx);
+        let _scale_tile: Tile<f32, { [] }> = scalar_to_tile(scale);
+
+        let tile = constant(1.0f32, const_shape![4]);
+        out.store(tile);
+    }
+
+    #[cutile::entry()]
+    fn array_pattern_element_constraints_kernel(out: &mut Tensor<f32, { [4] }>) {
+        let [idx, other] = [0, 1];
+        let _resolved_idx = expect_i64(idx);
+        let _other_passthrough = other;
+
+        let tile = constant(1.0f32, const_shape![4]);
+        out.store(tile);
+    }
+
+    #[cutile::entry()]
+    fn array_pattern_from_path_kernel(out: &mut Tensor<f32, { [4] }>) {
+        let values = [0i32, 1i32];
+        let [idx, other] = values;
+        let _other_tile: Tile<i32, { [] }> = scalar_to_tile(other);
+
+        let tile = constant(1.0f32, const_shape![4]);
+        let mut out_part = unsafe { out.partition_mut(const_shape![4]) };
+        unsafe { out_part.store(tile, [idx]) };
+    }
+
+    #[cutile::entry()]
+    fn struct_pattern_field_kernel(out: &mut Tensor<f32, { [4] }>) {
+        let carrier = TileCarrier {
+            tile: constant(1.0f32, const_shape![4]),
+        };
+        let TileCarrier { tile } = carrier;
+        out.store(tile);
+    }
+
+    #[cutile::entry()]
+    fn block_local_const_item_kernel(out: &mut Tensor<f32, { [4] }>) {
+        const IDX: i64 = 0;
+        let _resolved_idx = expect_i64(IDX);
+
+        let tile = constant(1.0f32, const_shape![4]);
+        out.store(tile);
+    }
+
+    #[cutile::entry()]
+    fn option_constructor_context_kernel(out: &mut Tensor<f32, { [4] }>) {
+        let tile = constant(1.0f32, const_shape![4]);
+        let some: Option<Tile<f32, { [4] }>> = Some(tile);
+        let none: Option<Tile<f32, { [4] }>> = None;
+        let _some = expect_option_tile_f32x4(some);
+        let _none = expect_option_tile_f32x4(none);
+        out.store(tile);
+    }
+
+    #[cutile::entry()]
+    fn autoref_trait_receiver_kernel(out: &mut Tensor<f32, { [4] }>) {
+        let _by_ref = expect_i64(out.trait_by_ref());
+        let _by_mut = expect_i64(out.trait_by_mut());
+
+        let tile = constant(1.0f32, const_shape![4]);
+        out.store(tile);
+    }
+
+    #[cutile::entry()]
+    fn shared_reference_receiver_kernel(
+        input: &Tensor<f32, { [4] }>,
+        out: &mut Tensor<f32, { [4] }>,
+    ) {
+        let _by_ref = expect_i64(input.trait_by_ref());
+
+        let tile = constant(1.0f32, const_shape![4]);
+        out.store(tile);
+    }
+
+    #[cutile::entry()]
+    fn qself_associated_const_typeck_kernel(out: &mut Tensor<f32, { [4] }>) {
+        let idx = <AssocConstHost as HasI64Const>::VALUE;
+        let _resolved_idx = expect_i64(idx);
+
+        let tile = constant(1.0f32, const_shape![4]);
+        out.store(tile);
+    }
+
+    #[cutile::entry()]
+    fn generic_associated_const_bound_kernel<T: ElementType>(out: &mut Tensor<T, { [4] }>) {
+        let zero = T::ZERO;
+        let tile: Tile<T, { [4] }> = constant(zero, const_shape![4]);
+        out.store(tile);
+    }
+
+    #[cutile::entry()]
+    fn generic_qself_associated_const_bound_kernel<T: ElementType>(out: &mut Tensor<T, { [4] }>) {
+        let tile: Tile<T, { [4] }> = constant(<T as ElementType>::ZERO, const_shape![4]);
+        out.store(tile);
+    }
+
+    #[cutile::entry()]
+    fn where_bound_associated_const_kernel<T>(out: &mut Tensor<T, { [4] }>)
+    where
+        T: ElementType,
+    {
+        let tile: Tile<T, { [4] }> = constant(T::ZERO, const_shape![4]);
+        out.store(tile);
+    }
+
+    #[cutile::entry()]
+    fn type_alias_tensor_entry_kernel(
+        input: &DynamicTensorAlias,
+        out: &mut TensorAlias,
+        scalar: ScalarAlias,
+    ) {
+        let _scalar: ScalarAlias = scalar;
+        let part = input.partition(const_shape![4]);
+        out.store(part.load([0i32]));
+    }
+
+    #[cutile::entry()]
+    unsafe fn type_alias_pointer_entry_kernel(ptr: PtrAlias, len: ScalarAlias) {
+        let _ptr = ptr;
+        let _len = len;
+    }
+
+    #[cutile::entry()]
+    fn global_const_shape_kernel(out: &mut Tensor<f32, { [GLOBAL_DIM] }>) {
+        let tile = constant(1.0f32, const_shape![GLOBAL_DIM]);
+        out.store(tile);
+    }
+
+    #[cutile::entry()]
+    fn global_bool_const_kernel(out: &mut Tensor<f32, { [4] }>) {
+        if GLOBAL_FLAG {
+            let _flag = GLOBAL_FLAG;
+        }
+        let tile = constant(1.0f32, const_shape![4]);
+        out.store(tile);
+    }
+
+    #[cutile::entry()]
+    fn global_scalar_const_kernel(out: &mut Tensor<f32, { [4] }>) {
+        let tile = constant(GLOBAL_SCALE, const_shape![4]);
+        out.store(tile);
+    }
+
+    #[cutile::entry()]
+    fn cga_index_const_shape_kernel<const S: [i32; 3]>(out: &mut Tensor<f32, { [S[0], S[2]] }>) {
+        let tile: Tile<f32, { [S[0], S[2]] }> = constant(1.0f32, const_shape![S[0], S[2]]);
+        out.store(tile);
+    }
+
+    #[cutile::entry()]
+    fn bool_const_generic_kernel<const DO_STORE: bool>(out: &mut Tensor<f32, { [4] }>) {
+        if DO_STORE {
+            let _flag = DO_STORE;
+        }
+        let tile = constant(1.0f32, const_shape![4]);
+        out.store(tile);
+    }
+}
+
+use type_inference_sanity_module::__module_ast_self;
+
+fn compile_kernel(name: &str, shape_constraints: &[(&str, &[i32])]) -> String {
+    compile_kernel_with_generic_args(name, &[], shape_constraints)
+}
+
+fn compile_kernel_with_generic_args(
+    name: &str,
+    generic_args: &[&str],
+    shape_constraints: &[(&str, &[i32])],
+) -> String {
+    compile_kernel_result_with_generic_args(name, generic_args, shape_constraints)
+        .expect("Failed to compile.")
+}
+
+fn compile_kernel_result_with_generic_args(
+    name: &str,
+    generic_args: &[&str],
+    shape_constraints: &[(&str, &[i32])],
+) -> Result<String, cutile_compiler::error::JITError> {
+    let modules = CUDATileModules::from_kernel(__module_ast_self())
+        .expect("Failed to create CUDATileModules");
+    let generic_args = generic_args
+        .iter()
+        .map(|arg| arg.to_string())
+        .collect::<Vec<_>>();
+    let compiler = CUDATileFunctionCompiler::new(
+        &modules,
+        "type_inference_sanity_module",
+        name,
+        &generic_args,
+        shape_constraints,
+        &[],
+        &[],
+        None,
+        "sm_120".to_string(),
+        &CompileOptions::default(),
+    )
+    .expect("Failed to create compiler.");
+    compiler.compile().map(|module| module.to_string())
+}
+
+fn typeck_dump(name: &str, shape_constraints: &[(&str, &[i32])]) -> String {
+    typeck_dump_with_generic_args(name, &[], shape_constraints)
+}
+
+fn typeck_dump_with_generic_args(
+    name: &str,
+    generic_args: &[&str],
+    shape_constraints: &[(&str, &[i32])],
+) -> String {
+    let modules = CUDATileModules::from_kernel(__module_ast_self())
+        .expect("Failed to create CUDATileModules");
+    let generic_args = generic_args
+        .iter()
+        .map(|arg| arg.to_string())
+        .collect::<Vec<_>>();
+    let compiler = CUDATileFunctionCompiler::new(
+        &modules,
+        "type_inference_sanity_module",
+        name,
+        &generic_args,
+        shape_constraints,
+        &[],
+        &[],
+        None,
+        "sm_120".to_string(),
+        &CompileOptions::default(),
+    )
+    .expect("Failed to create compiler.");
+    compiler
+        .debug_typeck_dump()
+        .expect("Failed to dump typeck results.")
+}
+
+fn assert_compiles_with_store(
+    name: &'static str,
+    shape_constraints: &'static [(&'static str, &'static [i32])],
+) {
+    common::with_test_stack(move || {
+        let module_op_str = compile_kernel(name, shape_constraints);
+        assert!(
+            module_op_str.contains("store_view_tko"),
+            "Expected `{name}` to emit a tile store.\n{module_op_str}"
+        );
+    });
+}
+
+fn assert_generic_compiles_with_store(
+    name: &'static str,
+    generic_args: &'static [&'static str],
+    shape_constraints: &'static [(&'static str, &'static [i32])],
+) {
+    common::with_test_stack(move || {
+        let module_op_str = compile_kernel_with_generic_args(name, generic_args, shape_constraints);
+        assert!(
+            module_op_str.contains("store_view_tko"),
+            "Expected `{name}` to emit a tile store.\n{module_op_str}"
+        );
+    });
+}
+
+#[test]
+fn unsafe_block_tail_types_feed_method_selection() {
+    assert_compiles_with_store(
+        "unsafe_block_tail_store_kernel",
+        &[("source", &[8, 8, 8]), ("out", &[1, 4, 8])],
+    );
+}
+
+#[test]
+fn if_tail_method_chain_types_feed_later_store() {
+    assert_compiles_with_store(
+        "if_tail_method_chain_kernel",
+        &[("source", &[8, 8, 8]), ("out", &[1, 1, 8])],
+    );
+}
+
+#[test]
+fn struct_literal_field_type_feeds_later_store() {
+    assert_compiles_with_store("struct_literal_field_kernel", &[("out", &[4])]);
+}
+
+#[test]
+fn tuple_destructure_types_feed_later_store() {
+    assert_compiles_with_store(
+        "tuple_destructure_method_chain_kernel",
+        &[("source", &[8]), ("out", &[4])],
+    );
+}
+
+#[test]
+fn index_result_type_feeds_method_argument() {
+    assert_compiles_with_store("index_result_method_arg_kernel", &[("out", &[4])]);
+}
+
+#[test]
+fn step_by_loop_local_type_feeds_method_argument() {
+    assert_compiles_with_store("step_by_loop_local_kernel", &[("out", &[4])]);
+}
+
+#[test]
+fn step_by_cast_usize_stays_surface_type() {
+    assert_compiles_with_store("step_by_cast_usize_kernel", &[("out", &[4])]);
+}
+
+#[test]
+fn typeck_dump_records_step_by_cast_usize_surface_type() {
+    common::with_test_stack(|| {
+        let dump = typeck_dump("step_by_cast_usize_kernel", &[("out", &[4])]);
+        assert!(
+            dump.contains("usize"),
+            "Expected `step as usize` to be recorded as a Rust surface type.\n{dump}"
+        );
+    });
+}
+
+#[test]
+fn if_else_uses_else_type_when_then_never() {
+    common::with_test_stack(|| {
+        let dump = typeck_dump("if_else_never_join_kernel", &[("out", &[4])]);
+        assert!(
+            dump.contains("Tile < f32 , { [4] } >"),
+            "Expected else branch to determine the if expression tile type.\n{dump}"
+        );
+        assert!(
+            dump.contains("method#"),
+            "Expected inferred tile to feed the following store method selection.\n{dump}"
+        );
+    });
+}
+
+#[test]
+fn unsuffixed_literals_compile_with_contextual_types_and_defaults() {
+    assert_compiles_with_store(
+        "unsuffixed_literal_context_kernel",
+        &[("source", &[8]), ("out", &[4])],
+    );
+}
+
+#[test]
+fn typeck_dump_records_unsuffixed_literal_context_and_defaults() {
+    common::with_test_stack(|| {
+        let dump = typeck_dump(
+            "unsuffixed_literal_context_kernel",
+            &[("source", &[8]), ("out", &[4])],
+        );
+        assert!(
+            dump.contains("[i32 ; 3usize]"),
+            "Expected unsuffixed index array to infer `[i32; 3]`.\n{dump}"
+        );
+        assert!(
+            dump.contains("f64"),
+            "Expected unconstrained unsuffixed float to use Rust's f64 fallback.\n{dump}"
+        );
+        assert!(
+            dump.contains("Tile < f32 , { [4] } >"),
+            "Expected annotated tile context to constrain `constant(1.0, ...)` to f32.\n{dump}"
+        );
+    });
+}
+
+#[test]
+fn backward_constraints_feed_local_literal_and_tile_types() {
+    assert_compiles_with_store("backward_literal_constraints_kernel", &[("out", &[4])]);
+}
+
+#[test]
+fn typeck_dump_records_backward_constraints() {
+    common::with_test_stack(|| {
+        let dump = typeck_dump("backward_literal_constraints_kernel", &[("out", &[4])]);
+        assert!(
+            dump.contains("i64"),
+            "Expected later function argument context to constrain aliased integer literal to i64.\n{dump}"
+        );
+        assert!(
+            dump.contains("f32"),
+            "Expected later function argument context to constrain aliased float literal to f32.\n{dump}"
+        );
+        assert!(
+            dump.contains("Tile < f32 , { [4] } >"),
+            "Expected later tile context to constrain the tile-producing call.\n{dump}"
+        );
+    });
+}
+
+#[test]
+fn var_to_var_binary_constraints_share_later_type() {
+    common::with_test_stack(|| {
+        let dump = typeck_dump("var_to_var_binary_constraints_kernel", &[("out", &[4])]);
+        assert!(
+            dump.contains("i64"),
+            "Expected constraining one binary operand to constrain related unknowns.\n{dump}"
+        );
+        assert!(
+            !dump.contains(": i32"),
+            "Expected related integer inference vars to resolve together, not fallback independently.\n{dump}"
+        );
+    });
+}
+
+#[test]
+fn var_to_var_branch_constraints_share_later_type() {
+    common::with_test_stack(|| {
+        let dump = typeck_dump("var_to_var_branch_constraints_kernel", &[("out", &[4])]);
+        assert!(
+            dump.contains("i64"),
+            "Expected constraining one branch variable to constrain the joined branch variables.\n{dump}"
+        );
+        assert!(
+            !dump.contains(": i32"),
+            "Expected joined integer inference vars to resolve together, not fallback independently.\n{dump}"
+        );
+    });
+}
+
+#[test]
+fn if_join_pushes_else_type_back_into_then_branch_var() {
+    common::with_test_stack(|| {
+        let dump = typeck_dump("if_join_direct_expr_constraints_kernel", &[("out", &[4])]);
+        assert!(
+            dump.contains("i64"),
+            "Expected typed else branch to constrain the unknown then-branch variable.\n{dump}"
+        );
+        assert!(
+            !dump.contains(": i32"),
+            "Expected branch-local integer inference var to resolve through the join, not fallback.\n{dump}"
+        );
+    });
+}
+
+#[test]
+fn if_join_ignores_diverging_branch_for_value_type() {
+    common::with_test_stack(|| {
+        let dump = typeck_dump(
+            "if_join_diverging_branch_constraints_kernel",
+            &[("out", &[4])],
+        );
+        assert!(
+            dump.contains("i64"),
+            "Expected non-diverging branch to determine the if expression type.\n{dump}"
+        );
+        assert!(
+            !dump.contains(": i32"),
+            "Expected diverging branch not to force integer fallback in the joined value.\n{dump}"
+        );
+    });
+}
+
+#[test]
+fn inline_array_index_backward_constraints_feed_elements() {
+    common::with_test_stack(|| {
+        let dump = typeck_dump(
+            "inline_array_index_backward_constraints_kernel",
+            &[("out", &[4])],
+        );
+        assert!(
+            dump.contains("[i64 ; 2usize]"),
+            "Expected later index value context to constrain the inline array element type.\n{dump}"
+        );
+    });
+}
+
+#[test]
+fn local_array_index_backward_constraints_feed_origin_elements() {
+    common::with_test_stack(|| {
+        let dump = typeck_dump(
+            "local_array_index_backward_constraints_kernel",
+            &[("out", &[4])],
+        );
+        assert!(
+            dump.contains("[i64 ; 2usize]"),
+            "Expected later index value context to constrain the local array origin element type.\n{dump}"
+        );
+    });
+}
+
+#[test]
+fn repeat_array_index_backward_constraints_feed_origin_element() {
+    common::with_test_stack(|| {
+        let dump = typeck_dump(
+            "repeat_array_index_backward_constraints_kernel",
+            &[("out", &[4])],
+        );
+        assert!(
+            dump.contains("[i64 ; 2usize]"),
+            "Expected later index value context to constrain the repeat array element type.\n{dump}"
+        );
+    });
+}
+
+#[test]
+fn inline_tuple_field_backward_constraints_feed_elements() {
+    common::with_test_stack(|| {
+        let dump = typeck_dump(
+            "inline_tuple_field_backward_constraints_kernel",
+            &[("out", &[4])],
+        );
+        assert!(
+            dump.contains("(i64 ,)"),
+            "Expected later field value context to constrain the inline tuple field type.\n{dump}"
+        );
+    });
+}
+
+#[test]
+fn local_tuple_field_backward_constraints_feed_origin_elements() {
+    common::with_test_stack(|| {
+        let dump = typeck_dump(
+            "local_tuple_field_backward_constraints_kernel",
+            &[("out", &[4])],
+        );
+        assert!(
+            dump.contains("(i64 ,)"),
+            "Expected later field value context to constrain the local tuple origin field type.\n{dump}"
+        );
+    });
+}
+
+#[test]
+fn assignment_constraints_update_mutated_local() {
+    common::with_test_stack(|| {
+        let dump = typeck_dump("assignment_backward_constraints_kernel", &[("out", &[4])]);
+        assert!(
+            dump.contains("i64"),
+            "Expected assignment RHS to constrain the mutated local.\n{dump}"
+        );
+        assert!(
+            !dump.contains(": i32"),
+            "Expected initial integer literal to resolve through assignment, not fallback independently.\n{dump}"
+        );
+    });
+}
+
+#[test]
+fn assignment_constraints_compile_with_mutated_local() {
+    assert_compiles_with_store("assignment_backward_constraints_kernel", &[("out", &[4])]);
+}
+
+#[test]
+fn assignment_constraints_update_accumulator_local() {
+    common::with_test_stack(|| {
+        let dump = typeck_dump(
+            "assignment_accumulator_constraints_kernel",
+            &[("out", &[4])],
+        );
+        assert!(
+            dump.contains("f32"),
+            "Expected accumulator assignment to constrain initial float literal to f32.\n{dump}"
+        );
+        assert!(
+            !dump.contains("f64"),
+            "Expected accumulator initial literal to resolve through assignment, not fallback to f64.\n{dump}"
+        );
+    });
+}
+
+#[test]
+fn assignment_accumulator_constraints_compile_with_mutated_local() {
+    assert_compiles_with_store(
+        "assignment_accumulator_constraints_kernel",
+        &[("out", &[4])],
+    );
+}
+
+#[test]
+fn cast_result_type_feeds_later_context() {
+    assert_compiles_with_store("cast_result_type_kernel", &[("out", &[4])]);
+}
+
+#[test]
+fn typeck_dump_records_cast_result_type() {
+    common::with_test_stack(|| {
+        let dump = typeck_dump("cast_result_type_kernel", &[("out", &[4])]);
+        assert!(
+            dump.contains("u32"),
+            "Expected cast expression to record its explicit result type.\n{dump}"
+        );
+    });
+}
+
+#[test]
+fn bool_condition_context_constrains_comparison_operands() {
+    assert_compiles_with_store("bool_condition_context_kernel", &[("out", &[4])]);
+}
+
+#[test]
+fn typeck_dump_records_bool_condition_context() {
+    common::with_test_stack(|| {
+        let dump = typeck_dump("bool_condition_context_kernel", &[("out", &[4])]);
+        assert!(
+            dump.contains("bool"),
+            "Expected comparison/logical condition to infer bool.\n{dump}"
+        );
+        assert!(
+            dump.contains("i64"),
+            "Expected comparison operands to unify with the typed RHS.\n{dump}"
+        );
+        assert!(
+            !dump.contains(": i32"),
+            "Expected comparison operand literal not to fallback independently.\n{dump}"
+        );
+    });
+}
+
+#[test]
+fn reduce_closure_body_is_typechecked_from_call_context() {
+    common::with_test_stack(|| {
+        let dump = typeck_dump("reduce_closure_body_typeck_kernel", &[("out", &[4])]);
+        assert!(
+            dump.contains("Tile < f32 , { [] } >"),
+            "Expected reduce closure parameters/body to be checked as scalar tiles.\n{dump}"
+        );
+    });
+}
+
+#[test]
+fn closure_params_are_typechecked_from_fn_bound_signature() {
+    common::with_test_stack(|| {
+        let dump = typeck_dump("signature_driven_closure_typeck_kernel", &[("out", &[4])]);
+        assert!(
+            dump.contains("Tile < f32 , { [] } >"),
+            "Expected generic `Fn(E, E) -> E` bound to type closure params as scalar tiles.\n{dump}"
+        );
+        assert!(
+            dump.contains("method#"),
+            "Expected typed closure params to feed method selection in the closure body.\n{dump}"
+        );
+    });
+}
+
+#[test]
+fn while_loop_body_types_feed_method_selection() {
+    assert_compiles_with_store(
+        "while_loop_body_method_selection_kernel",
+        &[("source", &[8]), ("out", &[4])],
+    );
+}
+
+#[test]
+fn while_loop_typeck_dump_records_body_method_selection() {
+    common::with_test_stack(|| {
+        let dump = typeck_dump(
+            "while_loop_body_method_selection_kernel",
+            &[("source", &[8]), ("out", &[4])],
+        );
+        assert!(
+            dump.contains("core::load"),
+            "Expected while body load method selection to be recorded.\n{dump}"
+        );
+        assert!(
+            dump.contains("core::store"),
+            "Expected while body store method selection to be recorded.\n{dump}"
+        );
+    });
+}
+
+#[test]
+fn loop_body_types_feed_method_selection() {
+    assert_compiles_with_store(
+        "loop_body_method_selection_kernel",
+        &[("source", &[8]), ("out", &[4])],
+    );
+}
+
+#[test]
+fn loop_typeck_dump_records_body_method_selection() {
+    common::with_test_stack(|| {
+        let dump = typeck_dump(
+            "loop_body_method_selection_kernel",
+            &[("source", &[8]), ("out", &[4])],
+        );
+        assert!(
+            dump.contains("core::load"),
+            "Expected loop body load method selection to be recorded.\n{dump}"
+        );
+        assert!(
+            dump.contains("core::store"),
+            "Expected loop body store method selection to be recorded.\n{dump}"
+        );
+    });
+}
+
+#[test]
+fn tuple_pattern_backward_constraints_feed_bindings() {
+    assert_compiles_with_store(
+        "tuple_pattern_backward_constraints_kernel",
+        &[("out", &[4])],
+    );
+}
+
+#[test]
+fn annotated_tuple_pattern_pushes_context_to_initializer() {
+    assert_compiles_with_store("annotated_tuple_pattern_context_kernel", &[("out", &[4])]);
+}
+
+#[test]
+fn array_pattern_element_constraints_share_later_type() {
+    assert_compiles_with_store("array_pattern_element_constraints_kernel", &[("out", &[4])]);
+}
+
+#[test]
+fn array_pattern_from_path_feeds_method_argument() {
+    assert_compiles_with_store("array_pattern_from_path_kernel", &[("out", &[4])]);
+}
+
+#[test]
+fn struct_pattern_field_type_feeds_later_store() {
+    assert_compiles_with_store("struct_pattern_field_kernel", &[("out", &[4])]);
+}
+
+#[test]
+fn block_local_const_items_are_available_to_later_expressions() {
+    assert_compiles_with_store("block_local_const_item_kernel", &[("out", &[4])]);
+}
+
+#[test]
+fn option_constructors_use_expected_option_context() {
+    common::with_test_stack(|| {
+        let dump = typeck_dump("option_constructor_context_kernel", &[("out", &[4])]);
+        assert!(
+            dump.contains("Option < Tile < f32 , { [4] } > >"),
+            "Expected Some/None constructors to use the annotated Option context.\n{dump}"
+        );
+    });
+}
+
+#[test]
+fn autoref_trait_receiver_methods_are_selected() {
+    common::with_test_stack(|| {
+        let dump = typeck_dump("autoref_trait_receiver_kernel", &[("out", &[4])]);
+        assert!(
+            dump.contains("trait_by_ref -> i64"),
+            "Expected method lookup to select a trait method through receiver autoref.\n{dump}"
+        );
+        assert!(
+            dump.contains("trait_by_mut -> i64"),
+            "Expected method lookup to select a mutable trait method through receiver autoref.\n{dump}"
+        );
+    });
+}
+
+#[test]
+fn shared_reference_receiver_selects_shared_method() {
+    common::with_test_stack(|| {
+        let dump = typeck_dump(
+            "shared_reference_receiver_kernel",
+            &[("input", &[4]), ("out", &[4])],
+        );
+        assert!(
+            dump.contains("trait_by_ref -> i64"),
+            "Expected method lookup to select `&self` through a shared reference receiver.\n{dump}"
+        );
+        assert!(
+            !dump.contains("trait_by_mut -> i64"),
+            "Did not expect a mutable receiver method selection for a shared reference receiver.\n{dump}"
+        );
+    });
+}
+
+#[test]
+fn qself_associated_const_infers_declared_type() {
+    common::with_test_stack(|| {
+        let dump = typeck_dump("qself_associated_const_typeck_kernel", &[("out", &[4])]);
+        assert!(
+            dump.contains("i64"),
+            "Expected `<AssocConstHost as HasI64Const>::VALUE` to infer i64.\n{dump}"
+        );
+    });
+}
+
+#[test]
+fn type_parameter_associated_const_uses_trait_bound() {
+    common::with_test_stack(|| {
+        let dump = typeck_dump_with_generic_args(
+            "generic_associated_const_bound_kernel",
+            &["f32"],
+            &[("out", &[4])],
+        );
+        assert!(
+            dump.contains("Tile < T , { [4] } >") || dump.contains("Tile < f32 , { [4] } >"),
+            "Expected `T::ZERO` to feed the annotated `Tile<T, ...>` context.\n{dump}"
+        );
+    });
+}
+
+#[test]
+fn qself_type_parameter_associated_const_uses_trait_bound() {
+    common::with_test_stack(|| {
+        let dump = typeck_dump_with_generic_args(
+            "generic_qself_associated_const_bound_kernel",
+            &["f32"],
+            &[("out", &[4])],
+        );
+        assert!(
+            dump.contains("Tile < T , { [4] } >") || dump.contains("Tile < f32 , { [4] } >"),
+            "Expected `<T as ElementType>::ZERO` to feed the annotated `Tile<T, ...>` context.\n{dump}"
+        );
+    });
+}
+
+#[test]
+fn qself_type_parameter_associated_const_compiles() {
+    assert_generic_compiles_with_store(
+        "generic_qself_associated_const_bound_kernel",
+        &["f32"],
+        &[("out", &[4])],
+    );
+}
+
+#[test]
+fn where_bound_associated_const_uses_trait_bound() {
+    assert_generic_compiles_with_store(
+        "where_bound_associated_const_kernel",
+        &["f32"],
+        &[("out", &[4])],
+    );
+}
+
+#[test]
+fn same_module_type_alias_tensor_entry_compiles() {
+    assert_compiles_with_store(
+        "type_alias_tensor_entry_kernel",
+        &[("input", &[1]), ("out", &[1])],
+    );
+}
+
+#[test]
+fn same_module_type_alias_pointer_entry_compiles() {
+    common::with_test_stack(|| {
+        let module_op_str = compile_kernel("type_alias_pointer_entry_kernel", &[]);
+        assert!(
+            module_op_str.contains("entry @type_alias_pointer_entry_kernel_entry"),
+            "Expected pointer-alias entry kernel to compile.\n{module_op_str}"
+        );
+    });
+}
+
+#[test]
+fn module_level_i32_const_works_in_tensor_type_and_const_shape() {
+    assert_compiles_with_store("global_const_shape_kernel", &[("out", &[4])]);
+}
+
+#[test]
+fn module_level_bool_const_works_in_expression() {
+    assert_compiles_with_store("global_bool_const_kernel", &[("out", &[4])]);
+}
+
+#[test]
+fn module_level_scalar_const_works_as_expression_input() {
+    assert_compiles_with_store("global_scalar_const_kernel", &[("out", &[4])]);
+}
+
+#[test]
+fn const_generic_array_index_works_in_const_shape_and_types() {
+    assert_generic_compiles_with_store(
+        "cga_index_const_shape_kernel",
+        &["4", "2", "8"],
+        &[("out", &[4, 8])],
+    );
+}
+
+#[test]
+fn bool_const_generic_works_in_expression() {
+    assert_generic_compiles_with_store("bool_const_generic_kernel", &["true"], &[("out", &[4])]);
+}
+
+#[test]
+fn typeck_dump_records_bool_const_generic() {
+    common::with_test_stack(|| {
+        let dump =
+            typeck_dump_with_generic_args("bool_const_generic_kernel", &["true"], &[("out", &[4])]);
+        assert!(
+            dump.contains("bool"),
+            "Expected bool const generic to be available in typeck results.\n{dump}"
+        );
+    });
+}
+
+#[test]
+fn unsupported_associated_const_value_has_specific_error() {
+    common::with_test_stack(|| {
+        let err = compile_kernel_result_with_generic_args(
+            "qself_associated_const_typeck_kernel",
+            &[],
+            &[("out", &[4])],
+        )
+        .expect_err("Expected arbitrary associated const value emission to fail.");
+        let message = err.to_string();
+        assert!(
+            message.contains("associated const values are not supported"),
+            "Expected a targeted associated const diagnostic.\n{message}"
+        );
+    });
+}
+
+#[test]
+fn typeck_dump_golden_for_struct_literal_field() {
+    common::with_test_stack(|| {
+        let dump = typeck_dump("struct_literal_field_kernel", &[("out", &[4])]);
+        let expected = r#"expr#0: TileCarrier
+expr#1: Tile < f32 , { [4] } >
+expr#2: f32
+expr#3: Shape < { [4] } >
+expr#4: ()
+method#4: core::store -> _
+expr#5: & mut Tensor < f32 , { [4] } >
+expr#6: Tile < f32 , { [4] } >
+expr#7: TileCarrier"#;
+        assert_eq!(dump, expected);
+    });
+}
+
+#[test]
+fn typeck_dump_golden_for_step_by_loop_local() {
+    common::with_test_stack(|| {
+        let dump = typeck_dump("step_by_loop_local_kernel", &[("out", &[4])]);
+        let expected = r#"expr#0: PartitionMut < 'a , f32 , { [4] } >
+expr#1: PartitionMut < 'a , f32 , { [4] } >
+method#1: core::partition_mut -> _
+expr#2: & mut Tensor < f32 , { [4] } >
+expr#3: Shape < { [4] } >
+expr#6: i32
+expr#7: i32
+expr#8: i32
+expr#9: Tile < f32 , { [4] } >
+expr#10: f32
+expr#11: Shape < { [4] } >
+expr#12: Token
+expr#13: Token
+method#13: core::store -> Token
+expr#15: Tile < f32 , { [4] } >
+expr#16: [i32 ; 1usize]
+expr#17: i32"#;
+        assert_eq!(dump, expected);
+    });
+}

--- a/scripts/run_cpu_tests.sh
+++ b/scripts/run_cpu_tests.sh
@@ -25,6 +25,18 @@ run_step \
     "cutile library tests" \
     cargo test -p cutile --lib
 
+run_step \
+    "cutile compile-only FMHA regression" \
+    cargo test -p cutile --test flash_attention_compile
+
+run_step \
+    "cutile load_tile_like compile-only regressions" \
+    cargo test -p cutile --test load_tile_like_examples
+
+run_step \
+    "cutile type inference sanity regressions" \
+    cargo test -p cutile --test type_inference_sanity
+
 print_summary_and_exit \
     "All CPU tests passed!" \
     "Some CPU checks failed. See output above for details."


### PR DESCRIPTION
## Summary

- drive more lowering decisions from the type inference pass instead of re-deriving expression types during emission
- add stable semantic node IDs, expanded type inference support, type aliases, global constants, and global memory lowering
- clean up user-facing diagnostics so internal node-id attributes are not shown in inference errors
- expand compile coverage for inference, globals, control flow, flash attention, and related lowering paths

## Testing

- `cargo fmt --check`
- `cargo check -p cutile-compiler`
- `cargo test -p cutile-compiler syn_utils::tests::user_expr_tokens_strips_internal_node_id_attrs -- --nocapture`
- `cargo test -p cutile compile_ptr_partition_mut_store_helper -- --nocapture`