### PR TITLE
feat(launch): support programmatic dependency ordering

### DIFF
--- a/cuda-async/src/launch.rs
+++ b/cuda-async/src/launch.rs
@@ -11,7 +11,10 @@ use crate::device_operation::{DeviceOp, ExecutionContext};
 use crate::error::DeviceError;
 use anyhow::{Context, Result};
 use cuda_core::sys::CUdeviceptr;
-use cuda_core::{launch_kernel, DType, Function, LaunchConfig, Stream};
+use cuda_core::{
+    launch_kernel, launch_kernel_with_attributes, DType, Function, LaunchAttributes, LaunchConfig,
+    Stream,
+};
 use std::ffi::c_void;
 use std::fmt::Debug;
 use std::future::IntoFuture;
@@ -24,6 +27,7 @@ pub struct AsyncKernelLaunch {
     pub func: Arc<Function>,
     pub args: Vec<*mut c_void>,
     cfg: Option<LaunchConfig>,
+    attributes: LaunchAttributes,
 }
 
 unsafe impl Send for AsyncKernelLaunch {}
@@ -48,6 +52,7 @@ impl AsyncKernelLaunch {
             func,
             args: Vec::new(),
             cfg: None,
+            attributes: LaunchAttributes::default(),
         }
     }
 
@@ -84,6 +89,12 @@ impl AsyncKernelLaunch {
         self
     }
 
+    /// Replaces the composable attributes used for this launch.
+    pub fn set_launch_attributes(&mut self, attributes: LaunchAttributes) -> &mut Self {
+        self.attributes = attributes;
+        self
+    }
+
     /// Launches the kernel on the given CUDA stream.
     ///
     /// # Safety
