### PR TITLE
fix: change the improper import of cutile/cuda_async and cutile/cuda

### DIFF
--- a/cutile-book/tutorials/01-hello-world.md
+++ b/cutile-book/tutorials/01-hello-world.md
@@ -11,8 +11,8 @@ Tile kernels are functions which run as `N` copies concurrently and in parallel 
 Here is a kernel that prints "hello" from the GPU:
 
 ```rust
-use cuda_async::device_operation::DeviceOp;
-use cuda_core::Device;
+use cutile::cuda_async::device_operation::DeviceOp;
+use cutile::cuda_core::Device;
 use cutile;
 use cutile::error::Error;
 use cutile::tile_kernel::TileKernel;

--- a/cutile-book/tutorials/02-vector-addition.md
+++ b/cutile-book/tutorials/02-vector-addition.md
@@ -7,8 +7,8 @@ In cutile, tile threads run concurrently and each tile knows its coordinates via
 ---
 
 ```rust
-use cuda_async::device_operation::DeviceOp;
-use cuda_core::Device;
+use cutile::cuda_async::device_operation::DeviceOp;
+use cutile::cuda_core::Device;
 use std::sync::Arc;
 use cutile;
 use cutile::api::{ones, zeros};

--- a/cutile-book/tutorials/03-saxpy.md
+++ b/cutile-book/tutorials/03-saxpy.md
@@ -21,8 +21,8 @@ Broadcasting is conceptual — the GPU doesn't actually allocate memory for all 
 ---
 
 ```rust
-use cuda_async::device_operation::DeviceOp;
-use cuda_core::Device;
+use cutile::cuda_async::device_operation::DeviceOp;
+use cutile::cuda_core::Device;
 use std::sync::Arc;
 use cutile;
 use cutile::api::arange;

--- a/cutile-book/tutorials/04-matrix-multiplication.md
+++ b/cutile-book/tutorials/04-matrix-multiplication.md
@@ -52,8 +52,8 @@ Each element of A is used BN times. Each element of B is used BM times. This **d
 ## The Code
 
 ```rust
-use cuda_async::device_operation::DeviceOp;
-use cuda_core::Device;
+use cutile::cuda_async::device_operation::DeviceOp;
+use cutile::cuda_core::Device;
 use std::sync::Arc;
 use cutile;
 use cutile::api;

--- a/cutile-book/tutorials/05-fused-softmax.md
+++ b/cutile-book/tutorials/05-fused-softmax.md
@@ -43,8 +43,8 @@ exp(x_i - max) / Σ exp(x_j - max)
 ## The Code
 
 ```rust
-use cuda_async::device_operation::DeviceOp;
-use cuda_core::Device;
+use cutile::cuda_async::device_operation::DeviceOp;
+use cutile::cuda_core::Device;
 use cutile;
 use cutile::api::arange;
 use cutile::error::Error;

--- a/cutile-book/tutorials/06-flash-attention.md
+++ b/cutile-book/tutorials/06-flash-attention.md
@@ -121,8 +121,8 @@ For each Q tile (row block of the output):
 ## The Code
 
 ```rust
-use cuda_async::device_operation::DeviceOp;
-use cuda_core::Device;
+use cutile::cuda_async::device_operation::DeviceOp;
+use cutile::cuda_core::Device;
 use std::sync::Arc;
 use cutile;
 use cutile::api::{randn, zeros};

--- a/cutile-book/tutorials/07-intro-to-async.md
+++ b/cutile-book/tutorials/07-intro-to-async.md
@@ -63,7 +63,7 @@ In cutile, a `DeviceOp` can be executed with either sync or async APIs. Given a 
 use cutile::api::{ones, zeros};
 use cutile::tensor::{Tensor, ToHostVec, Unpartition};
 use cutile::tile_kernel::{PartitionOp, TileKernel, ToHostVecOp};
