### PR TITLE
feat: add num_worker_warps_per_cta hint support

### DIFF
--- a/cutile-book/guide/jit-compilation.md
+++ b/cutile-book/guide/jit-compilation.md
@@ -111,6 +111,7 @@ Entry-level optimization hints are written on the `#[cutile::entry]` attribute:
             num_cta_in_cga = 2,
             occupancy = 2,
             max_divisibility = 16,
+            num_worker_warps_per_cta = 4, // Requires bytecode version 13.3 or newer.
         ),
         sm_90 = (
             num_cta_in_cga = 1,
@@ -127,7 +128,8 @@ use cutile::tile_kernel::CompileOptions;
 
 let opts = CompileOptions::default()
     .occupancy(4)
-    .num_cta_in_cga(2);
+    .num_cta_in_cga(2)
+    .num_worker_warps_per_cta(4); // Requires bytecode version 13.3 or newer.
 
 let _ = optimized_kernel(args)
     .compile_options(opts)

--- a/cutile-book/guide/jit-compilation.md
+++ b/cutile-book/guide/jit-compilation.md
@@ -111,7 +111,7 @@ Entry-level optimization hints are written on the `#[cutile::entry]` attribute:
             num_cta_in_cga = 2,
             occupancy = 2,
             max_divisibility = 16,
-            num_worker_warps_per_cta = 4, // Requires bytecode version 13.3 or newer.
+            num_worker_warps_per_cta = 4, // Bytecode 13.3+; valid values: 1, 2, 4, 8, 16, 32.
         ),
         sm_90 = (
             num_cta_in_cga = 1,
@@ -129,12 +129,14 @@ use cutile::tile_kernel::CompileOptions;
 let opts = CompileOptions::default()
     .occupancy(4)
     .num_cta_in_cga(2)
-    .num_worker_warps_per_cta(4); // Requires bytecode version 13.3 or newer.
+    .num_worker_warps_per_cta(4); // Bytecode 13.3+; valid values: 1, 2, 4, 8, 16, 32.
 
 let _ = optimized_kernel(args)
     .compile_options(opts)
     .sync_on(&stream)?;
 ```
+
+`num_worker_warps_per_cta` requires bytecode version 13.3 or newer. It must be a power of two in the inclusive range `[1, 32]` (`1`, `2`, `4`, `8`, `16`, or `32`).
 
 Different `CompileOptions` values produce separate JIT cache entries.
 

--- a/cutile-book/guide/performance.md
+++ b/cutile-book/guide/performance.md
@@ -125,14 +125,19 @@ Optimization hints guide code generation for a target architecture:
 ```rust
 #[cutile::entry(
     optimization_hints = (
-        sm_120 = (num_cta_in_cga = 2, occupancy = 2, max_divisibility = 16),
+        sm_120 = (
+            num_cta_in_cga = 2,
+            occupancy = 2,
+            max_divisibility = 16,
+            num_worker_warps_per_cta = 4, // Requires bytecode version 13.3 or newer.
+        ),
         sm_90 = (num_cta_in_cga = 1),
     )
 )]
 fn kernel<const S: [i32; 2]>(...) { ... }
 ```
 
-Runtime `CompileOptions` can override entry-level hints for autotuning. `occupancy` and `num_cta_in_cga` are architecture-specific scheduling hints; `max_divisibility` controls divisibility assumptions used by the compiler. Because compile options are part of the JIT cache key, benchmark a small set of candidates instead of generating many one-off specializations.
+Runtime `CompileOptions` can override entry-level hints for autotuning. `occupancy`, `num_cta_in_cga`, and `num_worker_warps_per_cta` are architecture-specific scheduling hints; `max_divisibility` controls divisibility assumptions used by the compiler. Because compile options are part of the JIT cache key, benchmark a small set of candidates instead of generating many one-off specializations.
 
 ## Common Pitfalls
 

--- a/cutile-book/guide/performance.md
+++ b/cutile-book/guide/performance.md
@@ -129,7 +129,7 @@ Optimization hints guide code generation for a target architecture:
             num_cta_in_cga = 2,
             occupancy = 2,
             max_divisibility = 16,
-            num_worker_warps_per_cta = 4, // Requires bytecode version 13.3 or newer.
+            num_worker_warps_per_cta = 4, // Bytecode 13.3+; valid values: 1, 2, 4, 8, 16, 32.
         ),
         sm_90 = (num_cta_in_cga = 1),
     )
@@ -137,7 +137,7 @@ Optimization hints guide code generation for a target architecture:
 fn kernel<const S: [i32; 2]>(...) { ... }
 ```
 
