### PR TITLE
Use zero padding for read-only tile-like loads

### DIFF
--- a/cutile/src/_core.rs
+++ b/cutile/src/_core.rs
@@ -588,7 +588,7 @@ pub mod core {
             // TODO (hme): Bounds checks.
             let tensor_token: Token = get_tensor_token(self);
             let p: Partition<E, R> =
-                make_partition_view(self, tile, padding::None, dim_map, tensor_token);
+                make_partition_view(self, tile, padding::Zero, dim_map, tensor_token);
             p
         }
         pub unsafe fn partition_mut<'a, const R: [i32; N]>(
@@ -2822,7 +2822,7 @@ pub mod core {
             let x_partition: Partition<E1, S> = make_partition_view(
                 x,
                 tile_shape,
-                padding::None,
+                padding::Zero,
                 dim_map::Identity,
                 tensor_token,
             );
@@ -2851,7 +2851,7 @@ pub mod core {
             let x_partition: Partition<E1, S> = make_partition_view(
                 x,
                 tile_shape,
-                padding::None,
+                padding::Zero,
                 dim_map::Identity,
                 tensor_token,
             );
@@ -2880,7 +2880,7 @@ pub mod core {
             let x_partition: Partition<E1, S> = make_partition_view(
                 x,
                 tile_shape,
-                padding::None,
+                padding::Zero,
                 dim_map::Identity,
                 tensor_token,
             );

--- a/cutile/tests/load_tile_like_examples.rs
+++ b/cutile/tests/load_tile_like_examples.rs
@@ -30,6 +30,17 @@ mod load_tile_like_examples_module {
         z.store(tile_x + tile_y);
     }
 
+    #[cutile::entry(unchecked_accesses = true)]
+    unsafe fn add_refs_like_unchecked<const B: i32>(
+        z: &mut Tensor<f32, { [B] }>,
+        x: &Tensor<f32, { [-1] }>,
+        y: &Tensor<f32, { [-1] }>,
+    ) {
+        let tile_x = load_tile_like(x, z);
+        let tile_y = load_tile_like(y, z);
+        z.store(tile_x + tile_y);
+    }
+
     #[cutile::entry()]
     fn saxpy_like<const S: [i32; 2]>(
         y: &mut Tensor<f32, S>,
@@ -61,6 +72,18 @@ mod load_tile_like_examples_module {
     ) {
         let tile_x = load_tile_like(x, z);
         z.store(tile_x);
+    }
+
+    #[cutile::entry()]
+    fn permuted_partition_like<const BM: i32, const BN: i32, const DIM_MAP: [i32; 2]>(
+        z: &mut Tensor<f32, { [BM, BN] }>,
+        x: &Tensor<f32, { [-1, -1] }>,
+    ) {
+        let pid: (i32, i32, i32) = get_tile_block_id();
+        let dim_map = const_array!(DIM_MAP);
+        let part = x.partition_permuted(const_shape![BM, BN], dim_map);
+        let tile: Tile<f32, { [BM, BN] }> = part.load([pid.0, pid.1]);
+        z.store(tile);
     }
 }
 
@@ -97,6 +120,36 @@ fn compiles_add_refs_style_1d_inference() {
         );
         assert!(mlir.contains("load_view_tko"));
         assert_eq!(mlir.matches("load_view_tko").count(), 2);
+        assert!(
+            mlir.contains("padding_value = zero"),
+            "load_tile_like should lower read-only input partitions with zero padding.\nMLIR:\n{mlir}"
+        );
+    });
+}
+
+#[test]
+fn unchecked_dynamic_1d_load_tile_like_uses_zero_padded_inputs() {
+    common::with_test_stack(|| {
+        let mlir = compile(
+            "add_refs_like_unchecked",
+            &[16384.to_string()],
+            &[("z", &[1]), ("x", &[1]), ("y", &[1])],
+        );
+        assert_eq!(mlir.matches("load_view_tko").count(), 2);
+        assert!(
+            mlir.matches("partition_view<tile=(16384), padding_value = zero, tensor_view<?xf32")
+                .count()
+                >= 4,
+            "Unchecked dynamic load_tile_like inputs should use zero-padded partition views.\nMLIR:\n{mlir}"
+        );
+        let store_line = mlir
+            .lines()
+            .find(|line| line.contains("store_view_tko"))
+            .expect("expected store_view_tko in add_refs_like_unchecked MLIR");
+        assert!(
+            !store_line.contains("padding_value = zero"),
+            "Mutable output store should remain non-padded.\nStore line:\n{store_line}\nMLIR:\n{mlir}"
+        );
     });
 }
 
@@ -118,14 +171,18 @@ fn compiles_saxpy_style_2d_inference() {
             !mlir.contains("mini"),
             "Mutable output entry lowering should not compute per-block remaining dimensions.\nMLIR:\n{mlir}"
         );
-        assert!(
-            !mlir.contains("padding_value = zero"),
-            "Tensor::load/store for mutable outputs should use padding::None.\nMLIR:\n{mlir}"
-        );
         let store_line = mlir
             .lines()
             .find(|line| line.contains("store_view_tko"))
             .expect("expected store_view_tko in saxpy_like MLIR");
+        assert!(
+            mlir.contains("padding_value = zero"),
+            "load_tile_like should lower read-only input partitions with zero padding.\nMLIR:\n{mlir}"
+        );
+        assert!(
+            !store_line.contains("padding_value = zero"),
+            "Tensor::store for mutable outputs should use padding::None.\nStore line:\n{store_line}\nMLIR:\n{mlir}"
+        );
         assert!(
             !store_line.contains("[0"),
             "Tensor::store should index by tile-block id, not [0, 0].\nStore line:\n{store_line}\nMLIR:\n{mlir}"
@@ -143,6 +200,22 @@ fn compiles_static_input_1d_inference() {
         );
         assert!(mlir.contains("load_view_tko"));
         assert!(mlir.contains("tile<4xf32>"));
+    });
+}
+
+#[test]
+fn permuted_read_only_partition_uses_zero_padding() {
+    common::with_test_stack(|| {
+        let mlir = compile(
+            "permuted_partition_like",
+            &[2.to_string(), 4.to_string(), 0.to_string(), 1.to_string()],
+            &[("z", &[4, 1]), ("x", &[4, 1])],
+        );
+        assert!(mlir.contains("load_view_tko"));
+        assert!(
+            mlir.contains("padding_value = zero"),
+            "partition_permuted should lower read-only partitions with zero padding.\nMLIR:\n{mlir}"
+        );
     });
 }
 


### PR DESCRIPTION
## Summary

Fixes the dynamic-shape elementwise load regression by making high-level read-only partition helpers emit zero-padded partition views by default.

Changes:
- make `load_tile_like(...)` construct read-only input partitions with `padding::Zero`
- make `Tensor::partition_permuted(...)` match `Tensor::partition(...)` and use `padding::Zero`
- keep mutable output partition/store paths non-padded
- keep explicit low-level `make_partition_view(..., padding::None, ...)` behavior unchanged
- add MLIR regression tests for unchecked dynamic 1D `load_tile_like` and permuted read-only partitioning

## Validation

- `cargo fmt --all --check`
- `cargo check -q -p cutile`
- `cargo test -q -p cutile --test load_tile_like_examples`
- `cargo test -q -p cutile --test tensor_views`