### PR TITLE
fix: expose libc headers to bindgen in nix shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,10 @@ https://developer.nvidia.com/cuda-downloads
 
 ### Configure Environment
 
-Set `CUDA_TOOLKIT_PATH` to your CUDA 13.3 install directory.
+Set `CUDA_TOOLKIT_PATH` to your CUDA 13.3 install directory for a reproducible
+setup. If it is unset, cuTile searches standard CUDA 13.3/13.2 install
+locations such as `/usr/local/cuda-13.3`, `/usr/local/cuda-13.2`,
+`/usr/local/cuda-13`, and `/usr/local/cuda`.
 
 Example `.cargo/config.toml`:
 ```toml

--- a/cuda-bindings/README.md
+++ b/cuda-bindings/README.md
@@ -7,5 +7,7 @@ This crate is intentionally low level. Most code should depend on `cuda-core` in
 # Notes
 
 - The bindings are generated at build time.
-- `CUDA_TOOLKIT_PATH` must point at the local CUDA toolkit installation.
+- `CUDA_TOOLKIT_PATH` can point at the local CUDA toolkit installation. If it
+  is unset, the build searches standard CUDA 13.3/13.2 install locations.
+- Set `CUTILE_SETUP_DIAGNOSTICS=1` to print CUDA toolkit discovery decisions.
 - The crate is licensed under [LICENSE-NVIDIA](../LICENSE-NVIDIA).

--- a/cuda-bindings/build.rs
+++ b/cuda-bindings/build.rs
@@ -1,7 +1,14 @@
 // SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 
-use std::{env, error::Error, fs, path::Path, process::exit};
+use std::{
+    env,
+    error::Error,
+    ffi::OsString,
+    fs,
+    path::{Path, PathBuf},
+    process::exit,
+};
 
 use bindgen::CodegenConfig;
 use proc_macro2::TokenStream;
@@ -10,6 +17,10 @@ use syn::{
     Expr, Fields, File, GenericArgument, Item, ItemStruct, PathArguments, ReturnType, Type,
     TypeBareFn,
 };
+
+const MIN_CUDA_VERSION: u32 = 13020;
+const CUDA_TOOLKIT_PATH_ENV: &str = "CUDA_TOOLKIT_PATH";
+const SETUP_DIAGNOSTICS_ENV: &str = "CUTILE_SETUP_DIAGNOSTICS";
 
 struct ApiSpec {
     virtual_header: &'static str,
@@ -57,10 +68,12 @@ fn main() {
 
 fn run() -> Result<(), Box<dyn Error>> {
     println!("cargo:rerun-if-changed=wrapper.h");
-    println!("cargo:rerun-if-env-changed=CUDA_TOOLKIT_PATH");
+    println!("cargo:rerun-if-env-changed={CUDA_TOOLKIT_PATH_ENV}");
+    println!("cargo:rerun-if-env-changed={SETUP_DIAGNOSTICS_ENV}");
 
-    let cuda_toolkit =
-        env::var("CUDA_TOOLKIT_PATH").expect("CUDA_TOOLKIT_PATH is required but not set");
+    let cuda_toolkit = resolve_cuda_toolkit()?;
+    let cuda_toolkit = cuda_toolkit.to_string_lossy().into_owned();
+    println!("cargo:rustc-env=CUTILE_RESOLVED_CUDA_TOOLKIT_PATH={cuda_toolkit}");
     let out_dir = env::var("OUT_DIR")?;
     let out_dir = Path::new(&out_dir);
 
@@ -70,6 +83,147 @@ fn run() -> Result<(), Box<dyn Error>> {
     }
 
     Ok(())
+}
+
+fn resolve_cuda_toolkit() -> Result<PathBuf, Box<dyn Error>> {
+    match env::var_os(CUDA_TOOLKIT_PATH_ENV) {
+        Some(value) if value.is_empty() => Err(format!(
+            "{CUDA_TOOLKIT_PATH_ENV} is set to an empty string. Set it to a CUDA 13.2+ toolkit directory."
+        )
+        .into()),
+        Some(value) => resolve_explicit_cuda_toolkit(value),
+        None => find_default_cuda_toolkit(),
+    }
+}
+
+fn resolve_explicit_cuda_toolkit(value: OsString) -> Result<PathBuf, Box<dyn Error>> {
+    let cuda_toolkit = PathBuf::from(value);
+    let version = validate_cuda_toolkit(&cuda_toolkit).map_err(|error| {
+        format!(
+            "{CUDA_TOOLKIT_PATH_ENV}={} is invalid: {error}",
+            cuda_toolkit.display()
+        )
+    })?;
+    emit_setup_diagnostic(format_args!(
+        "using {CUDA_TOOLKIT_PATH_ENV}={} (CUDA {})",
+        cuda_toolkit.display(),
+        format_cuda_version(version)
+    ));
+    Ok(cuda_toolkit)
+}
+
+fn find_default_cuda_toolkit() -> Result<PathBuf, Box<dyn Error>> {
+    let mut rejected = Vec::new();
+    for cuda_toolkit in default_cuda_toolkit_candidates() {
+        match validate_cuda_toolkit(cuda_toolkit) {
+            Ok(version) => {
+                emit_setup_diagnostic(format_args!(
+                    "{CUDA_TOOLKIT_PATH_ENV} is unset; using discovered CUDA toolkit {} (CUDA {})",
+                    cuda_toolkit.display(),
+                    format_cuda_version(version)
+                ));
+                return Ok(cuda_toolkit.to_path_buf());
+            }
+            Err(error) => {
+                emit_setup_diagnostic(format_args!(
+                    "{CUDA_TOOLKIT_PATH_ENV} is unset; skipping {}: {error}",
+                    cuda_toolkit.display()
+                ));
+                rejected.push(format!("  - {}: {error}", cuda_toolkit.display()));
+            }
+        }
+    }
+
+    Err(format!(
+        "{CUDA_TOOLKIT_PATH_ENV} is not set, and no CUDA 13.2+ toolkit was found in default locations:\n{}\nSet {CUDA_TOOLKIT_PATH_ENV} to a CUDA 13.2+ toolkit directory.",
+        rejected.join("\n")
+    )
+    .into())
+}
+
+fn default_cuda_toolkit_candidates() -> &'static [PathBuf] {
+    static CANDIDATES: std::sync::OnceLock<Vec<PathBuf>> = std::sync::OnceLock::new();
+    CANDIDATES.get_or_init(|| {
+        #[cfg(windows)]
+        let candidates = [
+            r"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.3",
+            r"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.2",
+        ];
+        #[cfg(not(windows))]
+        let candidates = [
+            "/usr/local/cuda-13.3",
+            "/usr/local/cuda-13.2",
+            "/usr/local/cuda-13",
+            "/usr/local/cuda",
+        ];
+
+        candidates.into_iter().map(PathBuf::from).collect()
+    })
+}
+
+fn validate_cuda_toolkit(cuda_toolkit: &Path) -> Result<u32, String> {
+    if !cuda_toolkit.is_dir() {
+        return Err(format!("{} is not a directory", cuda_toolkit.display()));
+    }
+
+    let cuda_h = cuda_toolkit.join("include").join("cuda.h");
+    if !cuda_h.is_file() {
+        return Err(format!(
+            "{} does not contain include/cuda.h",
+            cuda_toolkit.display(),
+        ));
+    }
+
+    let version = cuda_version_from_header(&cuda_h).map_err(|error| error.to_string())?;
+    if version < MIN_CUDA_VERSION {
+        return Err(format!(
+            "CUDA toolkit {} is too old. cuTile requires CUDA 13.2+ and recommends CUDA 13.3",
+            format_cuda_version(version)
+        ));
+    }
+
+    Ok(version)
+}
+
+fn cuda_version_from_header(cuda_h: &Path) -> Result<u32, Box<dyn Error>> {
+    let source = fs::read_to_string(cuda_h)?;
+    source
+        .lines()
+        .find_map(|line| {
+            let mut parts = line.split_whitespace();
+            match (parts.next(), parts.next(), parts.next()) {
+                (Some("#define"), Some("CUDA_VERSION"), Some(version)) => version.parse().ok(),
+                _ => None,
+            }
+        })
+        .ok_or_else(|| {
+            format!(
+                "could not find CUDA_VERSION in {}. Set CUDA_TOOLKIT_PATH to a CUDA 13.2+ toolkit directory.",
+                cuda_h.display()
+            )
+            .into()
+        })
+}
+
+fn format_cuda_version(version: u32) -> String {
+    format!("{}.{}", version / 1000, (version % 1000) / 10)
+}
+
+fn setup_diagnostics_enabled() -> bool {
+    env::var(SETUP_DIAGNOSTICS_ENV)
+        .map(|value| {
+            matches!(
+                value.as_str(),
+                "1" | "true" | "TRUE" | "yes" | "YES" | "on" | "ON"
+            )
+        })
+        .unwrap_or(false)
+}
+
+fn emit_setup_diagnostic(args: std::fmt::Arguments<'_>) {
+    if setup_diagnostics_enabled() {
+        println!("cargo:warning={args}");
+    }
 }
 
 fn generate_type_bindings(cuda_toolkit: &str, out_dir: &Path) -> Result<(), Box<dyn Error>> {

--- a/cuda-bindings/src/lib.rs
+++ b/cuda-bindings/src/lib.rs
@@ -43,10 +43,8 @@ mod generated_curand {
 mod dyn_load;
 pub use dyn_load::*;
 
-use std::env;
-
 pub fn cuda_toolkit_dir() -> String {
-    env::var("CUDA_TOOLKIT_PATH").expect("CUDA_TOOLKIT_PATH is required but not set")
+    env!("CUTILE_RESOLVED_CUDA_TOOLKIT_PATH").to_string()
 }
 
 #[cfg(test)]

--- a/cuda-tile-rs/build.rs
+++ b/cuda-tile-rs/build.rs
@@ -80,10 +80,6 @@ fn main() {
     // 1. Resolve build+install tree location (default: $OUT_DIR; opt-in cache
     //    under ~/.cache/cuda-tile-rs/<key>/).
     let build_root = resolve_build_root(&submodule, &out_dir);
-    println!(
-        "cargo:warning=cuda-tile-rs build tree: {}",
-        build_root.display()
-    );
     fs::create_dir_all(&build_root).expect("failed to create build root");
 
     // 2. Build cuda-tile + LLVM via cmake. We don't ask for the combined

--- a/cutile-benchmarks/paper/README.md
+++ b/cutile-benchmarks/paper/README.md
@@ -43,7 +43,7 @@ were run on an RTX 5090. Section 5.3 uses the Grout artifact and model weights
 from the companion Grout repository.
 
 The embedded Rust benchmark crates depend on the published cuTile Rust crates
-at version `0.1.1`; they do not require a sibling `cutile-rs` checkout.
+at version `0.2.0`; they do not require a sibling `cutile-rs` checkout.
 
 Checked-in CSV and JSONL files are the paper data. For smoke tests or local
 reruns, write results and generated figures outside this tree. Shell runners

--- a/cutile-benchmarks/paper/app_exp1_work_distribution/bimodal_gemms_rust/Cargo.lock
+++ b/cutile-benchmarks/paper/app_exp1_work_distribution/bimodal_gemms_rust/Cargo.lock
@@ -132,9 +132,9 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "cuda-async"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8c6808ecab7b3c1724faba96670e1055dba3d72906e8306ed726029602e9fef"
+checksum = "fd6c360df7c3df23ae84388ad92946adee91ed148c55238764158463836cdf02"
 dependencies = [
  "anyhow",
  "cuda-core",
@@ -145,9 +145,9 @@ dependencies = [
 
 [[package]]
 name = "cuda-bindings"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ee302eb2aa5640617da27c33bb8449b35830ba1c5ecdddcae6cc7d5f99593c1"
+checksum = "5fd5367a2bc87b28e51af60ac2ac0013adfc46a118a17c03f18c2e49d98d3b43"
 dependencies = [
  "bindgen",
  "libloading",
@@ -159,9 +159,9 @@ dependencies = [
 
 [[package]]
 name = "cuda-core"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5c0ad8ecce9319aec2f65357b9760a3f3f009fad134c7ebff6d6a9dac85b66"
+checksum = "619053ccb62b6553bb119ba71d32b5d310d0f598d35ed567ea48270cbbd8cd88"
 dependencies = [
  "anyhow",
  "cuda-bindings",
@@ -170,9 +170,9 @@ dependencies = [
 
 [[package]]
 name = "cutile"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52b1d8edbabb5ffdb1d753d465d463278a09acfcf622013a4ad811b9b2b94c3e"
+checksum = "ce552580483d74772e1e4b2cc266a04ad712e60c9f3ef62f20bd29a3c568fee5"
 dependencies = [
  "anyhow",
  "cuda-async",
@@ -190,9 +190,9 @@ dependencies = [
 
 [[package]]
 name = "cutile-compiler"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "772444fc9725dcf1476c4979bc08b836a5f44fe70a4427995649efbb21901391"
+checksum = "e890bb73c35443a7885ae4796694c1131c75eac9c7f439b38252dae0ccfbdfb4"
 dependencies = [
  "anyhow",
  "cuda-async",
@@ -211,9 +211,9 @@ dependencies = [
 
 [[package]]
 name = "cutile-ir"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4228384ee4a904d277a9e290b89e8beaaeea155bb8f6b38c3eb98799e63a784"
+checksum = "e23ea155ff0ce6b3549320fc735616048e7c6ce82fc6c99e31950a8fce8fb60a"
 dependencies = [
  "half",
  "indexmap",
@@ -222,9 +222,9 @@ dependencies = [
 
 [[package]]
 name = "cutile-macro"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38abc3c0dcaedeb9acac387d3744c183963aeafaad3a11f35ea98d4777dd979c"
+checksum = "034244ff1d795c923585a2587b8421d26c80d00cde21d44c45002fa1cb7f50b7"
 dependencies = [
  "convert_case",
  "cutile-compiler",

--- a/cutile-benchmarks/paper/app_exp1_work_distribution/bimodal_gemms_rust/Cargo.toml
+++ b/cutile-benchmarks/paper/app_exp1_work_distribution/bimodal_gemms_rust/Cargo.toml
@@ -10,11 +10,11 @@ name = "bimodal_gemms"
 path = "src/main.rs"
 
 [dependencies]
-cuda-core = "0.1.1"
-cuda-async = "0.1.1"
-cutile = "0.1.1"
-cutile-macro = "0.1.1"
-cutile-compiler = "0.1.1"
+cuda-core = "0.2.0"
+cuda-async = "0.2.0"
+cutile = "0.2.0"
+cutile-macro = "0.2.0"
+cutile-compiler = "0.2.0"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "sync", "time"] }
 
 [profile.release]

--- a/cutile-benchmarks/paper/sec5_exp1_safety_overhead/rust/elemwise/Cargo.lock
+++ b/cutile-benchmarks/paper/sec5_exp1_safety_overhead/rust/elemwise/Cargo.lock
@@ -120,9 +120,9 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "cuda-async"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8c6808ecab7b3c1724faba96670e1055dba3d72906e8306ed726029602e9fef"
+checksum = "fd6c360df7c3df23ae84388ad92946adee91ed148c55238764158463836cdf02"
 dependencies = [
  "anyhow",
  "cuda-core",
@@ -133,9 +133,9 @@ dependencies = [
 
 [[package]]
 name = "cuda-bindings"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ee302eb2aa5640617da27c33bb8449b35830ba1c5ecdddcae6cc7d5f99593c1"
+checksum = "5fd5367a2bc87b28e51af60ac2ac0013adfc46a118a17c03f18c2e49d98d3b43"
 dependencies = [
  "bindgen",
  "libloading",
@@ -147,9 +147,9 @@ dependencies = [
 
 [[package]]
 name = "cuda-core"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5c0ad8ecce9319aec2f65357b9760a3f3f009fad134c7ebff6d6a9dac85b66"
+checksum = "619053ccb62b6553bb119ba71d32b5d310d0f598d35ed567ea48270cbbd8cd88"
 dependencies = [
  "anyhow",
  "cuda-bindings",
@@ -158,9 +158,9 @@ dependencies = [
 
 [[package]]
 name = "cutile"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52b1d8edbabb5ffdb1d753d465d463278a09acfcf622013a4ad811b9b2b94c3e"
+checksum = "ce552580483d74772e1e4b2cc266a04ad712e60c9f3ef62f20bd29a3c568fee5"
 dependencies = [
  "anyhow",
  "cuda-async",
@@ -178,9 +178,9 @@ dependencies = [
 
 [[package]]
 name = "cutile-compiler"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "772444fc9725dcf1476c4979bc08b836a5f44fe70a4427995649efbb21901391"
+checksum = "e890bb73c35443a7885ae4796694c1131c75eac9c7f439b38252dae0ccfbdfb4"
 dependencies = [
  "anyhow",
  "cuda-async",
@@ -199,9 +199,9 @@ dependencies = [
 
 [[package]]
 name = "cutile-ir"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4228384ee4a904d277a9e290b89e8beaaeea155bb8f6b38c3eb98799e63a784"
+checksum = "e23ea155ff0ce6b3549320fc735616048e7c6ce82fc6c99e31950a8fce8fb60a"
 dependencies = [
  "half",
  "indexmap",
@@ -210,9 +210,9 @@ dependencies = [
 
 [[package]]
 name = "cutile-macro"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38abc3c0dcaedeb9acac387d3744c183963aeafaad3a11f35ea98d4777dd979c"
+checksum = "034244ff1d795c923585a2587b8421d26c80d00cde21d44c45002fa1cb7f50b7"
 dependencies = [
  "convert_case",
  "cutile-compiler",

--- a/cutile-benchmarks/paper/sec5_exp1_safety_overhead/rust/elemwise/Cargo.toml
+++ b/cutile-benchmarks/paper/sec5_exp1_safety_overhead/rust/elemwise/Cargo.toml
@@ -10,11 +10,11 @@ name = "elemwise_rust"
 path = "src/main.rs"
 
 [dependencies]
-cuda-core = "0.1.1"
-cuda-async = "0.1.1"
-cutile = "0.1.1"
-cutile-macro = "0.1.1"
-cutile-compiler = "0.1.1"
+cuda-core = "0.2.0"
+cuda-async = "0.2.0"
+cutile = "0.2.0"
+cutile-macro = "0.2.0"
+cutile-compiler = "0.2.0"
 
 [profile.release]
 opt-level = 3

--- a/cutile-benchmarks/paper/sec5_exp1_safety_overhead/rust/gemm/Cargo.lock
+++ b/cutile-benchmarks/paper/sec5_exp1_safety_overhead/rust/gemm/Cargo.lock
@@ -120,9 +120,9 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "cuda-async"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8c6808ecab7b3c1724faba96670e1055dba3d72906e8306ed726029602e9fef"
+checksum = "fd6c360df7c3df23ae84388ad92946adee91ed148c55238764158463836cdf02"
 dependencies = [
  "anyhow",
  "cuda-core",
@@ -133,9 +133,9 @@ dependencies = [
 
 [[package]]
 name = "cuda-bindings"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ee302eb2aa5640617da27c33bb8449b35830ba1c5ecdddcae6cc7d5f99593c1"
+checksum = "5fd5367a2bc87b28e51af60ac2ac0013adfc46a118a17c03f18c2e49d98d3b43"
 dependencies = [
  "bindgen",
  "libloading",
@@ -147,9 +147,9 @@ dependencies = [
 
 [[package]]
 name = "cuda-core"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5c0ad8ecce9319aec2f65357b9760a3f3f009fad134c7ebff6d6a9dac85b66"
+checksum = "619053ccb62b6553bb119ba71d32b5d310d0f598d35ed567ea48270cbbd8cd88"
 dependencies = [
  "anyhow",
  "cuda-bindings",
@@ -158,9 +158,9 @@ dependencies = [
 
 [[package]]
 name = "cutile"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52b1d8edbabb5ffdb1d753d465d463278a09acfcf622013a4ad811b9b2b94c3e"
+checksum = "ce552580483d74772e1e4b2cc266a04ad712e60c9f3ef62f20bd29a3c568fee5"
 dependencies = [
  "anyhow",
  "cuda-async",
@@ -178,9 +178,9 @@ dependencies = [
 
 [[package]]
 name = "cutile-compiler"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "772444fc9725dcf1476c4979bc08b836a5f44fe70a4427995649efbb21901391"
+checksum = "e890bb73c35443a7885ae4796694c1131c75eac9c7f439b38252dae0ccfbdfb4"
 dependencies = [
  "anyhow",
  "cuda-async",
@@ -199,9 +199,9 @@ dependencies = [
 
 [[package]]
 name = "cutile-ir"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4228384ee4a904d277a9e290b89e8beaaeea155bb8f6b38c3eb98799e63a784"
+checksum = "e23ea155ff0ce6b3549320fc735616048e7c6ce82fc6c99e31950a8fce8fb60a"
 dependencies = [
  "half",
  "indexmap",
@@ -210,9 +210,9 @@ dependencies = [
 
 [[package]]
 name = "cutile-macro"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38abc3c0dcaedeb9acac387d3744c183963aeafaad3a11f35ea98d4777dd979c"
+checksum = "034244ff1d795c923585a2587b8421d26c80d00cde21d44c45002fa1cb7f50b7"
 dependencies = [
  "convert_case",
  "cutile-compiler",

--- a/cutile-benchmarks/paper/sec5_exp1_safety_overhead/rust/gemm/Cargo.toml
+++ b/cutile-benchmarks/paper/sec5_exp1_safety_overhead/rust/gemm/Cargo.toml
@@ -10,11 +10,11 @@ name = "gemm_rust"
 path = "src/main.rs"
 
 [dependencies]
-cuda-core = "0.1.1"
-cuda-async = "0.1.1"
-cutile = "0.1.1"
-cutile-macro = "0.1.1"
-cutile-compiler = "0.1.1"
+cuda-core = "0.2.0"
+cuda-async = "0.2.0"
+cutile = "0.2.0"
+cutile-macro = "0.2.0"
+cutile-compiler = "0.2.0"
 
 [profile.release]
 opt-level = 3

--- a/cutile-benchmarks/paper/sec5_exp2_execution_mode_overhead/README.md
+++ b/cutile-benchmarks/paper/sec5_exp2_execution_mode_overhead/README.md
@@ -23,7 +23,7 @@ sec5_exp2_execution_mode_overhead/
   plot_part_a.py                 # writes exp2_execmode_latency.pdf
   plot_part_b.py                 # writes exp2_async_throughput.pdf
   launch_overhead_rust/
-    Cargo.toml                   # depends on published cuTile Rust crates 0.1.1
+    Cargo.toml                   # depends on published cuTile Rust crates 0.2.0
     src/main.rs                  # Part A: execution-mode schedules
     src/bin/async_throughput.rs  # Part B: sync/async overlap
     results_part_a.csv           # checked-in Part A data
@@ -125,7 +125,7 @@ PIN_CPU=8 ./run_part_b.sh
 - `../lock_clocks.sh` is retained as a local reproduction helper; its default
   lock target is 2.4 GHz.
 - The Rust crate depends on the published cuTile Rust crates at version
-  `0.1.1`.
+  `0.2.0`.
 - The plot scripts default to `python3`. Set `PY=/path/to/python` if the
   plotting dependencies live in another environment.
 - Use `RESULTS_DIR=/tmp/...` and `FIGURES_DIR=/tmp/...` for smoke tests that

--- a/cutile-benchmarks/paper/sec5_exp2_execution_mode_overhead/launch_overhead_rust/Cargo.lock
+++ b/cutile-benchmarks/paper/sec5_exp2_execution_mode_overhead/launch_overhead_rust/Cargo.lock
@@ -120,9 +120,9 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "cuda-async"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8c6808ecab7b3c1724faba96670e1055dba3d72906e8306ed726029602e9fef"
+checksum = "fd6c360df7c3df23ae84388ad92946adee91ed148c55238764158463836cdf02"
 dependencies = [
  "anyhow",
  "cuda-core",
@@ -133,9 +133,9 @@ dependencies = [
 
 [[package]]
 name = "cuda-bindings"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ee302eb2aa5640617da27c33bb8449b35830ba1c5ecdddcae6cc7d5f99593c1"
+checksum = "5fd5367a2bc87b28e51af60ac2ac0013adfc46a118a17c03f18c2e49d98d3b43"
 dependencies = [
  "bindgen",
  "libloading",
@@ -147,9 +147,9 @@ dependencies = [
 
 [[package]]
 name = "cuda-core"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5c0ad8ecce9319aec2f65357b9760a3f3f009fad134c7ebff6d6a9dac85b66"
+checksum = "619053ccb62b6553bb119ba71d32b5d310d0f598d35ed567ea48270cbbd8cd88"
 dependencies = [
  "anyhow",
  "cuda-bindings",
@@ -158,9 +158,9 @@ dependencies = [
 
 [[package]]
 name = "cutile"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52b1d8edbabb5ffdb1d753d465d463278a09acfcf622013a4ad811b9b2b94c3e"
+checksum = "ce552580483d74772e1e4b2cc266a04ad712e60c9f3ef62f20bd29a3c568fee5"
 dependencies = [
  "anyhow",
  "cuda-async",
@@ -178,9 +178,9 @@ dependencies = [
 
 [[package]]
 name = "cutile-compiler"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "772444fc9725dcf1476c4979bc08b836a5f44fe70a4427995649efbb21901391"
+checksum = "e890bb73c35443a7885ae4796694c1131c75eac9c7f439b38252dae0ccfbdfb4"
 dependencies = [
  "anyhow",
  "cuda-async",
@@ -199,9 +199,9 @@ dependencies = [
 
 [[package]]
 name = "cutile-ir"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4228384ee4a904d277a9e290b89e8beaaeea155bb8f6b38c3eb98799e63a784"
+checksum = "e23ea155ff0ce6b3549320fc735616048e7c6ce82fc6c99e31950a8fce8fb60a"
 dependencies = [
  "half",
  "indexmap",
@@ -210,9 +210,9 @@ dependencies = [
 
 [[package]]
 name = "cutile-macro"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38abc3c0dcaedeb9acac387d3744c183963aeafaad3a11f35ea98d4777dd979c"
+checksum = "034244ff1d795c923585a2587b8421d26c80d00cde21d44c45002fa1cb7f50b7"
 dependencies = [
  "convert_case",
  "cutile-compiler",

--- a/cutile-benchmarks/paper/sec5_exp2_execution_mode_overhead/launch_overhead_rust/Cargo.toml
+++ b/cutile-benchmarks/paper/sec5_exp2_execution_mode_overhead/launch_overhead_rust/Cargo.toml
@@ -14,11 +14,11 @@ name = "async_throughput"
 path = "src/bin/async_throughput.rs"
 
 [dependencies]
-cuda-core = "0.1.1"
-cuda-async = "0.1.1"
-cutile = "0.1.1"
-cutile-macro = "0.1.1"
-cutile-compiler = "0.1.1"
+cuda-core = "0.2.0"
+cuda-async = "0.2.0"
+cutile = "0.2.0"
+cutile-macro = "0.2.0"
+cutile-compiler = "0.2.0"
 tokio = { version = "1", features = ["rt", "macros"] }
 
 [profile.release]

--- a/cutile-compiler/README.md
+++ b/cutile-compiler/README.md
@@ -4,13 +4,24 @@ This crate compiles Rust DSL kernels into Tile IR bytecode for GPU execution
 via `tileiras`. Most users interact with it indirectly through `cutile` and
 `cutile-macro`.
 
-By default, the runtime invokes `tileiras` through normal `PATH` lookup. Set
-`CUTILE_TILEIRAS_PATH` to use a specific binary:
+The runtime resolves `tileiras` in this order:
+
+1. `CUTILE_TILEIRAS_PATH`, when set.
+2. `$CUDA_TOOLKIT_PATH/bin/tileiras`, when `CUDA_TOOLKIT_PATH` is set and the
+   binary exists there.
+3. Standard CUDA 13.3/13.2 install locations, when they contain
+   `bin/tileiras`.
+4. `tileiras` through normal `PATH` lookup.
+
+Set `CUTILE_TILEIRAS_PATH` to force a specific binary:
 
 ```bash
 CUTILE_TILEIRAS_PATH=/opt/cuda-tile/bin/tileiras \
     cargo test -p cutile-compiler
 ```
+
+Set `CUTILE_SETUP_DIAGNOSTICS=1` to print CUDA toolkit and `tileiras` discovery
+decisions during setup.
 
 ## Testing
 

--- a/cutile-compiler/src/cuda_tile_runtime_utils.rs
+++ b/cutile-compiler/src/cuda_tile_runtime_utils.rs
@@ -9,7 +9,7 @@
 use cuda_core::{get_device_sm_name, Device};
 use std::env;
 use std::ffi::OsString;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use uuid::Uuid;
 
@@ -18,26 +18,113 @@ use uuid::Uuid;
 /// Set this to an absolute path such as `/opt/cuda-tile/bin/tileiras` to use
 /// that binary instead of the `tileiras` found on `PATH`.
 pub const TILEIRAS_PATH_ENV: &str = "CUTILE_TILEIRAS_PATH";
+pub const SETUP_DIAGNOSTICS_ENV: &str = "CUTILE_SETUP_DIAGNOSTICS";
+
+const CUDA_TOOLKIT_PATH_ENV: &str = "CUDA_TOOLKIT_PATH";
+const MIN_CUDA_VERSION: u32 = 13020;
 
 /// Queries the CUDA driver to determine the SM architecture name (e.g. `"sm_90"`) for a device.
 pub fn get_gpu_name(device_id: usize) -> String {
-    let dev = Device::raw_device(device_id).expect("failed to get CUDA device");
-    unsafe { get_device_sm_name(dev) }.expect("failed to get SM name")
+    let dev = Device::raw_device(device_id).unwrap_or_else(|e| {
+        panic!(
+            "failed to get CUDA device {device_id}: {e}\n\
+             Ensure an NVIDIA GPU is visible to the process and the CUDA driver is installed."
+        )
+    });
+    unsafe { get_device_sm_name(dev) }.unwrap_or_else(|e| {
+        panic!(
+            "failed to query CUDA SM name for device {device_id}: {e}\n\
+             Ensure the installed CUDA driver supports this GPU."
+        )
+    })
 }
 
-fn resolve_tileiras_binary(value: Option<OsString>) -> PathBuf {
-    value
+fn tileiras_executable_name() -> &'static str {
+    if cfg!(windows) {
+        "tileiras.exe"
+    } else {
+        "tileiras"
+    }
+}
+
+fn cuda_toolkit_tileiras(cuda_toolkit_path: Option<OsString>) -> Option<PathBuf> {
+    let tileiras = cuda_toolkit_path
         .filter(|value| !value.as_os_str().is_empty())
         .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from("tileiras"))
+        .map(|path| path.join("bin").join(tileiras_executable_name()));
+    match tileiras {
+        Some(path) if path.is_file() => {
+            emit_setup_diagnostic(format_args!(
+                "using {CUDA_TOOLKIT_PATH_ENV} tileiras at {}",
+                path.display()
+            ));
+            Some(path)
+        }
+        Some(path) => {
+            emit_setup_diagnostic(format_args!(
+                "{CUDA_TOOLKIT_PATH_ENV} did not contain tileiras at {}",
+                path.display()
+            ));
+            None
+        }
+        None => None,
+    }
+}
+
+fn resolve_tileiras_binary(
+    tileiras_override: Option<OsString>,
+    cuda_toolkit_path: Option<OsString>,
+) -> PathBuf {
+    resolve_tileiras_binary_with_candidates(
+        tileiras_override,
+        cuda_toolkit_path,
+        default_cuda_toolkit_candidates(),
+    )
+}
+
+fn resolve_tileiras_binary_with_candidates(
+    tileiras_override: Option<OsString>,
+    cuda_toolkit_path: Option<OsString>,
+    default_cuda_toolkit_candidates: &[PathBuf],
+) -> PathBuf {
+    if let Some(path) = tileiras_override.filter(|value| !value.as_os_str().is_empty()) {
+        let path = PathBuf::from(path);
+        emit_setup_diagnostic(format_args!("using {TILEIRAS_PATH_ENV}={}", path.display()));
+        return path;
+    }
+
+    if let Some(path) = cuda_toolkit_tileiras(cuda_toolkit_path) {
+        if path.is_file() {
+            return path;
+        }
+    }
+
+    if let Some(path) = default_cuda_toolkit_tileiras(default_cuda_toolkit_candidates) {
+        return path;
+    }
+
+    emit_setup_diagnostic(format_args!(
+        "falling back to {} through PATH lookup",
+        tileiras_executable_name()
+    ));
+    PathBuf::from(tileiras_executable_name())
 }
 
 /// Returns the `tileiras` executable path used by the JIT.
 ///
-/// Defaults to `tileiras`, which uses normal `PATH` lookup. Set
-/// [`TILEIRAS_PATH_ENV`] to override this with a specific binary.
+/// Resolution order:
+///
+/// 1. [`TILEIRAS_PATH_ENV`] when set.
+/// 2. `$CUDA_TOOLKIT_PATH/bin/tileiras` when `CUDA_TOOLKIT_PATH` is set and
+///    the binary exists there.
+/// 3. `$CUDA_TOOLKIT_PATH`-style default CUDA installs with CUDA 13.2+ and
+///    `bin/tileiras`.
+/// 4. `tileiras` through normal `PATH` lookup.
 pub fn tileiras_binary() -> PathBuf {
-    resolve_tileiras_binary(env::var_os(TILEIRAS_PATH_ENV))
+    resolve_tileiras_binary(
+        env::var_os(TILEIRAS_PATH_ENV),
+        env::var_os(CUDA_TOOLKIT_PATH_ENV),
+    )
 }
 
 /// Compiles a `cutile_ir::Module` to a `.cubin` file via bytecode serialization and `tileiras`.
@@ -74,31 +161,196 @@ pub fn compile_tile_ir_module(module: &cutile_ir::Module, gpu_name: &str) -> Str
     std::fs::write(&bc_filename, &bytes)
         .unwrap_or_else(|e| panic!("Failed to write bytecode for {bc_filename}: {e}"));
     let tileiras = tileiras_binary();
+    let args = [
+        "--gpu-name",
+        gpu_name,
+        "--opt-level",
+        "3",
+        "-o",
+        &cubin_filename,
+        &bc_filename,
+    ];
     let output = Command::new(&tileiras)
-        .arg("--gpu-name")
-        .arg(gpu_name)
-        .arg("--opt-level")
-        .arg("3")
-        .arg("-o")
-        .arg(&cubin_filename)
-        .arg(&bc_filename)
+        .args(args)
         .output()
         .unwrap_or_else(|e| {
             panic!(
-                "Failed to launch {} for {bc_filename}: {e}",
-                tileiras.display()
+                "{}",
+                tileiras_launch_error(&tileiras, &args, &bc_filename, e)
             )
         });
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         let stdout = String::from_utf8_lossy(&output.stdout);
         panic!(
-            "{} failed (exit {}) for gpu {gpu_name}:\nstderr: {stderr}\nstdout: {stdout}",
+            "{} failed while compiling Tile IR bytecode.\n\
+             status: {}\n\
+             command: {}\n\
+             target gpu: {gpu_name}\n\
+             bytecode: {bc_filename}\n\
+             output cubin: {cubin_filename}\n\
+             stdout:\n{stdout}\n\
+             stderr:\n{stderr}\n\
+             hint: run with CUTILE_DUMP=ir,bytecode to include the generated Tile IR and decoded bytecode in stderr.",
             tileiras.display(),
-            output.status
+            output.status,
+            display_command(&tileiras, &args),
         );
     }
     cubin_filename
+}
+
+fn tileiras_launch_error(
+    tileiras: &Path,
+    args: &[&str],
+    bc_filename: &str,
+    error: std::io::Error,
+) -> String {
+    let mut message = format!(
+        "failed to launch tileiras.\n\
+         error: {error}\n\
+         command: {}\n\
+         bytecode: {bc_filename}\n\
+         CUTILE_TILEIRAS_PATH: {}\n\
+         CUDA_TOOLKIT_PATH: {}\n",
+        display_command(tileiras, args),
+        env::var(TILEIRAS_PATH_ENV).unwrap_or_else(|_| "<unset>".to_string()),
+        env::var(CUDA_TOOLKIT_PATH_ENV).unwrap_or_else(|_| "<unset>".to_string()),
+    );
+
+    if env::var_os(TILEIRAS_PATH_ENV).is_none() {
+        message.push_str(
+            "hint: install CUDA 13.2+ with tileiras, set CUDA_TOOLKIT_PATH to that toolkit, \
+             set CUTILE_TILEIRAS_PATH to the absolute tileiras path, or rerun with \
+             CUTILE_SETUP_DIAGNOSTICS=1 to trace toolkit discovery.",
+        );
+    } else {
+        message
+            .push_str("hint: verify CUTILE_TILEIRAS_PATH points to an executable tileiras binary.");
+    }
+
+    message
+}
+
+fn default_cuda_toolkit_candidates() -> &'static [PathBuf] {
+    static CANDIDATES: std::sync::OnceLock<Vec<PathBuf>> = std::sync::OnceLock::new();
+    CANDIDATES.get_or_init(|| {
+        #[cfg(windows)]
+        let candidates = [
+            r"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.3",
+            r"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.2",
+        ];
+        #[cfg(not(windows))]
+        let candidates = [
+            "/usr/local/cuda-13.3",
+            "/usr/local/cuda-13.2",
+            "/usr/local/cuda-13",
+            "/usr/local/cuda",
+        ];
+
+        candidates.into_iter().map(PathBuf::from).collect()
+    })
+}
+
+fn default_cuda_toolkit_tileiras(candidates: &[PathBuf]) -> Option<PathBuf> {
+    for candidate in candidates {
+        match supported_cuda_toolkit_tileiras(candidate) {
+            Ok(tileiras) => {
+                emit_setup_diagnostic(format_args!(
+                    "{CUDA_TOOLKIT_PATH_ENV} is unset; using discovered tileiras at {}",
+                    tileiras.display()
+                ));
+                return Some(tileiras);
+            }
+            Err(error) => {
+                emit_setup_diagnostic(format_args!(
+                    "{CUDA_TOOLKIT_PATH_ENV} is unset; skipping {}: {error}",
+                    candidate.display()
+                ));
+            }
+        }
+    }
+
+    None
+}
+
+fn supported_cuda_toolkit_tileiras(cuda_toolkit: &Path) -> Result<PathBuf, String> {
+    if !cuda_toolkit.is_dir() {
+        return Err("not a directory".to_string());
+    }
+
+    let cuda_h = cuda_toolkit.join("include").join("cuda.h");
+    let version = cuda_version_from_header(&cuda_h)?;
+    if version < MIN_CUDA_VERSION {
+        return Err(format!(
+            "CUDA toolkit {} is too old",
+            format_cuda_version(version)
+        ));
+    }
+
+    let tileiras = cuda_toolkit.join("bin").join(tileiras_executable_name());
+    if !tileiras.is_file() {
+        return Err(format!("missing {}", tileiras.display()));
+    }
+
+    Ok(tileiras)
+}
+
+fn cuda_version_from_header(cuda_h: &Path) -> Result<u32, String> {
+    let source = std::fs::read_to_string(cuda_h)
+        .map_err(|error| format!("could not read {}: {error}", cuda_h.display()))?;
+    source
+        .lines()
+        .find_map(|line| {
+            let mut parts = line.split_whitespace();
+            match (parts.next(), parts.next(), parts.next()) {
+                (Some("#define"), Some("CUDA_VERSION"), Some(version)) => version.parse().ok(),
+                _ => None,
+            }
+        })
+        .ok_or_else(|| format!("could not find CUDA_VERSION in {}", cuda_h.display()))
+}
+
+fn format_cuda_version(version: u32) -> String {
+    format!("{}.{}", version / 1000, (version % 1000) / 10)
+}
+
+fn setup_diagnostics_enabled() -> bool {
+    env::var(SETUP_DIAGNOSTICS_ENV)
+        .map(|value| {
+            matches!(
+                value.as_str(),
+                "1" | "true" | "TRUE" | "yes" | "YES" | "on" | "ON"
+            )
+        })
+        .unwrap_or(false)
+}
+
+fn emit_setup_diagnostic(args: std::fmt::Arguments<'_>) {
+    if setup_diagnostics_enabled() {
+        eprintln!("cutile setup: {args}");
+    }
+}
+
+fn display_command(program: &Path, args: &[&str]) -> String {
+    std::iter::once(shell_display(program.as_os_str()))
+        .chain(args.iter().map(|arg| shell_display(arg.as_ref())))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn shell_display(value: &std::ffi::OsStr) -> String {
+    let value = value.to_string_lossy();
+    if value.is_empty() {
+        "''".to_string()
+    } else if value
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.' | '/' | ':' | '='))
+    {
+        value.into_owned()
+    } else {
+        format!("'{}'", value.replace('\'', "'\\''"))
+    }
 }
 
 #[cfg(test)]
@@ -114,13 +366,20 @@ mod tests {
 
     #[test]
     fn tileiras_binary_defaults_to_path_lookup() {
-        assert_eq!(resolve_tileiras_binary(None), PathBuf::from("tileiras"));
+        assert_eq!(
+            resolve_tileiras_binary_with_candidates(None, None, &[]),
+            PathBuf::from("tileiras")
+        );
     }
 
     #[test]
     fn tileiras_binary_uses_override_path() {
         assert_eq!(
-            resolve_tileiras_binary(Some(OsString::from("/opt/cuda/bin/tileiras"))),
+            resolve_tileiras_binary_with_candidates(
+                Some(OsString::from("/opt/cuda/bin/tileiras")),
+                None,
+                &[]
+            ),
             PathBuf::from("/opt/cuda/bin/tileiras")
         );
     }
@@ -128,9 +387,74 @@ mod tests {
     #[test]
     fn tileiras_binary_treats_empty_override_as_default() {
         assert_eq!(
-            resolve_tileiras_binary(Some(OsString::new())),
+            resolve_tileiras_binary_with_candidates(Some(OsString::new()), None, &[]),
             PathBuf::from("tileiras")
         );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn tileiras_binary_uses_cuda_toolkit_path_when_present() {
+        let temp_dir = env::temp_dir().join(format!("cutile_cuda_toolkit_{}", Uuid::new_v4()));
+        let bin_dir = temp_dir.join("bin");
+        fs::create_dir_all(&bin_dir).unwrap();
+        let tileiras = bin_dir.join(tileiras_executable_name());
+        fs::write(&tileiras, "").unwrap();
+
+        assert_eq!(
+            resolve_tileiras_binary_with_candidates(
+                None,
+                Some(temp_dir.clone().into_os_string()),
+                &[]
+            ),
+            tileiras
+        );
+
+        let _ = fs::remove_file(bin_dir.join(tileiras_executable_name()));
+        let _ = fs::remove_dir(bin_dir);
+        let _ = fs::remove_dir(temp_dir);
+    }
+
+    #[test]
+    fn tileiras_binary_ignores_cuda_toolkit_path_without_tileiras() {
+        let temp_dir = env::temp_dir().join(format!("cutile_cuda_toolkit_{}", Uuid::new_v4()));
+        assert_eq!(
+            resolve_tileiras_binary_with_candidates(None, Some(temp_dir.into_os_string()), &[]),
+            PathBuf::from(tileiras_executable_name())
+        );
+    }
+
+    #[test]
+    fn tileiras_binary_uses_default_cuda_toolkit_when_supported() {
+        let temp_dir = env::temp_dir().join(format!("cutile_cuda_toolkit_{}", Uuid::new_v4()));
+        let tileiras = create_fake_cuda_toolkit(&temp_dir, 13020, true);
+
+        assert_eq!(
+            resolve_tileiras_binary_with_candidates(None, None, &[temp_dir.clone()]),
+            tileiras
+        );
+
+        let _ = fs::remove_dir_all(temp_dir);
+    }
+
+    #[test]
+    fn tileiras_binary_skips_old_default_cuda_toolkit() {
+        let old_dir = env::temp_dir().join(format!("cutile_cuda_toolkit_{}", Uuid::new_v4()));
+        let new_dir = env::temp_dir().join(format!("cutile_cuda_toolkit_{}", Uuid::new_v4()));
+        let _old_tileiras = create_fake_cuda_toolkit(&old_dir, 13010, true);
+        let new_tileiras = create_fake_cuda_toolkit(&new_dir, 13020, true);
+
+        assert_eq!(
+            resolve_tileiras_binary_with_candidates(
+                None,
+                None,
+                &[old_dir.clone(), new_dir.clone()]
+            ),
+            new_tileiras
+        );
+
+        let _ = fs::remove_dir_all(old_dir);
+        let _ = fs::remove_dir_all(new_dir);
     }
 
     #[test]
@@ -208,6 +532,24 @@ mod tests {
             .build(&mut module);
         module.functions.push(entry_id);
         module
+    }
+
+    fn create_fake_cuda_toolkit(path: &Path, cuda_version: u32, include_tileiras: bool) -> PathBuf {
+        let include_dir = path.join("include");
+        let bin_dir = path.join("bin");
+        fs::create_dir_all(&include_dir).unwrap();
+        fs::create_dir_all(&bin_dir).unwrap();
+        fs::write(
+            include_dir.join("cuda.h"),
+            format!("#define CUDA_VERSION {cuda_version}\n"),
+        )
+        .unwrap();
+
+        let tileiras = bin_dir.join(tileiras_executable_name());
+        if include_tileiras {
+            fs::write(&tileiras, "").unwrap();
+        }
+        tileiras
     }
 
     #[cfg(unix)]

--- a/cutile-compiler/src/passes/type_inference.rs
+++ b/cutile-compiler/src/passes/type_inference.rs
@@ -972,7 +972,7 @@ impl<'a, 'm> TypeInferenceCx<'a, 'm> {
             .compile_type(target_ty, self.generic_vars, &HashMap::new())
         {
             Ok(ty) => Ok(ty),
-            Err(err) if is_surface_only_scalar_type(target_ty) => Ok(None),
+            Err(_) if is_surface_only_scalar_type(target_ty) => Ok(None),
             Err(err) => Err(err),
         }
     }

--- a/cutile/src/_core.rs
+++ b/cutile/src/_core.rs
@@ -515,7 +515,7 @@ pub mod core {
 
     #[cuda_tile::variadic_impl(N = 6)]
     impl<E: ElementType, const D: [i32; N]> Tile<E, D> {
-        pub fn shape(&self) -> Shape<D> {
+        pub fn shape(&self) -> Shape<'_, D> {
             unreachable!()
         }
         pub fn broadcast<const R: [i32; N]>(self, shape: Shape<R>) -> Tile<E, R> {

--- a/flake.nix
+++ b/flake.nix
@@ -81,6 +81,8 @@
 
         # bindgen uses libclang to parse CUDA headers.
         libclang = pkgs.llvmPackages.libclang;
+        libcDev = pkgs.lib.getDev pkgs.stdenv.cc.libc;
+        bindgenClangArgs = pkgs.lib.optionalString (!isDarwin) "-isystem ${libcDev}/include";
 
         # Nightly Rust 
         rustToolchain =
@@ -114,6 +116,7 @@
           CMAKE_GENERATOR = "Ninja";
           CUDA_TOOLKIT_PATH = "${cudaToolkit}";
           LIBCLANG_PATH = "${libclang.lib}/lib";
+          BINDGEN_EXTRA_CLANG_ARGS = bindgenClangArgs;
 
           LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath ([
             pkgs.libffi


### PR DESCRIPTION
## Summary

Fixes #165.

The Nix dev shell already exports `CUDA_TOOLKIT_PATH` and `LIBCLANG_PATH`, but bindgen/libclang also needs the Nix libc headers when parsing CUDA headers. Without that, `cuda.h` can fail on `#include <stdlib.h>` in `nix develop`.

This exports `BINDGEN_EXTRA_CLANG_ARGS` on Linux with the dev output of the active stdenv libc.

## Validation

- `git diff --check -- flake.nix`
- Could not run `nix develop -c cargo run -p cutile-examples --example saxpy` here because `nix` is not installed in this environment.