-Runtime `CompileOptions` can override entry-level hints for autotuning. `occupancy`, `num_cta_in_cga`, and `num_worker_warps_per_cta` are architecture-specific scheduling hints; `max_divisibility` controls divisibility assumptions used by the compiler. Because compile options are part of the JIT cache key, benchmark a small set of candidates instead of generating many one-off specializations.
+Runtime `CompileOptions` can override entry-level hints for autotuning. `occupancy`, `num_cta_in_cga`, and `num_worker_warps_per_cta` are architecture-specific scheduling hints; `max_divisibility` controls divisibility assumptions used by the compiler. `num_worker_warps_per_cta` accepts powers of two in the inclusive range `[1, 32]` and requires bytecode version 13.3 or newer. Because compile options are part of the JIT cache key, benchmark a small set of candidates instead of generating many one-off specializations.
 
 ## Common Pitfalls
 

--- a/cutile-book/reference/host-api.md
+++ b/cutile-book/reference/host-api.md
@@ -241,7 +241,8 @@ use cutile::tile_kernel::CompileOptions;
 let opts = CompileOptions::default()
     .occupancy(4)
     .num_cta_in_cga(2)
-    .max_divisibility(16);
+    .max_divisibility(16)
+    .num_worker_warps_per_cta(4); // Requires bytecode version 13.3 or newer.
 
 let result = my_kernel(args).compile_options(opts).grid(grid).await?;
 ```
@@ -255,7 +256,7 @@ methods:
 |---|---|
 | `.grid((x, y, z))` | Set an explicit runtime launch grid instead of inferring it from partitioned tensor inputs. |
 | `.const_grid((x, y, z))` | Set a compile-time constant grid, enabling grid-dependent optimizations. |
-| `.compile_options(opts)` | Override occupancy, cluster/CTA, and divisibility hints for this compilation. |
+| `.compile_options(opts)` | Override occupancy, cluster/CTA, worker-warp, and divisibility hints for this compilation. |
 | `.generics(values)` | Bind type and const generic arguments manually when they cannot be inferred. |
 
 The JIT compiler invokes `tileiras` through normal `PATH` lookup by default.

--- a/cutile-book/reference/host-api.md
+++ b/cutile-book/reference/host-api.md
@@ -242,10 +242,12 @@ let opts = CompileOptions::default()
     .occupancy(4)
     .num_cta_in_cga(2)
     .max_divisibility(16)
-    .num_worker_warps_per_cta(4); // Requires bytecode version 13.3 or newer.
+    .num_worker_warps_per_cta(4); // Bytecode 13.3+; valid values: 1, 2, 4, 8, 16, 32.
 
 let result = my_kernel(args).compile_options(opts).grid(grid).await?;
 ```
+
+`num_worker_warps_per_cta` accepts powers of two in the inclusive range `[1, 32]`.
 
 Different `CompileOptions` values trigger separate JIT compilations and are part of the kernel cache key.
 

--- a/cutile-compiler/src/compiler/optimization_hints.rs
+++ b/cutile-compiler/src/compiler/optimization_hints.rs
@@ -35,6 +35,12 @@ pub fn build_entry_optimization_hints(hints: &OptimizationHints) -> Option<Attri
                 Attribute::Integer(occ as i64, Type::Scalar(ScalarType::I32)),
             ));
         }
+        if let Some(num_worker_warps) = sm_hints.num_worker_warps_per_cta {
+            arch_hints.push((
+                "num_worker_warps_per_cta".to_string(),
+                Attribute::Integer(num_worker_warps as i64, Type::Scalar(ScalarType::I32)),
+            ));
+        }
         if !arch_hints.is_empty() {
             entries.push((arch.clone(), arch_hints));
         }

--- a/cutile-compiler/src/hints.rs
+++ b/cutile-compiler/src/hints.rs
@@ -22,6 +22,7 @@ pub struct SMHints {
     pub num_cta_in_cga: Option<i32>,
     pub occupancy: Option<i32>,
     pub max_divisibility: Option<i32>,
+    pub num_worker_warps_per_cta: Option<i32>,
 }
 
 impl SMHints {
@@ -31,6 +32,7 @@ impl SMHints {
             num_cta_in_cga: None,
             occupancy: None,
             max_divisibility: None,
+            num_worker_warps_per_cta: None,
         }
     }
 