-use cuda_async::device_operation::*;
+use cutile::cuda_async::{error::DeviceError, device_operation::*};
 use std::sync::Arc;
 
 #[cutile::module]

--- a/cutile-book/tutorials/08-data-parallel-mlp.md
+++ b/cutile-book/tutorials/08-data-parallel-mlp.md
@@ -73,14 +73,14 @@ mod data_parallel_module {
 use data_parallel_module::{gemm, relu, matvec};
 
 #[tokio::main]
-async fn main() -> Result<(), DeviceError> {
+async fn main() -> Result<(), cutile::cuda_async::error::DeviceError> {
 
-    use cuda_async::device_operation::*;
+    use cutile::cuda_async::device_operation::*;
     use data_parallel_module::{gemm, relu, matvec};
     use cutile::api;
     use cutile::tensor::{Unpartition, Partition, Tensor, ToHostVec};
     use cutile::tile_kernel::{PartitionOp, TileKernel};
-    use cuda_async::device_context::global_policy;
+    use cutile::cuda_async::device_context::global_policy;
     use cutile::api::dup;
     use tokio::task::JoinHandle;
 
@@ -123,7 +123,7 @@ async fn main() -> Result<(), DeviceError> {
     }
 
     // Asynchronously compute forward pass for each batch of data on each device.
-    let mut futures: Vec<JoinHandle<Result<Partition<Tensor<f32>>, cuda_async::error::DeviceError>>> = vec![];
+    let mut futures: Vec<JoinHandle<Result<Partition<Tensor<f32>>, cutile::cuda_async::error::DeviceError>>> = vec![];
     for i in 0..num_devices {
         let w = &model_weights[i];
         let (w0, w1) = (w.0.clone(), w.1.clone());

--- a/cutile-examples/examples/async_add.rs
+++ b/cutile-examples/examples/async_add.rs
@@ -23,7 +23,7 @@ mod my_module {
 }
 
 #[tokio::main(flavor = "multi_thread", worker_threads = 16)]
-async fn main() -> Result<(), cuda_async::error::DeviceError> {
+async fn main() -> Result<(), cutile::cuda_async::error::DeviceError> {
     let len = 2usize.pow(5);
 
     // Run add kernel twice, chaining lazily with .then().

--- a/cutile-examples/examples/async_and_then_example.rs
+++ b/cutile-examples/examples/async_and_then_example.rs
@@ -2,11 +2,11 @@
  * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-use cuda_async::device_context::global_policy;
-use cuda_async::device_operation::{value, with_context, DeviceOp};
-use cuda_async::error::DeviceError;
-use cuda_async::launch::AsyncKernelLaunch;
-use cuda_core::LaunchConfig;
+use cutile::cuda_async::device_context::global_policy;
+use cutile::cuda_async::device_operation::{value, with_context, DeviceOp};
+use cutile::cuda_async::error::DeviceError;
+use cutile::cuda_async::launch::AsyncKernelLaunch;
+use cutile::cuda_core::LaunchConfig;
 use cutile::api::arange;
 use cutile::api::DeviceOpReshape;
 use cutile::tensor::{IntoPartition, ToHostVec};

--- a/cutile-examples/examples/async_device_op_example.rs
+++ b/cutile-examples/examples/async_device_op_example.rs
@@ -2,10 +2,10 @@
  * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-use cuda_async::device_operation;
-use cuda_async::device_operation::*;
-use cuda_async::error::DeviceError;
-use cuda_core::*;
+use cutile::cuda_async::device_operation;
+use cutile::cuda_async::device_operation::*;
+use cutile::cuda_async::error::DeviceError;
+use cutile::cuda_core::*;
 use cutile::tile_kernel::global_policy;
 
 #[tokio::main]

--- a/cutile-examples/examples/async_gemm.rs
+++ b/cutile-examples/examples/async_gemm.rs
@@ -2,7 +2,7 @@
  * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-use cuda_async::device_operation::*;
+use cutile::cuda_async::device_operation::*;
 use cutile::api;
 use cutile::half::f16;
 use cutile::tensor::{Tensor, ToHostVec, Unpartition};
@@ -69,7 +69,7 @@ fn gemm<T1: DType, T2: DType>(
 use cutile_examples::to_candle_tensor;
 
 #[tokio::main(flavor = "multi_thread", worker_threads = 16)]
-async fn main() -> Result<(), cuda_async::error::DeviceError> {
+async fn main() -> Result<(), cutile::cuda_async::error::DeviceError> {
     type In = f16;
     type Out = f32;
     let (m, n, k) = (64, 64, 16);

--- a/cutile-examples/examples/async_mlp_fused.rs
+++ b/cutile-examples/examples/async_mlp_fused.rs
@@ -2,11 +2,11 @@
  * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-use cuda_async::device_context;
-use cuda_async::device_context::global_policy;
-use cuda_async::device_operation::*;
-use cuda_async::launch::AsyncKernelLaunch;
-use cuda_core::LaunchConfig;
+use cutile::cuda_async::device_context;
+use cutile::cuda_async::device_context::global_policy;
+use cutile::cuda_async::device_operation::*;
+use cutile::cuda_async::launch::AsyncKernelLaunch;
+use cutile::cuda_core::LaunchConfig;
 use cutile::tensor::{Tensor, ToHostVec};
 use cutile::tile_kernel::PartitionOp;
 use cutile::{api, error::Error};

--- a/cutile-examples/examples/async_saxpy.rs
+++ b/cutile-examples/examples/async_saxpy.rs
@@ -2,8 +2,9 @@
  * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-use cuda_async::device_operation::value;
-use cutile::api::{arange, DeviceOpReshape};
+use cutile::cuda_async::device_operation::DeviceOp;
+use cutile::cuda_core::Device;
+use cutile::api::{arange, ones, zeros};
 use cutile::error::Error;
 use cutile::prelude::*;
 use cutile::tensor::ToHostVec;

--- a/cutile-examples/examples/async_saxpy_unsafe.rs
+++ b/cutile-examples/examples/async_saxpy_unsafe.rs
@@ -7,9 +7,9 @@
  * Manually use the async API to compile and launch the saxpy kernel using the cutile API.
  */
 
-use cuda_async::device_operation::{value, with_context, DeviceOp};
-use cuda_async::launch::AsyncKernelLaunch;
-use cuda_core::LaunchConfig;
+use cutile::cuda_async::device_operation::{value, with_context, DeviceOp};
+use cutile::cuda_async::launch::AsyncKernelLaunch;
+use cutile::cuda_core::LaunchConfig;
 use cutile::api::arange;
 use cutile::api::DeviceOpReshape;
 use cutile::error::Error;

--- a/cutile-examples/examples/batch_matmul.rs
+++ b/cutile-examples/examples/batch_matmul.rs
@@ -2,8 +2,8 @@
  * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-use cuda_async::device_operation::DeviceOp;
-use cuda_core::Device;
+use cutile::cuda_async::device_operation::DeviceOp;
+use cutile::cuda_core::Device;
 use cutile::api::{ones, zeros};
 use cutile::error::Error;
 use cutile::tensor::{IntoPartition, Partition, Tensor, ToHostVec};

--- a/cutile-examples/examples/book_examples.rs
+++ b/cutile-examples/examples/book_examples.rs
@@ -9,8 +9,8 @@
 //! This example verifies that all tutorial code from the book compiles and runs correctly.
 //! Run with: cargo run --example book_examples
 
-use cuda_async::device_operation::*;
-use cuda_core::{Device, Stream};
+use cutile::cuda_async::device_operation::*;
+use cutile::cuda_core::{Device, Stream};
 use cutile;
 use cutile::api::{arange, ones, randn, zeros};
 use cutile::error::Error;

--- a/cutile-examples/examples/cuda_graphs.rs
+++ b/cutile-examples/examples/cuda_graphs.rs
@@ -12,7 +12,7 @@
  *   cargo run -p cutile-examples --example cuda_graphs
  */
 
-use cuda_core::{Device, Stream};
+use cutile::cuda_core::{Device, Stream};
 use cutile::error::Error;
 use cutile::prelude::*;
 use std::time::Instant;

--- a/cutile-examples/examples/cuda_graphs_deviceop.rs
+++ b/cutile-examples/examples/cuda_graphs_deviceop.rs
@@ -9,7 +9,7 @@
  *   cargo run -p cutile-examples --example cuda_graphs
  */
 
-use cuda_core::{Device, Stream};
+use cutile::cuda_core::{Device, Stream};
 use cutile::error::Error;
 use cutile::prelude::*;
 use std::time::Instant;
@@ -220,7 +220,7 @@ impl GraphModel {
         buffers: Vec<LayerBuffers>,
     ) -> (impl DeviceOp<Output = ()>, SharedDeviceOp<Tensor<f32>>) {
         let mut hidden: SharedDeviceOp<Tensor<f32>> =
-            cuda_async::device_operation::shared(input.clone());
+            cutile::cuda_async::device_operation::shared(input.clone());
 
         let mut ops: Vec<BoxedDeviceOp<()>> = Vec::with_capacity(buffers.len());
 

--- a/cutile-examples/examples/cudarc_interop.rs
+++ b/cutile-examples/examples/cudarc_interop.rs
@@ -25,7 +25,7 @@
 //!      handles — the `source_*` handles still work afterward.
 
 use core::ffi::{c_int, c_void};
-use cuda_core::{Device, Stream};
+use cutile::cuda_core::{Device, Stream};
 use cutile::error::Error;
 use cutile::prelude::*;
 

--- a/cutile-examples/examples/dropout.rs
+++ b/cutile-examples/examples/dropout.rs
@@ -2,8 +2,8 @@
  * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-use cuda_async::device_operation::DeviceOp;
-use cuda_core::Device;
+use cutile::cuda_async::device_operation::DeviceOp;
+use cutile::cuda_core::Device;
 use cutile::api::{rand, randn, zeros};
 use cutile::error::Error;
 use cutile::tensor::{IntoPartition, Partition, Tensor, ToHostVec};

--- a/cutile-examples/examples/flash_attention.rs
+++ b/cutile-examples/examples/flash_attention.rs
@@ -4,8 +4,8 @@
  */
 extern crate core;
 
-use cuda_async::device_operation::{DeviceOp, Unzippable6};
-use cuda_core::Device;
+use cutile::cuda_async::device_operation::{DeviceOp, Unzippable6};
+use cutile::cuda_core::Device;
 use cutile;
 use cutile::api::{randn, zeros};
 use cutile::error::Error;

--- a/cutile-examples/examples/flash_attention_causal.rs
+++ b/cutile-examples/examples/flash_attention_causal.rs
@@ -4,8 +4,8 @@
  */
 extern crate core;
 
-use cuda_async::device_operation::DeviceOp;
-use cuda_core::Device;
+use cutile::cuda_async::device_operation::DeviceOp;
+use cutile::cuda_core::Device;
 use cutile::api::{randn, zeros};
 use cutile::error::Error;
 use cutile::tensor::{IntoPartition, Partition, Tensor, ToHostVec};

--- a/cutile-examples/examples/gemm.rs
+++ b/cutile-examples/examples/gemm.rs
@@ -2,8 +2,8 @@
  * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-use cuda_async::device_operation::*;
-use cuda_core::Device;
+use cutile::cuda_async::device_operation::*;
+use cutile::cuda_core::Device;
 use cutile::api;
 use cutile::error::Error;
 use cutile::tensor::*;

--- a/cutile-examples/examples/gemm_static.rs
+++ b/cutile-examples/examples/gemm_static.rs
@@ -2,8 +2,8 @@
  * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-use cuda_async::device_operation::*;
-use cuda_core::Device;
+use cutile::cuda_async::device_operation::*;
+use cutile::cuda_core::Device;
 use cutile::api;
 use cutile::error::Error;
 use cutile::tensor::*;

--- a/cutile-examples/examples/hello_world.rs
+++ b/cutile-examples/examples/hello_world.rs
@@ -4,8 +4,8 @@
  */
 #![allow(unused_variables)]
 
-use cuda_async::device_operation::DeviceOp;
-use cuda_core::Device;
+use cutile::cuda_async::device_operation::DeviceOp;
+use cutile::cuda_core::Device;
 use cutile::error::Error;
 use cutile::tile_kernel::TileKernel;
 

--- a/cutile-examples/examples/interop.rs
+++ b/cutile-examples/examples/interop.rs
@@ -15,13 +15,13 @@
 //!   - Wrapping a custom kernel in a `DeviceOp` struct for a safe call-site
 //!   - Chaining tile and custom kernels on the same stream with `and_then`
 
-use cuda_async::device_context::{load_module_from_ptx, with_default_device_policy};
-use cuda_async::device_future::DeviceFuture;
-use cuda_async::device_operation::DeviceOp;
-use cuda_async::device_operation::ExecutionContext;
-use cuda_async::error::DeviceError;
-use cuda_async::launch::AsyncKernelLaunch;
-use cuda_core::{Function, LaunchConfig};
+use cutile::cuda_async::device_context::{load_module_from_ptx, with_default_device_policy};
+use cutile::cuda_async::device_future::DeviceFuture;
+use cutile::cuda_async::device_operation::DeviceOp;
+use cutile::cuda_async::device_operation::ExecutionContext;
+use cutile::cuda_async::error::DeviceError;
+use cutile::cuda_async::launch::AsyncKernelLaunch;
+use cutile::cuda_core::{Function, LaunchConfig};
 use cutile::api::{arange, zeros};
 use cutile::tensor::{IntoPartition, Tensor, ToHostVec};
 use std::future::IntoFuture;

--- a/cutile-examples/examples/rms_norm.rs
+++ b/cutile-examples/examples/rms_norm.rs
@@ -2,8 +2,8 @@
  * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-use cuda_async::device_operation::DeviceOp;
-use cuda_core::Device;
+use cutile::cuda_async::device_operation::DeviceOp;
+use cutile::cuda_core::Device;
 use cutile::api::{randn, zeros};
 use cutile::error::Error;
 use cutile::tensor::{IntoPartition, Partition, Tensor, ToHostVec};

--- a/cutile-examples/examples/tensor_permute.rs
+++ b/cutile-examples/examples/tensor_permute.rs
@@ -4,8 +4,8 @@
  */
 extern crate core;
 
-use cuda_async::device_operation::DeviceOp;
-use cuda_core::Device;
+use cutile::cuda_async::device_operation::DeviceOp;
+use cutile::cuda_core::Device;
 use cutile::api::DeviceOpReshape;
 use cutile::api::{arange, zeros};
 use cutile::error::Error;


### PR DESCRIPTION
## Description

This PR addresses the issue reported in:
https://github.com/NVlabs/cutile-rs/issues/148

## Problem
The tutorial and example code currently use imports such as:
- `use cuda_async::*`
- `use cuda_core::*`

This can be misleading for new users, as it is not clear that these dependencies are intended to be used within the Cutile environment. As a result, users may incorrectly configure their `Cargo.toml` (e.g., missing `workspace = true`) or attempt to pull dependencies directly, leading to build errors.

## Changes
This PR updates the import paths to use the Cutile re-exported modules:

- `use cutile::cuda_async::*`
- `use cutile::cuda_core::*`

## Impact
- Clarifies the intended usage of the Cutile environment
- Reduces confusion for new users following tutorials
- Prevents incorrect dependency setup in `Cargo.toml`