### PR TITLE
fix: adapt CUDA driver flag types

### DIFF
--- a/cuda-async/src/device_future.rs
+++ b/cuda-async/src/device_future.rs
@@ -121,13 +121,14 @@ impl<T: Send, DO: DeviceOp<Output = T>> DeviceFuture<T, DO> {
         fn host_task_sync_mode() -> Option<::core::ffi::c_uint> {
             static MODE: std::sync::OnceLock<Option<::core::ffi::c_uint>> =
                 std::sync::OnceLock::new();
+            // CUDA driver flag bindings have platform-dependent integer types, so FFI calls cast them as `_`.
             *MODE.get_or_init(
                 || match std::env::var("CUDA_ASYNC_HOST_SYNC").ok()?.as_str() {
                     "spin" | "spinwait" => {
-                        Some(cuda_bindings::CUhostTaskSyncMode_enum_CU_HOST_TASK_SPINWAIT)
+                        Some(cuda_bindings::CUhostTaskSyncMode_enum_CU_HOST_TASK_SPINWAIT as _)
                     }
                     "block" | "blocking" => {
-                        Some(cuda_bindings::CUhostTaskSyncMode_enum_CU_HOST_TASK_BLOCKING)
+                        Some(cuda_bindings::CUhostTaskSyncMode_enum_CU_HOST_TASK_BLOCKING as _)
                     }
                     _ => None,
                 },

--- a/cuda-core/src/cudarc_shim.rs
+++ b/cuda-core/src/cudarc_shim.rs
@@ -8,6 +8,9 @@
 //\!
 //\! Thin `pub(crate)` modules around `cuda_bindings` calls. The public API
 //\! lives in [`crate::runtime`].
+//\!
+//\! CUDA driver flag bindings have platform-dependent integer types, so FFI
+//\! calls cast them as `_`.
 
 use crate::error::*;
 
@@ -181,7 +184,7 @@ pub(crate) mod ctx {
 
     /// Sets flags on the current context.
     pub fn set_flags(flags: cuda_bindings::CUctx_flags) -> Result<(), DriverError> {
-        unsafe { cuda_bindings::cuCtxSetFlags(flags).result() }
+        unsafe { cuda_bindings::cuCtxSetFlags(flags as _).result() }
     }
 
     /// Blocks until all work in the current context is complete.
@@ -228,7 +231,7 @@ pub(crate) mod stream {
     pub fn create(kind: StreamKind) -> Result<cuda_bindings::CUstream, DriverError> {
         let mut stream = MaybeUninit::uninit();
         unsafe {
-            cuda_bindings::cuStreamCreate(stream.as_mut_ptr(), kind.flags()).result()?;
+            cuda_bindings::cuStreamCreate(stream.as_mut_ptr(), kind.flags() as _).result()?;
             Ok(stream.assume_init())
         }
     }
@@ -275,7 +278,7 @@ pub(crate) mod stream {
         event: cuda_bindings::CUevent,
         flags: cuda_bindings::CUevent_wait_flags,
     ) -> Result<(), DriverError> {
-        cuda_bindings::cuStreamWaitEvent(stream, event, flags).result()
+        cuda_bindings::cuStreamWaitEvent(stream, event, flags as _).result()
     }
 
     /// Attaches memory to a stream for managed memory visibility.
@@ -288,7 +291,7 @@ pub(crate) mod stream {
         num_bytes: usize,
         flags: cuda_bindings::CUmemAttach_flags,
     ) -> Result<(), DriverError> {
-        cuda_bindings::cuStreamAttachMemAsync(stream, dptr, num_bytes, flags).result()
+        cuda_bindings::cuStreamAttachMemAsync(stream, dptr, num_bytes, flags as _).result()
     }
 
     /// Enqueues a host function callback on the stream.
@@ -433,7 +436,7 @@ pub(crate) mod event {
     ) -> Result<cuda_bindings::CUevent, DriverError> {
         let mut event = MaybeUninit::uninit();
         unsafe {
-            cuda_bindings::cuEventCreate(event.as_mut_ptr(), flags).result()?;
+            cuda_bindings::cuEventCreate(event.as_mut_ptr(), flags as _).result()?;
             Ok(event.assume_init())
         }
     }
@@ -630,7 +633,7 @@ pub(crate) mod memory {
         flags: sys::CUmemAttach_flags,
     ) -> Result<sys::CUdeviceptr, DriverError> {
         let mut dev_ptr = MaybeUninit::uninit();
-        sys::cuMemAllocManaged(dev_ptr.as_mut_ptr(), num_bytes, flags).result()?;
+        sys::cuMemAllocManaged(dev_ptr.as_mut_ptr(), num_bytes, flags as _).result()?;
         Ok(dev_ptr.assume_init())
     }
 


### PR DESCRIPTION
## Summary

Adapt the six CUDA Driver API flag arguments in `cuda-core` to the unsigned
types generated by CUDA 13.3 headers.

## Root cause

`cuda-core` exposes the flag aliases as `i32`, while bindgen generates the
corresponding CUDA driver parameters as `c_uint` (`u32`). This prevents the
crate from compiling with the current CUDA 13.3 SDK on the MSVC target.

## Validation

Ran on Windows with CUDA Toolkit 13.3 and the x64 MSVC developer environment:

```text
cargo +nightly-x86_64-pc-windows-msvc check -p cuda-core --target x86_64-pc-windows-msvc
```

The check completed successfully. A 64x64 cuTile GEMM using this patch also
executed on the GPU and passed host-side element verification.

Also ran the repository-required full suite in WSL with CUDA 13.3:

```text
bash scripts/run_all.sh
```

All CPU tests, GPU tests, 23 GPU examples, and 7 benchmark smoke tests passed.
