### PR TITLE
doc: add versioned book builds

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -4,9 +4,7 @@ name: pages
 on:
   push:
     branches: [main]
-    paths:
-      - "cutile-book/**"
-      - ".github/workflows/pages.yml"
+    tags: ["v*"]
 
 permissions:
   contents: read
@@ -24,6 +22,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Fetch docs refs
+        run: git fetch origin main --tags
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -34,12 +37,15 @@ jobs:
         run: pip install -r cutile-book/requirements.txt
 
       - name: Build book
-        run: sphinx-build -b html cutile-book cutile-book/_build/html
+        env:
+          CUTILE_DOCS_MAIN_REF: origin/main
+          CUTILE_DOCS_BASE_URL: /cutile-rs/
+        run: scripts/build_versioned_book.sh
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v5
         with:
-          path: cutile-book/_build/html
+          path: _site
 
   deploy:
     needs: build

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .vscode
 .cargo
 target
+_site
 
 **/*.bc
 **/*.cubin

--- a/cutile-book/README.md
+++ b/cutile-book/README.md
@@ -14,6 +14,27 @@ make livehtml
 
 By default, the book will be locally hosted here: `http://127.0.0.1:8000/`
 
+For local development, use the single-version book build:
+
+```
+make livehtml
+```
+
+or, from the repository root:
+
+```
+scripts/run_book.sh serve
+```
+
+GitHub Pages uses the versioned site build instead. To run the same build entry
+point locally, run from the repository root:
+
+```
+scripts/build_versioned_book.sh
+```
+
+The generated GitHub Pages site is written to `_site/`.
+
 ## Related Documentation
 
 - **API Docs**: Run `cargo doc --open` from the project root

--- a/cutile-book/conf.py
+++ b/cutile-book/conf.py
@@ -1,3 +1,5 @@
+import os
+
 # Configuration file for the Sphinx documentation builder.
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
@@ -5,7 +7,8 @@
 project = 'cuTile Rust'
 copyright = '2025, NVIDIA Corporation'
 author = 'Nihal Pasham'
