### PR TITLE
fix: allow load_tile_like from static-shaped tensors

### DIFF
--- a/cutile/src/_core.rs
+++ b/cutile/src/_core.rs
@@ -2379,8 +2379,8 @@ pub mod core {
         fn load_tile_like(&self, y: &Y) -> Self::Out;
     }
 
-    impl<E1: ElementType, E2: ElementType, const S: [i32; 1]> LoadTileLike<Tensor<E2, S>>
-        for Tensor<E1, { [-1] }>
+    impl<E1: ElementType, E2: ElementType, const X: [i32; 1], const S: [i32; 1]>
+        LoadTileLike<Tensor<E2, S>> for Tensor<E1, X>
     {
         type Out = Tile<E1, S>;
 
@@ -2408,8 +2408,8 @@ pub mod core {
         }
     }
 
-    impl<E1: ElementType, E2: ElementType, const S: [i32; 2]> LoadTileLike<Tensor<E2, S>>
-        for Tensor<E1, { [-1, -1] }>
+    impl<E1: ElementType, E2: ElementType, const X: [i32; 2], const S: [i32; 2]>
+        LoadTileLike<Tensor<E2, S>> for Tensor<E1, X>
     {
         type Out = Tile<E1, S>;
 
@@ -2437,8 +2437,8 @@ pub mod core {
         }
     }
 
-    impl<E1: ElementType, E2: ElementType, const S: [i32; 3]> LoadTileLike<Tensor<E2, S>>
-        for Tensor<E1, { [-1, -1, -1] }>
+    impl<E1: ElementType, E2: ElementType, const X: [i32; 3], const S: [i32; 3]>
+        LoadTileLike<Tensor<E2, S>> for Tensor<E1, X>
     {
         type Out = Tile<E1, S>;
 

--- a/cutile/tests/load_tile_like_examples.rs
+++ b/cutile/tests/load_tile_like_examples.rs
@@ -53,6 +53,15 @@ mod load_tile_like_examples_module {
         let tile_y = y.load();
         y.store(tile_a * tile_x + tile_y);
     }
+
+    #[cutile::entry()]
+    fn static_input_like<const B: i32, const N: i32>(
+        z: &mut Tensor<f32, { [B] }>,
+        x: &Tensor<f32, { [N] }>,
+    ) {
+        let tile_x = load_tile_like(x, z);
+        z.store(tile_x);
+    }
 }
 
 use load_tile_like_examples_module::__module_ast_self;
@@ -121,6 +130,19 @@ fn compiles_saxpy_style_2d_inference() {
             !store_line.contains("[0"),
             "Tensor::store should index by tile-block id, not [0, 0].\nStore line:\n{store_line}\nMLIR:\n{mlir}"
         );
+    });
+}
+
+#[test]
+fn compiles_static_input_1d_inference() {
+    common::with_test_stack(|| {
+        let mlir = compile(
+            "static_input_like",
+            &[4.to_string(), 16.to_string()],
+            &[("z", &[1]), ("x", &[1])],
+        );
+        assert!(mlir.contains("load_view_tko"));
+        assert!(mlir.contains("tile<4xf32>"));
     });
 }
 


### PR DESCRIPTION
## Summary

Broaden the `LoadTileLike` impls so the source tensor shape is rank-polymorphic instead of restricted to dynamic tensor shapes like `[-1]` / `[-1, -1]`.

This introduces an impl-local source CGA `X`, for example:

```rust
impl<E1, E2, const X: [i32; 2], const S: [i32; 2]>
    LoadTileLike<Tensor<E2, S>> for Tensor<E1, X>
```

`X` participates in receiver-type dispatch only. The returned tile shape remains tied to the destination tensor shape `S`.

## Testing

- `cargo test -q -p cutile --test load_tile_like_examples`
- Full `cargo test -q` and GPU tests were also reported passing locally before opening this PR.
