### PR TITLE
fix flake's tileiras failing and add aarch64 support

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -28,11 +28,14 @@
         # CUDA 13.3 fetched from nvidia (headers needed on all platforms for
         # bindgen type generation; runtime libraries only needed on Linux)
         cudaRedistBase = "https://developer.download.nvidia.com/compute/cuda/redist";
+        # NVIDIA publishes per-architecture redist archives; aarch64 (server) uses
+        # the "linux-sbsa" variant, everything else uses "linux-x86_64".
+        cudaRedistArch = if pkgs.stdenv.hostPlatform.isAarch64 then "linux-sbsa" else "linux-x86_64";
         fetchCudaRedist =
           { name, version, sha256 }:
           pkgs.fetchurl {
-            url = "${cudaRedistBase}/${name}/linux-x86_64/${name}-linux-x86_64-${version}-archive.tar.xz";
-            inherit sha256;
+            url = "${cudaRedistBase}/${name}/${cudaRedistArch}/${name}-${cudaRedistArch}-${version}-archive.tar.xz";
+            sha256 = sha256.${cudaRedistArch};
           };
         cudaToolkit = pkgs.symlinkJoin {
           name = "cuda-toolkit-13.3";
@@ -43,32 +46,50 @@
             (fetchCudaRedist {
               name = "cuda_crt";
               version = "13.3.33";
-              sha256 = "4755d36d24c6ef7697a2d3e1dbb23c4562c9c0d97d48390d4cbd8ab32dec5b5f";
+              sha256 = {
+                linux-x86_64 = "4755d36d24c6ef7697a2d3e1dbb23c4562c9c0d97d48390d4cbd8ab32dec5b5f";
+                linux-sbsa = "6f6194918c00b980d8fd2111bf0aa004977760855c6e1528e0653bf4c889fbef";
+              };
             })
             (fetchCudaRedist {
               name = "cuda_nvcc";
               version = "13.3.33";
-              sha256 = "93b098bda4a562ebf3541523ce82adc43f106a81dcf28bcbf8f0d8e093d1c66f";
+              sha256 = {
+                linux-x86_64 = "93b098bda4a562ebf3541523ce82adc43f106a81dcf28bcbf8f0d8e093d1c66f";
+                linux-sbsa = "b5dde44aadd52234af3944ae3b2e74e811ad8e71fb600bcc9dfe6d8540353499";
+              };
             })
             (fetchCudaRedist {
               name = "libnvvm";
               version = "13.3.33";
-              sha256 = "fc9c1fd5844e44c0e5eeb051378c1b13cf0e3bb3fe4966d5103c38885424f802";
+              sha256 = {
+                linux-x86_64 = "fc9c1fd5844e44c0e5eeb051378c1b13cf0e3bb3fe4966d5103c38885424f802";
+                linux-sbsa = "5f8ca5c9a10c3c9804b045960ee6192281efec4c7d83d5f3245ec2de8612118e";
+              };
             })
             (fetchCudaRedist {
               name = "cuda_cudart";
               version = "13.3.29";
-              sha256 = "1e59c4888267d27ba1a9bd0f3669a6439db1334a96e754cd9013c7c73e18dc9d";
+              sha256 = {
+                linux-x86_64 = "1e59c4888267d27ba1a9bd0f3669a6439db1334a96e754cd9013c7c73e18dc9d";
+                linux-sbsa = "0cdd73d11885062daf3aa98ad4d7b8bd84f89b398be11f7054edea9ed31f597d";
+              };
             })
             (fetchCudaRedist {
               name = "libcurand";
               version = "10.4.3.29";
-              sha256 = "0218e62ab413e435dcd0274ec8e63b62214e6aba8519201061d1597e73caadbb";
+              sha256 = {
+                linux-x86_64 = "0218e62ab413e435dcd0274ec8e63b62214e6aba8519201061d1597e73caadbb";
+                linux-sbsa = "3c2245e848ff8948663646ad7870cc8451b7cf1726758bedff7c123011126e4b";
+              };
             })
             (fetchCudaRedist {
               name = "cuda_tileiras";
               version = "13.3.36";
-              sha256 = "1b055db199f806c746d53331200ccd8480bfdddd14638ed2911f30ee0cc4447b";
+              sha256 = {
+                linux-x86_64 = "1b055db199f806c746d53331200ccd8480bfdddd14638ed2911f30ee0cc4447b";
+                linux-sbsa = "98d163bd49de3c06fc179e5534fe4d8d5e1ad65800bf8696f79d2aeccafa039e";
+              };
             })
           ];
           postBuild = ''

