### PR TITLE
feat(cuda-async): expose the raw CUgraph and CUgraphExec handles

### DIFF
--- a/cuda-async/src/cuda_graph.rs
+++ b/cuda-async/src/cuda_graph.rs
@@ -194,8 +194,13 @@ impl<T: Send> CudaGraph<T> {
     /// `cuGraphDebugDotPrint` to dump the captured DAG, or
     /// `cuGraphAddChildGraphNode` to nest this graph inside a larger one.
     ///
-    /// The handle stays valid until this `CudaGraph` is dropped, which
-    /// destroys it. Do not call `cuGraphDestroy` on the returned handle.
+    /// # Handle validity
+    ///
+    /// `CUgraph` is a raw pointer, so the returned handle is `Copy` and is
+    /// *not* bounded by the `&self` borrow. It dangles once this `CudaGraph`
+    /// is dropped, which calls `cuGraphDestroy`. Callers must not let the
+    /// handle outlive the wrapper, and must not destroy it themselves; the
+    /// `Drop` impl would then destroy it a second time.
     pub fn cu_graph(&self) -> sys::CUgraph {
         self.cu_graph
     }
@@ -207,8 +212,20 @@ impl<T: Send> CudaGraph<T> {
     /// `cuGraphExecKernelNodeSetParams` for per-node parameter updates that
     /// [`update`](CudaGraph::update) does not express.
     ///
-    /// The handle stays valid until this `CudaGraph` is dropped, which
-    /// destroys it. Do not call `cuGraphExecDestroy` on the returned handle.
+    /// # Handle validity
+    ///
+    /// `CUgraphExec` is a raw pointer, so the returned handle is `Copy` and is
+    /// *not* bounded by the `&self` borrow. It dangles once this `CudaGraph`
+    /// is dropped, which calls `cuGraphExecDestroy`. Callers must not let the
+    /// handle outlive the wrapper, and must not destroy it themselves; the
+    /// `Drop` impl would then destroy it a second time.
+    ///
+    /// # Concurrent replay
+    ///
+    /// Updating an executable while a replay of it is in flight is undefined
+    /// behaviour. [`launch`](CudaGraph::launch) copies this handle into the
+    /// returned op, so a pending or executing launch aliases it. Synchronize
+    /// the stream before calling any `cuGraphExec*` setter.
     pub fn cu_graph_exec(&self) -> sys::CUgraphExec {
         self.cu_graph_exec
     }

--- a/cuda-async/src/cuda_graph.rs
+++ b/cuda-async/src/cuda_graph.rs
@@ -186,6 +186,32 @@ impl<T: Send> CudaGraph<T> {
     pub fn stream(&self) -> &Arc<Stream> {
         &self.stream
     }
+
+    /// Returns the raw `CUgraph` handle for the captured topology.
+    ///
+    /// This is the immutable capture result, not the executable. Use it with
+    /// driver APIs that read or embed a graph's structure, such as
+    /// `cuGraphDebugDotPrint` to dump the captured DAG, or
+    /// `cuGraphAddChildGraphNode` to nest this graph inside a larger one.
+    ///
+    /// The handle stays valid until this `CudaGraph` is dropped, which
+    /// destroys it. Do not call `cuGraphDestroy` on the returned handle.
+    pub fn cu_graph(&self) -> sys::CUgraph {
+        self.cu_graph
+    }
+
+    /// Returns the raw `CUgraphExec` handle for the instantiated graph.
+    ///
+    /// This is the executable [`launch`](CudaGraph::launch) replays. Use it
+    /// with driver APIs that retune an instantiated graph in place, such as
+    /// `cuGraphExecKernelNodeSetParams` for per-node parameter updates that
+    /// [`update`](CudaGraph::update) does not express.
+    ///
+    /// The handle stays valid until this `CudaGraph` is dropped, which
+    /// destroys it. Do not call `cuGraphExecDestroy` on the returned handle.
+    pub fn cu_graph_exec(&self) -> sys::CUgraphExec {
+        self.cu_graph_exec
+    }
 }
 
 /// A [`DeviceOp`] that replays a captured CUDA graph.


### PR DESCRIPTION
## Problem

`CudaGraph` owns both a `CUgraph` and a `CUgraphExec` but exposes neither. It already exposes its other owned resource via `stream()`, so the omission reads as unintentional.

Without the raw handles, a captured graph cannot reach any driver API that `CudaGraph` does not itself wrap:

- **`cuGraphDebugDotPrint`** — dump the captured DAG. There is currently no way to inspect the topology of a graph you just captured.
- **`cuGraphAddChildGraphNode`** — nest a captured graph inside a larger one. Graph composition is not expressible today.
- **`cuGraphExecKernelNodeSetParams`** — retune one node's launch configuration on the instantiated graph. `update()` re-executes a `DeviceOp` on the graph's stream, which covers changing *inputs*, but not a node's parameters in place. **Note this API's own precondition:** updating an executable while a replay of it is in flight is UB, and `launch()` copies the handle into the returned op, so a pending launch aliases it. Callers must synchronize the stream first. This is documented on the accessor.

## Change

Two safe field reads:

```rust
pub fn cu_graph(&self) -> sys::CUgraph
pub fn cu_graph_exec(&self) -> sys::CUgraphExec
```

## Safety analysis

These are additive accessors that cannot cause UB by themselves, but they hand out something the type system will not police, so the obligations are worth stating precisely.

`CUgraph` is `pub type CUgraph = *mut CUgraph_st` — a bare pointer. The returned handle is therefore `Copy` and **is not bounded by the `&self` borrow**. The receiver looks like a borrow and enforces nothing. Two consequences, both reachable from safe code:

1. **Dangling** — copy the handle, drop the `CudaGraph`, use the stale pointer. `Drop` calls `cuGraphExecDestroy` then `cuGraphDestroy` (`cuda_graph.rs:255-268`).
2. **Double free** — the caller destroys the handle themselves. The `mem::replace(.., null_mut())` in `Drop` guards `Drop`'s own re-entry, not an external destroy.

Plus the aliasing window on the exec, described under the third use case above. All three are documented on the accessors rather than left implicit.

## API decisions

**Safe, not `unsafe`.** Creating a pointer is not UB; the obligation attaches to the driver call the caller makes with it, which is already `unsafe`. Marking these `unsafe fn` would be over-marking, and safe raw-handle accessors are an established family (`Vec::as_ptr`, `File::as_raw_fd`).

I want to be straight about the limits of that argument, though. `Stream::cu_stream()` (`cuda-core/src/runtime.rs:454`) is already a safe `pub fn` returning a raw `CUstream`, so this PR is consistent with your existing convention — but consistency is not by itself evidence the shape is right. std migrated `RawFd` to `BorrowedFd<'fd>` in RFC 3128 for exactly hazards 1 and 2 above, so "matches the neighbouring accessor" argues for the pre-RFC-3128 idiom specifically.

**Two accessors, not one.** `CUgraph` (immutable capture result) and `CUgraphExec` (instantiated executable) are distinct objects with disjoint API sets, and the use cases above need one or the other specifically. Collapsing them would force callers to guess which one a driver API wants.

**Borrowing, not transferring.** Neither accessor affects ownership. I considered an `into_raw`-style transfer and did not add it: nothing in the three use cases needs to outlive the wrapper, and adding a second ownership mode to a type with a two-stage `Drop` is a larger change than this problem justifies.

## Alternatives, and your call

The design fork here is yours, not mine to settle in a first patch:

1. **As submitted** — documented raw handles, consistent with `cu_stream()`.
2. **Lifetime-carrying** — `pub fn cu_graph(&self) -> BorrowedCuGraph<'_>`, making escape a compile error instead of a documented rule. Strictly safer; adds public types and diverges from your existing accessor convention.
3. **No handles at all** — wrap the three driver calls as safe methods (`debug_dot_print`, `add_as_child_of`, a node-parameter setter that synchronizes). Arguably the best end state, and it keeps the raw handles private; just a substantially larger change than this.

I am happy to switch to 2, pursue 3 in a follow-up, or close this if you would rather go straight to 3.

## Verification

Gates from `.github/workflows/pr.yml`, run locally:

- `cargo fmt -- --check` — clean
- `cargo clippy -p cuda-async` — no new findings. The `type_complexity`, `too_many_arguments`, and `GraphNode` supertrait warnings are pre-existing.
- `cargo test -p cuda-async --no-run` — compiles

The handle-lifetime and destroy-order claims were read off the `Drop` impl rather than assumed.

No tests added: these are field reads whose only contract is handle lifetime, enforced by `Drop` rather than by the accessors. Asserting non-null handles after a capture needs a GPU, which the CPU-only job cannot provide. Happy to add a GPU-gated test if you want one.