### PR TITLE
doc: correct pass pipeline diagram in passes/mod.rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,9 +31,9 @@ checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "ar_archive_writer"

--- a/cutile-compiler/src/passes/mod.rs
+++ b/cutile-compiler/src/passes/mod.rs
@@ -7,19 +7,34 @@
 //!
 //! Passes transform or annotate the syn AST in a defined order before IR
 //! emission. Each pass reads the previous pass's output and produces a
-//! progressively more resolved form.
+//! progressively more resolved form. Name resolution runs once per module;
+//! the remaining passes run per `#[entry]` function body just before it is
+//! lowered to `cutile-ir`.
 //!
 //! ```text
 //! Raw syn AST (from proc macro)
 //!     ↓
-//! [Pass 1: Name Resolution]  — build symbol table, resolve imports
+//! [Name Resolution]         — rustc-style DefId/Res/Namespace symbol table;
+//!                             resolve imports and paths           (per module)
 //!     ↓
-//! [Pass 2: Type Inference]   — (future) every expression typed
+//! [Proof Analysis]          — collect `#[entry(preconditions = ...)]` facts
+//!                             for IR emission to query
 //!     ↓
-//! [Pass 3: Instantiation]    — (future) no generics remain
+//! [Node IDs]                — assign stable ids to semantic expressions so
+//!                             type-check side tables can refer back to them
 //!     ↓
-//! [IR Emission]              — translation to cutile-ir
+//! [Type Inference]          — DSL-narrow inference: expression types,
+//!                             method/impl selection, dispatch-wrapper calls
+//!     ↓
+//! [Typed Dispatch Lowering] — rewrite trait-dispatch wrapper calls
+//!                             (`f(a, b)` → `a.method(b)`) from typeck results
+//!     ↓
+//! [IR Emission]             — translation to cutile-ir (compiler/compile_*)
 //! ```
+//!
+//! Type inference and dispatch lowering are DSL-narrow and compiler1-compatible
+//! rather than a full Rust type checker; generic instantiation is handled in
+//! [`crate::generics`], not as a pass here.
 
 pub mod name_resolution;
 pub mod node_ids;


### PR DESCRIPTION
The module-level pipeline diagram in `cutile-compiler/src/passes/mod.rs` was stale: it marked **Type Inference** as `(future)` and listed an **Instantiation** pass that does not exist, predating the current pass set.

Updated it to the passes that actually run, in execution order:

`name resolution → proof analysis → node ids → type inference → typed dispatch lowering → IR emission`

Also noted that generic instantiation lives in `generics.rs`, not as a pass here. Docs only — no behavior change.