### PR TITLE
feat: device-event kernel benchmarking (cutile::bench)

### DIFF
--- a/cuda-core/src/api.rs
+++ b/cuda-core/src/api.rs
@@ -94,6 +94,20 @@ pub unsafe fn malloc_from_pool_async(
 /// Asynchronously frees device memory on the given stream.
 ///
 /// # Safety
+/// Asynchronously sets `num_bytes` bytes at `dptr` to `value` on `stream`.
+///
+/// # Safety
+/// `dptr` must point to a device allocation of at least `num_bytes` bytes
+/// that stays valid until the operation completes on `stream`.
+pub unsafe fn memset_d8_async(
+    dptr: sys::CUdeviceptr,
+    value: u8,
+    num_bytes: usize,
+    stream: &Arc<Stream>,
+) -> Result<(), DriverError> {
+    crate::cudarc_shim::memory::memset_d8_async(dptr, value, num_bytes, stream.cu_stream())
+}
+
 /// `dptr` must have been allocated with `malloc_async` and must not be used after this call.
 pub unsafe fn free_async(dptr: sys::CUdeviceptr, stream: &Arc<Stream>) {
     crate::cudarc_shim::memory::free_async(dptr, stream.cu_stream()).expect("Free async failed.")

--- a/cuda-core/src/runtime.rs
+++ b/cuda-core/src/runtime.rs
@@ -479,14 +479,16 @@ impl Event {
         unsafe { crate::cudarc_shim::event::synchronize(self.cu_event) }
     }
 
-    /// Milliseconds elapsed on the device between `start` and this event.
+    /// Milliseconds elapsed on the device between this event and `end`
+    /// (called on the start event, `torch.cuda.Event` convention:
+    /// `start.elapsed_time(&end)`).
     ///
-    /// Both events must have been recorded, and this (later) event must have
-    /// completed — call [`synchronize`](Self::synchronize) first, or the
-    /// driver reports not-ready.
-    pub fn elapsed_ms_since(&self, start: &Event) -> Result<f32, DriverError> {
+    /// Both events must have been recorded, and `end` must have completed —
+    /// call [`synchronize`](Self::synchronize) on it first, or the driver
+    /// reports not-ready.
+    pub fn elapsed_time(&self, end: &Event) -> Result<f32, DriverError> {
         // Safety: both handles are valid by construction.
-        unsafe { crate::cudarc_shim::event::elapsed(start.cu_event, self.cu_event) }
+        unsafe { crate::cudarc_shim::event::elapsed(self.cu_event, end.cu_event) }
     }
 }
 

--- a/cuda-core/src/runtime.rs
+++ b/cuda-core/src/runtime.rs
@@ -440,6 +440,92 @@ pub(crate) fn teardown_lock() -> std::sync::MutexGuard<'static, ()> {
 unsafe impl Send for Stream {}
 unsafe impl Sync for Stream {}
 
+// ── Event ───────────────────────────────────────────────────────────────────
+
+/// A CUDA event, created with timing enabled, for device-side timing and
+/// cross-stream synchronization.
+///
+/// Owned RAII: the driver handle is destroyed on drop (the driver defers
+/// destruction of an event still captured in unfinished work, so dropping
+/// early is safe). An event is bound to its device at construction;
+/// recording it on a stream of another device is rejected.
+pub struct Event {
+    cu_event: cuda_bindings::CUevent,
+    device: Arc<Device>,
+}
+
+unsafe impl Send for Event {}
+unsafe impl Sync for Event {}
+
+impl Event {
+    /// Records this event on `stream`.
+    ///
+    /// Errors with `CUDA_ERROR_INVALID_VALUE` if the stream belongs to a
+    /// different device than the one this event was created on.
+    pub fn record(&self, stream: &Arc<Stream>) -> Result<(), DriverError> {
+        if stream.device().ordinal() != self.device.ordinal() {
+            return Err(DriverError(
+                cuda_bindings::cudaError_enum_CUDA_ERROR_INVALID_VALUE,
+            ));
+        }
+        // Safety: both handles are valid by construction (RAII wrappers),
+        // and the same-device check above pins them to one context.
+        unsafe { crate::cudarc_shim::event::record(self.cu_event, stream.cu_stream()) }
+    }
+
+    /// Blocks the calling thread until this event has completed.
+    pub fn synchronize(&self) -> Result<(), DriverError> {
+        // Safety: the handle is valid by construction.
+        unsafe { crate::cudarc_shim::event::synchronize(self.cu_event) }
+    }
+
+    /// Milliseconds elapsed on the device between `start` and this event.
+    ///
+    /// Both events must have been recorded, and this (later) event must have
+    /// completed — call [`synchronize`](Self::synchronize) first, or the
+    /// driver reports not-ready.
+    pub fn elapsed_ms_since(&self, start: &Event) -> Result<f32, DriverError> {
+        // Safety: both handles are valid by construction.
+        unsafe { crate::cudarc_shim::event::elapsed(start.cu_event, self.cu_event) }
+    }
+}
+
+impl Drop for Event {
+    fn drop(&mut self) {
+        // Safety: owned handle; the driver defers destruction while in use.
+        let _ = unsafe { crate::cudarc_shim::event::destroy(self.cu_event) };
+    }
+}
+
+impl Device {
+    /// Creates a timing-enabled event on this device.
+    pub fn new_event(self: &Arc<Self>) -> Result<Event, DriverError> {
+        self.bind_to_thread()?;
+        let cu_event =
+            crate::cudarc_shim::event::create(cuda_bindings::CUevent_flags_enum_CU_EVENT_DEFAULT)?;
+        Ok(Event {
+            cu_event,
+            device: self.clone(),
+        })
+    }
+
+    /// Returns the device's L2 cache size in bytes.
+    pub fn l2_cache_size_bytes(&self) -> Result<usize, DriverError> {
+        let mut value: core::ffi::c_int = 0;
+        // Safety: out-pointer is valid; the device handle is valid by
+        // construction.
+        unsafe {
+            cuda_bindings::cuDeviceGetAttribute(
+                &mut value,
+                cuda_bindings::CUdevice_attribute_enum_CU_DEVICE_ATTRIBUTE_L2_CACHE_SIZE,
+                self.cu_device,
+            )
+            .result()?;
+        }
+        Ok(value.max(0) as usize)
+    }
+}
+
 impl Drop for Stream {
     fn drop(&mut self) {
         if !self.owned {

--- a/cutile-book/guide/performance.md
+++ b/cutile-book/guide/performance.md
@@ -153,3 +153,19 @@ Profile before and after each change. [Debugging and Profiling](debugging-and-pr
 ---
 
 Continue to [Interoperability](interoperability.md).
+
+## Measuring Kernels
+
+`cutile::bench` provides device-event timing for kernel measurement and A/B comparison:
+
+```rust
+use cutile::bench::{do_bench, do_bench_paired, BenchOptions};
+
+let r = do_bench(&stream, &BenchOptions::default(), |s| {
+    my_kernel(z.partition([128]), x.clone(), y.clone()).sync_on(s).map(|_| ()).map_err(Into::into)
+})?;
+println!("median {:.3} ms over {} reps", r.median_ms(), r.reps());
+```
+
+Timing uses CUDA events (device timeline, not host clocks), warmup absorbs first-launch JIT, the L2 cache is cleared between reps, and results report medians and quantiles. When comparing two configurations, always use `do_bench_paired` — it alternates the arms rep by rep, so clock and thermal drift cannot masquerade as a difference between them.
+

--- a/cutile/src/bench.rs
+++ b/cutile/src/bench.rs
@@ -3,8 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-//! Device-event kernel benchmarking, in the spirit of Triton's
-//! `testing.do_bench`.
+//! Device-event kernel benchmarking, API-compatible in spirit and naming
+//! with Triton's `testing.do_bench` (`warmup`/`rep` are the same
+//! millisecond budgets, with the same defaults).
 //!
 //! [`do_bench`] times a closure with CUDA events on a stream: warmup by time
 //! budget (absorbing first-launch JIT), rep count derived from a measurement
@@ -32,10 +33,10 @@ pub struct BenchOptions {
     /// Wall-clock budget for untimed warmup iterations (absorbs JIT and
     /// clock ramp). At least one warmup iteration always runs.
     pub warmup: Duration,
-    /// Wall-clock budget the timed reps should roughly fill; the rep count
-    /// is `measure / estimated_rep_time`, clamped to
+    /// Wall-clock budget the timed reps should roughly fill (Triton's `rep`);
+    /// the timed-rep count is `rep / estimated_rep_time`, clamped to
     /// [`min_reps`](Self::min_reps)..=[`max_reps`](Self::max_reps).
-    pub measure: Duration,
+    pub rep: Duration,
     /// Lower bound on timed reps (medians need at least a few samples).
     pub min_reps: usize,
     /// Upper bound on timed reps.
@@ -49,7 +50,7 @@ impl Default for BenchOptions {
     fn default() -> Self {
         Self {
             warmup: Duration::from_millis(25),
-            measure: Duration::from_millis(100),
+            rep: Duration::from_millis(100),
             min_reps: 5,
             max_reps: 1000,
             clear_l2: true,
@@ -57,13 +58,14 @@ impl Default for BenchOptions {
     }
 }
 
-/// Timings from a [`do_bench`] run, in milliseconds per rep.
+/// Timings from a [`do_bench`] run, in milliseconds per rep (the analogue
+/// of `torch.utils.benchmark`'s `Measurement`).
 #[derive(Debug, Clone)]
-pub struct BenchResult {
+pub struct Measurement {
     times_ms: Vec<f32>,
 }
 
-impl BenchResult {
+impl Measurement {
     /// Number of timed reps.
     pub fn reps(&self) -> usize {
         self.times_ms.len()
@@ -158,7 +160,7 @@ where
     f(stream)?;
     end.record(stream)?;
     end.synchronize()?;
-    Ok(end.elapsed_ms_since(&start)?)
+    Ok(start.elapsed_time(&end)?)
 }
 
 /// Times `f` on `stream` with CUDA events. See the module docs for the
@@ -167,7 +169,7 @@ pub fn do_bench<F>(
     stream: &Arc<Stream>,
     opts: &BenchOptions,
     mut f: F,
-) -> Result<BenchResult, Error>
+) -> Result<Measurement, Error>
 where
     F: FnMut(&Arc<Stream>) -> Result<(), Error>,
 {
@@ -181,7 +183,7 @@ where
 
     // Derive the rep count from one timed estimate.
     let est_ms = time_one(stream, &mut f)?.max(1e-4);
-    let target_ms = opts.measure.as_secs_f64() * 1e3;
+    let target_ms = opts.rep.as_secs_f64() * 1e3;
     let reps = ((target_ms / est_ms as f64).round() as usize).clamp(opts.min_reps, opts.max_reps);
 
     let l2 = opts.clear_l2.then(|| L2Clear::new(stream));
@@ -192,7 +194,7 @@ where
         }
         times_ms.push(time_one(stream, &mut f)?);
     }
-    Ok(BenchResult { times_ms })
+    Ok(Measurement { times_ms })
 }
 
 /// Times two closures in strict A/B/A/B alternation on `stream` — the
@@ -204,7 +206,7 @@ pub fn do_bench_paired<A, B>(
     opts: &BenchOptions,
     mut a: A,
     mut b: B,
-) -> Result<(BenchResult, BenchResult), Error>
+) -> Result<(Measurement, Measurement), Error>
 where
     A: FnMut(&Arc<Stream>) -> Result<(), Error>,
     B: FnMut(&Arc<Stream>) -> Result<(), Error>,
@@ -218,7 +220,7 @@ where
     }
 
     let est_ms = time_one(stream, &mut a)?.max(1e-4);
-    let target_ms = opts.measure.as_secs_f64() * 1e3;
+    let target_ms = opts.rep.as_secs_f64() * 1e3;
     // Each pair runs both arms; halve the budget-derived count per arm.
     let reps =
         (((target_ms / est_ms as f64) / 2.0).round() as usize).clamp(opts.min_reps, opts.max_reps);
@@ -236,8 +238,8 @@ where
         times_b.push(time_one(stream, &mut b)?);
     }
     Ok((
-        BenchResult { times_ms: times_a },
-        BenchResult { times_ms: times_b },
+        Measurement { times_ms: times_a },
+        Measurement { times_ms: times_b },
     ))
 }
 
@@ -245,8 +247,8 @@ where
 mod tests {
     use super::*;
 
-    fn result(times: &[f32]) -> BenchResult {
-        BenchResult {
+    fn result(times: &[f32]) -> Measurement {
+        Measurement {
             times_ms: times.to_vec(),
         }
     }

--- a/cutile/src/bench.rs
+++ b/cutile/src/bench.rs
@@ -43,6 +43,10 @@ pub struct BenchOptions {
     pub max_reps: usize,
     /// Clear the device's L2 cache before every timed rep, so reps measure
     /// cold-cache behavior instead of the previous rep's residency.
+    ///
+    /// Allocates a device buffer of about twice the L2 size (64 MiB to
+    /// 512 MiB) for the duration of the run; like all cutile allocations,
+    /// running out of device memory panics.
     pub clear_l2: bool,
 }
 

--- a/cutile/src/bench.rs
+++ b/cutile/src/bench.rs
@@ -1,0 +1,279 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Device-event kernel benchmarking, in the spirit of Triton's
+//! `testing.do_bench`.
+//!
+//! [`do_bench`] times a closure with CUDA events on a stream: warmup by time
+//! budget (absorbing first-launch JIT), rep count derived from a measurement
+//! budget, and the L2 cache cleared between reps so every rep sees cold
+//! caches instead of the previous rep's footprint. Results report medians and
+//! quantiles rather than means: on machines without locked clocks, means
+//! drift with sustained load while medians stay stable.
+//!
+//! [`do_bench_paired`] measures two closures in strict A/B/A/B alternation.
+//! Use it whenever two configurations are *compared*: back-to-back sequential
+//! runs let clock and thermal drift masquerade as multi-percent differences.
+//!
+//! The closure must enqueue its GPU work on the stream it is given — for
+//! cutile ops, `op.sync_on(stream)`. Work sent to other streams is not
+//! covered by the timing events.
+
+use crate::error::Error;
+use cuda_core::Stream;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+/// Options for [`do_bench`] and [`do_bench_paired`].
+#[derive(Debug, Clone)]
+pub struct BenchOptions {
+    /// Wall-clock budget for untimed warmup iterations (absorbs JIT and
+    /// clock ramp). At least one warmup iteration always runs.
+    pub warmup: Duration,
+    /// Wall-clock budget the timed reps should roughly fill; the rep count
+    /// is `measure / estimated_rep_time`, clamped to
+    /// [`min_reps`](Self::min_reps)..=[`max_reps`](Self::max_reps).
+    pub measure: Duration,
+    /// Lower bound on timed reps (medians need at least a few samples).
+    pub min_reps: usize,
+    /// Upper bound on timed reps.
+    pub max_reps: usize,
+    /// Clear the device's L2 cache before every timed rep, so reps measure
+    /// cold-cache behavior instead of the previous rep's residency.
+    pub clear_l2: bool,
+}
+
+impl Default for BenchOptions {
+    fn default() -> Self {
+        Self {
+            warmup: Duration::from_millis(25),
+            measure: Duration::from_millis(100),
+            min_reps: 5,
+            max_reps: 1000,
+            clear_l2: true,
+        }
+    }
+}
+
+/// Timings from a [`do_bench`] run, in milliseconds per rep.
+#[derive(Debug, Clone)]
+pub struct BenchResult {
+    times_ms: Vec<f32>,
+}
+
+impl BenchResult {
+    /// Number of timed reps.
+    pub fn reps(&self) -> usize {
+        self.times_ms.len()
+    }
+
+    /// All rep times, in the order measured.
+    pub fn times_ms(&self) -> &[f32] {
+        &self.times_ms
+    }
+
+    /// Fastest rep.
+    pub fn min_ms(&self) -> f32 {
+        self.times_ms.iter().copied().fold(f32::INFINITY, f32::min)
+    }
+
+    /// Arithmetic mean. Prefer [`median_ms`](Self::median_ms) for
+    /// comparisons; the mean is reported for completeness.
+    pub fn mean_ms(&self) -> f32 {
+        self.times_ms.iter().sum::<f32>() / self.times_ms.len() as f32
+    }
+
+    /// Median rep time — the headline number.
+    pub fn median_ms(&self) -> f32 {
+        self.quantile_ms(0.5)
+    }
+
+    /// Linearly-interpolated quantile, `q` in `[0, 1]`.
+    pub fn quantile_ms(&self, q: f32) -> f32 {
+        let mut sorted = self.times_ms.clone();
+        sorted.sort_by(|a, b| a.total_cmp(b));
+        let q = q.clamp(0.0, 1.0);
+        let pos = q * (sorted.len() - 1) as f32;
+        let lo = pos.floor() as usize;
+        let hi = pos.ceil() as usize;
+        if lo == hi {
+            sorted[lo]
+        } else {
+            let frac = pos - lo as f32;
+            sorted[lo] * (1.0 - frac) + sorted[hi] * frac
+        }
+    }
+}
+
+/// A device buffer sized past the L2 cache, memset before each timed rep to
+/// evict prior residency. Freed asynchronously on the stream when dropped.
+struct L2Clear {
+    dptr: cuda_core::sys::CUdeviceptr,
+    num_bytes: usize,
+    stream: Arc<Stream>,
+}
+
+impl L2Clear {
+    /// Twice the L2 size flushes reliably; clamp keeps pathological
+    /// attribute readings from allocating absurd buffers.
+    fn new(stream: &Arc<Stream>) -> Self {
+        let l2 = stream.device().l2_cache_size_bytes().unwrap_or(0);
+        let num_bytes = (l2 * 2).clamp(64 << 20, 512 << 20);
+        // Safety: freed in Drop on the same stream; never exposed.
+        let dptr = unsafe { cuda_core::malloc_async(num_bytes, stream) };
+        Self {
+            dptr,
+            num_bytes,
+            stream: stream.clone(),
+        }
+    }
+
+    fn clear(&self) -> Result<(), Error> {
+        // Safety: dptr covers num_bytes and outlives the enqueued memset
+        // (freed on the same stream, so stream order protects it).
+        unsafe { cuda_core::memset_d8_async(self.dptr, 0, self.num_bytes, &self.stream) }?;
+        Ok(())
+    }
+}
+
+impl Drop for L2Clear {
+    fn drop(&mut self) {
+        // Safety: allocated by us with malloc_async; stream order guarantees
+        // the free lands after every enqueued memset.
+        unsafe { cuda_core::free_async(self.dptr, &self.stream) };
+    }
+}
+
+/// One event-timed execution of `f` on `stream`.
+fn time_one<F>(stream: &Arc<Stream>, f: &mut F) -> Result<f32, Error>
+where
+    F: FnMut(&Arc<Stream>) -> Result<(), Error>,
+{
+    let device = stream.device();
+    let start = device.new_event()?;
+    let end = device.new_event()?;
+    start.record(stream)?;
+    f(stream)?;
+    end.record(stream)?;
+    end.synchronize()?;
+    Ok(end.elapsed_ms_since(&start)?)
+}
+
+/// Times `f` on `stream` with CUDA events. See the module docs for the
+/// protocol; `f` must enqueue its work on the stream it receives.
+pub fn do_bench<F>(
+    stream: &Arc<Stream>,
+    opts: &BenchOptions,
+    mut f: F,
+) -> Result<BenchResult, Error>
+where
+    F: FnMut(&Arc<Stream>) -> Result<(), Error>,
+{
+    // Warmup: at least once, then until the budget is spent. Absorbs the
+    // first-launch JIT so it never lands in a timed rep.
+    let warmup_start = Instant::now();
+    f(stream)?;
+    while warmup_start.elapsed() < opts.warmup {
+        f(stream)?;
+    }
+
+    // Derive the rep count from one timed estimate.
+    let est_ms = time_one(stream, &mut f)?.max(1e-4);
+    let target_ms = opts.measure.as_secs_f64() * 1e3;
+    let reps = ((target_ms / est_ms as f64).round() as usize).clamp(opts.min_reps, opts.max_reps);
+
+    let l2 = opts.clear_l2.then(|| L2Clear::new(stream));
+    let mut times_ms = Vec::with_capacity(reps);
+    for _ in 0..reps {
+        if let Some(l2) = &l2 {
+            l2.clear()?;
+        }
+        times_ms.push(time_one(stream, &mut f)?);
+    }
+    Ok(BenchResult { times_ms })
+}
+
+/// Times two closures in strict A/B/A/B alternation on `stream` — the
+/// protocol for *comparing* two configurations, immune to the clock and
+/// thermal drift that corrupts sequential comparisons. Both arms run the
+/// same number of reps, derived from arm A's estimate.
+pub fn do_bench_paired<A, B>(
+    stream: &Arc<Stream>,
+    opts: &BenchOptions,
+    mut a: A,
+    mut b: B,
+) -> Result<(BenchResult, BenchResult), Error>
+where
+    A: FnMut(&Arc<Stream>) -> Result<(), Error>,
+    B: FnMut(&Arc<Stream>) -> Result<(), Error>,
+{
+    let warmup_start = Instant::now();
+    a(stream)?;
+    b(stream)?;
+    while warmup_start.elapsed() < opts.warmup {
+        a(stream)?;
+        b(stream)?;
+    }
+
+    let est_ms = time_one(stream, &mut a)?.max(1e-4);
+    let target_ms = opts.measure.as_secs_f64() * 1e3;
+    // Each pair runs both arms; halve the budget-derived count per arm.
+    let reps =
+        (((target_ms / est_ms as f64) / 2.0).round() as usize).clamp(opts.min_reps, opts.max_reps);
+
+    let l2 = opts.clear_l2.then(|| L2Clear::new(stream));
+    let (mut times_a, mut times_b) = (Vec::with_capacity(reps), Vec::with_capacity(reps));
+    for _ in 0..reps {
+        if let Some(l2) = &l2 {
+            l2.clear()?;
+        }
+        times_a.push(time_one(stream, &mut a)?);
+        if let Some(l2) = &l2 {
+            l2.clear()?;
+        }
+        times_b.push(time_one(stream, &mut b)?);
+    }
+    Ok((
+        BenchResult { times_ms: times_a },
+        BenchResult { times_ms: times_b },
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn result(times: &[f32]) -> BenchResult {
+        BenchResult {
+            times_ms: times.to_vec(),
+        }
+    }
+
+    #[test]
+    fn quantiles_interpolate_and_clamp() {
+        let r = result(&[4.0, 1.0, 3.0, 2.0]);
+        assert_eq!(r.min_ms(), 1.0);
+        assert_eq!(r.median_ms(), 2.5);
+        assert_eq!(r.quantile_ms(0.0), 1.0);
+        assert_eq!(r.quantile_ms(1.0), 4.0);
+        assert_eq!(r.quantile_ms(-1.0), 1.0);
+        assert_eq!(r.quantile_ms(2.0), 4.0);
+        assert!((r.mean_ms() - 2.5).abs() < 1e-6);
+    }
+
+    #[test]
+    fn single_sample_quantiles_are_that_sample() {
+        let r = result(&[7.0]);
+        assert_eq!(r.median_ms(), 7.0);
+        assert_eq!(r.quantile_ms(0.25), 7.0);
+    }
+
+    #[test]
+    fn median_is_robust_to_one_outlier() {
+        let r = result(&[1.0, 1.0, 1.0, 1.0, 100.0]);
+        assert_eq!(r.median_ms(), 1.0);
+        assert!(r.mean_ms() > 20.0);
+    }
+}

--- a/cutile/src/lib.rs
+++ b/cutile/src/lib.rs
@@ -179,6 +179,7 @@ static __CUTILE_REEXPORT_CORE: cutile_compiler::registry::CutileModuleEntry =
         build: _core::core::__module_ast_self,
     };
 pub mod api;
+pub mod bench;
 pub mod kernels;
 pub mod prelude;
 pub mod tensor;

--- a/cutile/tests/do_bench.rs
+++ b/cutile/tests/do_bench.rs
@@ -1,0 +1,86 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! GPU integration tests for `cutile::bench` (device-event timing).
+
+use cuda_core::Device;
+use cutile::bench::{do_bench, do_bench_paired, BenchOptions};
+use cutile::prelude::*;
+use std::sync::Arc;
+use std::time::Duration;
+
+fn quick_opts() -> BenchOptions {
+    BenchOptions {
+        warmup: Duration::from_millis(5),
+        measure: Duration::from_millis(20),
+        min_reps: 3,
+        max_reps: 50,
+        clear_l2: true,
+    }
+}
+
+#[test]
+fn do_bench_times_a_kernel() {
+    let device = Device::new(0).expect("device 0");
+    let stream = device.new_stream().expect("stream");
+
+    let result = do_bench(&stream, &quick_opts(), |s| {
+        api::full(1.0f32, &[1 << 20])
+            .sync_on(s)
+            .map(|_| ())
+            .map_err(Into::into)
+    })
+    .expect("do_bench");
+
+    assert!(result.reps() >= 3, "at least min_reps timed reps");
+    assert!(
+        result.times_ms().iter().all(|t| t.is_finite() && *t >= 0.0),
+        "all rep times finite and non-negative: {:?}",
+        result.times_ms()
+    );
+    assert!(result.min_ms() <= result.median_ms());
+    assert!(result.median_ms() > 0.0, "a 1M-element fill takes time");
+}
+
+#[test]
+fn do_bench_paired_runs_equal_reps() {
+    let device = Device::new(0).expect("device 0");
+    let stream = device.new_stream().expect("stream");
+
+    let (a, b) = do_bench_paired(
+        &stream,
+        &quick_opts(),
+        |s| {
+            api::full(1.0f32, &[1 << 20])
+                .sync_on(s)
+                .map(|_| ())
+                .map_err(Into::into)
+        },
+        |s| {
+            api::full(2.0f32, &[1 << 18])
+                .sync_on(s)
+                .map(|_| ())
+                .map_err(Into::into)
+        },
+    )
+    .expect("do_bench_paired");
+
+    assert_eq!(a.reps(), b.reps(), "arms must be measured in pairs");
+    assert!(a.reps() >= 3);
+    assert!(a.median_ms() > 0.0 && b.median_ms() > 0.0);
+}
+
+#[test]
+fn closure_errors_propagate() {
+    let device = Device::new(0).expect("device 0");
+    let stream = device.new_stream().expect("stream");
+
+    let err = do_bench(&stream, &quick_opts(), |_| {
+        Err(cutile::error::Error::Tensor(cutile::error::TensorError(
+            "intentional".into(),
+        )))
+    });
+    assert!(err.is_err(), "closure errors must not be swallowed");
+}

--- a/cutile/tests/do_bench.rs
+++ b/cutile/tests/do_bench.rs
@@ -14,7 +14,7 @@ use std::time::Duration;
 fn quick_opts() -> BenchOptions {
     BenchOptions {
         warmup: Duration::from_millis(5),
-        measure: Duration::from_millis(20),
+        rep: Duration::from_millis(20),
         min_reps: 3,
         max_reps: 50,
         clear_l2: true,

--- a/scripts/run_gpu_tests.sh
+++ b/scripts/run_gpu_tests.sh
@@ -11,6 +11,7 @@ print_header "Running GPU tests"
 
 for test_target in \
     arange \
+    do_bench \
     dtype_float_ops \
     gpu_execution_ops \
     nested_partition_mut \


### PR DESCRIPTION
Adds `cutile::bench`: CUDA-event kernel timing following Triton's `testing.do_bench` (same `warmup`/`rep` millisecond budgets and defaults) and PyTorch's benchmarking vocabulary (`Measurement` with median/mean/times; `torch.cuda.Event`-style `start.elapsed_time(&end)`). `do_bench` runs a closure on a stream with warmup absorbing first-launch JIT, a rep count derived from the budget, the L2 cache cleared between reps, and median/quantile reporting. `do_bench_paired` measures two closures in strict A/B/A/B alternation — the protocol for comparing configurations without clock/thermal drift reading as a difference.

Underneath, cuda-core gains safe RAII primitives: `Event` (timing-enabled, device-bound at construction; recording on another device's stream is rejected), `Device::l2_cache_size_bytes()`, and a `memset_d8_async` wrapper.

Measurement core for the upcoming autotuner; `cutile-benchmarks` adoption (TFLOPS/baseline columns) is a follow-up. GPU tests added to the suite (`--test do_bench`); verified on an RTX 5090.
