### PR TITLE
fix tutorial imports and resolve type mismatches in examples

### DIFF
--- a/cutile-book/tutorials/04-matrix-multiplication.md
+++ b/cutile-book/tutorials/04-matrix-multiplication.md
@@ -57,13 +57,14 @@ cargo add candle-core
 ```
 
 ```rust
-use cuda_async::device_operation::DeviceOp;
-use cuda_core::Device;
+use cutile::cuda_async::device_operation::DeviceOp;
+use cutile::cuda_core::Device;
 use std::sync::Arc;
 use cutile;
 use cutile::api;
-use cutile::candle_core::WithDType;
+use candle_core::WithDType;
 use cutile::error::Error;
+use cutile::prelude::PartitionOp;
 use cutile::tensor::{IntoPartition, Tensor, ToHostVec, Unpartition};
 use cutile::tile_kernel::TileKernel;
 
@@ -98,7 +99,7 @@ fn main() -> Result<(), Error> {
     let device = Device::new(0)?;
     let stream = device.new_stream()?;
 
-    let (bm, bn, bk): (i32, i32, i32) = (16, 16, 8);
+    let (bm, bn, bk): (usize, usize, usize) = (16, 16, 8);
     let (m, n, k) = (64usize, 64usize, 64usize);
 
     let generics = vec![

--- a/cutile-book/tutorials/04-matrix-multiplication.md
+++ b/cutile-book/tutorials/04-matrix-multiplication.md
@@ -50,6 +50,11 @@ Each element of A is used BN times. Each element of B is used BM times. This **d
 ---
 
 ## The Code
+Note: Before running this code, ensure you have the candle-core crate added to your project dependencies. You can do this by running the command in terminal:
+
+```Bash
+cargo add candle-core
+```
 
 ```rust
 use cuda_async::device_operation::DeviceOp;

--- a/cutile-book/tutorials/05-fused-softmax.md
+++ b/cutile-book/tutorials/05-fused-softmax.md
@@ -86,7 +86,7 @@ fn main() -> Result<(), Error> {
     let stream = device.new_stream()?;
 
     let (m, n) = (4usize, 8usize);
-    let (bm, bn) = (2i32, n as i32);
+    let (bm, bn) = (2usize, n as usize);
 
     let input: Arc<Tensor<f32>> = arange(m * n).sync_on(&stream)?.into();
     let x: Arc<Tensor<f32>> = input.dup().sync_on(&stream)?.reshape(&[m, n])?.into();

--- a/cutile-book/tutorials/09-pointer-addition.md
+++ b/cutile-book/tutorials/09-pointer-addition.md
@@ -83,6 +83,12 @@ async fn async_main() -> Result<(), cutile::error::Error> {
     }
     Ok(())
 }
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    async_main().await?;
+    Ok(())
+}
 ```
 
 **Output:**


### PR DESCRIPTION
Hi,

This PR is to fix several compilation issues and misleading import paths in the cutile tutorials and examples.

**changes:**

**1. Rust Dependencies Hint**: Corrected the dependencies  to let learner know to install candle-core by `cargo add candle-core`

**2. Type Mismatch Fix**: Resolved a type mismatch error in the Softmax example where `i32` was used for partition() dimensions instead of `usize`.

**3. Refactor/Cleanup**: Cleaned up dependency handling and type usage across the examples to ensure consistent compilation with current Rust standards.

I have verified these changes within the cutile-examples environment, and they resolve the build failures I encountered.

Thanks for maintaining this project!
