### PR TITLE
doc: document kernel warmup in the compilation and performance guides

### DIFF
--- a/cutile-book/guide/jit-compilation.md
+++ b/cutile-book/guide/jit-compilation.md
@@ -198,6 +198,23 @@ The fields mean:
 
 Values outside this pattern are ordinary launch or data inputs. Tensor contents, floating-point scalar values, and runtime grid values passed with `.grid(...)` do not create cache entries by themselves.
 
+## Kernel Warmup
+
+The first launch of each specialization pays JIT compilation — typically hundreds of milliseconds — while later launches of the same specialization are cache hits. When first-call latency matters, pre-compile a specialization before its first real launch: build the exact call you would launch, but pass `api::meta` tensors and end with `.compile()` (or `.compile_on(stream)`) instead of `.sync()`:
+
+```rust
+let z = api::meta::<f32>(&[1024]).partition([128]);
+let x = api::meta::<f32>(&[1024]);
+let y = api::meta::<f32>(&[1024]);
+kernels::vector_add(z, x, y).generics(["f32", "128"]).compile()?;
+```
+
+A meta tensor carries shape, stride, and specialization metadata but allocates no GPU memory. Because `.compile()` reuses the normal launcher and derives the cache key from argument metadata, the warmed entry is identical to what the real launch looks up — including specialization hints for reshaped, viewed, or sliced inputs. `.compile()` also performs the same argument and launch-grid validation as a launch, so a configuration that warms up successfully will not fail grid inference on its first real call.
+
+The kernel cache is process-global and deduplicated: a specialization compiles exactly once per process even when multiple threads race on the same kernel, and warmup on one thread benefits all threads. `.compile()` warms the calling thread's current device; `.compile_on(stream)` warms the stream's device, mirroring `sync`/`sync_on` for per-device or interop-stream warmup.
+
+Meta tensors exist only for warmup. Reading a meta tensor's device pointer — launching it in a kernel with `.sync()`, or copying to or from it — panics, because no allocation backs it.
+
 ## Compile-Only API
 
 Most users compile kernels by launching a generated `#[cutile::entry]` launcher. cuTile also exposes `cutile::compile_api::KernelCompiler` for pre-compilation and other compile-only workflows that need Tile IR text or bytecode without launching a kernel.
@@ -217,7 +234,7 @@ let bytecode = artifacts.bytecode()?;
 
 `KernelCompiler` takes the same specialization information that a launcher normally infers from its arguments: entry-function generics, tensor stride and specialization hints, scalar hints, target architecture, optional constant grid, and compile options. Use it for pre-compilation pipelines, tooling, tests, and CPU-only validation of generated IR or bytecode. The `.target("sm_...")` value supplies the target architecture explicitly because there is no active CUDA device in compile-only mode.
 
-Compile-only pre-compilation is separate from the launch-time JIT cache. `KernelCompiler` returns artifacts for the specialization you describe; it does not allocate tensors, launch CUDA work, insert a compiled function into the process-local JIT cache, or produce a host-side result value. A later call through the generated launcher still performs the normal cache lookup and may compile on first launch unless that launch path is taught to consume the precompiled artifacts.
+Compile-only pre-compilation is separate from the launch-time JIT cache. `KernelCompiler` returns artifacts for the specialization you describe; it does not allocate tensors, launch CUDA work, insert a compiled function into the process-local JIT cache, or produce a host-side result value. A later call through the generated launcher still performs the normal cache lookup and may compile on first launch unless that launch path is taught to consume the precompiled artifacts. To pre-populate the launch-time JIT cache itself, use kernel warmup above instead.
 
 ## Inspecting Compiler Output
 

--- a/cutile-book/guide/performance.md
+++ b/cutile-book/guide/performance.md
@@ -141,6 +141,7 @@ Runtime `CompileOptions` can override entry-level hints for autotuning. `occupan
 - Wrong dtype: using `f32` when `f16`, `bf16`, FP8, or block-scaled formats are acceptable can leave Tensor Core throughput unused.
 - Excessive synchronization: `.sync()` after every operation creates CPU/GPU gaps.
 - Unfused pipeline: intermediate tensors add global memory traffic.
+- First-launch JIT latency in a latency-sensitive path: each new specialization compiles on first use. Pre-compile hot specializations with kernel warmup (`api::meta` inputs and a `.compile()` terminal); see [Compilation](jit-compilation.md).
 - Strided access pattern: tile loads coalesce well, but algorithmic strides can still reduce effective bandwidth.
 
 Profile before and after each change. [Debugging and Profiling](debugging-and-profiling.md) describes Nsight Compute and Nsight Systems.


### PR DESCRIPTION
Documents the kernel warmup API merged in #147, which previously had rustdoc coverage only.

- Adds a **Kernel Warmup** section to the compilation guide: the `api::meta` + `.compile()` / `.compile_on(stream)` pattern, how the warmed cache entry matches the real launch's key, the process-global once-per-process compile behavior, and the meta-tensor panic-on-device-pointer-read caveat.
- Updates the Compile-Only API section to distinguish `KernelCompiler` (artifacts, no cache) from warmup (populates the JIT cache) — it previously implied no cache-populating pre-compilation path existed.
- Adds a first-launch JIT latency entry to the performance guide's Common Pitfalls.