@@ -60,6 +62,15 @@ impl SMHints {
         self.max_divisibility = Some(get_int_hint(hint)?);
         Ok(())
     }
+
+    pub fn set_num_worker_warps_per_cta(&mut self, hint: &Expr) -> Result<(), JITError> {
+        if self.num_worker_warps_per_cta.is_some() {
+            return SourceLocation::unknown()
+                .jit_error_result("num_worker_warps_per_cta hint has already been set");
+        }
+        self.num_worker_warps_per_cta = Some(get_int_hint(hint)?);
+        Ok(())
+    }
 }
 
 fn get_int_hint(expr: &Expr) -> Result<i32, JITError> {
@@ -86,6 +97,7 @@ pub struct CompileOptions {
     pub occupancy: Option<i32>,
     pub num_cta_in_cga: Option<i32>,
     pub max_divisibility: Option<i32>,
+    pub num_worker_warps_per_cta: Option<i32>,
 }
 
 impl CompileOptions {
@@ -105,6 +117,11 @@ impl CompileOptions {
 
     pub fn max_divisibility(mut self, max_divisibility: i32) -> Self {
         self.max_divisibility = Some(max_divisibility);
+        self
+    }
+
+    pub fn num_worker_warps_per_cta(mut self, num_worker_warps_per_cta: i32) -> Self {
+        self.num_worker_warps_per_cta = Some(num_worker_warps_per_cta);
         self
     }
 }
@@ -172,6 +189,9 @@ impl OptimizationHints {
                             "num_cta_in_cga" => sm_hints_result.set_num_cta_in_cga(&hints)?,
                             "occupancy" => sm_hints_result.set_occupancy(&hints)?,
                             "max_divisibility" => sm_hints_result.set_max_divisibility(&hints)?,
+                            "num_worker_warps_per_cta" => {
+                                sm_hints_result.set_num_worker_warps_per_cta(&hints)?
+                            }
                             "allow_tma" | "latency" => {
                                 return SourceLocation::unknown().jit_error_result(&format!(
                                     "'{key}' is a per-op hint and cannot be set at the entry level. \
@@ -209,6 +229,7 @@ impl OptimizationHints {
         if options.occupancy.is_none()
             && options.num_cta_in_cga.is_none()
             && options.max_divisibility.is_none()
+            && options.num_worker_warps_per_cta.is_none()
         {
             return;
         }
@@ -228,6 +249,9 @@ impl OptimizationHints {
         }
         if let Some(max_divisibility) = options.max_divisibility {
             sm_hints.max_divisibility = Some(max_divisibility);
+        }
+        if let Some(num_worker_warps_per_cta) = options.num_worker_warps_per_cta {
+            sm_hints.num_worker_warps_per_cta = Some(num_worker_warps_per_cta);
         }
     }
 }

--- a/cutile-ir/src/bytecode/writer.rs
+++ b/cutile-ir/src/bytecode/writer.rs
@@ -797,7 +797,27 @@ fn write_function_section(out: &mut Vec<u8>, ctx: &mut WriterCtx) -> Result<()> 
 
         // Entry flag.
         let is_entry = op.opcode == Opcode::Entry;
-        let has_hints = find_attr(&op.attributes, "optimization_hints").is_some();
+        let hints_attr = if is_entry {
+            find_attr(&op.attributes, "optimization_hints").cloned()
+        } else {
+            None
+        };
+        if ctx.version < BytecodeVersion::V13_3 {
+            if let Some(Attribute::OptimizationHints(hints)) = &hints_attr {
+                for (_, arch_hints) in &hints.entries {
+                    if arch_hints
+                        .iter()
+                        .any(|(name, _)| name == "num_worker_warps_per_cta")
+                    {
+                        return Err(Error::BytecodeWrite(format!(
+                            "optimization hint 'num_worker_warps_per_cta' requires bytecode version 13.3 or newer, requested {}",
+                            ctx.version
+                        )));
+                    }
+                }
+            }
+        }
+        let has_hints = hints_attr.is_some();
         let mut flags: u8 = 0;
         if is_entry {
             flags |= FunctionFlag::KindKernel as u8;
@@ -811,16 +831,14 @@ fn write_function_section(out: &mut Vec<u8>, ctx: &mut WriterCtx) -> Result<()> 
         w.write_varint(0);
 
         // Write optimization hints if present.
-        if is_entry && has_hints {
-            if let Some(hints_attr) = find_attr(&op.attributes, "optimization_hints").cloned() {
-                write_self_contained_attribute(
-                    &hints_attr,
-                    &mut w,
-                    &mut ctx.strings,
-                    &mut ctx.types,
-                    &mut ctx.constants,
-                )?;
-            }
+        if let Some(hints_attr) = hints_attr {
+            write_self_contained_attribute(
+                &hints_attr,
+                &mut w,
+                &mut ctx.strings,
+                &mut ctx.types,
+                &mut ctx.constants,
+            )?;
         }
 
         // Write function body.

--- a/cutile-ir/tests/bytecode_version.rs
+++ b/cutile-ir/tests/bytecode_version.rs
@@ -36,6 +36,24 @@ fn build_kernel(name: &str) -> Module {
     module
 }
 
+fn build_kernel_with_worker_warps(name: &str, num_worker_warps_per_cta: i64) -> Module {
+    let mut module = build_kernel(name);
+    let entry = module.functions[0];
+    module.op_mut(entry).attributes.push((
+        "optimization_hints".into(),
+        Attribute::OptimizationHints(OptimizationHints {
+            entries: vec![(
+                "sm_120".into(),
+                vec![(
+                    "num_worker_warps_per_cta".into(),
+                    Attribute::i32(num_worker_warps_per_cta),
+                )],
+            )],
+        }),
+    ));
+    module
+}
+
 // =========================================================================
 // Tests
 // =========================================================================
@@ -116,6 +134,30 @@ fn reject_unsupported_version() {
     };
     let result = write_bytecode_version(&module, old_version);
     assert!(result.is_err(), "should reject version below MIN_SUPPORTED");
+}
+
+#[test]
+fn worker_warps_hint_requires_version_13_3() {
+    use cutile_ir::bytecode::write_bytecode_version;
+
+    let module = build_kernel_with_worker_warps("ver_worker_warps_reject", 4);
+    let error = write_bytecode_version(&module, BytecodeVersion::V13_2)
+        .expect_err("worker warps hint should require bytecode version 13.3");
+    assert!(
+        error.to_string().contains(
+            "optimization hint 'num_worker_warps_per_cta' requires bytecode version 13.3 or newer"
+        ),
+        "unexpected error: {error}"
+    );
+}
+
+#[test]
+fn worker_warps_hint_is_supported_in_version_13_3() {
+    use cutile_ir::bytecode::write_bytecode_version;
+
+    let module = build_kernel_with_worker_warps("ver_worker_warps_accept", 4);
+    write_bytecode_version(&module, BytecodeVersion::V13_3)
+        .expect("worker warps hint should be supported in bytecode version 13.3");
 }
 
 #[test]

--- a/cutile/tests/optimization_hints.rs
+++ b/cutile/tests/optimization_hints.rs
@@ -135,7 +135,7 @@ mod opt_hints_module {
     }
 
     #[cutile::entry(optimization_hints = (
-        sm_120 = (num_worker_warps_per_cta = 3,),
+        sm_120 = (num_worker_warps_per_cta = 1,),
     ))]
     fn worker_warps_value_kernel<const S: [i32; 1]>(output: &mut Tensor<f32, S>) {
         let tile: Tile<f32, S> = constant(1.0f32, output.shape());
@@ -318,14 +318,14 @@ fn worker_warps_values_are_forwarded_to_backend() {
             &[("output", &[1])],
             &CompileOptions::default(),
         );
-        assert!(entry_mlir.contains("num_worker_warps_per_cta = 3"));
+        assert!(entry_mlir.contains("num_worker_warps_per_cta = 1"));
 
         let options_mlir = compile_kernel(
             "entry_hints_kernel",
             &[("output", &[1])],
-            &CompileOptions::default().num_worker_warps_per_cta(64),
+            &CompileOptions::default().num_worker_warps_per_cta(32),
         );
-        assert!(options_mlir.contains("num_worker_warps_per_cta = 64"));
+        assert!(options_mlir.contains("num_worker_warps_per_cta = 32"));
     });
 }
 