--- a/flake.nix
+++ b/flake.nix
@@ -37,75 +37,78 @@
             url = "${cudaRedistBase}/${name}/${cudaRedistArch}/${name}-${cudaRedistArch}-${version}-archive.tar.xz";
             sha256 = sha256.${cudaRedistArch};
           };
-        cudaToolkit = pkgs.symlinkJoin {
-          name = "cuda-toolkit-13.3";
-          paths = map (src: pkgs.runCommand (builtins.baseNameOf (toString src)) { } ''
-            mkdir -p $out
+        cudaRedistArchives = [
+          (fetchCudaRedist {
+            name = "cuda_crt";
+            version = "13.3.33";
+            sha256 = {
+              linux-x86_64 = "4755d36d24c6ef7697a2d3e1dbb23c4562c9c0d97d48390d4cbd8ab32dec5b5f";
+              linux-sbsa = "6f6194918c00b980d8fd2111bf0aa004977760855c6e1528e0653bf4c889fbef";
+            };
+          })
+          (fetchCudaRedist {
+            name = "cuda_nvcc";
+            version = "13.3.33";
+            sha256 = {
+              linux-x86_64 = "93b098bda4a562ebf3541523ce82adc43f106a81dcf28bcbf8f0d8e093d1c66f";
+              linux-sbsa = "b5dde44aadd52234af3944ae3b2e74e811ad8e71fb600bcc9dfe6d8540353499";
+            };
+          })
+          (fetchCudaRedist {
+            name = "libnvvm";
+            version = "13.3.33";
+            sha256 = {
+              linux-x86_64 = "fc9c1fd5844e44c0e5eeb051378c1b13cf0e3bb3fe4966d5103c38885424f802";
+              linux-sbsa = "5f8ca5c9a10c3c9804b045960ee6192281efec4c7d83d5f3245ec2de8612118e";
+            };
+          })
+          (fetchCudaRedist {
+            name = "cuda_cudart";
+            version = "13.3.29";
+            sha256 = {
+              linux-x86_64 = "1e59c4888267d27ba1a9bd0f3669a6439db1334a96e754cd9013c7c73e18dc9d";
+              linux-sbsa = "0cdd73d11885062daf3aa98ad4d7b8bd84f89b398be11f7054edea9ed31f597d";
+            };
+          })
+          (fetchCudaRedist {
+            name = "libcurand";
+            version = "10.4.3.29";
+            sha256 = {
+              linux-x86_64 = "0218e62ab413e435dcd0274ec8e63b62214e6aba8519201061d1597e73caadbb";
+              linux-sbsa = "3c2245e848ff8948663646ad7870cc8451b7cf1726758bedff7c123011126e4b";
+            };
+          })
+          (fetchCudaRedist {
+            name = "cuda_tileiras";
+            version = "13.3.36";
+            sha256 = {
+              linux-x86_64 = "1b055db199f806c746d53331200ccd8480bfdddd14638ed2911f30ee0cc4447b";
+              linux-sbsa = "98d163bd49de3c06fc179e5534fe4d8d5e1ad65800bf8696f79d2aeccafa039e";
+            };
+          })
+        ];
+        # All archives must be extracted into one real directory tree, NOT
+        # merged with symlinkJoin: tileiras locates libnvvm relative to its
+        # own dereferenced path (/proc/self/exe), so through a symlink farm
+        # it would look for nvvm/lib64/libnvvm.so inside the cuda_tileiras
+        # store path, where it doesn't exist, and fail with exit status 5.
+        cudaToolkit = pkgs.runCommand "cuda-toolkit-13.3" { } ''
+          mkdir -p $out
+          ${pkgs.lib.concatMapStrings (src: ''
             tar xf ${src} --strip-components=1 -C $out
-          '') [
-            (fetchCudaRedist {
-              name = "cuda_crt";
-              version = "13.3.33";
-              sha256 = {
-                linux-x86_64 = "4755d36d24c6ef7697a2d3e1dbb23c4562c9c0d97d48390d4cbd8ab32dec5b5f";
-                linux-sbsa = "6f6194918c00b980d8fd2111bf0aa004977760855c6e1528e0653bf4c889fbef";
-              };
-            })
-            (fetchCudaRedist {
-              name = "cuda_nvcc";
-              version = "13.3.33";
-              sha256 = {
-                linux-x86_64 = "93b098bda4a562ebf3541523ce82adc43f106a81dcf28bcbf8f0d8e093d1c66f";
-                linux-sbsa = "b5dde44aadd52234af3944ae3b2e74e811ad8e71fb600bcc9dfe6d8540353499";
-              };
-            })
-            (fetchCudaRedist {
-              name = "libnvvm";
-              version = "13.3.33";
-              sha256 = {
-                linux-x86_64 = "fc9c1fd5844e44c0e5eeb051378c1b13cf0e3bb3fe4966d5103c38885424f802";
-                linux-sbsa = "5f8ca5c9a10c3c9804b045960ee6192281efec4c7d83d5f3245ec2de8612118e";
-              };
-            })
-            (fetchCudaRedist {
-              name = "cuda_cudart";
-              version = "13.3.29";
-              sha256 = {
-                linux-x86_64 = "1e59c4888267d27ba1a9bd0f3669a6439db1334a96e754cd9013c7c73e18dc9d";
-                linux-sbsa = "0cdd73d11885062daf3aa98ad4d7b8bd84f89b398be11f7054edea9ed31f597d";
-              };
-            })
-            (fetchCudaRedist {
-              name = "libcurand";
-              version = "10.4.3.29";
-              sha256 = {
-                linux-x86_64 = "0218e62ab413e435dcd0274ec8e63b62214e6aba8519201061d1597e73caadbb";
-                linux-sbsa = "3c2245e848ff8948663646ad7870cc8451b7cf1726758bedff7c123011126e4b";
-              };
-            })
-            (fetchCudaRedist {
-              name = "cuda_tileiras";
-              version = "13.3.36";
-              sha256 = {
-                linux-x86_64 = "1b055db199f806c746d53331200ccd8480bfdddd14638ed2911f30ee0cc4447b";
-                linux-sbsa = "98d163bd49de3c06fc179e5534fe4d8d5e1ad65800bf8696f79d2aeccafa039e";
-              };
-            })
-          ];
-          postBuild = ''
-            # cuda-bindings/build.rs also looks for libs in lib64/
-            if [ -d "$out/lib" ] && [ ! -e "$out/lib64" ]; then
-              ln -s lib "$out/lib64"
-            fi
-          '';
-        };
+          '') cudaRedistArchives}
+          # cuda-bindings/build.rs also looks for libs in lib64/
+          if [ -d "$out/lib" ] && [ ! -e "$out/lib64" ]; then
+            ln -s lib "$out/lib64"
+          fi
+        '';
 
         # bindgen uses libclang to parse CUDA headers.
         libclang = pkgs.llvmPackages.libclang;
         libcDev = pkgs.lib.getDev pkgs.stdenv.cc.libc;
         bindgenClangArgs = pkgs.lib.optionalString (!isDarwin) "-isystem ${libcDev}/include";
 