@@ -92,15 +103,27 @@ impl AsyncKernelLaunch {
         let cfg = self.cfg.ok_or(DeviceError::Launch(
             "Await called before launching the kernel.".to_string(),
         ))?;
-        launch_kernel(
-            self.func.cu_function(),
-            cfg.grid_dim,
-            cfg.block_dim,
-            cfg.shared_mem_bytes,
-            stream.cu_stream(),
-            &mut self.args,
-        )
-        .with_context(|| {
+        let result = if self.attributes == LaunchAttributes::default() {
+            launch_kernel(
+                self.func.cu_function(),
+                cfg.grid_dim,
+                cfg.block_dim,
+                cfg.shared_mem_bytes,
+                stream.cu_stream(),
+                &mut self.args,
+            )
+        } else {
+            launch_kernel_with_attributes(
+                self.func.cu_function(),
+                cfg.grid_dim,
+                cfg.block_dim,
+                cfg.shared_mem_bytes,
+                self.attributes,
+                stream.cu_stream(),
+                &mut self.args,
+            )
+        };
+        result.with_context(|| {
             format!(
                 r#"
                 Failed to launch kernel.

--- a/cuda-core/src/api.rs
+++ b/cuda-core/src/api.rs
@@ -20,7 +20,7 @@ use std::mem::{self, MaybeUninit};
 use std::sync::Arc;
 
 use crate::error::*;
-use crate::runtime::Stream;
+use crate::runtime::{LaunchAttributes, Stream};
 
 /// Initializes the CUDA driver API. Must be called before any other driver call.
 ///
@@ -67,6 +67,68 @@ pub unsafe fn launch_kernel(
         std::ptr::null_mut(),
     )
     .result()
+}
+
+fn encode_i32_launch_attribute(
+    id: cuda_bindings::CUlaunchAttributeID_enum,
+    value: i32,
+) -> cuda_bindings::CUlaunchAttribute_st {
+    // Bindgen keeps CUlaunchAttribute_st opaque across CUDA toolkit revisions.
+    // Its C layout is an enum at byte 0 followed by an eight-byte-aligned union
+    // payload at byte 8.
+    let mut attribute: cuda_bindings::CUlaunchAttribute_st = unsafe { std::mem::zeroed() };
+    unsafe {
+        let base = &mut attribute as *mut _ as *mut u8;
+        (base as *mut u32).write(id);
+        (base.add(8) as *mut i32).write(value);
+    }
+    attribute
+}
+
+/// Launches a CUDA kernel with composable extended-launch attributes.
+///
+/// # Safety
+///
+/// The caller must uphold the same function, stream, argument, and launch
+/// configuration requirements as [`launch_kernel`]. When
+/// `programmatic_stream_serialization` is enabled, device code must establish
+/// an ordering edge before reading prerequisite output.
+#[inline]
+pub unsafe fn launch_kernel_with_attributes(
+    f: cuda_bindings::CUfunction,
+    grid_dim: (c_uint, c_uint, c_uint),
+    block_dim: (c_uint, c_uint, c_uint),
+    shared_mem_bytes: c_uint,
+    attributes: LaunchAttributes,
+    stream: cuda_bindings::CUstream,
+    kernel_params: &mut [*mut c_void],
+) -> Result<(), DriverError> {
+    let mut encoded_attributes = Vec::with_capacity(1);
+    if attributes.programmatic_stream_serialization {
+        encoded_attributes.push(encode_i32_launch_attribute(
+            cuda_bindings::CUlaunchAttributeID_enum_CU_LAUNCH_ATTRIBUTE_PROGRAMMATIC_STREAM_SERIALIZATION,
+            1,
+        ));
+    }
+    let attrs = if encoded_attributes.is_empty() {
+        std::ptr::null_mut()
+    } else {
+        encoded_attributes.as_mut_ptr()
+    };
+    let config = cuda_bindings::CUlaunchConfig_st {
+        gridDimX: grid_dim.0,
+        gridDimY: grid_dim.1,
+        gridDimZ: grid_dim.2,
+        blockDimX: block_dim.0,
+        blockDimY: block_dim.1,
+        blockDimZ: block_dim.2,
+        sharedMemBytes: shared_mem_bytes,
+        hStream: stream,
+        attrs,
+        numAttrs: encoded_attributes.len() as u32,
+    };
+    cuda_bindings::cuLaunchKernelEx(&config, f, kernel_params.as_mut_ptr(), std::ptr::null_mut())
+        .result()
 }
 
 /// Asynchronously allocates `num_bytes` of device memory on the given stream.

--- a/cuda-core/src/runtime.rs
+++ b/cuda-core/src/runtime.rs
@@ -27,6 +27,19 @@ pub struct LaunchConfig {
     pub shared_mem_bytes: u32,
 }
 
+/// Optional attributes submitted with a CUDA extended kernel launch.
+///
+/// Keep launch behavior in one value so new attributes can be composed
+/// without adding mutually exclusive launch entry points.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct LaunchAttributes {
+    /// Permit this grid to overlap the preceding grid in the same stream.
+    ///
+    /// The dependent kernel must establish a device-side dependency before it
+    /// consumes prerequisite output.
+    pub programmatic_stream_serialization: bool,
+}
+
 /// A GPU device handle wrapping a CUDA primary context.
 ///
 /// Can be either **owned** (created via [`Device::new`], releases the

--- a/cutile-macro/src/_module.rs
+++ b/cutile-macro/src/_module.rs
@@ -394,7 +394,7 @@ fn module_inner(
                 use #tile_rust_crate_root::tile_kernel::{*};
                 use #tile_rust_crate_root::cuda_async::error::{*};
                 use #tile_rust_crate_root::cuda_async::scheduling_policies::SchedulingPolicy;
-                use #tile_rust_crate_root::cuda_core::{Device, Function, Module, Stream, DriverError, LaunchConfig};
+                use #tile_rust_crate_root::cuda_core::{Device, Function, Module, Stream, DriverError, LaunchAttributes, LaunchConfig};
                 // use #tile_rust_crate_root::cutile_compiler::cuda_tile::ModuleOperation;
                 // use #tile_rust_crate_root::cutile_compiler::compiler::{CUDATileModules, CUDATileFunctionCompiler};
                 // Module asts and generated type data.
@@ -832,6 +832,7 @@ pub fn kernel_launcher(
             function_generics: Option<Vec<String>>,
             _phantom: std::marker::PhantomData<( #(#ki_phantom_types,)* )>,
             _compile_options: CompileOptions,
+            _launch_attributes: LaunchAttributes,
             // When true, `execute` skips its launch block (set by `.compile()`).
             _compile_only: bool,
         }
@@ -845,6 +846,7 @@ pub fn kernel_launcher(
                     function_generics: None,
                     _phantom: std::marker::PhantomData,
                     _compile_options: CompileOptions::default(),
+                    _launch_attributes: LaunchAttributes::default(),
                     _compile_only: false,
                 }
             }
@@ -911,6 +913,10 @@ pub fn kernel_launcher(
             }
             fn get_launch_grid(&self) -> (u32, u32, u32) {
                 self._grid
+            }
+            fn launch_attributes(mut self, attributes: LaunchAttributes) -> Self {
+                self._launch_attributes = attributes;
+                self
             }
             fn generics(mut self, generics: Vec<String>) -> Self {
                 self.function_generics = Some(generics);

--- a/cutile-macro/src/kernel_launcher_generator.rs
+++ b/cutile-macro/src/kernel_launcher_generator.rs
@@ -945,7 +945,8 @@ pub fn generate_kernel_launcher(
                     grid_dim: launch_grid,
                     block_dim: (1, 1, 1),
                     shared_mem_bytes: 0
-                });
+                })
+                .set_launch_attributes(self._launch_attributes);
             kernel_launch.execute(ctx)?;
         }})
         .unwrap()

