### PR TITLE
feat: compute the persistent-cache key for compile-only artifacts

### DIFF
--- a/cutile-book/guide/jit-compilation.md
+++ b/cutile-book/guide/jit-compilation.md
@@ -234,6 +234,8 @@ The eviction policy is LRU by file mtime with a high/low watermark pair (default
 
 Concurrent cold-starting processes do not deduplicate compilation across process boundaries, so they may all run `tileiras` for the same missing key before their atomic writes converge on one entry. To avoid this one-time compilation stampede, warm the shared cache with a single process before launching parallel workers.
 
+`CompileArtifacts::cache_key` (from the compile-only API below) computes the exact key a launch of that specialization resolves to under the current toolchain — useful for pre-seeding a cache from CI, deleting a specific entry, or verifying that a deployment artifact still matches the workspace it was built from.
+
 See `cutile-examples/examples/jit_disk_cache.rs`; run it twice to watch the second process hit the disk. For implementing a custom backend (an object store, a database), see `cutile-examples/examples/jit_custom_store.rs`.
 
 ## Compile-Only API
@@ -251,6 +253,7 @@ let artifacts = KernelCompiler::new(my_kernels::__module_ast_self, "my_kernels",
 
 let ir_text = artifacts.ir_text();
 let bytecode = artifacts.bytecode()?;
+let key = artifacts.cache_key()?; // 64-hex persistent-cache key (see below)
 ```
 
 `KernelCompiler` takes the same specialization information that a launcher normally infers from its arguments: entry-function generics, tensor stride and specialization hints, scalar hints, target architecture, optional constant grid, and compile options. Use it for pre-compilation pipelines, tooling, tests, and CPU-only validation of generated IR or bytecode. The `.target("sm_...")` value supplies the target architecture explicitly because there is no active CUDA device in compile-only mode.

--- a/cutile-compiler/src/compile_api.rs
+++ b/cutile-compiler/src/compile_api.rs
@@ -35,6 +35,7 @@ use crate::specialization::{DivHint, SpecializationBits};
 /// do not require a GPU or CUDA driver.
 pub struct CompileArtifacts {
     module: cutile_ir::Module,
+    gpu_name: String,
 }
 
 impl CompileArtifacts {
@@ -54,9 +55,49 @@ impl CompileArtifacts {
         &self.module
     }
 
+    /// Returns the target GPU architecture these artifacts were compiled for.
+    pub fn gpu_name(&self) -> &str {
+        &self.gpu_name
+    }
+
+    /// Computes the 64-char hex key that a launch of this exact specialization
+    /// resolves to in the persistent disk cache (see `jit_cache`).
+    ///
+    /// The bytecode is serialized with the same version selection as the
+    /// launch path, and the key covers the same inputs (bytecode, target
+    /// architecture, opt level, `tileiras` fingerprint) — so the result
+    /// matches what `jit_cache` looks up and stores at launch time. Use it to
+    /// pre-seed a cache, delete a specific entry, or verify that a persisted
+    /// tuning or deployment artifact still resolves under the current
+    /// toolchain.
+    ///
+    /// Unlike the other methods here, this consults the local toolchain (the
+    /// bytecode-version resolution and `tileiras --version`); it still
+    /// requires no GPU or CUDA driver.
+    pub fn cache_key(&self) -> Result<String, JITError> {
+        let (bytecode, bc_version) =
+            crate::cuda_tile_runtime_utils::serialize_tile_ir_bytecode(&self.module)?;
+        Ok(crate::jit_cache::l2_key(
+            &bytecode,
+            bc_version,
+            &self.gpu_name,
+            crate::cuda_tile_runtime_utils::DEFAULT_OPT_LEVEL,
+            crate::cuda_tile_runtime_utils::tileiras_fingerprint(),
+        ))
+    }
+
     /// Consumes the artifacts and returns the underlying `cutile_ir::Module`.
     pub fn into_module(self) -> cutile_ir::Module {
         self.module
+    }
+
+    /// Test-only constructor: wraps an already-built IR module.
+    #[cfg(test)]
+    pub(crate) fn for_tests(module: cutile_ir::Module, gpu_name: &str) -> Self {
+        Self {
+            module,
+            gpu_name: gpu_name.to_string(),
+        }
     }
 }
 
@@ -184,6 +225,7 @@ impl<F: Fn() -> crate::ast::Module> KernelCompiler<F> {
             .map(|(name, hint)| (name.as_str(), hint))
             .collect();
 
+        let gpu_name = self.gpu_name.clone();
         let compiler = CUDATileFunctionCompiler::new(
             &modules,
             &self.module_name,
@@ -198,6 +240,6 @@ impl<F: Fn() -> crate::ast::Module> KernelCompiler<F> {
         )?;
 
         let module = compiler.compile()?;
-        Ok(CompileArtifacts { module })
+        Ok(CompileArtifacts { module, gpu_name })
     }
 }

--- a/cutile-compiler/src/cuda_tile_runtime_utils.rs
+++ b/cutile-compiler/src/cuda_tile_runtime_utils.rs
@@ -1322,6 +1322,50 @@ mod tests {
         }
     }
 
+    /// `CompileArtifacts::cache_key` must equal the key the launch path
+    /// computes for the same module, and respond to every key input.
+    #[test]
+    #[cfg(unix)]
+    fn compile_artifacts_cache_key_matches_launch_path() {
+        let _env_guard = ENV_LOCK.lock().unwrap();
+        let temp_dir = env::temp_dir().join(format!("cutile_cache_key_test_{}", Uuid::new_v4()));
+        fs::create_dir_all(&temp_dir).unwrap();
+        let fake_tileiras = temp_dir.join("tileiras");
+        write_fake_tileiras(&fake_tileiras);
+        let _tileiras_env = EnvVarGuard::set(TILEIRAS_PATH_ENV, &fake_tileiras);
+
+        let module = empty_kernel_module();
+        let (bytecode, bc_version) =
+            serialize_tile_ir_bytecode(&module).expect("serialize should succeed");
+        let expected = crate::jit_cache::l2_key(
+            &bytecode,
+            bc_version,
+            "sm_120",
+            DEFAULT_OPT_LEVEL,
+            tileiras_fingerprint(),
+        );
+
+        let artifacts = crate::compile_api::CompileArtifacts::for_tests(module, "sm_120");
+        let key = artifacts.cache_key().expect("cache_key should succeed");
+        assert_eq!(key, expected, "must match the launch path's key derivation");
+        assert_eq!(key.len(), 64);
+        assert_eq!(
+            key,
+            artifacts.cache_key().unwrap(),
+            "key must be deterministic"
+        );
+
+        let other_arch =
+            crate::compile_api::CompileArtifacts::for_tests(artifacts.into_module(), "sm_100");
+        assert_ne!(
+            other_arch.cache_key().unwrap(),
+            expected,
+            "target architecture must change the key"
+        );
+
+        let _ = fs::remove_dir_all(&temp_dir);
+    }
+
     fn empty_kernel_module() -> Module {
         let mut module = Module::new("tileiras_override_test");
         let func_type = Type::Func(FuncType {


### PR DESCRIPTION
Adds `CompileArtifacts::cache_key()`: the 64-hex key that a launch of the same specialization resolves to in the persistent disk cache. It serializes with the launch path's bytecode-version selection and keys on the same inputs (bytecode, target architecture, opt level, tileiras fingerprint), so the result matches what `jit_cache` looks up and stores — pinned by a test asserting equality with the launch path's derivation.

Enables pre-seeding a cache from CI, deleting a specific entry, and verifying that persisted artifacts (e.g. future autotuning results) still resolve under the current toolchain — all without a GPU. First half of #207; the L1-key one-liner remains tracked there.