-release = '0.1.0'
+release = os.environ.get('CUTILE_DOCS_VERSION', '0.1.0')
+version = release
 
 # -- General configuration ---------------------------------------------------
 extensions = [
@@ -80,6 +83,21 @@ html_theme_options = {
     "pygments_dark_style": "monokai",
     "show_prev_next": True,
 }
+
+_docs_version = os.environ.get('CUTILE_DOCS_VERSION')
+if _docs_version:
+    html_theme_options["switcher"] = {
+        "json_url": os.environ.get(
+            "CUTILE_DOCS_SWITCHER_JSON",
+            "/cutile-rs/_static/versions.json",
+        ),
+        "version_match": _docs_version,
+    }
+    html_theme_options["check_switcher"] = False
+    html_theme_options["navbar_center"] = [
+        *html_theme_options.get("navbar_center", []),
+        "version-switcher",
+    ]
 
 # LEFT SIDEBAR configuration
 html_sidebars = {

--- a/cutile-book/requirements.txt
+++ b/cutile-book/requirements.txt
@@ -5,4 +5,4 @@ myst-parser>=2.0
 sphinx-copybutton>=0.5
 sphinx-design>=0.5
 sphinx-autobuild>=2024.0  # Live reload for local development
-
+sphinx-sitemap>=2.6

--- a/scripts/build_versioned_book.sh
+++ b/scripts/build_versioned_book.sh
@@ -1,0 +1,144 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+SPHINX_BUILD="${SPHINX_BUILD:-sphinx-build}"
+OUT_DIR="${CUTILE_DOCS_SITE_DIR:-$REPO_ROOT/_site}"
+MAIN_REF="${CUTILE_DOCS_MAIN_REF:-HEAD}"
+MAIN_VERSION="${CUTILE_DOCS_MAIN_VERSION:-main}"
+TAG_PATTERN="${CUTILE_DOCS_TAG_PATTERN:-v*}"
+BASE_URL="${CUTILE_DOCS_BASE_URL:-/cutile-rs/}"
+
+if [[ "$BASE_URL" != /* ]]; then
+    BASE_URL="/$BASE_URL"
+fi
+if [[ "$BASE_URL" != */ ]]; then
+    BASE_URL="$BASE_URL/"
+fi
+
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/cutile-docs.XXXXXX")"
+WORKTREES=()
+
+cleanup() {
+    for worktree in "${WORKTREES[@]}"; do
+        git -C "$REPO_ROOT" worktree remove --force "$worktree" >/dev/null 2>&1 || true
+    done
+    rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+if [[ -n "${CUTILE_DOCS_TAGS+x}" ]]; then
+    # Space- or newline-separated explicit tag list. Set to an empty string to
+    # build only the main docs.
+    if [[ -z "$CUTILE_DOCS_TAGS" ]]; then
+        TAGS=()
+    else
+        readarray -t TAGS < <(printf '%s\n' $CUTILE_DOCS_TAGS)
+    fi
+else
+    readarray -t TAGS < <(git -C "$REPO_ROOT" tag --list "$TAG_PATTERN" --sort=-v:refname)
+fi
+
+rm -rf "$OUT_DIR"
+mkdir -p "$OUT_DIR/_static"
+touch "$OUT_DIR/.nojekyll"
+
+write_versions_json() {
+    python3 - "$OUT_DIR/_static/versions.json" "$BASE_URL" "$MAIN_VERSION" "${TAGS[@]}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+output = Path(sys.argv[1])
+base_url = sys.argv[2]
+main_version = sys.argv[3]
+tags = sys.argv[4:]
+
+def version_url(version: str) -> str:
+    return f"{base_url}{version}/"
+
+def display_version(ref: str) -> str:
+    return ref[1:] if ref.startswith("v") else ref
+
+versions = [
+    {
+        "name": main_version,
+        "version": main_version,
+        "url": version_url(main_version),
+    }
+]
+
+for tag in tags:
+    version = display_version(tag)
+    entry = {
+        "name": version,
+        "version": version,
+        "url": version_url(version),
+    }
+    versions.append(entry)
+
+output.write_text(json.dumps(versions, indent=2) + "\n", encoding="utf-8")
+PY
+}
+
+write_root_index() {
+    cat > "$OUT_DIR/index.html" <<EOF
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=${MAIN_VERSION}/">
+    <title>cuTile Rust Documentation</title>
+  </head>
+  <body>
+    <p>Redirecting to <a href="${MAIN_VERSION}/">cuTile Rust ${MAIN_VERSION} documentation</a>.</p>
+  </body>
+</html>
+EOF
+}
+
+build_ref() {
+    local ref="$1"
+    local version="$2"
+    local src="$REPO_ROOT"
+    local out="$OUT_DIR/$version"
+
+    if [[ "$ref" != "HEAD" ]]; then
+        src="$TMP_ROOT/$version"
+        git -C "$REPO_ROOT" worktree add --detach "$src" "$ref" >/dev/null
+        WORKTREES+=("$src")
+    fi
+
+    if [[ ! -f "$src/cutile-book/conf.py" ]]; then
+        echo "Skipping $version: cutile-book/conf.py not found at $ref" >&2
+        return
+    fi
+
+    echo "Building cuTile book for $version ($ref)"
+    CUTILE_DOCS_VERSION="$version" \
+    CUTILE_DOCS_SWITCHER_JSON="${BASE_URL}_static/versions.json" \
+        "$SPHINX_BUILD" -b html "$src/cutile-book" "$out"
+
+    # Older tags may enable sphinx-sitemap with unversioned URLs. The versioned
+    # Pages layout does not need per-version sitemap files.
+    rm -f "$out/sitemap.xml" "$out/sitemap.xml.gz"
+}
+
+write_versions_json
+write_root_index
+
+build_ref "$MAIN_REF" "$MAIN_VERSION"
+
+for tag in "${TAGS[@]}"; do
+    [[ -n "$tag" ]] || continue
+    version="${tag#v}"
+    build_ref "$tag" "$version"
+done
+
+echo "Built versioned documentation into $OUT_DIR"


### PR DESCRIPTION
Build GitHub Pages docs as a versioned site with main development docs and release-tag snapshots. Adds the pydata version switcher metadata and updates the Pages workflow to publish the generated _site tree.