### PR TITLE
feat(cutile): legalize mixed FP8xFP4 mmaf_scaled for Tile IR 13.3

### DIFF
--- a/cutile-book/reference/dsl-api.md
+++ b/cutile-book/reference/dsl-api.md
@@ -587,7 +587,7 @@ let prefix: Tile<f32, { [128] }> = scan_sum(row, 0i32, reverse::Forward, 0.0f32)
 | Function | Signature | Description |
 |---|---|---|
 | `mma(a, b, c)` | `(Tile<E, {[M,K]}>, Tile<E, {[K,N]}>, Tile<E, {[M,N]}>) -> Tile<E, {[M,N]}>` | Matrix multiply-accumulate |
-| `mmaf_scaled(a, b, c, a_scale, b_scale)` | `(Tile<E, A>, Tile<E, B>, Tile<f32, C>, Tile<S, AS>, Tile<S, BS>) -> Tile<f32, C>` | Block-scaled floating-point matrix multiply-accumulate |
+| `mmaf_scaled(a, b, c, a_scale, b_scale)` | `(Tile<EA, A>, Tile<EB, B>, Tile<f32, C>, Tile<S, AS>, Tile<S, BS>) -> Tile<f32, C>` | Block-scaled floating-point matrix multiply-accumulate |
 
 Maps to hardware tensor cores when available.
 
@@ -608,6 +608,12 @@ ops operate on rank-1 tiles; the FP4 tile methods emit the required
 flatten/pack-or-unpack/reshape sequence. See
 [Inference with NVFP4/MXFP8](../tutorials/11-nvfp4-inference.md)
 for the full pattern.
+
+The Rust frontend also accepts one FP8 operand and one FP4 operand. CUDA Tile
+IR 13.3 requires the two `mmaf_scaled` operands to have the same element type,
+so the compiler legalizes that combination by widening the logical FP4 tile
+exactly to the FP8 type before emitting Tile IR. This preserves W4A8 values and
+W4 storage, but it does not claim native mixed-input MMA throughput.
 
 ### Low-Level Memory Ops
 

--- a/cutile-compiler/src/compiler/compile_cuda_tile_op.rs
+++ b/cutile-compiler/src/compiler/compile_cuda_tile_op.rs
@@ -28,7 +28,8 @@ use super::utils::*;
 use cutile_ir::builder::{append_op, build_block, OpBuilder};
 use cutile_ir::bytecode::Opcode;
 use cutile_ir::ir::{
-    Attribute, BlockId, Module, PartitionViewType, Region, Type as TileIrType, Value,
+    Attribute, BlockId, Module, PartitionViewType, Region, ScalarType, TileElementType, TileType,
+    Type as TileIrType, Value,
 };
 
 use quote::ToTokens;
@@ -2459,6 +2460,63 @@ impl<'m> CUDATileFunctionCompiler<'m> {
             }
             operand_lengths.push(arg_values.len().to_string());
             op_operands.extend_from_slice(&arg_values);