--- a/cutile/tests/optimization_hints.rs
+++ b/cutile/tests/optimization_hints.rs
@@ -123,9 +123,21 @@ mod opt_hints_module {
     }
 
     #[cutile::entry(optimization_hints = (
-        sm_120 = (occupancy = 4, num_cta_in_cga = 2),
+        sm_120 = (
+            occupancy = 4,
+            num_cta_in_cga = 2,
+            num_worker_warps_per_cta = 4,
+        ),
     ))]
     fn entry_hints_kernel<const S: [i32; 1]>(output: &mut Tensor<f32, S>) {
+        let tile: Tile<f32, S> = constant(1.0f32, output.shape());
+        output.store(tile);
+    }
+
+    #[cutile::entry(optimization_hints = (
+        sm_120 = (num_worker_warps_per_cta = 3,),
+    ))]
+    fn worker_warps_value_kernel<const S: [i32; 1]>(output: &mut Tensor<f32, S>) {
         let tile: Tile<f32, S> = constant(1.0f32, output.shape());
         output.store(tile);
     }
@@ -267,13 +279,20 @@ fn entry_level_occupancy_hints_in_mlir() {
             mlir.contains("num_cta_in_cga = 2"),
             "Expected num_cta_in_cga=2 in entry optimization_hints.\nMLIR:\n{mlir}"
         );
