### PR TITLE
Fix host copy source lifetime

### DIFF
--- a/cuda-core/src/runtime.rs
+++ b/cuda-core/src/runtime.rs
@@ -423,16 +423,23 @@ impl Stream {
     /// # Safety
     /// The caller must ensure the parent device's context is current on
     /// the calling thread.
-    pub unsafe fn launch_host_function<F: FnOnce() + Send>(
+    pub unsafe fn launch_host_function<F: FnOnce() + Send + 'static>(
         &self,
         host_func: F,
     ) -> Result<(), DriverError> {
         let boxed_host_func = Box::new(host_func);
-        stream::launch_host_function(
+        let raw_host_func = Box::into_raw(boxed_host_func);
+        match stream::launch_host_function(
             self.cu_stream,
             Self::callback_wrapper::<F>,
-            Box::into_raw(boxed_host_func) as *mut c_void,
-        )
+            raw_host_func as *mut c_void,
+        ) {
+            Ok(()) => Ok(()),
+            Err(error) => {
+                drop(Box::from_raw(raw_host_func));
+                Err(error)
+            }
+        }
     }
 
     unsafe extern "C" fn callback_wrapper<F: FnOnce() + Send>(callback: *mut c_void) {

--- a/cutile/src/api.rs
+++ b/cutile/src/api.rs
@@ -392,7 +392,20 @@ impl<T: DType> DeviceOp for CopyHostVecToDevice<T> {
         let shape = vec![num_elements as i32];
         let strides = vec![1];
         let dptr = ctx.alloc_async(element_size * num_elements);
-        memcpy_htod_async(dptr, vec.as_ptr(), num_elements, ctx.get_cuda_stream());
+        let stream = ctx.get_cuda_stream();
+        memcpy_htod_async(dptr, vec.as_ptr(), num_elements, stream);
+        let keep_alive = vec.clone();
+        if let Err(callback_error) = stream.launch_host_function(move || drop(keep_alive)) {
+            match stream.synchronize() {
+                Ok(()) => return Err(callback_error.into()),
+                Err(sync_error) => {
+                    // Avoid letting an in-flight DMA read freed host memory if
+                    // neither callback registration nor synchronization worked.
+                    std::mem::forget(vec);
+                    return Err(sync_error.into());
+                }
+            }
+        }
         Ok(Tensor::from_raw_parts(
             dptr,
             element_size * num_elements,

--- a/cutile/tests/gpu_execution_ops.rs
+++ b/cutile/tests/gpu_execution_ops.rs
@@ -10,7 +10,8 @@
 
 use cutile::tile_kernel::DeviceOp;
 use cutile::{api, tensor::*};
-use std::sync::Arc;
+use std::sync::{mpsc, Arc};
+use std::time::Duration;
 
 mod common;
 
@@ -115,6 +116,51 @@ use gpu_exec_module::{
     broadcast_add_kernel, cat_kernel, iota_kernel, permute_kernel, reduce_accumulate_kernel,
     reduce_max_kernel, reduce_sum_kernel, scan_prefix_sum_kernel,
 };
+
+#[test]
+fn copy_host_vec_to_device_keeps_source_alive_until_stream_completion() {
+    common::with_test_stack(|| {
+        let device = cuda_core::Device::new(0).expect("device");
+        let stream = device.new_stream().expect("stream");
+        let (blocked_tx, blocked_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+
+        unsafe {
+            stream
+                .launch_host_function(move || {
+                    blocked_tx.send(()).expect("send blocked signal");
+                    release_rx.recv().expect("wait for release signal");
+                })
+                .expect("enqueue stream blocker");
+        }
+
+        let host = Arc::new((0..4096_u32).collect::<Vec<_>>());
+        let weak_host = Arc::downgrade(&host);
+        let tensor = unsafe { api::copy_host_vec_to_device(&host).async_on(&stream) }
+            .expect("copy host vec to device");
+
+        drop(host);
+        blocked_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("stream blocker did not start");
+        assert!(
+            weak_host.upgrade().is_some(),
+            "host source should stay alive while the stream copy is pending"
+        );
+
+        release_tx.send(()).expect("release stream blocker");
+        unsafe { stream.synchronize() }.expect("stream synchronize");
+        assert!(
+            weak_host.upgrade().is_none(),
+            "host source should be released after stream completion"
+        );
+
+        let host_out: Vec<u32> = tensor.to_host_vec().sync_on(&stream).expect("to_host");
+        assert_eq!(host_out[0], 0);
+        assert_eq!(host_out[123], 123);
+        assert_eq!(host_out[4095], 4095);
+    });
+}
 
 // ---------------------------------------------------------------------------
 // 1. Reduce sum


### PR DESCRIPTION
## Summary

- Keep the `Arc<Vec<T>>` source for `copy_host_vec_to_device` alive until the CUDA stream reaches a host callback queued after the H→D copy.
- Tighten `Stream::launch_host_function` so callbacks must be `'static` and the boxed callback is reclaimed if enqueueing fails.
- Add a regression test that blocks the stream before the copy, drops the caller's `Arc`, and verifies the source stays alive until stream completion.

## Root Cause

`CopyHostVecToDevice::execute` enqueued `memcpy_htod_async` with `vec.as_ptr()` and then returned a `Tensor`, letting the operation-owned `Arc<Vec<T>>` drop immediately. Awaiting the `DeviceFuture` waited for stream completion, but nothing kept the host source buffer alive while the copy was still pending.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test -p cutile --test gpu_execution_ops copy_host_vec_to_device_keeps_source_alive_until_stream_completion -- --nocapture` blocked locally because `CUDA_TOOLKIT_PATH` is unset and no CUDA 13.2+ toolkit exists at the default `/usr/local/cuda*` paths.
- `cargo check -p cutile` blocked for the same missing CUDA toolkit.