+        }
+
+        // CUDA Tile IR 13.3 requires both `mmaf_scaled` inputs to have the
+        // same element type even though SM120 has a native FP8 x FP4 MMA.
+        // Keep the Rust DSL useful for W4A8 kernels by legalizing a mixed
+        // logical call to the closest representable Tile IR: FP4 values are
+        // exactly representable in FP8, so widen only the FP4 tile and retain
+        // its original block scales. This is a semantic fallback, not a claim
+        // that Tile IR emitted the native mixed-input instruction.
+        if opcode == Opcode::MmaFScaled && op_operands.len() == 5 {
+            let lhs_type = module.value_type(op_operands[0]).clone();
+            let rhs_type = module.value_type(op_operands[1]).clone();
+            let tile_scalar = |ty: &TileIrType| match ty {
+                TileIrType::Tile(TileType {
+                    element_type: TileElementType::Scalar(scalar),
+                    ..
+                }) => Some(*scalar),
+                _ => None,
+            };
+            let lhs_scalar = tile_scalar(&lhs_type);
+            let rhs_scalar = tile_scalar(&rhs_type);
+            if lhs_scalar != rhs_scalar {
+                let (narrow_index, wide_scalar) = match (lhs_scalar, rhs_scalar) {
+                    (Some(ScalarType::F4E2M1FN), Some(wide @ ScalarType::F8E4M3FN))
+                    | (Some(ScalarType::F4E2M1FN), Some(wide @ ScalarType::F8E5M2)) => {
+                        (0usize, wide)
+                    }
+                    (Some(wide @ ScalarType::F8E4M3FN), Some(ScalarType::F4E2M1FN))
+                    | (Some(wide @ ScalarType::F8E5M2), Some(ScalarType::F4E2M1FN)) => {
+                        (1usize, wide)
+                    }
+                    _ => {
+                        return self.jit_error_result(
+                            &call_expr.span(),
+                            &format!(
+                                "unsupported mixed mmaf_scaled input types: {lhs_type:?} and {rhs_type:?}"
+                            ),
+                        );
+                    }
+                };
+                let TileIrType::Tile(narrow_tile) = module.value_type(op_operands[narrow_index])
+                else {
+                    unreachable!("mixed scaled-MMA operand was already checked as a tile")
+                };
+                let widened_type = TileIrType::Tile(TileType {
+                    shape: narrow_tile.shape.clone(),
+                    element_type: TileElementType::Scalar(wide_scalar),
+                });
+                let (convert_op, results) =
+                    OpBuilder::new(Opcode::FToF, self.ir_location(&call_expr.span()))
+                        .operand(op_operands[narrow_index])
+                        .result(widened_type)
+                        .attr("rounding_mode", rounding_mode_attr("nearest_even").1)
+                        .build(module);
+                append_op(module, block_id, convert_op);
+                op_operands[narrow_index] = results[0];
+            }
         }
 
         let mut attrs: Vec<(String, Attribute)> = vec![];

--- a/cutile/src/_core.rs
+++ b/cutile/src/_core.rs
@@ -1852,7 +1852,8 @@ pub mod core {
     )]
     #[cuda_tile::variadic_op(N = 3)]
     pub fn mmaf_scaled<
-        EIn: ElementType,
+        ELhs: ElementType,
+        ERhs: ElementType,
         EScale: ElementType,
         const LHS: [i32; N],
         const RHS: [i32; N],