+        assert!(
+            mlir.contains("num_worker_warps_per_cta = 4"),
+            "Expected num_worker_warps_per_cta=4 in entry optimization_hints.\nMLIR:\n{mlir}"
+        );
     });
 }
 
 #[test]
 fn compile_options_override_entry_hints() {
     common::with_test_stack(|| {
-        let options = CompileOptions::default().occupancy(8).num_cta_in_cga(4);
+        let options = CompileOptions::default()
+            .occupancy(8)
+            .num_cta_in_cga(4)
+            .num_worker_warps_per_cta(8);
         let mlir = compile_kernel("entry_hints_kernel", &[("output", &[1])], &options);
         println!("{mlir}");
         assert!(
@@ -284,6 +303,29 @@ fn compile_options_override_entry_hints() {
             mlir.contains("num_cta_in_cga = 4"),
             "Expected runtime num_cta_in_cga=4 to override entry-level num_cta_in_cga=2.\nMLIR:\n{mlir}"
         );
+        assert!(
+            mlir.contains("num_worker_warps_per_cta = 8"),
+            "Expected runtime num_worker_warps_per_cta=8 to override entry-level value 4.\nMLIR:\n{mlir}"
+        );
+    });
+}
+
+#[test]
+fn worker_warps_values_are_forwarded_to_backend() {
+    common::with_test_stack(|| {
+        let entry_mlir = compile_kernel(
+            "worker_warps_value_kernel",
+            &[("output", &[1])],
+            &CompileOptions::default(),
+        );
+        assert!(entry_mlir.contains("num_worker_warps_per_cta = 3"));
+
+        let options_mlir = compile_kernel(
+            "entry_hints_kernel",
+            &[("output", &[1])],
+            &CompileOptions::default().num_worker_warps_per_cta(64),
+        );
+        assert!(options_mlir.contains("num_worker_warps_per_cta = 64"));
     });
 }
 

--- a/cutile/tests/warmup.rs
+++ b/cutile/tests/warmup.rs
@@ -152,6 +152,14 @@ fn cache_key_different_compile_options() {
         .compile_options(CompileOptions::default().occupancy(4))
         .build();
     assert_ne!(key_c, key_d);
+
+    let key_e = default_key()
+        .compile_options(CompileOptions::default().num_worker_warps_per_cta(4))
+        .build();
+    let key_f = default_key()
+        .compile_options(CompileOptions::default().num_worker_warps_per_cta(8))
+        .build();
+    assert_ne!(key_e, key_f);
 }
 
 #[test]


### PR DESCRIPTION
## Background
  `num_worker_warps_per_cta` is an optimization hint officially supported by Tile IR bytecode 13.3. It suggests how many worker warps `tileiras` should allocate to each CTA. 


## Changes

  Add `num_worker_warps_per_cta` optimization hint support to cutile-rs.

  - Supports entry-level, SM-specific hints.
  - Supports runtime overrides through `CompileOptions`.
  - Requires **Tile IR bytecode 13.3** or newer.
  - Add `num_worker_warps_per_cta` to entry optimization hints and `CompileOptions`.
  - Add tests and documentation.

## Example

  ```rust
  #[cutile::entry(optimization_hints = (
      sm_120 = (num_worker_warps_per_cta = 4,),
  ))]
  fn kernel(...) {
      // ...
  }

  let options = CompileOptions::default()
      .num_worker_warps_per_cta(8);

  kernel(...)
      .compile_options(options);
```

## Validation

  - Ran `bash scripts/run_all.sh` locally.
  - Successfully generated the documentation locally with Sphinx.