-        # Nightly Rust 
+        # Nightly Rust
         rustToolchain =
           pkgs.rust-bin.nightly."2025-07-16".default.override
             {

--- a/flake.nix
+++ b/flake.nix
@@ -133,7 +133,7 @@
               export LD_LIBRARY_PATH="/run/opengl-driver/lib:$LD_LIBRARY_PATH"
             else
               _nv_drv_dir=$(mktemp -d /tmp/nix-nvidia-driver.XXXXXX)
-              for d in /usr/lib/x86_64-linux-gnu /lib/x86_64-linux-gnu /usr/lib /usr/lib64; do
+              for d in /usr/lib/x86_64-linux-gnu /lib/x86_64-linux-gnu /usr/lib/aarch64-linux-gnu /lib/aarch64-linux-gnu /usr/lib /usr/lib64; do
                 if [ -e "$d/libcuda.so.1" ]; then
                   for lib in "$d"/libcuda.so* "$d"/libnvidia-ptxjitcompiler.so* "$d"/libnvidia-gpucomp.so*; do
                     [ -e "$lib" ] && ln -sf "$lib" "$_nv_drv_dir/"


### PR DESCRIPTION
close https://github.com/NVlabs/cutile-rs/issues/172

NOTE: This change will make macos targets built for aarch64 targets by default instead of x86 ones.