@@ -1860,8 +1861,8 @@ pub mod core {
         const LHS_SCALE: [i32; N],
         const RHS_SCALE: [i32; N],
     >(
-        lhs: Tile<EIn, LHS>,
-        rhs: Tile<EIn, RHS>,
+        lhs: Tile<ELhs, LHS>,
+        rhs: Tile<ERhs, RHS>,
         acc: Tile<f32, ACC>,
         lhs_scale: Tile<EScale, LHS_SCALE>,
         rhs_scale: Tile<EScale, RHS_SCALE>,

--- a/cutile/tests/tensor_and_matrix_ops.rs
+++ b/cutile/tests/tensor_and_matrix_ops.rs
@@ -283,6 +283,28 @@ mod tensor_and_matrix_ops_module {
     }
 
     #[cutile::entry()]
+    fn raw_mmaf_scaled_fp8_fp4_kernel(
+        output: &mut Tensor<f32, { [16, 16] }>,
+        lhs: &Tensor<f8e4m3fn, { [-1, -1] }>,
+        rhs_bytes: &Tensor<f4e2m1fnx2, { [-1, -1] }>,
+        lhs_scale: &Tensor<f8e8m0fnu, { [-1, -1] }>,
+        rhs_scale: &Tensor<f8e8m0fnu, { [-1, -1] }>,
+    ) {
+        let lhs_tile: Tile<f8e4m3fn, { [16, 64] }> = load_tile(lhs, const_shape![16, 64], [0, 0]);
+        let rhs_raw: Tile<f4e2m1fnx2, { [32, 16] }> =
+            load_tile(rhs_bytes, const_shape![32, 16], [0, 0]);
+        let rhs_tile: Tile<f4e2m1fn, { [64, 16] }> = rhs_raw.unpack(const_shape![64, 16]);
+        let lscale: Tile<f8e8m0fnu, { [16, 2] }> =
+            load_tile(lhs_scale, const_shape![16, 2], [0, 0]);
+        let rscale: Tile<f8e8m0fnu, { [2, 16] }> =
+            load_tile(rhs_scale, const_shape![2, 16], [0, 0]);
+        let acc: Tile<f32, { [16, 16] }> = load_tile_mut(output);
+
+        let result: Tile<f32, { [16, 16] }> = mmaf_scaled(lhs_tile, rhs_tile, acc, lscale, rscale);
+        output.store(result);
+    }
+
+    #[cutile::entry()]
     fn batch_mmaf_scaled_fp8_kernel(
         output: &mut Tensor<f32, { [2, 16, 16] }>,
         lhs: &Tensor<f8e4m3fn, { [-1, -1, -1] }>,
@@ -699,6 +721,29 @@ fn compile_raw_mmaf_scaled_fp8() -> () {
         assert!(module_op_str.contains("= mmaf_scaled"));
         assert!(module_op_str.contains("f8e4m3fn"));
         assert!(module_op_str.contains("f8e8m0fnu"));
+    });
+}
+
+#[test]
+fn compile_raw_mmaf_scaled_fp8_fp4_legalizes_for_tile_ir_13_3() -> () {
+    common::with_test_stack(|| {
+        let module_op_str = compile_ir(
+            "raw_mmaf_scaled_fp8_fp4_kernel",
+            &[],
+            &[
+                ("output", &[16, 16]),
+                ("lhs", &[16, 64]),
+                ("rhs_bytes", &[32, 16]),
+                ("lhs_scale", &[16, 2]),
+                ("rhs_scale", &[2, 16]),
+            ],
+        );
+
+        assert!(module_op_str.contains("= unpack"));
+        assert!(module_op_str.contains("= ftof"));
+        assert!(module_op_str.contains("= mmaf_scaled"));
+        assert!(module_op_str.contains("tile<64x16xf4e2m1fn>"));
+        assert!(module_op_str.contains("tile<64x16xf8e4m3fn>"));
     });
 }
 


### PR DESCRIPTION
## Motivation

W4A8 kernels (e.g. MoE weight-path GEMMs with FP4 weights and FP8 activations) naturally want a block-scaled MMA with one FP8 and one FP4 operand. Today `mmaf_scaled` requires both operands to share a single element type (`EIn`), so this combination is not expressible in the DSL at all.

## What this adds

- **`cutile::core::mmaf_scaled`** is generalized from one element-type parameter (`EIn`) to two (`ELhs`, `ERhs`).
- **Compiler legalization**: CUDA Tile IR 13.3 requires both `mmaf_scaled` operands to have the same element type, so a mixed FP8×FP4 call is legalized at emission time: the logical FP4 tile is widened to the FP8 type with an exact `ftof` (nearest-even — every FP4 E2M1 value is exactly representable in FP8 E4M3/E5M2), keeping the original block scales unchanged. Unsupported mixed combinations are rejected with a clear error.

This is documented honestly in `cutile-book`: the legalization preserves W4A8 values and W4 storage, but it is a semantic fallback — it does not claim native mixed-input MMA throughput. If Tile IR later exposes a native mixed-input scaled MMA, the legalization can be retired behind the same DSL signature.

## Tests

`compile_raw_mmaf_scaled_fp8_fp4_legalizes_for_tile_ir_13_3` compiles a kernel feeding an `f8e4m3fn` lhs tile and an unpacked `f4e2m1fn` rhs tile (with E8M0 block scales) into `mmaf_scaled` and asserts the emitted MLIR contains the `unpack`, the widening `ftof`, and a same-type `mmaf_scaled`. The full `tensor_and_matrix_ops` suite (19 tests, including the existing same-type scaled-MMA coverage) passes.