--- a/cutile/src/tile_kernel.rs
+++ b/cutile/src/tile_kernel.rs
@@ -910,6 +910,8 @@ where
     fn const_grid(self, grid: (u32, u32, u32)) -> Self;
     /// Sets the runtime launch grid dimensions.
     fn grid(self, grid: (u32, u32, u32)) -> Self;
+    /// Sets composable CUDA extended-launch attributes.
+    fn launch_attributes(self, attributes: cuda_core::LaunchAttributes) -> Self;
     /// Sets the runtime compile options (occupancy, num_cta_in_cga).
     fn compile_options(self, options: CompileOptions) -> Self;
     /// Infers the launch grid from partitioned tensor inputs, or uses the explicit grid.

--- a/cutile/tests/gpu.rs
+++ b/cutile/tests/gpu.rs
@@ -47,5 +47,8 @@ mod async_device_op;
 #[path = "gpu/book_snippets.rs"]
 mod book_snippets;
 
+#[path = "gpu/launch_attributes.rs"]
+mod launch_attributes;
+
 #[path = "gpu/tensor_permute.rs"]
 mod tensor_permute;

--- a/cutile/tests/gpu/launch_attributes.rs
+++ b/cutile/tests/gpu/launch_attributes.rs
@@ -1,0 +1,54 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Smoke test: launching with composable CUDA extended-launch attributes.
+//!
+//! `programmatic_stream_serialization` permits this grid to overlap the
+//! preceding grid in the same stream. The kernel under test has no
+//! cross-grid dependency, so overlapping is safe; the test verifies the
+//! `cuLaunchKernelEx` attribute path launches and computes correctly.
+
+use cutile::cuda_core::LaunchAttributes;
+use cutile::prelude::*;
+use my_module::add;
+
+use crate::common;
+
+#[cutile::module]
+mod my_module {
+    use cutile::core::*;
+    #[cutile::entry()]
+    fn add<const S: [i32; 1]>(
+        c: &mut Tensor<f32, S>,
+        a: &Tensor<f32, { [-1] }>,
+        b: &Tensor<f32, { [-1] }>,
+    ) {
+        let pid = get_tile_block_id().0;
+        let tile_a = a.load_tile(const_shape!(S), [pid]);
+        let tile_b = b.load_tile(const_shape!(S), [pid]);
+        c.store(tile_a + tile_b);
+    }
+}
+
+#[test]
+fn launch_with_programmatic_stream_serialization() {
+    common::with_test_stack(|| {
+        let c_host_vec = add(
+            api::zeros(&[32]).partition([4]),
+            api::ones(&[32]),
+            api::ones(&[32]),
+        )
+        .grid((8, 1, 1))
+        .launch_attributes(LaunchAttributes {
+            programmatic_stream_serialization: true,
+        })
+        .first()
+        .unpartition()
+        .to_host_vec()
+        .sync()
+        .expect("kernel with launch attributes should run");
+        assert!(c_host_vec.iter().all(|&v| (v - 2.0f32).abs() < 1e-6));
+    });
+}


### PR DESCRIPTION
## Motivation

CUDA 12.0+ programmatic dependent launch (PDL) lets a dependent grid start while the preceding grid in the same stream is still running, removing the full-grid serialization gap between back-to-back kernels. There is currently no way to attach launch attributes to cuTile-generated kernel launches, so consumers cannot opt into `CU_LAUNCH_ATTRIBUTE_PROGRAMMATIC_STREAM_SERIALIZATION`.

## What this adds

- **cuda-core**: a composable `LaunchAttributes` value (starting with `programmatic_stream_serialization: bool`) and `launch_kernel_with_attributes`, which encodes the attributes into a `CUlaunchConfig` and launches via `cuLaunchKernelEx`.
  - `CUlaunchAttribute` stays opaque in the bindgen output across toolkit revisions, so the attribute is encoded through its documented C layout (4-byte `id` at offset 0, 8-byte-aligned payload union at offset 8) — noted in a comment at the encoder.
- **cuda-async**: `AsyncKernelLaunch::set_launch_attributes`. Launches with default attributes keep using the plain `launch_kernel` path unchanged; only non-default attributes take the `cuLaunchKernelEx` path.
- **cutile**: generated kernel launchers gain a `.launch_attributes(...)` builder method (declared on the `TileKernel` trait), threading the value through to the async launch.

## Example

```rust
kernel(args).grid(grid)
    .launch_attributes(LaunchAttributes {
        programmatic_stream_serialization: true,
    })
    .async_on(&stream)?;
```

The dependent kernel is responsible for establishing the device-side ordering edge (e.g. `cudaGridDependencySynchronize` or an application-level ready-flag protocol) before consuming prerequisite output — the attribute only permits the overlap.

## Tests

Added `cutile/tests/gpu/launch_attributes.rs`: launches a basic add kernel with `programmatic_stream_serialization: true` and verifies results, exercising the `cuLaunchKernelEx` encoding end-to-end. Passes on an SM120 GPU; the default-attribute path is unchanged and covered by the existing launch tests.