### PR TITLE
feat: hoist checks out of kernels.

### DIFF
--- a/cuda-async/src/device_context.rs
+++ b/cuda-async/src/device_context.rs
@@ -82,6 +82,11 @@ pub struct TensorParamType {
 #[derive(Debug, Clone)]
 pub struct Validator {
     pub params: Vec<ValidParamType>,
+    /// Compiler-emitted checks to run at launch, before `cuLaunchKernel`. Each
+    /// is a canonical [`crate::predicate::Predicate`] the compiler hoisted out
+    /// of the device kernel; the host evaluates it against the launched tensors'
+    /// extents. Empty unless a kernel hoists a launch-known safety check.
+    pub launch_checks: Vec<crate::predicate::LaunchCheck>,
 }
 
 // ── Global Device (process-wide, per-device singleton) ─────────────────────

--- a/cuda-async/src/lib.rs
+++ b/cuda-async/src/lib.rs
@@ -14,6 +14,7 @@ pub mod device_operation;
 pub mod error;
 pub mod launch;
 mod loom_compat;
+pub mod predicate;
 pub mod prelude;
 // The real CUDA backend wraps pinned memory via `AtomicU32::from_ptr`, which is
 // incompatible with loom's swapped atomics; under `--cfg loom` the protocol is

--- a/cuda-async/src/predicate.rs
+++ b/cuda-async/src/predicate.rs
@@ -1,0 +1,679 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Canonical predicate / term algebra for staged obligation resolution.
+//!
+//! Plain data shared by the compiler (which builds and resolves obligations)
+//! and the host launcher (which evaluates launch-stage predicates). It lives in
+//! this low crate so a *single* representation serves all three stages — the
+//! same [`Predicate`] is folded at JIT, evaluated against tensor extents at
+//! launch, and (later) lowered to an in-kernel assert.
+//!
+//! ## Normal form (follows LLVM ScalarEvolution and MLIR `AffineExpr`)
+//!
+//! A [`Term`] is kept in a canonical form, so **semantic equality is structural
+//! equality** (`PartialEq`/`Hash`). For the linear fragment we use a sparse
+//! coefficient map rather than a rewritten expression tree: the map makes the
+//! operand-ordering, constant-folding and like-term-combination rules those
+//! systems apply by hand (e.g. MLIR `simplifyAdd`) automatic and confluent by
+//! construction. Anything non-linear (a `mod`/`floordiv` residue, an opaque
+//! product) enters as a leaf [`Atom`], exactly as SCEV treats `SCEVUnknown` /
+//! `SCEVUDivExpr` as leaves.
+//!
+//! Overflow follows MLIR (`mlir/lib/IR/AffineExpr.cpp`): a construction that
+//! overflows `i64` is *not canonicalizable* and returns `None`, so the caller
+//! falls back to a weaker (later) stage. This keeps the algebra sound — an
+//! un-formed term simply fails to discharge an obligation early; it never
+//! produces a wrong equality.
+
+use std::collections::BTreeMap;
+
+/// The compilation / execution stage at which a value becomes available:
+/// `Jit ⊑ Launch ⊑ Device` (earlier is cheaper — fewer device registers).
+/// `Ord` is derived with `Jit` smallest, so `max` over a term's atoms yields
+/// the earliest stage at which the whole term is evaluable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Stage {
+    Jit,
+    Launch,
+    Device,
+}
+
+/// An indivisible term operand, tagged with the stage at which its value is
+/// known.
+///
+/// Atoms are identified by *resolved* symbols, never source names: a tensor
+/// axis extent by kernel-parameter position, an induction variable by its
+/// opaque IR value id. This makes the launch-known classifier structural — a
+/// term's stage is the `max` over its atoms (see [`Term::stage`]), so
+/// liftability is computed, not judged per predicate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Atom {
+    /// `extent(param, axis)` — a tensor axis extent, identified by kernel
+    /// parameter position. Known at [`Stage::Launch`]: the host has every
+    /// extent before `cuLaunchKernel`.
+    Dim { param: usize, axis: usize },
+    /// A kernel-runtime induction variable, by opaque IR value id.
+    /// [`Stage::Device`].
+    Iv(u32),
+    /// A special register: the tile-block id on grid axis `k`
+    /// (`get_tile_block_id().k`). [`Stage::Device`] — a per-CTA runtime value.
+    TileBlockId(usize),
+    /// A special register: the number of tile blocks on grid axis `k`
+    /// (`get_num_tile_blocks().k`, i.e. `gridDim.k`). [`Stage::Launch`] — the
+    /// host fixes the grid before `cuLaunchKernel`.
+    ///
+    /// **This is the CTA-*slab* count, not an in-kernel tile count.** It equals
+    /// `div_ceil(root_shape, slab_shape)` (`Partition::grid`) — the quantity
+    /// `validate_grids` checks the launch grid against. A partition access needs
+    /// the tile count *within* the kernel-visible view (`ceil(view_shape /
+    /// tile)`), which for a `&mut Tensor` param is tiles inside one slab. **The
+    /// two are unrelated**: never treat `NumTileBlocks(k)` as a partition's tile
+    /// count without a *verified* `Launch` obligation equating them. Conflating
+    /// them once admitted out-of-bounds stores (reverted).
+    NumTileBlocks(usize),
+    /// `view_extent(param, axis)` — the extent of the parameter's
+    /// *kernel-visible view*, identified by kernel parameter position.
+    /// [`Stage::Launch`]: the host chose the view when it partitioned.
+    ///
+    /// **Frame.** [`Atom::Dim`] is the *root* frame (the whole tensor, what
+    /// `param_shapes` holds — and the frame declared `preconditions` are stated
+    /// in). This atom is the *view* frame: for an immutable `&Tensor` the view
+    /// is the whole tensor (same value as `Dim`), but for a slabbed
+    /// `&mut Tensor` it is the per-work-item piece, a different quantity. The
+    /// two frames are different atom variants precisely so that a root-frame
+    /// fact can never entail a view-frame obligation (or vice versa) by
+    /// structural equality — the frame confusion that once admitted
+    /// out-of-bounds stores is unrepresentable rather than merely avoided.
+    ViewExtent { param: usize, axis: usize },
+    /// `ceil(extent(param, axis) / tile)` — the number of `tile`-sized tiles
+    /// along a tensor axis, identified by kernel parameter position with the
+    /// tile size baked into the atom's identity (the same axis at two tile
+    /// sizes is two different quantities). [`Stage::Launch`]: the host holds
+    /// the extent and the tile is a compile-time constant.
+    ///
+    /// **Frame: ROOT, like [`Atom::Dim`]** — the whole tensor's tile count,
+    /// which is what an index walked from an immutable partition's axis is
+    /// bounded by. A view-frame variant (tiles within a `&mut` slab) is the
+    /// extension point if a consumer ever needs it; keeping the frames as
+    /// separate variants is this module's standing rule.
+    ///
+    /// This is a NAME, not a fact: like every atom it is a free variable the
+    /// host evaluates, and no relationship between `TileCount` and `Dim` is
+    /// known to the solver — a goal stated over tile counts cannot be
+    /// discharged by a believed extent fact except through explicit code.
+    /// `tile` must be >= 1; minting sites enforce it.
+    TileCount {
+        param: usize,
+        axis: usize,
+        tile: i32,
+    },
+}
+
+impl Atom {
+    /// The stage at which this atom's value is known.
+    pub fn stage(&self) -> Stage {
+        match self {
+            Atom::Dim { .. }
+            | Atom::NumTileBlocks(_)
+            | Atom::ViewExtent { .. }
+            | Atom::TileCount { .. } => Stage::Launch,
+            Atom::Iv(_) | Atom::TileBlockId(_) => Stage::Device,
+        }
+    }
+}
+
+/// A canonical linear integer term: `sum(coeff_i * atom_i) + constant`.
+///
+/// Normal-form invariant: `coeffs` holds no zero coefficients and is sorted by
+/// [`Atom`] (a `BTreeMap`). Two terms are semantically equal iff structurally
+/// equal, so `PartialEq`/`Hash` *are* the equality test. Build only through the
+/// constructors below — each preserves the invariant.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
+pub struct Term {
+    coeffs: BTreeMap<Atom, i64>,
+    constant: i64,
+}
+
+impl Term {
+    /// The constant term `c`.
+    pub fn constant(c: i64) -> Self {
+        Term {
+            coeffs: BTreeMap::new(),
+            constant: c,
+        }
+    }
+
+    /// The term `atom` (coefficient 1).
+    pub fn atom(a: Atom) -> Self {
+        let mut coeffs = BTreeMap::new();
+        coeffs.insert(a, 1);
+        Term {
+            coeffs,
+            constant: 0,
+        }
+    }
+
+    /// The affine term `scale * atom + offset`. Consolidates the old
+    /// `AffineForm { scale, var, offset }`. `None` iff `scale == 0` would be
+    /// preferred as a plain constant — instead a zero scale folds to `offset`.
+    pub fn affine(a: Atom, scale: i64, offset: i64) -> Self {
+        if scale == 0 {
+            return Term::constant(offset);
+        }
+        let mut coeffs = BTreeMap::new();
+        coeffs.insert(a, scale);
+        Term {
+            coeffs,
+            constant: offset,
+        }
+    }
+
+    /// The whole-term constant, if it has no atoms.
+    pub fn as_constant(&self) -> Option<i64> {
+        self.coeffs.is_empty().then_some(self.constant)
+    }
+
+    /// Read access to the coefficient map (sorted, zero-free).
+    pub fn coeffs(&self) -> &BTreeMap<Atom, i64> {
+        &self.coeffs
+    }
+
+    /// The constant part (may be nonzero even when atoms are present).
+    pub fn constant_part(&self) -> i64 {
+        self.constant
+    }
+
+    /// The stage at which the whole term becomes evaluable: the `max` over its
+    /// atoms; a constant term is [`Stage::Jit`]. A predicate over this term can
+    /// be decided no earlier than this stage.
+    pub fn stage(&self) -> Stage {
+        self.coeffs
+            .keys()
+            .map(Atom::stage)
+            .max()
+            .unwrap_or(Stage::Jit)
+    }
+
+    /// `self + other`, or `None` on `i64` overflow (not canonicalizable — the
+    /// caller sinks to a later stage). Follows MLIR `AffineExpr` overflow policy.
+    pub fn add(&self, other: &Term) -> Option<Term> {
+        let mut coeffs = self.coeffs.clone();
+        for (atom, &c) in &other.coeffs {
+            let entry = coeffs.entry(*atom).or_insert(0);
+            *entry = entry.checked_add(c)?;
+            if *entry == 0 {
+                coeffs.remove(atom);
+            }
+        }
+        Some(Term {
+            coeffs,
+            constant: self.constant.checked_add(other.constant)?,
+        })
+    }
+
+    /// `-self`, or `None` on overflow.
+    pub fn neg(&self) -> Option<Term> {
+        let mut coeffs = BTreeMap::new();
+        for (atom, &c) in &self.coeffs {
+            coeffs.insert(*atom, c.checked_neg()?);
+        }
+        Some(Term {
+            coeffs,
+            constant: self.constant.checked_neg()?,
+        })
+    }
+
+    /// `self - other`, or `None` on overflow.
+    pub fn sub(&self, other: &Term) -> Option<Term> {
+        self.add(&other.neg()?)
+    }
+
+    /// `k * self`, or `None` on overflow.
+    pub fn mul_const(&self, k: i64) -> Option<Term> {
+        if k == 0 {
+            return Some(Term::constant(0));
+        }
+        let mut coeffs = BTreeMap::new();
+        for (atom, &c) in &self.coeffs {
+            coeffs.insert(*atom, c.checked_mul(k)?);
+        }
+        Some(Term {
+            coeffs,
+            constant: self.constant.checked_mul(k)?,
+        })
+    }
+
+    /// A sign-canonical representative: negate iff the leading (least-[`Atom`])
+    /// nonzero coefficient — or the constant, when there are no atoms — is
+    /// negative. Used to give sign-invariant predicates (`== 0`, `!= 0`,
+    /// `% d == 0`) one representative, so e.g. `a == b` and `b == a` unify.
+    fn sign_canonical(&self) -> Term {
+        let leading_negative = match self.coeffs.iter().next() {
+            Some((_, &c)) => c < 0,
+            None => self.constant < 0,
+        };
+        if leading_negative {
+            // A canonical term's negation cannot overflow in practice; if it
+            // somehow would, keep the original — still sound (equality may miss,
+            // sinking a stage), never wrong.
+            self.neg().unwrap_or_else(|| self.clone())
+        } else {
+            self.clone()
+        }
+    }
+
+    /// If the term is `scale * atom + offset` — exactly one atom — return
+    /// `(atom, scale, offset)`. This projects to the single-variable affine
+    /// fragment used by loop check-hoisting (the strongest-instance
+    /// substitution): a richer term (two IVs, a product) returns `None`, so the
+    /// hoister declines it exactly as it declined a non-affine index before.
+    pub fn as_single_affine(&self) -> Option<(Atom, i64, i64)> {
+        if self.coeffs.len() != 1 {
+            return None;
+        }
+        let (&atom, &scale) = self.coeffs.iter().next().unwrap();
+        Some((atom, scale, self.constant))
+    }
+
+    /// Evaluate given a resolver from atom to concrete value. `None` if any atom
+    /// is unresolved or arithmetic overflows.
+    pub fn eval(&self, resolve_atom: &impl Fn(&Atom) -> Option<i64>) -> Option<i64> {
+        let mut acc = self.constant;
+        for (atom, &c) in &self.coeffs {
+            let v = resolve_atom(atom)?;
+            acc = acc.checked_add(c.checked_mul(v)?)?;
+        }
+        Some(acc)
+    }
+}
+
+/// A relation over canonical [`Term`]s. Constructors put each predicate into a
+/// canonical representative, so structurally-equal predicates compare equal.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum Predicate {
+    /// `term == 0`. Equalities `a == b` are stored as `Zero(a - b)`.
+    Zero(Term),
+    /// `term != 0`. For a non-negative operand this is `term > 0`.
+    Nonzero(Term),
+    /// `term > 0` (strict). The canonical form of an inequality `a < b`, stored
+    /// as `Positive(b - a)`. Unlike `Zero`/`Nonzero`, this is *not*
+    /// sign-invariant (`a < b` ≠ `b < a`), so no sign canonicalization is
+    /// applied — the term `b - a` is already canonical.
+    Positive(Term),
+    /// `term % divisor == 0`, with `divisor >= 1`.
+    DivisibleBy { term: Term, divisor: i64 },
+}
+
+impl Predicate {
+    /// `a == b`, canonicalized as `Zero(sign_canonical(a - b))`. `None` on
+    /// overflow forming `a - b`.
+    pub fn eq(a: &Term, b: &Term) -> Option<Predicate> {
+        Some(Predicate::Zero(a.sub(b)?.sign_canonical()))
+    }
+
+    /// `term != 0` (for a non-negative operand, `term > 0`).
+    pub fn nonzero(term: Term) -> Predicate {
+        Predicate::Nonzero(term.sign_canonical())
+    }
+
+    /// `a < b`, canonicalized as `Positive(b - a)` (i.e. `b - a > 0`). `None` on
+    /// overflow forming `b - a`.
+    pub fn lt(a: &Term, b: &Term) -> Option<Predicate> {
+        Some(Predicate::Positive(b.sub(a)?))
+    }
+
+    /// `a <= b` over integers, canonicalized as `a < b + 1`, i.e.
+    /// `Positive(b - a + 1)`. `None` on overflow.
+    ///
+    /// This is the natural form for an access-safety goal: an index drawn
+    /// from `[0, ceil(a/t))` stays inside an axis of extent `b` exactly when
+    /// `a <= b` bounds it from above (see the checker's linearization). An
+    /// *equality* in that position is not the same claim — it also rejects
+    /// every `b` strictly larger than `a`, which is safe.
+    pub fn le(a: &Term, b: &Term) -> Option<Predicate> {
+        Some(Predicate::Positive(b.add(&Term::constant(1))?.sub(a)?))
+    }
+
+    /// `term % divisor == 0`. Coefficients and constant are reduced modulo
+    /// `divisor` into `[0, divisor)` — valid because `c * a ≡ (c mod d) * a
+    /// (mod d)` for every integer `a` — giving a canonical residue term.
+    /// `None` if `divisor < 1`.
+    pub fn divisible_by(term: Term, divisor: i64) -> Option<Predicate> {
+        if divisor < 1 {
+            return None;
+        }
+        let mut coeffs = BTreeMap::new();
+        for (atom, &c) in &term.coeffs {
+            let r = c.rem_euclid(divisor);
+            if r != 0 {
+                coeffs.insert(*atom, r);
+            }
+        }
+        let reduced = Term {
+            coeffs,
+            constant: term.constant.rem_euclid(divisor),
+        };
+        Some(Predicate::DivisibleBy {
+            term: reduced.sign_canonical(),
+            divisor,
+        })
+    }
+
+    /// The stage at which this predicate can be decided (its term's stage).
+    pub fn stage(&self) -> Stage {
+        match self {
+            Predicate::Zero(t) | Predicate::Nonzero(t) | Predicate::Positive(t) => t.stage(),
+            Predicate::DivisibleBy { term, .. } => term.stage(),
+        }
+    }
+
+    /// Evaluate the predicate against an atom resolver (used to fold at JIT and
+    /// to check tensor extents at launch). `None` if any atom is unresolved.
+    pub fn eval(&self, resolve_atom: &impl Fn(&Atom) -> Option<i64>) -> Option<bool> {
+        match self {
+            Predicate::Zero(t) => Some(t.eval(resolve_atom)? == 0),
+            Predicate::Nonzero(t) => Some(t.eval(resolve_atom)? != 0),
+            Predicate::Positive(t) => Some(t.eval(resolve_atom)? > 0),
+            Predicate::DivisibleBy { term, divisor } => {
+                Some(term.eval(resolve_atom)?.rem_euclid(*divisor) == 0)
+            }
+        }
+    }
+}
+
+/// A predicate hoisted out of the device kernel to the host launcher, with a
+/// diagnostic `cause` rendered if it fails. Carried on the compiled kernel
+/// (`Validator`) and evaluated once per launch by the host's `validate_launch`.
+/// This is the same [`Predicate`] the compiler resolved — one representation,
+/// evaluated at launch instead of emitted in-kernel.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LaunchCheck {
+    pub predicate: Predicate,
+    pub cause: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dim(param: usize, axis: usize) -> Atom {
+        Atom::Dim { param, axis }
+    }
+
+    // ── Normal form: canonical by construction, confluent ──────────────────
+
+    #[test]
+    fn like_terms_combine_and_order_is_irrelevant() {
+        let a = Term::atom(dim(0, 0));
+        let b = Term::atom(dim(1, 0));
+        // (a + b) and (b + a) reach the same normal form.
+        assert_eq!(a.add(&b).unwrap(), b.add(&a).unwrap());
+        // a + a == 2a.
+        assert_eq!(a.add(&a).unwrap(), a.mul_const(2).unwrap());
+    }
+
+    #[test]
+    fn like_terms_cancel_to_drop_zero_coefficients() {
+        let a = Term::atom(dim(0, 0));
+        let zero = a.sub(&a).unwrap();
+        assert_eq!(zero, Term::constant(0));
+        assert!(zero.coeffs().is_empty());
+    }
+
+    #[test]
+    fn confluence_two_build_orders_agree() {
+        let a = Term::atom(dim(0, 0));
+        let b = Term::atom(dim(1, 1));
+        // (2a + b) + 3   vs   (b + 3) + 2a
+        let lhs = a
+            .mul_const(2)
+            .unwrap()
+            .add(&b)
+            .unwrap()
+            .add(&Term::constant(3))
+            .unwrap();
+        let rhs = b
+            .add(&Term::constant(3))
+            .unwrap()
+            .add(&a.mul_const(2).unwrap())
+            .unwrap();
+        assert_eq!(lhs, rhs);
+    }
+
+    #[test]
+    fn affine_consolidates_scale_var_offset() {
+        let a = dim(0, 0);
+        // 3 * a + 5 built two ways.
+        assert_eq!(
+            Term::affine(a, 3, 5),
+            Term::atom(a)
+                .mul_const(3)
+                .unwrap()
+                .add(&Term::constant(5))
+                .unwrap()
+        );
+        // A zero scale folds to the constant.
+        assert_eq!(Term::affine(a, 0, 7), Term::constant(7));
+    }
+
+    // ── Stage is the max over atoms ────────────────────────────────────────
+
+    #[test]
+    fn as_single_affine_projects_only_single_var_forms() {
+        let a = dim(0, 0);
+        // 3*a + 5 projects to (a, 3, 5).
+        assert_eq!(Term::affine(a, 3, 5).as_single_affine(), Some((a, 3, 5)));
+        // A constant (zero atoms) does not project.
+        assert_eq!(Term::constant(7).as_single_affine(), None);
+        // Two atoms do not project (richer than single-var affine).
+        let two = Term::atom(dim(0, 0)).add(&Term::atom(dim(1, 0))).unwrap();
+        assert_eq!(two.as_single_affine(), None);
+    }
+
+    #[test]
+    fn stage_is_max_over_atoms() {
+        assert_eq!(Term::constant(4).stage(), Stage::Jit);
+        assert_eq!(Term::atom(dim(0, 0)).stage(), Stage::Launch);
+        let mixed = Term::atom(dim(0, 0)).add(&Term::atom(Atom::Iv(7))).unwrap();
+        assert_eq!(mixed.stage(), Stage::Device);
+    }
+
+    // ── Overflow bails (MLIR policy), never wraps ──────────────────────────
+
+    #[test]
+    fn overflow_bails_to_none() {
+        let big = Term::constant(i64::MAX);
+        assert!(big.add(&Term::constant(1)).is_none());
+        assert!(Term::atom(dim(0, 0))
+            .mul_const(2)
+            .unwrap()
+            .mul_const(i64::MAX)
+            .is_none());
+    }
+
+    // ── Predicate canonicalization ─────────────────────────────────────────
+
+    #[test]
+    fn equality_is_symmetric_after_canonicalization() {
+        let a = Term::atom(dim(0, 0));
+        let b = Term::atom(dim(1, 0));
+        // a == b and b == a produce the same canonical predicate.
+        assert_eq!(
+            Predicate::eq(&a, &b).unwrap(),
+            Predicate::eq(&b, &a).unwrap()
+        );
+    }
+
+    #[test]
+    fn nonzero_is_sign_invariant() {
+        let a = Term::atom(dim(0, 0));
+        let neg_a = a.neg().unwrap();
+        assert_eq!(Predicate::nonzero(a), Predicate::nonzero(neg_a));
+    }
+
+    #[test]
+    fn divisibility_reduces_coefficients_mod_divisor() {
+        let a = dim(0, 0);
+        // 6a + 9  and  0a + 3 (== 3)  are both "divisible by 3": 6≡0, 9≡0 mod 3.
+        let p1 = Predicate::divisible_by(Term::affine(a, 6, 9), 3).unwrap();
+        // 6 ≡ 0 (mod 3) drops the atom; 9 ≡ 0 (mod 3): reduces to `0 % 3 == 0`.
+        let expected = Predicate::divisible_by(Term::constant(0), 3).unwrap();
+        assert_eq!(p1, expected);
+        assert!(Predicate::divisible_by(Term::constant(0), 0).is_none());
+    }
+
+    // ── Evaluation (the launch / fold interpreter) ─────────────────────────
+
+    #[test]
+    fn eval_resolves_atoms_and_decides() {
+        // extent(param 0, axis 0) = 128.
+        let env = |atom: &Atom| match atom {
+            Atom::Dim { param: 0, axis: 0 } => Some(128),
+            _ => None,
+        };
+        let nonzero = Predicate::nonzero(Term::atom(dim(0, 0)));
+        assert_eq!(nonzero.eval(&env), Some(true));
+
+        let zero_env = |atom: &Atom| match atom {
+            Atom::Dim { param: 0, axis: 0 } => Some(0),
+            _ => None,
+        };
+        assert_eq!(nonzero.eval(&zero_env), Some(false));
+
+        // Unresolved atom → cannot decide.
+        let missing = Predicate::nonzero(Term::atom(dim(9, 9)));
+        assert_eq!(missing.eval(&env), None);
+    }
+
+    // ── Special registers + Lt canonical inequality ───────────────────────
+
+    #[test]
+    fn special_register_stages() {
+        // The tile-block id is a per-CTA runtime value (Device); the grid dim is
+        // host-known before launch (Launch).
+        assert_eq!(Atom::TileBlockId(0).stage(), Stage::Device);
+        assert_eq!(Atom::NumTileBlocks(0).stage(), Stage::Launch);
+        assert_eq!(Term::atom(Atom::TileBlockId(0)).stage(), Stage::Device);
+        assert_eq!(Term::atom(Atom::NumTileBlocks(0)).stage(), Stage::Launch);
+    }
+
+    #[test]
+    fn lt_is_the_hardware_axiom_and_directional() {
+        let id = Term::atom(Atom::TileBlockId(0));
+        let n = Term::atom(Atom::NumTileBlocks(0));
+        // The universal axiom `TileBlockId(0) < NumTileBlocks(0)`.
+        let axiom = Predicate::lt(&id, &n).unwrap();
+        // Directional: `a < b` differs from `b < a` (no sign canonicalization).
+        assert_ne!(axiom, Predicate::lt(&n, &id).unwrap());
+        // Stage is Device (mixes a Device id with a Launch grid dim), so it can
+        // only discharge at Jit via a matching assumption, never hoist.
+        assert_eq!(axiom.stage(), Stage::Device);
+    }
+
+    #[test]
+    fn lt_evaluates_strictly() {
+        let env = |atom: &Atom| match atom {
+            Atom::TileBlockId(0) => Some(3),
+            Atom::NumTileBlocks(0) => Some(4),
+            _ => None,
+        };
+        let lt = Predicate::lt(
+            &Term::atom(Atom::TileBlockId(0)),
+            &Term::atom(Atom::NumTileBlocks(0)),
+        )
+        .unwrap();
+        assert_eq!(lt.eval(&env), Some(true)); // 3 < 4
+        let eq_env = |atom: &Atom| match atom {
+            Atom::TileBlockId(0) => Some(4),
+            Atom::NumTileBlocks(0) => Some(4),
+            _ => None,
+        };
+        assert_eq!(lt.eval(&eq_env), Some(false)); // 4 < 4 is false (strict)
+    }
+
+    #[test]
+    fn tile_count_evaluates_ceil_div_in_the_root_frame() {
+        let ta = Term::atom(Atom::TileCount {
+            param: 0,
+            axis: 1,
+            tile: 32,
+        });
+        let tb = Term::atom(Atom::TileCount {
+            param: 1,
+            axis: 0,
+            tile: 32,
+        });
+        let le = Predicate::le(&ta, &tb).unwrap();
+        assert_eq!(le.stage(), Stage::Launch);
+        let env = |a_extent: i64, b_extent: i64| {
+            move |atom: &Atom| match atom {
+                Atom::TileCount {
+                    param: 0,
+                    axis: 1,
+                    tile: 32,
+                } => Some((a_extent + 31) / 32),
+                Atom::TileCount {
+                    param: 1,
+                    axis: 0,
+                    tile: 32,
+                } => Some((b_extent + 31) / 32),
+                _ => None,
+            }
+        };
+        // The sub-tile band: shorter in elements, equal in tiles — admitted.
+        assert_eq!(le.eval(&env(128, 100)), Some(true));
+        // Genuinely fewer tiles — rejected.
+        assert_eq!(le.eval(&env(128, 96)), Some(false));
+        // Distinct tile sizes are distinct atoms, not the same quantity.
+        assert_ne!(
+            Term::atom(Atom::TileCount {
+                param: 0,
+                axis: 1,
+                tile: 32
+            }),
+            Term::atom(Atom::TileCount {
+                param: 0,
+                axis: 1,
+                tile: 16
+            })
+        );
+    }
+
+    #[test]
+    fn le_admits_equality_and_larger_and_rejects_smaller() {
+        let a = Term::atom(Atom::Dim { param: 0, axis: 1 });
+        let b = Term::atom(Atom::Dim { param: 1, axis: 0 });
+        let le = Predicate::le(&a, &b).unwrap();
+        let env = |x: i64, y: i64| {
+            move |atom: &Atom| match atom {
+                Atom::Dim { param: 0, axis: 1 } => Some(x),
+                Atom::Dim { param: 1, axis: 0 } => Some(y),
+                _ => None,
+            }
+        };
+        assert_eq!(le.eval(&env(64, 64)), Some(true)); // equal: safe
+        assert_eq!(le.eval(&env(64, 256)), Some(true)); // target larger: safe
+        assert_eq!(le.eval(&env(128, 96)), Some(false)); // target short: reject
+                                                         // Not the same claim as equality: eq rejects the larger target.
+        let eq = Predicate::eq(&a, &b).unwrap();
+        assert_eq!(eq.eval(&env(64, 256)), Some(false));
+        // Self-comparison folds without an environment: `a <= a` is Positive(1).
+        let refl = Predicate::le(&a, &a).unwrap();
+        assert_eq!(refl.eval(&|_| None), Some(true));
+    }
+
+    #[test]
+    fn eval_divisibility() {
+        let env = |atom: &Atom| match atom {
+            Atom::Dim { param: 0, axis: 0 } => Some(256),
+            _ => None,
+        };
+        let div = Predicate::divisible_by(Term::atom(dim(0, 0)), 64).unwrap();
+        assert_eq!(div.eval(&env), Some(true));
+        let div2 = Predicate::divisible_by(Term::atom(dim(0, 0)), 100).unwrap();
+        assert_eq!(div2.eval(&env), Some(false));
+    }
+}

--- a/cutile-benchmarks/benches/rmsnorm.rs
+++ b/cutile-benchmarks/benches/rmsnorm.rs
@@ -61,7 +61,7 @@ mod kernels {
             let tx: Tile<f16, { [1, BLOCK_SIZE] }> = x_part.load([row, j]);
             let tw: Tile<f16, { [1, BLOCK_SIZE] }> = w_part.load([j]).reshape(tile_shape);
             let tout: Tile<f16, { [1, BLOCK_SIZE] }> = tx * rms * tw;
-            unsafe { out_part.store(tout, [0i32, j]) };
+            out_part.store(tout, [0i32, j]);
         }
     }
 }

--- a/cutile-benchmarks/paper/sec5_exp1_safety_overhead/rust/gemm/src/main.rs
+++ b/cutile-benchmarks/paper/sec5_exp1_safety_overhead/rust/gemm/src/main.rs
@@ -96,7 +96,6 @@ mod kernels {
     }
 
     #[cutile::entry(
-        unchecked_accesses = false,
         optimization_hints = (
             sm_120 = (num_cta_in_cga = 2,),
             sm_100 = (num_cta_in_cga = 2,),
@@ -526,7 +525,6 @@ mod kernels {
                         sm_120 = (num_cta_in_cga = 2,),
                         sm_100 = (num_cta_in_cga = 2,),
                     ),
-                    unchecked_accesses = false,
     )]
     fn gemm_static<
         T: ElementType,
@@ -559,7 +557,6 @@ mod kernels {
                         sm_120 = (num_cta_in_cga = 2,),
                         sm_100 = (num_cta_in_cga = 2,),
                     ),
-                    unchecked_accesses = false,
     )]
     fn gemm_persistent_static<
         T: ElementType,

--- a/cutile-book/guide/bounds-check-placement.md
+++ b/cutile-book/guide/bounds-check-placement.md
@@ -1,0 +1,186 @@
+# Bounds-Check Placement
+
+Accesses through the safe partition API are checked by default — no
+attribute needed — and checks are not free or expensive by themselves:
+their cost is determined by *where the compiler places them*. The count of
+checks in a tile kernel is tiny; what matters is whether a check sits
+inside a hot loop, between loads and the compute that consumes them, where
+it can defeat software pipelining. The compiler therefore places each check
+at the best position it can prove correct, and this chapter states the
+placement rules as a contract you can write code against, plus the tools to
+inspect the decision instead of guessing.
+
+Every checked access dimension gets one of three outcomes. **Discharged**:
+the compiler proves the access in bounds at compile time and emits nothing
+in the kernel — stores through `iter_indices()` indices, loads indexed by a
+partition's own minted coordinates, constant indices against static shapes,
+and facts established by declared `preconditions` all land here, as do
+cross-tensor facts the compiler derives and verifies at launch. **Hoisted**:
+the check runs once, before the loop (or the outermost provable loop), off
+the hot path. **In place**: the check runs at the access, every iteration.
+
+Setting `deny_in_kernel_checks = true` on the entry turns the third outcome
+into a compile error: "every check left the kernel" becomes a contract the
+build enforces rather than a property you audit. The diagnostic names the
+access and the restructuring that would fix it.
+
+## When a Check Hoists
+
+A check on an access inside a loop is hoisted to before the loop when all of
+the following hold, per index coordinate:
+
+| Index coordinate form | Placement |
+|---|---|
+| Value computed before the loop | Hoisted |
+| Compile-time constant, or value with known constant bounds | Hoisted (or discharged against static shapes) |
+| The loop variable `j` of a `for j in lo..hi` loop | Hoisted, checked at `hi - 1` |
+| `a * j + b` with constant `a`, `b` | Hoisted at the extreme iteration, when that extreme provably fits `i32`; otherwise in place |
+| Loop variable of a `.step_by(...)` loop | In place |
+| Value computed *inside* the loop body (other than the forms above) | In place |
+| Any access written inside an `if`/`else` in the loop | In place |
+
+Additionally, a hoisted check keeps climbing outward through directly
+nested loops whose trip counts are statically non-zero, stopping at the
+first loop whose bound it depends on. Hoisted checks are guarded so that a
+loop which executes zero times can never trap — semantics are unchanged
+except that a genuine violation traps before the loop instead of at its
+first offending iteration.
+
+The practical rules of thumb that fall out of the table:
+
+- **Compute index arithmetic above the innermost loop.** `let kv_head =
+  q_head / group;` written before the K/V loop hoists every check that uses
+  it; the same expression written inside the loop body does not (the
+  compiler does not currently chase invariant arithmetic through the loop
+  body — it proves invariance by position).
+- **Index hot-loop accesses with the loop variable directly**, or an
+  affine expression of it, and write the loop as `for j in lo..hi` without
+  `step_by`.
+- **Keep hot-loop accesses unconditional.** A load under an `if` may
+  execute on no iteration, so its check cannot move; lift the condition out
+  of the loop or accept the in-place check.
+- **Keep index arithmetic wrap-free.** A range fact survives an operation
+  only when the operation provably cannot overflow `i32`; an expression
+  that can wrap forfeits its facts (even if later `max`/`%` steps pull the
+  mathematical range back in bounds), and the access pays an in-place check
+  over the actual runtime value.
+
+```rust
+for index in out.iter_indices() {
+    let (q_tile, q_head, _) = index.components();
+    let kv_head = q_head / GROUP;          // above the loop: hoists
+    for j in 0i32..kv_tiles {
+        let k = k_part.load_pipelined::<L>([kv_head, j, 0i32]);
+        //                                  ^ hoisted  ^ hoisted (checked at kv_tiles - 1)
+        // ...
+    }
+}
+```
+
+## Checks That Leave the Kernel Entirely
+
+Hoisting to the loop preheader is not the last stop. A check whose operands
+are all launch-known — tensor extents, never loop variables or loaded values —
+leaves the kernel altogether and becomes one host comparison in the generated
+launcher, evaluated against the real shapes before the kernel exists. It costs
+zero registers and cannot be reordered or pipelined against: it either passes
+once or the launch is refused with an error naming the check.
+
+The main client is a fact the compiler derives on its own. An index that
+walks one tensor's axis — the variable of a `for j in 0..num_tiles(&p, a)`
+loop, or a component of a mapped partition's `iter_indices()` — carries
+that provenance, and using it to index a *different* tensor turns the
+cross-tensor tie into a launch check over tile counts, for example
+`ceil(dim(x, 1)/BK) <= ceil(dim(y, 0)/BK)`. No annotation and no signature
+change: a persistent GEMM whose mapped components index `x` and `y` and
+whose k loop iterates `num_tiles` compiles with every check discharged from
+the kernel and its shape ties enforced at launch
+(`cutile-examples/examples/persistent_gemm.rs` is the canonical form, and
+it builds under `deny_in_kernel_checks = true`).
+
+Declared `preconditions` go one step further: the launcher already verifies
+each declared fact against the real shapes, so the compiler assumes it and
+discharges the matching checks at compile time. A kernel that declares
+`dim(x, 1) % 64 == 0` emits nothing anywhere for the matching binding, and
+`dim(a, i) == dim(b, j)` relates two tensors' axes exactly as the derived
+form does. Declare a precondition when you want the contract visible in the
+signature or need a fact the walk cannot derive; note the declared equality
+is stricter than the derived comparison (`==` on extents versus `<=` on
+tile counts), so it rejects some launches the derived form accepts.
+
+The `with_bounds`/`Dim` annotation family is deprecated: everything it
+proved is subsumed by the derived facts and declared preconditions above,
+with the checks landing at launch instead of possibly in the kernel.
+
+## Reading the Compiler's Decision
+
+Never tune by guessing — the placement of every check is observable.
+`CUTILE_JIT_TIMING=1` reports per-kernel totals on each compile line:
+
+```text
+CUTILE_JIT_TIMING module=kernels function=fmha_prefill ... \
+    checks_discharged=3 checks_hoisted=4 checks_in_place=2
+```
+
+`CUTILE_JIT_LOG=1` explains each check that stays in a loop body:
+
+```text
+[cutile::jit] bounds check for dim 1 stays in the loop body: index is
+computed inside the loop body
+```
+
+Counts summarize; the emitted Tile IR is the ground truth, and comparing it
+against the unsafe twin catches a scheduling regression before you run
+anything. Make the twin in three edits — `unchecked_accesses = true` on the
+entry, `unsafe` on the kernel fn, and `unsafe { ... }` around the launch
+call, since the generated launcher inherits the kernel's unsafety — then
+dump both variants (the dump prints to stderr) and diff:
+
+```bash
+dump() { CUTILE_DUMP=ir CUTILE_DUMP_FILTER=kernels::fmha_prefill ./my_app 2>&1 \
+         | sed -n '/=== CUTILE DUMP: ir/,/^}/p'; }
+dump > safe.ir
+# flip the kernel to its unsafe twin, then:
+dump > raw.ir
+diff safe.ir raw.ir
+```
+
+For a fully placed kernel the diff is **empty**: the persistent GEMM
+example (`cutile-examples/examples/persistent_gemm.rs`) dumps byte-identical
+IR in its safe and unsafe variants — same 103 ops, same loop bodies — with
+the entire safety contract living in the launcher. When the diff is not
+empty, two things are regressions worth stopping for. Any `assert` op means
+a check stayed in the kernel (`grep -c assert safe.ir` should be zero when
+you expect full placement — and `deny_in_kernel_checks = true` makes the
+build enforce that). Any extra op *inside a loop body* — a compare, select,
+or branch sitting between the loads and the `mma`-class ops that consume
+them — is the pipelining hazard this chapter exists to prevent, even when
+the totals look small. A hoisted check appearing before a loop is the
+accepted middle ground, not a regression. If the IR matches but performance
+still differs, compare register counts next; the checked and unchecked
+builds of a fully placed kernel should match exactly.
+
+Two ablation knobs let you measure placement with the same binary, no
+rebuild: `CUTILE_DISABLE_CHECK_HOISTING=1` pins every residual check at its
+access site, and `CUTILE_FORCE_DEVICE_CHECKS=1` additionally suppresses
+every proof, checking each access two-sided over its actual values — the
+reference semantics the test suite diffs placement against.
+
+## When to Reach for `unsafe`
+
+Measure before dropping a kernel to `unchecked_accesses = true`: after
+hoisting, the answer is usually "it buys almost nothing." On the
+flash-attention prefill kernel that motivated this machinery (RTX 5090,
+`checks_in_place=2`), the fully checked kernel runs at 55.0 µs/call against
+a 53.6 µs floor with all checks disabled — about 2.5%, all of it from the
+two in-place checks on schedule-derived coordinates that execute once per
+persistent index, not per inner-loop iteration. The unsafe twin of the same
+kernel runs at 56.7 µs; the checked version is faster.
+
+The cases where `unsafe` still pays are the in-place rows of the table
+above when they land in a genuinely hot loop: stepped-loop indices,
+data-dependent indices (values loaded from memory), conditional accesses,
+and index arithmetic the compiler cannot prove wrap-free. If
+`CUTILE_JIT_LOG` shows in-place checks in your inner loop and restructuring
+per the rules above can't move them, that — and only that — is the measured
+case for `unchecked_accesses = true`.

--- a/cutile-book/index.md
+++ b/cutile-book/index.md
@@ -95,6 +95,7 @@ guide/tensors-and-tiles
 guide/jit-compilation
 guide/device-operations
 guide/performance
+guide/bounds-check-placement
 guide/interoperability
 guide/debugging-and-profiling
 guide/useful-mental-models

--- a/cutile-book/reference/dsl-api.md
+++ b/cutile-book/reference/dsl-api.md
@@ -49,16 +49,27 @@ mod my_kernels {
 | Attribute | Type | Description |
 |---|---|---|
 | `print_ir = true` | bool | Print three stages at JIT compile time: (1) the generated entry point wrapper (Rust), (2) the original kernel function, (3) the compiled Tile IR text |
-| `unchecked_accesses` | bool | Disable partition bounds checks. Requires `unsafe fn`. Removes runtime assertions on partition index ranges |
+| `unchecked_accesses` | bool | **Unsafe waiver.** Emit *no* safety checks — no verification in the kernel, at launch, or at compile time. Requires `unsafe fn`. The caller asserts correctness |
+| `deny_in_kernel_checks` | bool | **Safe strict.** Error at compile time if any safety check would remain in the kernel (i.e. cannot be discharged at compile time or hoisted to launch). Checks are still fully verified — this only forbids ones that cost device registers. The diagnostic names the check that could not leave the kernel and why |
+| `preconditions = ( ... )` | expr | Declared shape facts, verified by the generated launcher before the kernel runs and assumed by the compiler when discharging safety checks. Two forms: `dim(a, i) == dim(b, j)` (two axis extents are equal) and `dim(t, k) % d == 0` (an axis extent is a multiple of the integer literal `d`). A launch whose shapes violate a declared fact is rejected with an error naming it |
 | `optimization_hints = expr` | expr | Pass an `OptimizationHints` expression to the compiler for target-specific optimization |
 | `dump_mlir_dir = "path"` | string | Write the compiled Tile IR text to a file in the specified directory |
+
+`unchecked_accesses` and `deny_in_kernel_checks` are opposite poles and are *not*
+interchangeable: `unchecked_accesses` removes verification (unsafe), while
+`deny_in_kernel_checks` demands full verification with zero in-kernel cost (safe).
 
 ```rust
 #[cutile::entry(print_ir = true)]
 fn debug_kernel<const S: [i32; 1]>(output: &mut Tensor<f32, S>) { ... }
 
+// Unsafe: skip all checks, no verification.
 #[cutile::entry(unchecked_accesses)]
 unsafe fn fast_kernel<const S: [i32; 1]>(output: &mut Tensor<f32, S>) { ... }
+
+// Safe + strict: fail to compile if any safety check would stay in the kernel.
+#[cutile::entry(deny_in_kernel_checks = true)]
+fn zero_check_kernel<const S: [i32; 1]>(output: &mut Tensor<f32, S>) { ... }
 
 #[cutile::entry(dump_mlir_dir = "/tmp/cutile-ir")]
 fn traced_kernel<const S: [i32; 1]>(output: &mut Tensor<f32, S>) { ... }

--- a/cutile-compiler/src/bounds.rs
+++ b/cutile-compiler/src/bounds.rs
@@ -37,6 +37,8 @@ pub enum TileBinaryOp {
     BitAnd,
     BitOr,
     BitXor,
+    Shl,
+    Shr,
 }
 
 /// Maps a string operation name (e.g. `"add"`, `"ceil_div"`) to a [`TileBinaryOp`].
@@ -60,6 +62,8 @@ pub fn get_binary_op_from_op_str(op_str: &str) -> Result<TileBinaryOp, JITError>
         "and" => Ok(TileBinaryOp::BitAnd),
         "or" => Ok(TileBinaryOp::BitOr),
         "xor" => Ok(TileBinaryOp::BitXor),
+        "shl" => Ok(TileBinaryOp::Shl),
+        "shr" => Ok(TileBinaryOp::Shr),
         _ => SourceLocation::unknown()
             .jit_error_result(&format!("unrecognized arithmetic operation `{op_str}`")),
     }
@@ -84,6 +88,8 @@ pub fn get_tile_bop_from_rust_bop(rust_bin_op: &BinOp) -> Result<TileBinaryOp, J
         BinOp::BitXor(_) => Ok(TileBinaryOp::BitXor),
         BinOp::And(_) => Ok(TileBinaryOp::BitAnd),
         BinOp::Or(_) => Ok(TileBinaryOp::BitOr),
+        BinOp::Shl(_) => Ok(TileBinaryOp::Shl),
+        BinOp::Shr(_) => Ok(TileBinaryOp::Shr),
         _ => SourceLocation::unknown().jit_error_result("this binary operator is not supported"),
     }
 }
@@ -365,6 +371,9 @@ fn bitwise_bounds(op: &TileBinaryOp, a: &Bounds<i64>, b: &Bounds<i64>) -> Bounds
 /// Returns the result bounds for a [`TileBinaryOp`], or `None` on division by zero.
 pub fn bounds_from_bop(op: &TileBinaryOp, a: &Bounds<i64>, b: &Bounds<i64>) -> Option<Bounds<i64>> {
     match op {
+        // Shift intervals are not corner-monotone for negative or oversized
+        // operands; stay conservative.
+        TileBinaryOp::Shl | TileBinaryOp::Shr => None,
         TileBinaryOp::CeilDiv | TileBinaryOp::Div | TileBinaryOp::TrueDiv | TileBinaryOp::Rem => {
             // Any op with a divisor is handled here so it can reject a zero
             // divisor. Reject when zero lies anywhere in the divisor's inclusive

--- a/cutile-compiler/src/compile_api.rs
+++ b/cutile-compiler/src/compile_api.rs
@@ -41,18 +41,43 @@ use crate::error::JITError;
 use crate::hints::CompileOptions;
 use crate::specialization::{DivHint, SpecializationBits};
 
+/// Where each checked partition access's bounds check ended up: proven at
+/// compile time (nothing emitted), hoisted to a loop preheader, or emitted
+/// in place at the access.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct CheckPlacementCounts {
+    pub discharged: u32,
+    pub hoisted: u32,
+    pub in_place: u32,
+}
+
 /// Compiled kernel artifacts: IR and bytecode.
 ///
 /// Produced by [`KernelCompiler::compile`]. All methods are pure Rust and
 /// do not require a GPU or CUDA driver.
 pub struct CompileArtifacts {
     module: cutile_ir::Module,
+    check_counts: CheckPlacementCounts,
+    launch_checks: Vec<cuda_async::predicate::LaunchCheck>,
 }
 
 impl CompileArtifacts {
     /// Returns the human-readable Tile IR text (MLIR-like syntax).
     pub fn ir_text(&self) -> String {
         self.module.to_mlir_text()
+    }
+
+    /// Bounds-check placement counters for the compiled kernel — the same
+    /// numbers reported on the `CUTILE_JIT_TIMING` line.
+    pub fn check_counts(&self) -> CheckPlacementCounts {
+        self.check_counts
+    }
+
+    /// Safety checks the compiler hoisted out of the kernel to launch time. The
+    /// host runs these (via `validate_launch_checks`) before each launch; here
+    /// they let a compile-only test inspect exactly what was evacuated.
+    pub fn launch_checks(&self) -> &[cuda_async::predicate::LaunchCheck] {
+        &self.launch_checks
     }
 
     /// Serializes the compiled module to bytecode.
@@ -225,6 +250,16 @@ impl<F: Fn() -> crate::ast::Module> KernelCompiler<F> {
         )?;
 
         let module = compiler.compile()?;
-        Ok(CompileArtifacts { module })
+        let check_counts = CheckPlacementCounts {
+            discharged: compiler.check_stats.discharged.get(),
+            hoisted: compiler.check_stats.hoisted.get(),
+            in_place: compiler.check_stats.in_place.get(),
+        };
+        let launch_checks = compiler.launch_checks.borrow().clone();
+        Ok(CompileArtifacts {
+            module,
+            check_counts,
+            launch_checks,
+        })
     }
 }

--- a/cutile-compiler/src/compiler/_function.rs
+++ b/cutile-compiler/src/compiler/_function.rs
@@ -48,7 +48,28 @@ pub struct CUDATileFunctionCompiler<'m> {
     pub(crate) entry: syn::ItemFn,
     pub(crate) entry_attrs: EntryAttrs,
     pub(crate) const_grid: Option<(u32, u32, u32)>,
-    pub(crate) proof_results: ProofResults,
+    /// The believed-fact set, parsed once from declared preconditions. It is
+    /// invariant for the whole compile, and every obligation resolution
+    /// consults it — rebuilding it per obligation was O(accesses x facts) on
+    /// the JIT hot path (issue #217).
+    pub(crate) assumptions: crate::passes::obligation::Assumptions,
+    /// Kernel parameter name → 0-based position in the signature (same order as
+    /// `Validator.params` and the host arg-push order). Resolves the tensor
+    /// names in obligations/preconditions to the `predicate::Atom::Dim` param
+    /// index — the resolved-symbol identity the launch checks key on.
+    pub(crate) param_index: HashMap<String, usize>,
+    /// Parameter mutability by signature position. This decides the *frame* a
+    /// parameter's extents live in: an immutable `&Tensor` is passed whole
+    /// (view == root, which is what the host's shape array holds), while a
+    /// `&mut Tensor` is slabbed and each work item sees one piece. Any atom
+    /// naming an extent must respect it. See
+    /// `.internal/tasks/in_progress/check_hoisting/BOUNDS_HOISTING_ANALYSIS.md` §SC1.
+    pub(crate) param_is_mutable: Vec<bool>,
+    /// Launch-time checks hoisted out of this kernel during compilation
+    /// (`Resolution::Launch`). Interior-mutable because compile passes take
+    /// `&self`; merged into the `Validator` in [`Self::get_validator`] and run
+    /// once per launch by the host `validate_launch`.
+    pub(crate) launch_checks: RefCell<Vec<cuda_async::predicate::LaunchCheck>>,
     pub(crate) gpu_name: String,
     pub(crate) optimization_hints: OptimizationHints,
     pub(crate) stride_args: HashMap<String, Vec<i32>>,
@@ -56,6 +77,18 @@ pub struct CUDATileFunctionCompiler<'m> {
     pub(crate) validator: Validator,
     pub(crate) module_name_stack: Vec<String>,
     pub(crate) typeck_results: RefCell<Option<crate::passes::type_inference::TypeckResults>>,
+    /// Per-compile partition-access check accounting: statically discharged /
+    /// hoisted to a loop preheader / emitted in the access's own block.
+    /// Reported on the `CUTILE_JIT_TIMING` line for coverage measurement.
+    pub check_stats: CheckHoistStats,
+}
+
+/// Counters for where partition-access bounds checks ended up.
+#[derive(Debug, Default)]
+pub struct CheckHoistStats {
+    pub discharged: std::cell::Cell<u32>,
+    pub hoisted: std::cell::Cell<u32>,
+    pub in_place: std::cell::Cell<u32>,
 }
 
 struct FunctionParamTypes {
@@ -64,6 +97,325 @@ struct FunctionParamTypes {
 }
 
 impl<'m> CUDATileFunctionCompiler<'m> {
+    /// Route a `dim(a) == dim(b)` discharge through the obligation solver.
+    ///
+    /// Returns `true` when the equality is settled without an in-kernel check:
+    /// at `Jit` if a declared `preconditions` fact entails it, otherwise at
+    /// `Launch`, since both operands are extents the host holds before
+    /// `cuLaunchKernel`. `false` only when it must fall to the device.
+    ///
+    /// Use this only where equality IS the requirement — today that is the
+    /// shared mapped-grid check, whose zipped index streams need equal grids.
+    /// An access bound wants [`Self::resolve_dim_le`] instead: emitting an
+    /// equality there also rejects every target strictly larger than the
+    /// source, which is safe.
+    pub(crate) fn resolve_dim_eq(
+        &self,
+        a_tensor: &str,
+        a_axis: usize,
+        b_tensor: &str,
+        b_axis: usize,
+    ) -> bool {
+        use cuda_async::predicate::{Atom, Predicate, Term};
+        // Resolve both tensor names to param indices; if either is not a
+        // parameter, the equality can't be canonicalized — conservatively not
+        // discharged (falls to the existing in-kernel path).
+        let (Some(&a_param), Some(&b_param)) = (
+            self.param_index.get(a_tensor),
+            self.param_index.get(b_tensor),
+        ) else {
+            return false;
+        };
+        let a = Term::atom(Atom::Dim {
+            param: a_param,
+            axis: a_axis,
+        });
+        let b = Term::atom(Atom::Dim {
+            param: b_param,
+            axis: b_axis,
+        });
+        let Some(predicate) = Predicate::eq(&a, &b) else {
+            return false;
+        };
+        self.lower_obligation(
+            predicate,
+            format!("dim({a_tensor}, {a_axis}) == dim({b_tensor}, {b_axis})"),
+        )
+    }
+
+    /// Route a `tiles(a) <= tiles(b)` discharge through the obligation
+    /// solver — the exact form an access bound needs. An index drawn from
+    /// `[0, ceil(dim(a)/t))` stays inside an axis of `ceil(dim(b)/t)` tiles
+    /// (same tile `t`) exactly when the source has at most as many tiles;
+    /// a target shorter in elements but equal in tiles is safe.
+    ///
+    /// Two steps, because the believed facts are equalities. A declared
+    /// `dim(a) == dim(b)` entails the inequality but the solver has no
+    /// entailment theory, so the equality is tried first purely as evidence
+    /// (`Jit`, no check anywhere); only then is the inequality itself lowered,
+    /// landing at `Launch` since extents are host-known. Emitting the
+    /// inequality rather than the equality is what keeps the derived check
+    /// faithful: with `<=`, the only over-rejection left is the sub-tile band
+    /// where a shorter target happens to round up to the same tile count —
+    /// exactness there needs an atom naming a tile count (see
+    /// `HOISTING_COVERAGE.md`).
+    pub(crate) fn resolve_dim_le(
+        &self,
+        a_tensor: &str,
+        a_axis: usize,
+        b_tensor: &str,
+        b_axis: usize,
+        tile: i32,
+    ) -> bool {
+        use crate::passes::obligation::{resolve, Obligation, Resolution};
+        use cuda_async::predicate::{Atom, Predicate, Term};
+        let (Some(&a_param), Some(&b_param)) = (
+            self.param_index.get(a_tensor),
+            self.param_index.get(b_tensor),
+        ) else {
+            return false;
+        };
+        let a = Term::atom(Atom::Dim {
+            param: a_param,
+            axis: a_axis,
+        });
+        let b = Term::atom(Atom::Dim {
+            param: b_param,
+            axis: b_axis,
+        });
+        // Step 1: a declared equality decides the goal at Jit. Evidence only —
+        // when it is not entailed, no equality check is emitted anywhere.
+        if let Some(eq) = Predicate::eq(&a, &b) {
+            let obligation = Obligation::new(eq, "");
+            if matches!(resolve(&obligation, &self.assumptions), Resolution::Jit) {
+                return true;
+            }
+        }
+        // Step 2: state the real goal — over TILE COUNTS, which is what the
+        // walk is actually bounded by — and let it land where its operands
+        // are known, a host compare at launch. Stating it over extents was
+        // stricter than the device check it replaced (a target shorter in
+        // elements but equal in tiles was rejected; issue #216); the
+        // TileCount atom closes that band exactly. Under placement ablation
+        // the goal stays with the access as a device check; step 1 still
+        // ran, because a declared fact is a verified proof, not a placement.
+        if crate::cuda_tile_runtime_utils::force_device_checks() {
+            return false;
+        }
+        if tile < 1 {
+            return false;
+        }
+        let ta = Term::atom(Atom::TileCount {
+            param: a_param,
+            axis: a_axis,
+            tile,
+        });
+        let tb = Term::atom(Atom::TileCount {
+            param: b_param,
+            axis: b_axis,
+            tile,
+        });
+        let Some(le) = Predicate::le(&ta, &tb) else {
+            return false;
+        };
+        self.lower_obligation(
+            le,
+            format!(
+                "ceil(dim({a_tensor}, {a_axis})/{tile}) <= ceil(dim({b_tensor}, {b_axis})/{tile})"
+            ),
+        )
+    }
+
+    /// Lower a safety obligation: resolve `predicate` against the in-scope
+    /// assumptions and route the result. Returns `true` when the obligation was
+    /// placed without any in-kernel check — either statically discharged
+    /// (`Jit`) or evacuated to a host launch check (`Launch`, collected here);
+    /// `false` when it must fall to a device-stage (in-kernel) assert, which the
+    /// caller emits.
+    ///
+    /// This is the shared "lower an assert to an obligation" path. Any client
+    /// that can name a `Predicate` routes through it and the check lands at the
+    /// earliest stage a dominating assumption allows — the bounded-access check
+    /// today; a programmer `require`/`assert` op next. It is what lets *any*
+    /// assert be hoisted out of the kernel when its operands are launch-known.
+    pub(crate) fn lower_obligation(
+        &self,
+        predicate: cuda_async::predicate::Predicate,
+        cause: impl Into<String>,
+    ) -> bool {
+        use crate::passes::obligation::{resolve, Obligation, Resolution};
+        let obligation = Obligation::new(predicate, cause);
+        match resolve(&obligation, &self.assumptions) {
+            Resolution::Jit => true,
+            Resolution::Launch(check) => {
+                // Canonical predicates make duplicate detection exact. Two
+                // obligations reducing to the same host compare (e.g. a shared
+                // `Dim`'s divisibility, once per binding) cost one check.
+                let mut checks = self.launch_checks.borrow_mut();
+                if !checks.iter().any(|c| c.predicate == check.predicate) {
+                    checks.push(check);
+                }
+                true
+            }
+            Resolution::Device => false,
+        }
+    }
+
+    /// The kernel-visible extent of `partition`'s axis `axis`, taken from the
+    /// *declared* parameter shape.
+    ///
+    /// The partition view type erases a `&mut Tensor` parameter's shape to `?`
+    /// — the host passes a slab, so the view is built from runtime shape
+    /// operands — which loses extents the signature states outright
+    /// (`&mut Tensor<f32, {[1, N]}>` lowers to `tensor_view<?x?xf32>`). The
+    /// validator still holds them, and the generated launcher rejects a
+    /// mismatch (`valid_shape == given_shape`) before the kernel runs, so this
+    /// is a *verified* assumption rather than a trusted one (SC2).
+    ///
+    /// This exists so that the binding check and the access check answer
+    /// "what is this axis's extent?" from the *same* source. They previously
+    /// disagreed — the binding read the declared shape and folded at compile
+    /// time, the access read the erased view type and fell back to a launch
+    /// check — which manufactured launch checks for extents the signature had
+    /// already pinned.
+    ///
+    /// FRAME (SC1): the declared shape may stand in for the view extent only
+    /// where the two coincide. That holds for `Partition` and `PartitionMut` —
+    /// an immutable `&Tensor` has view == root, and a `&mut Tensor`'s declared
+    /// shape *is* its per-CTA slab. It does **not** hold for a
+    /// `MappedPartition*`, whose declared shape is the *tile* shape, so callers
+    /// must be reachable only from plain partition paths. See
+    /// `.internal/tasks/in_progress/check_hoisting/BOUNDS_HOISTING_ANALYSIS.md` §SC1.
+    pub(crate) fn declared_view_extent(
+        &self,
+        partition: &TileRustValue,
+        dim_map: &[i32],
+        axis: usize,
+    ) -> Option<i32> {
+        let tensor_axis = *dim_map.get(axis).filter(|&&d| d >= 0)? as usize;
+        let idx = *self.param_index.get(partition.tensor_origin.as_ref()?)?;
+        let shape = match self.validator.params.get(idx)? {
+            cuda_async::device_context::ValidParamType::Tensor(t) => &t.shape,
+            _ => return None,
+        };
+        shape.get(tensor_axis).copied().filter(|&e| e >= 0)
+    }
+
+    /// Give `x.shape()`'s per-axis values their symbolic identity: axis `k` of
+    /// a tensor *parameter*'s shape is exactly `extent(param, k)`, so label it
+    /// with that atom.
+    ///
+    /// This is the bridge between the two fact systems. Facts carried on values
+    /// (bounds, provenance) and predicates over [`cuda_async::predicate::Atom`]s
+    /// have no shared vocabulary, so an extent read out of the signature was an
+    /// opaque scalar: an obligation mentioning it could not be seen as
+    /// launch-known and fell straight to a device check. One label makes every
+    /// such extent speakable in the predicate language, for every obligation —
+    /// nothing here is specific to any one check.
+    ///
+    /// FRAME (SC1): the atom picks the frame, via [`Self::extent_atom`] — the
+    /// one place that decision lives. `x.shape()` inside the kernel returns
+    /// whatever the kernel sees (the whole tensor for an immutable param, the
+    /// per-CTA slab for a `&mut`), and the chosen atom resolves on the host
+    /// against the array holding exactly that quantity.
+    pub(crate) fn label_param_extents(&self, shape: &mut TileRustValue, tensor: &TileRustValue) {
+        let Some(param) = tensor
+            .tensor_origin
+            .as_ref()
+            .and_then(|name| self.param_index.get(name).copied())
+        else {
+            return;
+        };
+        let Some(dims) = shape
+            .fields
+            .as_mut()
+            .and_then(|fields| fields.get_mut("dims"))
+            .and_then(|dims| dims.values.as_mut())
+        else {
+            return;
+        };
+        for (axis, dim) in dims.iter_mut().enumerate() {
+            if dim.term.is_none() {
+                dim.term = Some(cuda_async::predicate::Term::atom(
+                    self.extent_atom(param, axis),
+                ));
+            }
+        }
+    }
+
+    /// The atom naming `param`'s extent on `axis`, in the frame the kernel
+    /// actually sees — the single place the SC1 frame decision is encoded.
+    ///
+    /// An immutable `&Tensor` is passed whole, so its kernel-visible extent is
+    /// the *root* extent: [`cuda_async::predicate::Atom::Dim`], the frame
+    /// declared `preconditions` are stated in (so declared facts can entail
+    /// obligations over it). A `&mut Tensor` is slabbed — each work item sees
+    /// one piece — so its extent is
+    /// [`cuda_async::predicate::Atom::ViewExtent`], resolved on the host
+    /// against the partition shape. The two are distinct atom variants
+    /// precisely so a root-frame fact can never entail a view-frame obligation
+    /// by structural equality: the frame confusion is unrepresentable.
+    pub(crate) fn extent_atom(&self, param: usize, axis: usize) -> cuda_async::predicate::Atom {
+        if self.param_is_mutable.get(param).copied().unwrap_or(true) {
+            cuda_async::predicate::Atom::ViewExtent { param, axis }
+        } else {
+            cuda_async::predicate::Atom::Dim { param, axis }
+        }
+    }
+
+    /// `tensor`'s parameter index, but only when its kernel-visible extent IS
+    /// its root extent — the frame declared `preconditions` speak in.
+    ///
+    /// Any reasoning that relates a partition axis to a *declared* fact must
+    /// go through this: `dim(t, a)` names the whole tensor, so a fact about it
+    /// says nothing about a `&mut` parameter's per-CTA slab, and a tile count
+    /// taken over that slab is not the count the fact divides. Rather than
+    /// re-deriving mutability, this asks [`Self::extent_atom`] — the one place
+    /// the frame decision lives — and accepts only the root answer.
+    pub(crate) fn root_framed_param(&self, tensor: &str) -> Option<usize> {
+        let param = *self.param_index.get(tensor)?;
+        matches!(
+            self.extent_atom(param, 0),
+            cuda_async::predicate::Atom::Dim { .. }
+        )
+        .then_some(param)
+    }
+
+    /// The `deny_in_kernel_checks` policy, applied at the one moment it means
+    /// something: a *compiler-synthesized* safety check is about to become a
+    /// device instruction.
+    ///
+    /// Every synthesized check must call this immediately before emitting its
+    /// `Assert`. The attribute promises that no safety check remains in the
+    /// kernel; a site that skips it makes the promise partial, which is worse
+    /// than absent — an author who trusts the flag would ship exactly the
+    /// register cost it claims to forbid. (A programmer-written `assert!` is
+    /// not a synthesized check and must NOT route through here: the flag
+    /// governs what the compiler adds, not what the author asked for.)
+    ///
+    /// `what` names the check; `remedy` says how to discharge it. The caller
+    /// keeps emitting its own assert when the flag is off, so this is purely a
+    /// policy gate — it never changes what is verified, only whether a residual
+    /// in-kernel check is tolerated.
+    pub(crate) fn deny_residual_check(
+        &self,
+        what: &str,
+        remedy: &str,
+        span: &proc_macro2::Span,
+    ) -> Result<(), JITError> {
+        if !self.entry_attrs.get_entry_arg_bool("deny_in_kernel_checks") {
+            return Ok(());
+        }
+        self.jit_error_result(
+            span,
+            &format!(
+                "`deny_in_kernel_checks`: {what} could not be discharged at compile time \
+                 or hoisted to launch, so it would be emitted in the kernel and cost \
+                 device registers. {remedy}. Or drop the flag."
+            ),
+        )
+    }
+
     pub fn new(
         modules: &'m CUDATileModules,
         module_name: &str,
@@ -185,14 +537,39 @@ impl<'m> CUDATileFunctionCompiler<'m> {
             println!();
         }
 
+        // Resolve parameter names to signature positions (same order as
+        // `Validator.params` and the host arg-push order).
+        let param_index: HashMap<String, usize> = function
+            .sig
+            .inputs
+            .iter()
+            .enumerate()
+            .filter_map(|(i, arg)| match arg {
+                syn::FnArg::Typed(pat_type) => match pat_type.pat.as_ref() {
+                    syn::Pat::Ident(pat_ident) => Some((pat_ident.ident.to_string(), i)),
+                    _ => None,
+                },
+                syn::FnArg::Receiver(_) => None,
+            })
+            .collect();
+
+        let param_is_mutable = get_sig_param_mutability(&function.sig);
+
         // 12. Build struct directly.
+        let assumptions = crate::passes::obligation::Assumptions::from_preconditions(
+            &proof_results,
+            &param_index,
+        );
         Ok(CUDATileFunctionCompiler {
             modules,
             module_name: module_name.to_string(),
             _function_name: function_name.to_string(),
             entry_attrs,
             const_grid,
-            proof_results,
+            assumptions,
+            param_index,
+            param_is_mutable,
+            launch_checks: RefCell::new(Vec::new()),
             gpu_name,
             optimization_hints,
             _function: function,
@@ -202,6 +579,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
             stride_args,
             module_name_stack: vec![module_name.to_string()],
             typeck_results: RefCell::new(None),
+            check_stats: CheckHoistStats::default(),
         })
     }
 
@@ -470,6 +848,11 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                 } else {
                     Mutability::Immutable
                 };
+                // Record which kernel parameter this value *is*. Names do not
+                // survive inlining -- inside `Tensor::shape(&self)` the receiver
+                // is `self` -- so provenance has to ride the value, not the
+                // syntax, for anything downstream to resolve it to a parameter.
+                val.tensor_origin = Some(name.clone());
                 ctx.vars.insert(name.clone(), val);
             }
         }
@@ -555,7 +938,11 @@ impl<'m> CUDATileFunctionCompiler<'m> {
     }
 
     pub fn get_validator(&self) -> Validator {
-        self.validator.clone()
+        let mut validator = self.validator.clone();
+        // Surface the launch checks hoisted during compilation so the host runs
+        // them at launch.
+        validator.launch_checks = self.launch_checks.borrow().clone();
+        validator
     }
 
     pub fn gpu_name(&self) -> &str {

--- a/cutile-compiler/src/compiler/_module.rs
+++ b/cutile-compiler/src/compiler/_module.rs
@@ -438,7 +438,66 @@ fn find_impl_method<'a>(item_impl: &'a ItemImpl, method_name: &str) -> Option<&'
     })
 }
 
-fn instantiate_type_for_lookup(
+/// Returns `false` only when an impl provably cannot apply to the receiver:
+/// an impl const generic declared with a literal array rank (`const D: [i32; 2]`)
+/// appears in the impl self type at a position where the receiver's resolved
+/// const-generic array has a different rank. Variadic impls (`[i32; N]`) and
+/// anything unresolved stay compatible, preserving the permissive name-based
+/// lookup. This disambiguates same-named methods defined per rank, like
+/// `PartitionIndex::components` for rank 2 and rank 3.
+pub(crate) fn impl_self_type_rank_matches(
+    item_impl: &ItemImpl,
+    receiver_ty: &Type,
+    generic_vars: &GenericVars,
+) -> bool {
+    let mut const_ranks: HashMap<String, usize> = HashMap::new();
+    for param in &item_impl.generics.params {
+        if let syn::GenericParam::Const(const_param) = param {
+            if let Type::Array(type_array) = &const_param.ty {
+                if let syn::Expr::Lit(len_lit) = &type_array.len {
+                    if let syn::Lit::Int(len_int) = &len_lit.lit {
+                        if let Ok(rank) = len_int.base10_parse::<usize>() {
+                            const_ranks.insert(const_param.ident.to_string(), rank);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    if const_ranks.is_empty() {
+        return true;
+    }
+    let Some(impl_args) = maybe_generic_args(&item_impl.self_ty) else {
+        return true;
+    };
+    let Some(receiver_args) = maybe_generic_args(receiver_ty) else {
+        return true;
+    };
+    for (impl_arg, receiver_arg) in impl_args.args.iter().zip(receiver_args.args.iter()) {
+        let param_ident = match impl_arg {
+            syn::GenericArgument::Const(syn::Expr::Path(path)) => path.path.get_ident(),
+            syn::GenericArgument::Type(Type::Path(type_path)) => type_path.path.get_ident(),
+            _ => None,
+        };
+        let Some(param_ident) = param_ident else {
+            continue;
+        };
+        let Some(&expected_rank) = const_ranks.get(&param_ident.to_string()) else {
+            continue;
+        };
+        let Some(receiver_cga) =
+            crate::generics::get_cga_from_generic_argument(receiver_arg, generic_vars)
+        else {
+            continue;
+        };
+        if receiver_cga.len() != expected_rank {
+            return false;
+        }
+    }
+    true
+}
+
+pub(crate) fn instantiate_type_for_lookup(
     ty: &Type,
     generic_vars: &GenericVars,
     primitives: &HashMap<(String, String), ItemImpl>,
@@ -830,6 +889,9 @@ impl CUDATileModules {
         if let Some(receiver_type_str) = receiver_type_str.as_deref() {
             if let Some(impls_vec) = self.name_resolver.struct_impls().get(receiver_type_str) {
                 for (module_name, item_impl) in impls_vec {
+                    if !impl_self_type_rank_matches(item_impl, &receiver_lookup_ty, generic_vars) {
+                        continue;
+                    }
                     if let Some(impl_method) = find_impl_method(item_impl, &method_name) {
                         return Ok(Some((
                             module_name.clone(),

--- a/cutile-compiler/src/compiler/_value.rs
+++ b/cutile-compiler/src/compiler/_value.rs
@@ -63,6 +63,42 @@ impl TypeMeta {
     }
 }
 
+/// One enclosing loop, for hoisting bounds checks out of hot loop bodies.
+///
+/// `value_watermark` is the module's value count taken just before the loop
+/// body block was built: a value with a smaller index was defined before the
+/// loop and therefore dominates `preheader_block` (the block the `for` op is
+/// appended to; ops emitted there during body compilation land before it).
+#[derive(Debug, Clone)]
+pub(crate) struct LoopFrame {
+    pub(crate) preheader_block: cutile_ir::ir::BlockId,
+    /// The loop body block. Hoisting is only sound for checks emitted
+    /// directly in the body — never from nested conditional blocks, where
+    /// the guarded access may not execute on every iteration.
+    pub(crate) body_block: cutile_ir::ir::BlockId,
+    pub(crate) value_watermark: u32,
+    /// The raw induction block argument and any assumption-wrapped aliases
+    /// the loop variable was bound to.
+    pub(crate) induction_values: Vec<Value>,
+    /// Loop bounds `[lower, upper)` as preheader values.
+    pub(crate) lower: Value,
+    pub(crate) upper: Value,
+    /// True when the step is the constant 1, making `upper - 1` the exact
+    /// maximum induction value for a non-empty loop.
+    pub(crate) unit_step: bool,
+    /// True when static bounds prove the loop executes at least once
+    /// (`max(lower) < min(upper)`). Lets hoisted checks skip the vacuous-trip
+    /// guard, and lets checks hoist past this loop entirely.
+    pub(crate) known_non_empty: bool,
+    /// The induction variable's inclusive value range `[lower, upper - 1]` when
+    /// both loop bounds are compile-time constants (and the step is unit). Lets
+    /// the hoister derive an affine index's static range from its `Term` (via
+    /// `value_facts::term_range`) — discharging it as a compile-time constant
+    /// instead of a runtime strongest-instance substitution. `None` when either
+    /// bound is a runtime value.
+    pub(crate) induction_range: Option<crate::bounds::Bounds<i64>>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct PartitionAxisOrigin {
     pub(crate) tensor: String,
@@ -98,12 +134,21 @@ pub struct TileRustValue {
     pub(crate) string_literal: Option<syn::Expr>,
     pub(crate) enum_variant: Option<String>,
     pub(crate) enum_payload: Option<Box<syn::Expr>>,
-    pub(crate) partition_origin: Option<Value>,
+    pub(crate) partition_origins: Option<Vec<Value>>,
     pub(crate) tensor_origin: Option<String>,
     pub(crate) partition_axis_origin: Option<PartitionAxisOrigin>,
     pub(crate) dim_origin: Option<DimOrigin>,
     pub(crate) index_origin: Option<DimOrigin>,
     pub(crate) bounded_axes: Option<Vec<DimOrigin>>,
+    /// `floor(numerator / divisor)` provenance for a value produced by integer
+    /// division by a constant. Analysis-side only: see [`crate::value_facts::FloorDiv`].
+    pub(crate) floor_div: Option<crate::value_facts::FloorDiv>,
+    /// Symbolic (canonical linear) form of this scalar value, when known:
+    /// `sum(coeff*atom) + constant` over induction-variable / dim atoms. The
+    /// affine fragment used by loop check-hoisting is [`Term::as_single_affine`].
+    /// Consolidates the former `AffineForm { scale, var, offset }` (its single-
+    /// `Iv`-atom special case).
+    pub(crate) term: Option<cuda_async::predicate::Term>,
 }
 
 impl TileRustValue {
@@ -120,12 +165,14 @@ impl TileRustValue {
             string_literal: None,
             enum_variant: None,
             enum_payload: None,
-            partition_origin: None,
+            partition_origins: None,
             tensor_origin: None,
             partition_axis_origin: None,
             dim_origin: None,
             index_origin: None,
             bounded_axes: None,
+            floor_div: None,
+            term: None,
         }
     }
 
@@ -142,12 +189,14 @@ impl TileRustValue {
             string_literal: None,
             enum_variant: None,
             enum_payload: None,
-            partition_origin: None,
+            partition_origins: None,
             tensor_origin: None,
             partition_axis_origin: None,
             dim_origin: None,
             index_origin: None,
             bounded_axes: None,
+            floor_div: None,
+            term: None,
         }
     }
 
@@ -168,12 +217,14 @@ impl TileRustValue {
             string_literal: None,
             enum_variant: None,
             enum_payload: None,
-            partition_origin: None,
+            partition_origins: None,
             tensor_origin: None,
             partition_axis_origin: None,
             dim_origin: None,
             index_origin: None,
             bounded_axes: None,
+            floor_div: None,
+            term: None,
         }
     }
 
@@ -194,12 +245,14 @@ impl TileRustValue {
             string_literal: None,
             enum_variant: None,
             enum_payload: None,
-            partition_origin: None,
+            partition_origins: None,
             tensor_origin: None,
             partition_axis_origin: None,
             dim_origin: None,
             index_origin: None,
             bounded_axes: None,
+            floor_div: None,
+            term: None,
         }
     }
 
@@ -216,12 +269,14 @@ impl TileRustValue {
             string_literal: Some(string_literal),
             enum_variant: None,
             enum_payload: None,
-            partition_origin: None,
+            partition_origins: None,
             tensor_origin: None,
             partition_axis_origin: None,
             dim_origin: None,
             index_origin: None,
             bounded_axes: None,
+            floor_div: None,
+            term: None,
         }
     }
 
@@ -242,12 +297,14 @@ impl TileRustValue {
             string_literal: None,
             enum_variant: Some(variant.into()),
             enum_payload: payload.map(Box::new),
-            partition_origin: None,
+            partition_origins: None,
             tensor_origin: None,
             partition_axis_origin: None,
             dim_origin: None,
             index_origin: None,
             bounded_axes: None,
+            floor_div: None,
+            term: None,
         }
     }
 
@@ -273,12 +330,14 @@ impl TileRustValue {
                 string_literal: None,
                 enum_variant: None,
                 enum_payload: None,
-                partition_origin: None,
+                partition_origins: None,
                 tensor_origin: None,
                 partition_axis_origin: None,
                 dim_origin: None,
                 index_origin: None,
                 bounded_axes: None,
+                floor_div: None,
+                term: None,
             },
         }
     }
@@ -296,12 +355,14 @@ impl TileRustValue {
             string_literal: Some(literal_expr),
             enum_variant: None,
             enum_payload: None,
-            partition_origin: None,
+            partition_origins: None,
             tensor_origin: None,
             partition_axis_origin: None,
             dim_origin: None,
             index_origin: None,
             bounded_axes: None,
+            floor_div: None,
+            term: None,
         }
     }
 
@@ -438,6 +499,57 @@ impl TileRustValue {
         Ok(())
     }
 
+    /// Clears every fact a control-flow join can invalidate, recursively:
+    /// interval bounds, the symbolic term, axis/index provenance, floor-div
+    /// lineage, and the structural facts (`tensor_origin`, `bounded_axes`,
+    /// `partition_origins`). Called when a value is reconstructed at a
+    /// control-flow join or loop carry, where the value it describes may
+    /// differ from the one the facts were established for — keeping them
+    /// discharged bounds checks for conditionally reassigned indices and
+    /// partitions (issue #212, both halves).
+    ///
+    /// Only type wiring survives: `kind`, `ty`, `mutability`, `type_meta`
+    /// structure, and comptime payloads — reassignment cannot change what
+    /// type the variable is. Clearing structural facts does NOT break
+    /// partitions carried across their own store loops, because repack runs
+    /// only on the mutated/captured set and storing through a partition
+    /// does not reassign the binding — such partitions never enter this
+    /// path and keep their brands.
+    pub(crate) fn invalidate_join_facts(&mut self) {
+        self.bounds = None;
+        self.term = None;
+        self.index_origin = None;
+        self.partition_axis_origin = None;
+        self.dim_origin = None;
+        self.floor_div = None;
+        self.partition_origins = None;
+        // Structural facts too: a variable reaching this path was reassigned
+        // (repack runs only on the mutated/captured set), so a branch may
+        // have pointed it at a DIFFERENT partition. Keeping `tensor_origin`
+        // or `bounded_axes` from the pre-branch template would let the
+        // cross-tensor rung bound an access against the wrong tensor's extent
+        // — an out-of-bounds access proven safe (issue #212, structural
+        // residual). A partition that is merely READ across a branch is not
+        // in the reassigned set and keeps its facts.
+        self.tensor_origin = None;
+        self.bounded_axes = None;
+        if let Some(values) = &mut self.values {
+            for v in values.iter_mut() {
+                v.invalidate_join_facts();
+            }
+        }
+        if let Some(fields) = &mut self.fields {
+            for v in fields.values_mut() {
+                v.invalidate_join_facts();
+            }
+        }
+        if let Some(type_meta) = &mut self.type_meta {
+            for v in type_meta.fields.values_mut() {
+                v.invalidate_join_facts();
+            }
+        }
+    }
+
     pub fn repack_from(
         &self,
         values: &Vec<Value>,
@@ -499,6 +611,10 @@ pub struct CompilerContext {
     pub carry_vars: Option<Vec<String>>,
     pub default_terminator: Option<BlockTerminator>,
     pub module_scope: Vec<String>,
+    /// Enclosing loops, innermost last. Lets check emission hoist
+    /// loop-invariant and induction-variable bounds checks into the
+    /// innermost loop's preheader instead of the hot loop body.
+    pub(crate) loop_frames: Vec<LoopFrame>,
 }
 
 impl CompilerContext {
@@ -508,6 +624,7 @@ impl CompilerContext {
             carry_vars: None,
             default_terminator: None,
             module_scope: vec![],
+            loop_frames: vec![],
         }
     }
 
@@ -534,6 +651,7 @@ impl CompilerContext {
             carry_vars,
             default_terminator,
             module_scope,
+            loop_frames: self.loop_frames.clone(),
         })
     }
 
@@ -561,10 +679,29 @@ impl CompilerContext {
             };
             let (mut new_value, new_pos) = value.repack_from(vars, pos)?;
             if invalidate_bounds {
-                new_value.bounds = None;
+                new_value.invalidate_join_facts();
             }
             pos = new_pos;
             self.vars.insert(key.clone(), new_value);
+        }
+        Ok(())
+    }
+
+    /// Publishes complete values from a path compiled directly into the
+    /// current block. Unlike [`Self::repack_some_vars`], this preserves the
+    /// facts established by that path because there is no control-flow join:
+    /// one compile-time-known branch is the only possible definition.
+    pub fn replace_some_vars_from(
+        &mut self,
+        keys: &[String],
+        source: &CompilerContext,
+    ) -> Result<(), JITError> {
+        for key in keys {
+            let value = source
+                .vars
+                .get(key)
+                .ok_or_else(|| JITError::Generic(format!("Variable not found {key}")))?;
+            self.vars.insert(key.clone(), value.clone());
         }
         Ok(())
     }

--- a/cutile-compiler/src/compiler/checks/goals.rs
+++ b/cutile-compiler/src/compiler/checks/goals.rs
@@ -1,0 +1,368 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Per-axis goal formation, and the proof sources that decide goals at JIT
+//! time.
+//!
+//! For a coordinate `i` into logical axis `axis` of a partition whose tile
+//! extent there is `t` and whose (remapped) tensor extent is `e`, access
+//! safety is exactly the pair of linear goals
+//!
+//! ```text
+//!     0 <= i          (lower)
+//!     i * t < e       (upper)
+//! ```
+//!
+//! The upper goal is the linearization `i < ceil(e/t)  <=>  i*t < e` for
+//! `t >= 1`, which keeps `ceil` out of the predicate term language: every
+//! goal stays linear, so static ranges, declared facts, and launch metadata
+//! can all decide it. [`AxisGoals`] is the formed pair — the index, the
+//! tile extent, and the identity of the extent bounding it. The functions
+//! here are proof *sources* over that one representation: each either
+//! decides both goals or leaves them open for the next rung, in the ladder
+//! order documented in [`super`]. What no source decides falls to residual
+//! placement (`super::placement`).
+
+use proc_macro2::Span;
+use syn::spanned::Spanned;
+use syn::ExprCall;
+
+use super::super::_function::CUDATileFunctionCompiler;
+use super::super::_value::{DimOrigin, TileRustValue};
+use crate::error::JITError;
+
+/// One coordinate axis of a partition access, resolved: the two linear
+/// goals `0 <= i` and `i * t < e` in data form.
+///
+/// The extent identity is resolved through the partition's dim-map at
+/// formation time: `extent_axis = dim_map[axis]` is the tensor axis whose
+/// extent bounds this coordinate, and every proof source must speak about
+/// that axis — a permuted partition's logical axis `axis` is bounded by
+/// root axis `dim_map[axis]`, never by `axis` itself (2026-08-04 review,
+/// finding Ask3-2).
+pub(super) struct AxisGoals<'v> {
+    /// Logical coordinate position; diagnostics name this axis.
+    pub(super) axis: usize,
+    /// `dim_map[axis]`: the tensor axis whose extent `e` bounds the access.
+    pub(super) extent_axis: usize,
+    /// Static tile extent `t >= 1`.
+    pub(super) tile: i32,
+    /// `e` when a static source pins it: the partition view type when it
+    /// kept the extent, otherwise the declared parameter shape — which the
+    /// generated launcher verifies against the real tensor before the
+    /// kernel runs (SC2), so it is evidence, not trust. `None` means the
+    /// extent is genuinely runtime.
+    pub(super) static_extent: Option<i32>,
+    /// The coordinate `i`, with whatever facts it carries: constant bounds,
+    /// a symbolic term, and axis provenance.
+    pub(super) index: &'v TileRustValue,
+}
+
+/// A statically provable goal violation, produced by [`fold_static`]. The
+/// calling family turns it into its own compile error.
+pub(super) struct StaticViolation {
+    /// The index's smallest possible value (decides the lower goal).
+    pub(super) min: i64,
+    /// The index's largest possible value (decides the upper goal).
+    pub(super) max: i64,
+    /// `ceil(e / t)`: the number of tiles the axis actually has.
+    pub(super) num_tiles: i64,
+}
+
+/// What the brand rung concludes about a coordinate (bounded family).
+pub(super) enum Brand {
+    /// Branded by exactly the `Dim` that `with_bounds` bound to this axis:
+    /// the binding check already related that `Dim` to the axis's tile
+    /// count, so both goals hold by construction.
+    Matched,
+    /// Branded by a *different* dimension. A foreign brand is a compile
+    /// error in the bounded family: the coordinate provably iterates some
+    /// other axis's domain.
+    Foreign,
+}
+
+/// The brand-provenance rung: compare the coordinate's origin against the
+/// `Dim` recorded for this axis by `with_bounds`. `None` means the
+/// coordinate is unbranded and the rung is open.
+pub(super) fn brand_of(goals: &AxisGoals<'_>, bound_origin: &DimOrigin) -> Option<Brand> {
+    match goals.index.index_origin.as_ref() {
+        Some(origin) if origin == bound_origin => Some(Brand::Matched),
+        Some(_) => Some(Brand::Foreign),
+        None => None,
+    }
+}
+
+/// The static-fold rung: a statically ranged index against a statically
+/// pinned extent decides both goals outright. `None` leaves the rung open
+/// (runtime index range or runtime extent); `Some(Err(_))` is a provable
+/// violation the family must surface as a compile error, mirroring how a
+/// constant out-of-range subscript is rejected rather than checked.
+pub(super) fn fold_static(goals: &AxisGoals<'_>) -> Option<Result<(), StaticViolation>> {
+    let bounds = goals.index.bounds?;
+    let extent = goals.static_extent?;
+    let num_tiles = (extent as i64 + goals.tile as i64 - 1) / goals.tile as i64;
+    Some(if 0 <= bounds.start && bounds.end < num_tiles {
+        Ok(())
+    } else {
+        Err(StaticViolation {
+            min: bounds.start,
+            max: bounds.end,
+            num_tiles,
+        })
+    })
+}
+
+impl<'m> CUDATileFunctionCompiler<'m> {
+    /// Form the goal pair for one coordinate axis: resolve the extent axis
+    /// through the dim-map, then attach the static extent when the view
+    /// type or the declared (launch-verified) parameter shape pins it.
+    ///
+    /// This is the one place the goals are formed; every proof source and
+    /// the residual placement consume what it returns. In particular the
+    /// extent-frame question (root extent vs per-CTA slab) never reaches
+    /// the rungs: the static sources used here coincide with the kernel's
+    /// view by construction, and the predicate-language rungs name the
+    /// extent through [`Self::extent_atom`], the single place that frame
+    /// decision lives.
+    pub(super) fn form_axis_goals<'v>(
+        &self,
+        partition: &TileRustValue,
+        static_tile: &[i32],
+        static_shape: &[i32],
+        dim_map: &[i32],
+        axis: usize,
+        index: &'v TileRustValue,
+    ) -> AxisGoals<'v> {
+        let extent_axis = dim_map[axis] as usize;
+        let static_extent = match static_shape[extent_axis] {
+            -1 => self.declared_view_extent(partition, dim_map, axis),
+            extent => Some(extent),
+        };
+        AxisGoals {
+            axis,
+            extent_axis,
+            tile: static_tile[axis],
+            static_extent,
+            index,
+        }
+    }
+
+    /// The axis-provenance rung (plain family): the coordinate's origin
+    /// proves it iterates the very axis it indexes.
+    ///
+    /// Two forms of the same evidence:
+    ///
+    /// * Cross-tensor: the coordinate iterates axis `a` of some *other*
+    ///   tensor with the same tile extent, so it is bounded by that axis's
+    ///   tile count, and `dim(other, a) <= dim(target, extent_axis)` carries
+    ///   the bound across — settled at JIT by a declared equality, or checked
+    ///   on the host at launch. The goal is the INEQUALITY, source at most
+    ///   target: a target strictly larger than the source is safe, and
+    ///   stating equality instead rejected it (found 2026-08-05, in review of
+    ///   `2ca6e3d`). The target side of the query is the REMAPPED axis
+    ///   `extent_axis`, never the logical coordinate `axis`: for a permuted
+    ///   partition the extent bounding logical axis `axis` is root axis
+    ///   `dim_map[axis]` (2026-08-04 review, finding Ask3-2; regression
+    ///   pinned in `partition_access_soundness.rs`).
+    /// * Same-view: the coordinate came from iterating this partition's own
+    ///   axis (`num_tiles(&p, axis)` provenance), so `i < ceil(e/t)` and
+    ///   `0 <= i` hold by the iteration domain.
+    pub(super) fn discharge_by_axis_provenance(
+        &self,
+        goals: &AxisGoals<'_>,
+        partition: &TileRustValue,
+    ) -> bool {
+        if let (Some(origin), Some(target)) = (
+            goals.index.partition_axis_origin.as_ref(),
+            partition.tensor_origin.as_ref(),
+        ) {
+            // Both sides must be root-framed: the equality is stated over
+            // `dim(t, a)`, which names whole tensors. For a slabbed `&mut`
+            // target the access is bounded by its per-CTA extent, which a
+            // declared root fact does not describe — so a match there would
+            // discharge against evidence about a different quantity. The
+            // source side is guarded where the provenance is minted.
+            if origin.tile_dim == goals.tile
+                && self.root_framed_param(target).is_some()
+                && self.resolve_dim_le(
+                    &origin.tensor,
+                    origin.axis,
+                    target,
+                    goals.extent_axis,
+                    goals.tile,
+                )
+            {
+                return true;
+            }
+        }
+        if let (
+            Some(DimOrigin::PartitionAxis {
+                view,
+                axis,
+                tile_dim,
+            }),
+            Some(partition_view),
+        ) = (goals.index.index_origin.as_ref(), partition.value)
+        {
+            if *view == partition_view && *axis == goals.axis && *tile_dim == goals.tile {
+                return true;
+            }
+        }
+        false
+    }
+
+    /// The block-id axiom rung (plain family): a coordinate that IS the
+    /// special register `tile_block_id(k)` is bounded by the launch grid —
+    /// `0 <= bid < num_tile_blocks(k)` is the CUDA execution model, the one
+    /// hardware axiom this module admits. What remains of the goal pair is
+    /// `num_tile_blocks(k) <= ceil(e/t)`, whose operands are all
+    /// launch-known: stated linearized (`ntb * t <= e + t - 1`, sound for
+    /// `t >= 1`) over the extent atom so the frame decision stays in
+    /// [`Self::extent_atom`], and routed through the shared obligation
+    /// path — verified against the actual launch grid before the kernel
+    /// runs. This is exactly the "verified `Launch` obligation" the
+    /// `NumTileBlocks` vocabulary doc requires before the grid may be
+    /// related to a tile count; the unverified form of this rung once
+    /// admitted out-of-bounds stores and was reverted (2026-08-04 review).
+    ///
+    /// The rung accepts only the canonical bare register — one atom,
+    /// coefficient 1, no constant. Arithmetic that changes the value
+    /// forfeits the term and falls to the later rungs; identities the term
+    /// algebra normalizes away (`+ c - c`, `* 1`) keep it, and are
+    /// value-equal to the register by the ring semantics of wrapping
+    /// arithmetic, so the substitution stays sound (2026-08-18 review, H1;
+    /// the wrapping identity is executed on-GPU by the review's probe).
+    pub(super) fn discharge_by_block_id_axiom(
+        &self,
+        goals: &AxisGoals<'_>,
+        partition: &TileRustValue,
+    ) -> bool {
+        use cuda_async::predicate::{Atom, Predicate, Term};
+        let Some(term) = goals.index.term.as_ref() else {
+            return false;
+        };
+        if term.constant_part() != 0 || term.coeffs().len() != 1 {
+            return false;
+        }
+        let Some((atom, &coeff)) = term.coeffs().iter().next() else {
+            return false;
+        };
+        let k = match (atom, coeff) {
+            (Atom::TileBlockId(k), 1) => *k,
+            _ => return false,
+        };
+        let Some(tensor) = partition.tensor_origin.as_ref() else {
+            return false;
+        };
+        let Some(&param) = self.param_index.get(tensor) else {
+            return false;
+        };
+        let tile = goals.tile as i64;
+        let Some(lhs) = Term::atom(Atom::NumTileBlocks(k)).mul_const(tile) else {
+            return false;
+        };
+        let Some(rhs) =
+            Term::atom(self.extent_atom(param, goals.extent_axis)).add(&Term::constant(tile - 1))
+        else {
+            return false;
+        };
+        let Some(le) = Predicate::le(&lhs, &rhs) else {
+            return false;
+        };
+        let cause = format!(
+            "num_tile_blocks({k}) <= ceil(extent({tensor}, {})/{})",
+            goals.extent_axis, goals.tile
+        );
+        self.lower_obligation(le, cause)
+    }
+
+    /// The entailment/launch rung for a constant zero coordinate against a
+    /// runtime extent: `i ∈ [0, 0]` reduces the goal pair to
+    /// `extent(tensor, extent_axis) > 0`, a launch-known predicate. Routed
+    /// through the shared assert-to-obligation path, it is discharged at
+    /// JIT or hoisted to a host check at launch — zero in-kernel cost
+    /// either way. The extent atom picks the frame (SC1): the check states
+    /// the *kernel-visible* extent is non-empty, which for a `&mut` param
+    /// is the slab, not the root.
+    ///
+    /// Both families use this rung. It costs one thing: a launch whose
+    /// tensor is empty on this axis is rejected even if the access would
+    /// have sat behind a false runtime condition and never executed. That
+    /// trade was already accepted for branded accesses (pinned by
+    /// `hoisted_check_rejects_zero_extent_at_launch`), and the two families
+    /// must be able to prove the same goals from the same evidence — a
+    /// discharge reachable only through `with_bounds` would become a
+    /// capability lost when that annotation goes away, not a capability
+    /// kept.
+    pub(super) fn hoist_zero_coordinate_nonempty_extent(
+        &self,
+        goals: &AxisGoals<'_>,
+        partition: &TileRustValue,
+    ) -> bool {
+        use cuda_async::predicate::{Predicate, Term};
+        if goals.static_extent.is_some() {
+            return false;
+        }
+        let Some(bounds) = goals.index.bounds else {
+            return false;
+        };
+        if !(bounds.start == 0 && bounds.end == 0) {
+            return false;
+        }
+        let Some(tensor) = partition.tensor_origin.as_ref() else {
+            return false;
+        };
+        let Some(&param) = self.param_index.get(tensor) else {
+            return false;
+        };
+        let predicate = Predicate::nonzero(Term::atom(self.extent_atom(param, goals.extent_axis)));
+        let cause = format!(
+            "partition access on axis {} of `{tensor}` requires a non-empty extent",
+            goals.extent_axis
+        );
+        self.lower_obligation(predicate, cause)
+    }
+
+    /// The runtime scalar holding the extent for a goal whose static
+    /// sources all came up empty: the per-axis value of the view's shape
+    /// operands. Only the residual path needs it — a discharged goal never
+    /// touches the shape values — so callers resolve it after the ladder,
+    /// not at formation.
+    pub(super) fn resolve_dynamic_extent(
+        &self,
+        goals: &AxisGoals<'_>,
+        static_shape: &[i32],
+        shape_dims: &[TileRustValue],
+        call_expr: &ExprCall,
+    ) -> Result<TileRustValue, JITError> {
+        let span: Span = call_expr.span();
+        // The shape operands hold values only for the view type's dynamic
+        // dims, in axis order: count the dynamic dims through the extent
+        // axis to find this axis's position among them.
+        let dynamic_shape_index = static_shape
+            .iter()
+            .take(goals.extent_axis + 1)
+            .filter(|&&dim| dim == -1)
+            .count()
+            .checked_sub(1)
+            .ok_or_else(|| {
+                self.jit_error(
+                    &span,
+                    "internal: dynamic partition dimension was not found in tensor shape metadata",
+                )
+            })?;
+        shape_dims
+            .get(dynamic_shape_index)
+            .cloned()
+            .ok_or_else(|| {
+                self.jit_error(
+                    &span,
+                    &format!(
+                        "internal: tensor shape metadata is missing dynamic dimension {dynamic_shape_index}"
+                    ),
+                )
+            })
+    }
+}

--- a/cutile-compiler/src/compiler/checks/mod.rs
+++ b/cutile-compiler/src/compiler/checks/mod.rs
@@ -1,0 +1,384 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Access-safety checks for partition loads and stores: the one place a
+//! coordinate is proven inside its partition grid.
+//!
+//! Per axis, safety is the pair of linear goals `0 <= i` and `i * t < e`
+//! (see [`goals`]). Every access check forms that pair through one path —
+//! [`goals::AxisGoals`], built by `form_axis_goals` — and then tries the
+//! same ladder of proof sources, top-down, stopping at the first rung that
+//! decides it:
+//!
+//! 1. **Provenance match** — the index is branded by the axis it indexes
+//!    (a `with_bounds` binding, a partition-axis iterand), so both goals
+//!    hold by construction (`brand_of`, `discharge_by_axis_provenance`).
+//! 2. **Static fold** — a statically-known index range against a
+//!    statically-known tile grid decides both goals; a violation is a
+//!    compile error (`fold_static`). A `tile_block_id(k)` coordinate is
+//!    decided here too, by the grid axiom: the id is grid-bounded by the
+//!    execution model, and the grid-vs-tile-count claim moves to a launch
+//!    check (`discharge_by_block_id_axiom`).
+//! 3. **Declared-fact entailment** — the goal follows at JIT time from
+//!    launch-verified preconditions ([`lower_obligation`],
+//!    [`resolve_dim_eq`]).
+//! 4. **Launch hoist** — the goal's operands are launch-known, so it
+//!    evacuates to a host-side check before the kernel runs (also via
+//!    [`lower_obligation`]).
+//! 5. **Residual device placement** — an in-kernel assert, hoisted to the
+//!    outermost loop preheader whose frame decides it; gated by
+//!    [`deny_residual_check`] ([`placement`]).
+//!
+//! The two access families are two *policies* over that one ladder, not
+//! two frameworks. The plain family ([`compile_check_partition_access`],
+//! behind `Partition::load`) draws provenance from partition-axis
+//! iteration and declared root-dimension equalities, and lets an undecided
+//! goal fall to rung 5. The bounded family
+//! ([`compile_check_bounded_partition_access`], behind
+//! `BoundedPartition{,Mut}` accesses) draws provenance from `with_bounds`
+//! brands, reaches rung 4 through the zero-coordinate extent obligation,
+//! and treats an undecided goal as a compile error — never a device check.
+//!
+//! [`lower_obligation`]: CUDATileFunctionCompiler::lower_obligation
+//! [`resolve_dim_eq`]: CUDATileFunctionCompiler::resolve_dim_eq
+//! [`deny_residual_check`]: CUDATileFunctionCompiler::deny_residual_check
+//! [`compile_check_bounded_partition_access`]: CUDATileFunctionCompiler::compile_check_bounded_partition_access
+//! [`compile_check_partition_access`]: CUDATileFunctionCompiler::compile_check_partition_access
+
+mod goals;
+mod placement;
+
+use syn::spanned::Spanned;
+use syn::ExprCall;
+
+use quote::ToTokens;
+
+use super::_function::CUDATileFunctionCompiler;
+use super::_value::{CompilerContext, TileRustValue};
+use super::shared_types::Kind;
+use crate::error::JITError;
+use crate::generics::GenericVars;
+
+use cutile_ir::ir::{BlockId, Module};
+
+impl<'m> CUDATileFunctionCompiler<'m> {
+    /// One goal pair decided without any in-kernel cost.
+    fn count_discharged(&self) {
+        self.check_stats
+            .discharged
+            .set(self.check_stats.discharged.get() + 1);
+    }
+
+    /// Compiles a `check_partition_access` compiler_op call: the per-axis
+    /// access check guarding `Partition::load`. Walks the ladder per
+    /// coordinate axis; what no proof source decides is placed as a
+    /// residual device check.
+    pub(super) fn compile_check_partition_access(
+        &self,
+        module: &mut Module,
+        block_id: BlockId,
+        call_expr: &ExprCall,
+        generic_vars: &GenericVars,
+        ctx: &mut CompilerContext,
+    ) -> Result<Option<TileRustValue>, JITError> {
+        let mut args =
+            self.compile_call_args(module, block_id, &call_expr.args, generic_vars, ctx)?;
+        let partition_value = args.remove(0);
+        let index_value = args.remove(0);
+        if partition_value.kind != Kind::StructuredType {
+            return self.jit_error_result(
+                &call_expr.span(),
+                &format!(
+                    "expected a structured or primitive type for first argument of `{}`, got {:?}",
+                    &call_expr.to_token_stream().to_string(),
+                    partition_value.kind
+                ),
+            );
+        }
+        if index_value.kind != Kind::Compound {
+            return self.jit_error_result(
+                &call_expr.span(),
+                &format!(
+                    "Unexpected kind for arg 1 in {}",
+                    &call_expr.to_token_stream().to_string()
+                ),
+            );
+        }
+        let (static_tile, static_shape, dim_map) =
+            self.partition_static_geometry(&partition_value, &call_expr.span())?;
+
+        // The runtime shape operands, for residual checks over dynamic
+        // extents.
+        let tensor_shape_value = partition_value
+            .get_type_meta_field("tensor_view.shape()")
+            .ok_or_else(|| {
+                self.jit_error(
+                    &call_expr.span(),
+                    "Failed to obtain type meta field tensor_view.shape().",
+                )
+            })?;
+        let Some(tensor_shape_values) = tensor_shape_value.fields.as_ref() else {
+            return self.jit_error_result(
+                &call_expr.span(),
+                "Expected fields for tensor shape expression.",
+            );
+        };
+        let Some(shape_dims) = tensor_shape_values.get("dims") else {
+            return self.jit_error_result(
+                &call_expr.span(),
+                "Expected dims field for shape expression.",
+            );
+        };
+        let Some(dynamic_shape) = shape_dims.values.as_ref() else {
+            return self.jit_error_result(&call_expr.span(), "expected a compound (tuple) value");
+        };
+
+        let Some(indexes) = index_value.values.as_ref() else {
+            return self.jit_error_result(&call_expr.span(), "expected a compound (tuple) value");
+        };
+        let len = static_tile.len();
+        if len != indexes.len() || len != static_shape.len() {
+            return self.jit_error_result(
+                &call_expr.span(),
+                &format!(
+                    "Unexpected tile ({}), shape ({}), or index ({}) length mismatch.",
+                    len,
+                    static_shape.len(),
+                    indexes.len()
+                ),
+            );
+        }
+        for (axis, index) in indexes.iter().enumerate() {
+            let axis_goals = self.form_axis_goals(
+                &partition_value,
+                &static_tile,
+                &static_shape,
+                &dim_map,
+                axis,
+                index,
+            );
+            // Rungs 1 and 2 are proofs, not placements — but under full
+            // placement ablation they are skipped anyway: the ablated build
+            // is the differential harness's semantic reference, and a
+            // reference that inherits the very proofs under audit cannot
+            // catch one that is wrong (2026-08-12 review, S2). The bounded
+            // family keeps its rungs — its undischarged checks are compile
+            // errors, so it has no device placement to ablate to.
+            if !crate::cuda_tile_runtime_utils::force_device_checks() {
+                // Rung 1/3: axis provenance — a same-view iterand, or a
+                // foreign iterand whose axis a declared root-dimension
+                // equality relates to this one.
+                if self.discharge_by_axis_provenance(&axis_goals, &partition_value) {
+                    self.count_discharged();
+                    continue;
+                }
+                // Rung 2: static fold.
+                match goals::fold_static(&axis_goals) {
+                    Some(Ok(())) => {
+                        self.count_discharged();
+                        continue;
+                    }
+                    Some(Err(violation)) => {
+                        return self.jit_error_result(
+                            &call_expr.span(),
+                            &format!(
+                                "Bounds check failed: 0 <= {} && {} < {}",
+                                violation.min, violation.max, violation.num_tiles
+                            ),
+                        );
+                    }
+                    None => {}
+                }
+                // Rung 2.5: the block-id axiom — `tile_block_id(k)` is
+                // grid-bounded by the execution model; the residual
+                // grid-vs-tile-count claim moves to a launch check
+                // (goals.rs, discharge_by_block_id_axiom).
+                if self.discharge_by_block_id_axiom(&axis_goals, &partition_value) {
+                    self.count_discharged();
+                    continue;
+                }
+            }
+            // Rung 3/4: a constant `[0, 0]` coordinate against a dynamic
+            // extent reduces to `extent > 0`, a launch-known predicate.
+            // Gated here, not inside the rung: the bounded family shares it
+            // and MUST keep it under ablation, since its undischarged checks
+            // are compile errors rather than device placements.
+            if !crate::cuda_tile_runtime_utils::force_device_checks()
+                && self.hoist_zero_coordinate_nonempty_extent(&axis_goals, &partition_value)
+            {
+                self.count_discharged();
+                continue;
+            }
+            // Rung 5: residual device placement.
+            let dynamic_extent = if axis_goals.static_extent.is_none() {
+                Some(self.resolve_dynamic_extent(
+                    &axis_goals,
+                    &static_shape,
+                    dynamic_shape,
+                    call_expr,
+                )?)
+            } else {
+                None
+            };
+            self.place_residual_check(
+                module,
+                block_id,
+                &axis_goals,
+                dynamic_extent,
+                generic_vars,
+                ctx,
+                &call_expr.span(),
+            )?;
+        }
+        Ok(None)
+    }
+
+    /// Compiles a `check_bounded_partition_access` compiler_op call: the
+    /// per-axis access check for a `coord(...)` coordinate into a bounded
+    /// partition (`BoundedPartition{,Mut}`). Each axis discharges by brand
+    /// provenance, the static fold, or the launch-hoisted non-empty-extent
+    /// obligation; an unresolved coordinate is a compile error, never a
+    /// device check.
+    pub(super) fn compile_check_bounded_partition_access(
+        &self,
+        module: &mut Module,
+        block_id: BlockId,
+        call_expr: &ExprCall,
+        generic_vars: &GenericVars,
+        ctx: &mut CompilerContext,
+    ) -> Result<Option<TileRustValue>, JITError> {
+        if call_expr.args.len() != 2 {
+            return self.jit_error_result(
+                &call_expr.span(),
+                &format!(
+                    "`check_bounded_partition_access` expects 2 arguments, got {}",
+                    call_expr.args.len()
+                ),
+            );
+        }
+        let mut args =
+            self.compile_call_args(module, block_id, &call_expr.args, generic_vars, ctx)?;
+        let partition = args.remove(0);
+        let coord = args.remove(0);
+        let Some(bound_axes) = partition.bounded_axes.as_ref() else {
+            return self.jit_error_result(
+                &call_expr.args[0].span(),
+                "bounded partition load requires bounds established by `Partition::with_bounds`",
+            );
+        };
+        let Some(fields) = coord.fields.as_ref() else {
+            return self.jit_error_result(
+                &call_expr.args[1].span(),
+                "bounded partition load requires a coordinate created by `coord(...)`",
+            );
+        };
+        let Some(coords) = fields.get("coords") else {
+            return self.jit_error_result(
+                &call_expr.args[1].span(),
+                "coordinate is missing its metadata",
+            );
+        };
+        let Some(coord_values) = coords.values.as_ref() else {
+            return self.jit_error_result(
+                &call_expr.args[1].span(),
+                "coordinates must be a compound value",
+            );
+        };
+        if coord_values.len() != bound_axes.len() {
+            return self.jit_error_result(
+                &call_expr.args[1].span(),
+                &format!(
+                    "coordinate rank {} does not match bounded partition rank {}",
+                    coord_values.len(),
+                    bound_axes.len()
+                ),
+            );
+        }
+        let (static_tile, static_shape, dim_map) =
+            self.partition_static_geometry(&partition, &call_expr.args[0].span())?;
+        for (axis, (coord_value, bound_origin)) in
+            coord_values.iter().zip(bound_axes.iter()).enumerate()
+        {
+            let axis_goals = self.form_axis_goals(
+                &partition,
+                &static_tile,
+                &static_shape,
+                &dim_map,
+                axis,
+                coord_value,
+            );
+            // Rung 1: brand provenance.
+            match goals::brand_of(&axis_goals, bound_origin) {
+                Some(goals::Brand::Matched) => {
+                    self.count_discharged();
+                    continue;
+                }
+                Some(goals::Brand::Foreign) => {
+                    return self.jit_error_result(
+                        &call_expr.args[1].span(),
+                        &format!(
+                            "bounded partition coordinate axis {axis} was produced by a different dimension"
+                        ),
+                    );
+                }
+                None => {}
+            }
+            // Rung 2: static fold.
+            match goals::fold_static(&axis_goals) {
+                Some(Ok(())) => {
+                    self.count_discharged();
+                    continue;
+                }
+                Some(Err(violation)) => {
+                    return self.jit_error_result(
+                        &call_expr.args[1].span(),
+                        &format!(
+                            "bounded partition coordinate axis {axis}: constant range [{}, {}] is not within the {}-tile grid",
+                            violation.min, violation.max, violation.num_tiles
+                        ),
+                    );
+                }
+                None => {}
+            }
+            // Rung 3/4: a constant `[0, 0]` coordinate against a dynamic
+            // extent reduces to `extent > 0`, a launch-known predicate.
+            if self.hoist_zero_coordinate_nonempty_extent(&axis_goals, &partition) {
+                self.count_discharged();
+                continue;
+            }
+            // NOTE: there is deliberately NO tile-block-id discharge rung
+            // here. Two different quantities have both been called "the
+            // partition grid", and conflating them is unsound:
+            //
+            //   * `NumTileBlocks(k)` (the launch grid) counts CTA *slabs*:
+            //     `div_ceil(root_shape, slab_shape)` (`Partition::grid`),
+            //     which is what `validate_grids` checks at launch.
+            //   * the bound this access needs is the tile count *within*
+            //     the kernel-visible view: `ceil(static_shape / static_tile)`
+            //     computed above — for a `&mut Tensor` param that view is
+            //     one slab, so this counts tiles inside a slab.
+            //
+            // These are unrelated, so the hardware axiom `TileBlockId(k) <
+            // NumTileBlocks(k)` does NOT bound this access. A previous rung
+            // (reverted) formed that axiom *as* its obligation and proved it
+            // against itself — a tautology that discharged every block-id
+            // access and admitted out-of-bounds stores (reproduced on
+            // hardware: CTAs writing other CTAs' rows).
+            //
+            // The real fix must form the actual proposition
+            // `TileBlockId(axis) < num_partitions(view, axis)` and obtain
+            // `NumTileBlocks(axis) == num_partitions(view, axis)` as a
+            // *verified* `Launch` obligation, never as an assumption.
+            // See `.internal/tasks/in_progress/check_hoisting/OBLIGATION_SYSTEM_DESIGN.md`.
+            return self.jit_error_result(
+                &call_expr.args[1].span(),
+                &format!(
+                    "bounded partition coordinate axis {axis} must come from iterating the matching dimension or be a constant within the axis's static tile grid"
+                ),
+            );
+        }
+        Ok(None)
+    }
+}

--- a/cutile-compiler/src/compiler/checks/placement.rs
+++ b/cutile-compiler/src/compiler/checks/placement.rs
@@ -1,0 +1,622 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Residual placement: where a goal that no JIT-stage proof source decided
+//! becomes a device check, and in what instantiated form.
+//!
+//! When the check sits directly in a loop body and the index is
+//! loop-invariant (or affine in the unit-step induction variable), the
+//! whole comparison chain is emitted in the loop's preheader instead of
+//! the hot body: the upper goal takes the strongest extreme instance of
+//! the index, the lower goal the weakest, and the pair is wrapped in an
+//! `upper <= lower || in_bounds` guard so an empty loop — whose accesses
+//! never execute — cannot trap spuriously. Assert semantics are otherwise
+//! unchanged: the same violation traps, before the loop instead of at the
+//! offending iteration. Everything else stays an in-place check at the
+//! access block.
+//!
+//! Either way the check is about to become a device instruction, so
+//! placement is also where the `deny_in_kernel_checks` policy fires,
+//! through the one shared gate ([`CUDATileFunctionCompiler::deny_residual_check`]).
+
+use proc_macro2::Span;
+
+use super::super::_function::CUDATileFunctionCompiler;
+use super::super::_value::{CompilerContext, LoopFrame};
+use super::super::shared_utils::TileBinaryOp;
+use super::goals::AxisGoals;
+use crate::compiler::_value::TileRustValue;
+use crate::compiler::tile_rust_type::TileRustType;
+use crate::error::JITError;
+use crate::generics::GenericVars;
+
+use cutile_ir::builder::{append_op, OpBuilder};
+use cutile_ir::bytecode::Opcode;
+use cutile_ir::ir::{BlockId, Module};
+
+/// How the residual check's index is instantiated in the emission block.
+pub(super) enum HoistIndex {
+    /// A statically-known index range: `max` drives the upper check, `min`
+    /// decides the lower goal (`0 <= index`).
+    Const { min: i32, max: i32 },
+    /// A loop-invariant runtime index: guarded directly, in the preheader.
+    Invariant,
+    /// `scale * induction + offset`: each goal substitutes the loop extreme
+    /// that is worst for it (identity is scale 1, offset 0). Carries the
+    /// bounds of the loop the affine was CLASSIFIED against (the innermost),
+    /// because the outward walk may choose an outer frame as the emission
+    /// target and the extremes must still be the inner loop's — substituting
+    /// the target frame's bounds would test the wrong index instance
+    /// (audit finding F1, 2026-08-08: latent today only because a bound that
+    /// makes the inner loop known_non_empty also gives the iterand interval
+    /// bounds, which classify as `Const` first; nothing enforces that
+    /// coincidence).
+    InductionAffine {
+        scale: i64,
+        offset: i64,
+        lower: cutile_ir::ir::Value,
+        upper: cutile_ir::ir::Value,
+    },
+}
+
+/// Which extreme instance of an affine index over `[lower, upper)` a goal
+/// substitutes: the strongest instance drives the upper goal, the weakest
+/// the lower goal. For positive scale the strongest sits at `upper - 1`
+/// and the weakest at `lower`; a negative scale mirrors them.
+enum Extreme {
+    Strongest,
+    Weakest,
+}
+
+/// Placement may substitute a bound for the index only when the bound is
+/// exactly representable in the index's runtime type: range analysis is
+/// mathematical `i64`, the kernel computes wrapping `i32`, and a narrowing
+/// `as i32` here turned a hoisted check into one that passes while the
+/// actual wrapped indices run wild (issue #213). A range outside `i32` is
+/// treated as no range at all — the check falls back to testing the raw
+/// runtime value, which wraps exactly as the access does.
+///
+/// Since the 2026-08-12 review (S1), [`crate::value_facts::transfer`]
+/// enforces this per op — an interval survives only if the op that made it
+/// provably cannot wrap — so an `i32` value's range always fits here. The
+/// gate stays as defense in depth for facts minted outside that path.
+fn fits_i32(bounds: &crate::bounds::Bounds<i64>) -> bool {
+    bounds.start >= i32::MIN as i64 && bounds.end <= i32::MAX as i64
+}
+
+impl<'m> CUDATileFunctionCompiler<'m> {
+    /// Classify where the residual check for `goals` can be emitted:
+    /// against the innermost loop first, then walking outward to the
+    /// maximal preheader the check's operands dominate. `None` means the
+    /// check stays in place; the second component records the
+    /// innermost-classification failure for diagnostics.
+    fn classify_hoist(
+        &self,
+        goals: &AxisGoals<'_>,
+        dynamic_extent: Option<&TileRustValue>,
+        block_id: BlockId,
+        ctx: &CompilerContext,
+    ) -> (Option<(LoopFrame, HoistIndex)>, Option<&'static str>) {
+        let mut no_hoist_why: Option<&'static str> = None;
+        let hoist = 'classify: {
+            if crate::cuda_tile_runtime_utils::check_hoisting_disabled() {
+                no_hoist_why = Some("hoisting disabled via CUTILE_DISABLE_CHECK_HOISTING");
+                break 'classify None;
+            }
+            let frames = &ctx.loop_frames;
+            let Some(innermost) = frames.last() else {
+                break 'classify None;
+            };
+            if block_id != innermost.body_block {
+                no_hoist_why = Some("check sits inside a conditional block");
+                break 'classify None;
+            }
+            // Values the emitted check will reference; each must dominate
+            // the target preheader (index() below the target watermark).
+            let mut operand_deps: Vec<cutile_ir::ir::Value> = vec![];
+            if let Some(shape_value) = dynamic_extent {
+                let Some(value) = shape_value.value else {
+                    no_hoist_why = Some("dynamic shape operand has no direct value");
+                    break 'classify None;
+                };
+                operand_deps.push(value);
+            }
+            let kind = if let Some(bounds) = goals.index.bounds.filter(fits_i32) {
+                HoistIndex::Const {
+                    min: bounds.start as i32,
+                    max: bounds.end as i32,
+                }
+            } else {
+                let Some(value) = goals.index.value else {
+                    no_hoist_why = Some("index has no direct value");
+                    break 'classify None;
+                };
+                let affine = if innermost.induction_values.contains(&value) {
+                    Some((value.index(), 1i64, 0i64))
+                } else {
+                    // Project the index's symbolic term to the single-var
+                    // affine fragment `scale * iv + offset`, and only when
+                    // that `iv` is the innermost loop's induction variable.
+                    goals
+                        .index
+                        .term
+                        .as_ref()
+                        .and_then(|term| term.as_single_affine())
+                        .and_then(|(atom, scale, offset)| match atom {
+                            cuda_async::predicate::Atom::Iv(id)
+                                if innermost.induction_values.iter().any(|v| v.index() == id) =>
+                            {
+                                Some((id, scale, offset))
+                            }
+                            _ => None,
+                        })
+                };
+                if let Some((iv_id, scale, offset)) = affine {
+                    if !innermost.unit_step {
+                        no_hoist_why = Some("index depends on a non-unit-step induction variable");
+                        break 'classify None;
+                    }
+                    if scale == 0 {
+                        no_hoist_why = Some("degenerate affine index");
+                        break 'classify None;
+                    }
+                    // When the loop's induction range is a compile-time
+                    // constant, the index's range follows from its term
+                    // (value_facts::term_range): discharge it as a static
+                    // constant — the strongest instance is the range's max —
+                    // instead of a runtime strongest-instance substitution.
+                    let static_max = innermost.induction_range.and_then(|iv_range| {
+                        crate::value_facts::term_range(
+                            &cuda_async::predicate::Term::affine(
+                                cuda_async::predicate::Atom::Iv(iv_id),
+                                scale,
+                                offset,
+                            ),
+                            &|atom| match atom {
+                                cuda_async::predicate::Atom::Iv(id) if *id == iv_id => {
+                                    Some(iv_range)
+                                }
+                                _ => None,
+                            },
+                        )
+                    });
+                    if let Some(range) = static_max.filter(fits_i32) {
+                        HoistIndex::Const {
+                            min: range.start as i32,
+                            max: range.end as i32,
+                        }
+                    } else if !(scale == 1 && offset == 0) {
+                        // A non-identity instance is emitted as wrapping i32
+                        // multiply/add; without a static range proving the
+                        // image fits, the substituted extreme can wrap and
+                        // pass while the real indices are out of range
+                        // (issue #213). Identity is exact: the instance IS
+                        // the loop bound.
+                        no_hoist_why = Some("non-identity affine instance could overflow i32");
+                        break 'classify None;
+                    } else {
+                        // The substituted instances reference BOTH loop
+                        // bounds: the strongest instance uses one extreme and
+                        // the lower guard (always emitted for affine — the
+                        // index carries no bounds here) uses the other. Both
+                        // must dominate wherever the walk emits the check.
+                        operand_deps.push(innermost.upper);
+                        operand_deps.push(innermost.lower);
+                        HoistIndex::InductionAffine {
+                            scale,
+                            offset,
+                            lower: innermost.lower,
+                            upper: innermost.upper,
+                        }
+                    }
+                } else if value.index() < innermost.value_watermark {
+                    operand_deps.push(value);
+                    HoistIndex::Invariant
+                } else {
+                    no_hoist_why = Some("index is computed inside the loop body");
+                    break 'classify None;
+                }
+            };
+            // Walk outward: cross a loop only when it is directly nested
+            // (its preheader is the enclosing body), statically non-empty
+            // (its accesses execute on every enclosing iteration), and
+            // every operand dominates the enclosing preheader.
+            let mut target = frames.len() - 1;
+            while target > 0 {
+                let inner = &frames[target];
+                let outer = &frames[target - 1];
+                let contiguous = inner.preheader_block == outer.body_block;
+                let deps_dominate = operand_deps
+                    .iter()
+                    .all(|value| value.index() < outer.value_watermark);
+                if contiguous && inner.known_non_empty && deps_dominate {
+                    target -= 1;
+                } else {
+                    break;
+                }
+            }
+            Some((frames[target].clone(), kind))
+        };
+        (hoist, no_hoist_why)
+    }
+
+    /// One extreme instance of `scale * j + offset` over the frame's
+    /// induction range `[lower, upper)`. The strongest and weakest builders
+    /// are exact mirrors — the same op sequence at opposite loop extremes —
+    /// so one parameterized emitter serves both goals.
+    #[allow(clippy::too_many_arguments)]
+    fn affine_extreme_instance(
+        &self,
+        module: &mut Module,
+        check_block: BlockId,
+        lower: cutile_ir::ir::Value,
+        upper: cutile_ir::ir::Value,
+        scale: i64,
+        offset: i64,
+        extreme: Extreme,
+        index_ty: &TileRustType,
+        generic_vars: &GenericVars,
+        ctx: &mut CompilerContext,
+        span: &Span,
+    ) -> Result<TileRustValue, JITError> {
+        let at_last_iteration = (scale > 0) == matches!(extreme, Extreme::Strongest);
+        let mut instance = if at_last_iteration {
+            let upper_value = TileRustValue::new_primitive(upper, index_ty.clone(), None);
+            let one = self.compile_constant(module, check_block, generic_vars, 1)?;
+            self.compile_binary_op_from_values(
+                module,
+                check_block,
+                upper_value,
+                one,
+                &TileBinaryOp::Sub,
+                generic_vars,
+                ctx,
+                None,
+                span,
+            )?
+        } else {
+            TileRustValue::new_primitive(lower, index_ty.clone(), None)
+        };
+        if scale != 1 {
+            let scale_value =
+                self.compile_constant(module, check_block, generic_vars, scale as i32)?;
+            instance = self.compile_binary_op_from_values(
+                module,
+                check_block,
+                instance,
+                scale_value,
+                &TileBinaryOp::Mul,
+                generic_vars,
+                ctx,
+                None,
+                span,
+            )?;
+        }
+        if offset != 0 {
+            let offset_value =
+                self.compile_constant(module, check_block, generic_vars, offset as i32)?;
+            instance = self.compile_binary_op_from_values(
+                module,
+                check_block,
+                instance,
+                offset_value,
+                &TileBinaryOp::Add,
+                generic_vars,
+                ctx,
+                None,
+                span,
+            )?;
+        }
+        Ok(instance)
+    }
+
+    /// Place the residual device check for one axis's goals: classify the
+    /// hoist target, decide the lower goal statically when a known range
+    /// allows it, apply the deny gate, then emit the comparison chain and
+    /// assert at the chosen block.
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn place_residual_check(
+        &self,
+        module: &mut Module,
+        block_id: BlockId,
+        goals: &AxisGoals<'_>,
+        dynamic_extent: Option<TileRustValue>,
+        generic_vars: &GenericVars,
+        ctx: &mut CompilerContext,
+        span: &Span,
+    ) -> Result<(), JITError> {
+        let axis = goals.axis;
+        let (hoist, no_hoist_why) =
+            self.classify_hoist(goals, dynamic_extent.as_ref(), block_id, ctx);
+        let (check_block, guard_bounds, hoist_kind) = match &hoist {
+            Some((frame, kind)) => (
+                frame.preheader_block,
+                // Vacuous-trip guard, elided when static bounds prove the
+                // target loop runs at least once.
+                (!frame.known_non_empty).then_some((frame.lower, frame.upper)),
+                Some(kind),
+            ),
+            None => (block_id, None, None),
+        };
+        // The lower access goal `0 <= index` is shape-independent, so any
+        // statically-known range decides it here: a provably negative block
+        // index is rejected outright (mirroring the static-fold rung), and a
+        // proven-nonnegative one discharges the lower guard. Only a genuinely
+        // unknown index pays a runtime guard below. Previously the dynamic
+        // path emitted ONLY the upper comparison, so a signed `-1` passed
+        // `index < ceil(extent/tile)` and reached the access (2026-08-04
+        // review, finding Ask3-1).
+        // Under placement ablation nothing is inferred: the reference build
+        // tests the actual value on BOTH sides, or it cannot referee the
+        // inference that removed a side (2026-08-12 review, S2).
+        let lower_static: Option<i64> = if crate::cuda_tile_runtime_utils::force_device_checks() {
+            None
+        } else {
+            goals
+                .index
+                .bounds
+                .filter(fits_i32)
+                .map(|b| b.start)
+                .or(match &hoist_kind {
+                    Some(HoistIndex::Const { min, .. }) => Some(*min as i64),
+                    _ => None,
+                })
+        };
+        if let Some(min) = lower_static {
+            if min < 0 {
+                return self.jit_error_result(
+                    span,
+                    &format!(
+                        "partition access out of bounds: dim {axis}, block index can be {min} \
+                         (0 <= index is required)"
+                    ),
+                );
+            }
+        }
+        let needs_lower_guard = lower_static.is_none();
+        // The check could not be discharged at compile time or hoisted to
+        // launch, so it is about to be emitted *in* the kernel (either at
+        // the access block or, hoisted, the loop preheader — both cost
+        // device registers). The shared gate makes that a hard error under
+        // `deny_in_kernel_checks`.
+        let placement_detail = no_hoist_why
+            .map(|why| format!(" ({why})"))
+            .unwrap_or_default();
+        // Name the two fixes concretely. The overwhelmingly common cause is an
+        // index computed by hand — `n / TILE`, or a `Dim` built from one —
+        // which is the right *number* carrying none of the provenance the
+        // checker needs, so the remedy is to iterate the count the compiler
+        // minted instead. The second form covers an index that legitimately
+        // comes from another tensor.
+        self.deny_residual_check(
+            &format!("the bounds check for partition axis {axis}{placement_detail}"),
+            &format!(
+                "For a loop counter, iterate `0..num_tiles(&partition, {axis})`, whose \
+                 result carries the axis it counts (a hand-computed `n / TILE` is the \
+                 same number but proves nothing); for an index from a different tensor, \
+                 relate the extents with `preconditions = (dim(a, i) == dim(b, j),)`; \
+                 a tile-block id cannot be proven against a partition's tile count \
+                 today, since the launch grid counts CTA slabs rather than tiles"
+            ),
+            span,
+        )?;
+        if hoist.is_some() {
+            self.check_stats
+                .hoisted
+                .set(self.check_stats.hoisted.get() + 1);
+        } else {
+            self.check_stats
+                .in_place
+                .set(self.check_stats.in_place.get() + 1);
+            if let Some(why) = no_hoist_why {
+                if crate::cuda_tile_runtime_utils::jit_hoist_log_enabled() {
+                    eprintln!(
+                        "[cutile::jit] bounds check for dim {axis} stays in the loop body: {why}"
+                    );
+                }
+            }
+        }
+        let tile_dim_value =
+            self.compile_constant(module, check_block, generic_vars, goals.tile)?;
+        // Upper goal operand: the strongest instance of the index.
+        let index_instance = match hoist_kind {
+            Some(HoistIndex::InductionAffine {
+                scale,
+                offset,
+                lower,
+                upper,
+            }) => {
+                // The extremes are the CLASSIFIED loop's bounds, carried in
+                // the variant — never the walk target's (audit F1).
+                self.affine_extreme_instance(
+                    module,
+                    check_block,
+                    *lower,
+                    *upper,
+                    *scale,
+                    *offset,
+                    Extreme::Strongest,
+                    &goals.index.ty,
+                    generic_vars,
+                    ctx,
+                    span,
+                )?
+            }
+            Some(HoistIndex::Const { max, .. }) => {
+                self.compile_constant(module, check_block, generic_vars, *max)?
+            }
+            Some(HoistIndex::Invariant) | None => {
+                // Under placement ablation the check is the semantic
+                // reference, so it tests the index's ACTUAL value; the
+                // static-max substitution below is an optimization that
+                // deliberately over-tests (the range's extreme), which is
+                // exactly what the differential harness must not inherit
+                // from the thing it referees.
+                if crate::cuda_tile_runtime_utils::force_device_checks() {
+                    goals.index.clone()
+                } else if let Some(bounds) = goals.index.bounds.filter(fits_i32) {
+                    self.compile_constant(module, check_block, generic_vars, bounds.end as i32)?
+                } else {
+                    goals.index.clone()
+                }
+            }
+        };
+        let shape_dim_value = match dynamic_extent {
+            Some(shape_value) => shape_value,
+            None => {
+                let extent = goals
+                    .static_extent
+                    .expect("residual check without a dynamic extent has a static one");
+                self.compile_constant(module, check_block, generic_vars, extent)?
+            }
+        };
+        // Compute ceil_div(shape, tile) as (shape + tile - 1) / tile
+        // using floor division. This avoids positive_inf rounding which
+        // can be misoptimized when the dividend carries assume hints.
+        let tile_minus_one =
+            self.compile_constant(module, check_block, generic_vars, goals.tile - 1)?;
+        let shape_plus_tile_minus_one = self.compile_binary_op_from_values(
+            module,
+            check_block,
+            shape_dim_value.clone(),
+            tile_minus_one,
+            &TileBinaryOp::Add,
+            generic_vars,
+            ctx,
+            None,
+            span,
+        )?;
+        let div_result_value = self.compile_binary_op_from_values(
+            module,
+            check_block,
+            shape_plus_tile_minus_one,
+            tile_dim_value,
+            &TileBinaryOp::Div,
+            generic_vars,
+            ctx,
+            None,
+            span,
+        )?;
+        let ineq_result_value = self.compile_binary_op_from_values(
+            module,
+            check_block,
+            index_instance,
+            div_result_value,
+            &TileBinaryOp::Lt,
+            generic_vars,
+            ctx,
+            None,
+            span,
+        )?;
+        // Runtime lower guard, only when no static range decided the lower
+        // goal above. For an affine hoisted index the weakest instance
+        // mirrors the strongest one at the opposite loop extreme; otherwise
+        // the raw (invariant or in-place) value is guarded directly.
+        let ineq_result_value = if needs_lower_guard {
+            let guard_operand = match hoist_kind {
+                Some(HoistIndex::InductionAffine {
+                    scale,
+                    offset,
+                    lower,
+                    upper,
+                }) => self.affine_extreme_instance(
+                    module,
+                    check_block,
+                    *lower,
+                    *upper,
+                    *scale,
+                    *offset,
+                    Extreme::Weakest,
+                    &goals.index.ty,
+                    generic_vars,
+                    ctx,
+                    span,
+                )?,
+                _ => goals.index.clone(),
+            };
+            let zero = self.compile_constant(module, check_block, generic_vars, 0)?;
+            let lower_ok = self.compile_binary_op_from_values(
+                module,
+                check_block,
+                guard_operand,
+                zero,
+                &TileBinaryOp::Ge,
+                generic_vars,
+                ctx,
+                None,
+                span,
+            )?;
+            self.compile_binary_op_from_values(
+                module,
+                check_block,
+                lower_ok,
+                ineq_result_value,
+                &TileBinaryOp::BitAnd,
+                generic_vars,
+                ctx,
+                None,
+                span,
+            )?
+        } else {
+            ineq_result_value
+        };
+        // Hoisted checks are guarded against vacuous loops: when
+        // `upper <= lower` the body never runs, so no access exists to
+        // be out of bounds.
+        let checked_value = if let Some((lower, upper)) = guard_bounds {
+            let upper_value =
+                TileRustValue::new_primitive(upper, self.scalar_i32_type(span)?, None);
+            let lower_value =
+                TileRustValue::new_primitive(lower, self.scalar_i32_type(span)?, None);
+            let vacuous = self.compile_binary_op_from_values(
+                module,
+                check_block,
+                upper_value,
+                lower_value,
+                &TileBinaryOp::Le,
+                generic_vars,
+                ctx,
+                None,
+                span,
+            )?;
+            self.compile_binary_op_from_values(
+                module,
+                check_block,
+                vacuous,
+                ineq_result_value,
+                &TileBinaryOp::BitOr,
+                generic_vars,
+                ctx,
+                None,
+                span,
+            )?
+        } else {
+            ineq_result_value
+        };
+        let result_value = checked_value
+            .value
+            .ok_or_else(|| self.jit_error(span, "failed to compile a binary expression operand"))?;
+        let shape_desc = match goals.static_extent {
+            Some(extent) => format!("{extent}"),
+            None => "?".to_string(),
+        };
+        let suffix = if needs_lower_guard {
+            " or index < 0"
+        } else {
+            ""
+        };
+        let message = format!(
+            "partition access out of bounds: dim {axis}, block index >= ceil({shape_desc}/{})\
+             {suffix}",
+            goals.tile
+        );
+        let (assert_op_id, _) = OpBuilder::new(Opcode::Assert, self.ir_location(span))
+            .attr("message", cutile_ir::ir::Attribute::String(message))
+            .operand(result_value)
+            .build(module);
+        append_op(module, check_block, assert_op_id);
+        Ok(())
+    }
+}

--- a/cutile-compiler/src/compiler/compile_binary_op.rs
+++ b/cutile-compiler/src/compiler/compile_binary_op.rs
@@ -21,9 +21,9 @@ use super::tile_rust_type::TileRustType;
 use super::utils::{
     cmp_ordering_attr, cmp_pred_attr, flag_attr, rounding_mode_attr, signedness_attr, NamedAttr,
 };
-use crate::bounds::bounds_from_bop;
 use crate::error::JITError;
 use crate::generics::GenericVars;
+use crate::value_facts;
 
 use cutile_ir::builder::{append_op, OpBuilder};
 use cutile_ir::bytecode::Opcode;
@@ -319,6 +319,18 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                                 .result(operand_result_ty.clone())
                                 .build(module)
                         }
+                        TileBinaryOp::Shl => OpBuilder::new(Opcode::ShLI, self.ir_location(span))
+                            .operand(lhs_value)
+                            .operand(rhs_value)
+                            .attr("overflow", Attribute::i32(0))
+                            .result(operand_result_ty.clone())
+                            .build(module),
+                        TileBinaryOp::Shr => OpBuilder::new(Opcode::ShRI, self.ir_location(span))
+                            .operand(lhs_value)
+                            .operand(rhs_value)
+                            .attr(sign_attr.0, sign_attr.1)
+                            .result(operand_result_ty.clone())
+                            .build(module),
                         _ => {
                             return self.jit_error_result(
                                 span,
@@ -434,7 +446,10 @@ impl<'m> CUDATileFunctionCompiler<'m> {
             }
         };
 
-        let op_bounds = if let (Some(a), Some(b)) = (lhs.bounds, rhs.bounds) {
+        // Value-fact transfer (interval + symbolic), gathered in `value_facts`.
+        // Interval facts require primitive operands; the symbolic term still
+        // propagates when only one side has a range (e.g. an affine index).
+        let facts = if lhs.bounds.is_some() && rhs.bounds.is_some() {
             if !(lhs.kind == Kind::PrimitiveType && rhs.kind == Kind::PrimitiveType) {
                 return self.jit_error_result(
                     span,
@@ -444,11 +459,19 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                     ),
                 );
             }
-            bounds_from_bop(tile_rust_arithmetic_op, &a, &b)
+            let result_domain = return_type
+                .get_instantiated_rust_element_type(&self.modules.primitives())
+                .as_deref()
+                .and_then(value_facts::int_value_domain);
+            value_facts::transfer(tile_rust_arithmetic_op, &lhs, &rhs, result_domain)
         } else {
-            None
+            value_facts::ScalarFacts {
+                bounds: None,
+                term: value_facts::propagate_term(tile_rust_arithmetic_op, &lhs, &rhs),
+                floor_div: value_facts::propagate_floor_div(tile_rust_arithmetic_op, &lhs, &rhs),
+            }
         };
-        if let Some(bounds) = &op_bounds {
+        if let Some(bounds) = &facts.bounds {
             if bounds.is_exact() {
                 // The lower/upper bounds are equivalent — emit a constant
                 // instead. The op allocated above becomes dead (not appended
@@ -468,7 +491,9 @@ impl<'m> CUDATileFunctionCompiler<'m> {
         append_op(module, block_id, op_id);
         let value = results[0];
         let mut tr_value = TileRustValue::new_value_kind_like(value, return_type.clone());
-        tr_value.bounds = op_bounds;
+        tr_value.bounds = facts.bounds;
+        tr_value.term = facts.term;
+        tr_value.floor_div = facts.floor_div;
         Ok(tr_value)
     }
 }

--- a/cutile-compiler/src/compiler/compile_block.rs
+++ b/cutile-compiler/src/compiler/compile_block.rs
@@ -35,7 +35,12 @@ impl<'m> CUDATileFunctionCompiler<'m> {
         };
         matches!(
             ident.to_string().as_str(),
-            "Tensor" | "Partition" | "BoundedPartition" | "PartitionMut" | "MappedPartitionMut"
+            "Tensor"
+                | "Partition"
+                | "BoundedPartition"
+                | "BoundedPartitionMut"
+                | "PartitionMut"
+                | "MappedPartitionMut"
         )
     }
 

--- a/cutile-compiler/src/compiler/compile_cuda_tile_op.rs
+++ b/cutile-compiler/src/compiler/compile_cuda_tile_op.rs
@@ -15,7 +15,7 @@ use super::tile_rust_type::TileRustType;
 use crate::bounds::Bounds;
 use crate::error::JITError;
 use crate::generics::{
-    get_cga_from_generic_argument, get_cga_from_type, GenericVars, TypeInstance,
+    get_cga_from_generic_argument, get_cga_from_type, parse_expr_as_i32, GenericVars, TypeInstance,
 };
 use crate::passes::name_resolution::{DefKind, Res};
 use crate::syn_utils::*;
@@ -28,7 +28,8 @@ use super::utils::*;
 use cutile_ir::builder::{append_op, build_block, OpBuilder};
 use cutile_ir::bytecode::Opcode;
 use cutile_ir::ir::{
-    Attribute, BlockId, Module, PartitionViewType, Region, Type as TileIrType, Value,
+    Attribute, BlockId, GatherScatterViewType, Module, PartitionViewType, Region, StridedViewType,
+    Type as TileIrType, Value,
 };
 
 use quote::ToTokens;
@@ -504,6 +505,9 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                 ctx,
                 return_type,
             ),
+            "cuda_tile.atomic_red_view_tko" => {
+                self.compile_atomic_red_view_tko(module, block_id, call_expr, generic_args, ctx)
+            }
             "load_view_tko" => self.compile_load_view_tko(
                 module,
                 block_id,
@@ -550,6 +554,40 @@ impl<'m> CUDATileFunctionCompiler<'m> {
             "cuda_tile.scan" => {
                 self.compile_scan_op(module, block_id, call_expr, generic_args, ctx)
             }
+            "cuda_tile.make_gather_scatter_view" => self.compile_make_gather_scatter_view(
+                module,
+                block_id,
+                call_expr,
+                generic_args,
+                ctx,
+                return_type.clone(),
+            ),
+            "cuda_tile.make_strided_view" => self.compile_make_strided_view(
+                module,
+                block_id,
+                call_expr,
+                generic_args,
+                ctx,
+                return_type.clone(),
+            ),
+            "cuda_tile.load_gather_scatter_view_tko" => self.compile_load_gather_scatter_view_tko(
+                module,
+                block_id,
+                call_expr,
+                fn_item,
+                generic_args,
+                ctx,
+                return_type,
+            ),
+            "cuda_tile.load_strided_view_tko" => self.compile_load_strided_view_tko(
+                module,
+                block_id,
+                call_expr,
+                fn_item,
+                generic_args,
+                ctx,
+                return_type,
+            ),
             _ => Ok(None),
         }
     }
@@ -1381,6 +1419,170 @@ impl<'m> CUDATileFunctionCompiler<'m> {
             None,
         ));
         Ok(Some(TileRustValue::new_compound(values, return_type_outer)))
+    }
+
+    fn compile_atomic_red_view_tko(
+        &self,
+        module: &mut Module,
+        block_id: BlockId,
+        call_expr: &ExprCall,
+        generic_args: &GenericVars,
+        ctx: &mut CompilerContext,
+    ) -> Result<Option<TileRustValue>, JITError> {
+        let token_result_ir_ty = TileIrType::Token;
+        let view_arg = &call_expr.args[0];
+        let Some(view_value) =
+            self.compile_expression(module, block_id, view_arg, generic_args, ctx, None)?
+        else {
+            return self.jit_error_result(&view_arg.span(), "Unable to compile view");
+        };
+        let Some(cuda_tile_view_value) = view_value.value else {
+            return self.jit_error_result(&view_arg.span(), "Unable to compile view");
+        };
+        let Some(type_meta) = view_value.type_meta.as_ref() else {
+            return self.jit_error_result(&view_arg.span(), "Expected some TypeMeta for view");
+        };
+        let Some(token_value) = type_meta.fields.get("token") else {
+            return self.jit_error_result(
+                &view_arg.span(),
+                "Expected token value in TypeMeta for view",
+            );
+        };
+        let Some(cuda_tile_token) = token_value.value else {
+            return self.jit_error_result(
+                &view_arg.span(),
+                "Expected token value in TypeMeta for view",
+            );
+        };
+        let nested_access_offset = type_meta
+            .fields
+            .get(NESTED_MUTABLE_ACCESS_OFFSET_META)
+            .cloned();
+
+        let value_value = self
+            .compile_expression(
+                module,
+                block_id,
+                &call_expr.args[1],
+                generic_args,
+                ctx,
+                None,
+            )?
+            .ok_or_else(|| {
+                self.jit_error(
+                    &call_expr.args[1].span(),
+                    "unable to compile value for `atomic_red_view_tko`",
+                )
+            })?;
+        let Some(value_val) = value_value.value else {
+            return self.jit_error_result(
+                &call_expr.args[1].span(),
+                "expected a tile value for `atomic_red_view_tko`",
+            );
+        };
+
+        let index_arg = &call_expr.args[2];
+        let index_value = self
+            .compile_expression(module, block_id, index_arg, generic_args, ctx, None)?
+            .ok_or_else(|| self.jit_error(&index_arg.span(), "unable to compile index"))?;
+        let Some(index_elems) = index_value.values else {
+            return self.jit_error_result(&index_arg.span(), "Expected values for index");
+        };
+        let mut index_value_elems = Vec::new();
+        for value in index_elems.into_iter() {
+            if value.value.is_none() {
+                return self.jit_error_result(&index_arg.span(), "unexpected nested array index");
+            }
+            index_value_elems.push(value);
+        }
+        if let Some(access_offset) = nested_access_offset.as_ref() {
+            index_value_elems = self.offset_nested_mutable_indices(
+                module,
+                block_id,
+                &call_expr.span(),
+                access_offset,
+                index_value_elems,
+                generic_args,
+                ctx,
+            )?;
+        }
+        let index_values = index_value_elems
+            .iter()
+            .map(|value| value.value.expect("validated index value"))
+            .collect::<Vec<_>>();
+
+        let mode = super::shared_utils::extract_zst_type_name(&call_expr.args[3], "mode")?;
+        let memory_ordering =
+            super::shared_utils::extract_zst_type_name(&call_expr.args[4], "memory_ordering")?;
+        let memory_scope =
+            super::shared_utils::extract_zst_type_name(&call_expr.args[5], "memory_scope")?;
+
+        if memory_ordering != "Relaxed" {
+            return self.jit_error_result(
+                &call_expr.args[4].span(),
+                &format!(
+                    "invalid `memory_ordering` for `atomic_red_view_tko`: '{memory_ordering}'. Valid: Relaxed"
+                ),
+            );
+        }
+        let memory_ordering_value: i64 = 1;
+        let memory_scope_value: i64 = match memory_scope.as_str() {
+            "TileBlock" => 0,
+            "Device" => 1,
+            _ => {
+                return self.jit_error_result(
+                    &call_expr.args[5].span(),
+                    &format!(
+                        "invalid `memory_scope` for `atomic_red_view_tko`: '{memory_scope}'. Valid: TileBlock, Device"
+                    ),
+                )
+            }
+        };
+        let elem_ty_prefix = view_value
+            .ty
+            .get_cuda_tile_element_type_prefix(&self.modules.primitives())?;
+        let atomic_mode = AtomicMode::new(mode.as_str(), elem_ty_prefix)? as i64;
+
+        let mut all_operands = vec![cuda_tile_view_value];
+        all_operands.extend_from_slice(&index_values);
+        all_operands.push(value_val);
+        all_operands.push(cuda_tile_token);
+        let operand_segments: Vec<i64> = vec![1, index_values.len() as i64, 1, 1];
+
+        let (op_id, results) = OpBuilder::new(
+            Opcode::AtomicRedViewTko,
+            self.ir_location(&call_expr.span()),
+        )
+        .result(token_result_ir_ty)
+        .operands(all_operands.iter().copied())
+        .attr(
+            "memory_ordering_semantics",
+            Attribute::i32(memory_ordering_value),
+        )
+        .attr("memory_scope", Attribute::i32(memory_scope_value))
+        .attr("mode", Attribute::i32(atomic_mode))
+        .attr(
+            "operandSegmentSizes",
+            Attribute::Array(
+                operand_segments
+                    .iter()
+                    .map(|&x| Attribute::i32(x))
+                    .collect(),
+            ),
+        )
+        .build(module);
+        append_op(module, block_id, op_id);
+        let _old = super::shared_utils::update_token(view_arg, results[0], ctx);
+        let Some(var_arg_ident) = get_ident_from_expr(view_arg) else {
+            return self.jit_error_result(&view_arg.span(), "Unexpected expression");
+        };
+        let Some(result) = ctx.vars.get(var_arg_ident.to_string().as_str()) else {
+            return self.jit_error_result(
+                &view_arg.span(),
+                &format!("Unexpected state: Expected {var_arg_ident} in ctx"),
+            );
+        };
+        Ok(Some(result.clone()))
     }
 
     /// Reads `memory_ordering`, `memory_scope` ZST args from a view op call.
@@ -2898,7 +3100,22 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                                         else if op_name == "cuda_tile.get_tile_block_id" { let cb = match i { 0 => const_grid.0, 1 => const_grid.1, 2 => const_grid.2, _ => unreachable!() }; Some(Bounds::new(0i64, cb as i64 - 1)) }
                                         else { None }
                                     } else { None };
-                                    values.push(TileRustValue::new_primitive(op_value, elem_ty.clone(), maybe_bounds));
+                                    let mut prim =
+                                        TileRustValue::new_primitive(op_value, elem_ty.clone(), maybe_bounds);
+                                    // Tag the special-register component with its
+                                    // canonical atom so a partition-access
+                                    // obligation can discharge against the
+                                    // `TileBlockId(k) < NumTileBlocks(k)` axiom.
+                                    if op_name == "cuda_tile.get_tile_block_id" {
+                                        prim.term = Some(cuda_async::predicate::Term::atom(
+                                            cuda_async::predicate::Atom::TileBlockId(i),
+                                        ));
+                                    } else if op_name == "cuda_tile.get_num_tile_blocks" {
+                                        prim.term = Some(cuda_async::predicate::Term::atom(
+                                            cuda_async::predicate::Atom::NumTileBlocks(i),
+                                        ));
+                                    }
+                                    values.push(prim);
                                 }
                                 Kind::StructuredType => { values.push(TileRustValue::new_structured_type(results[i], elem_ty.clone(), None)); }
                                 Kind::Compound | Kind::Struct | Kind::String | Kind::Enum => return self.jit_error_result(&call_expr.span(), &format!("this operation returned an unsupported element type ({:?}); only scalar and structured types are supported", elem_ty.kind)),
@@ -3080,6 +3297,707 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                 &format!("unrecognized macro `{}`", mac_ident),
             ),
         }
+    }
+
+    // ── GatherScatterView / StridedView handlers ─────────────────────────────
+
+    /// Read a scalar `i32` const generic from a return-type annotation at `pos`
+    /// (0-indexed angle-bracket arg, lifetimes excluded). Used for params like
+    /// `SPARSE_DIM` that cannot be inferred from regular function arguments and
+    /// must come from the let binding's type annotation.
+    fn return_type_scalar_generic_arg(
+        &self,
+        return_ty: &TileRustType,
+        generic_args: &GenericVars,
+        pos: usize,
+        fn_name: &str,
+        param_name: &str,
+    ) -> Result<i32, JITError> {
+        let syn::Type::Path(type_path) = &return_ty.rust_ty else {
+            return self.jit_error_result(
+                &return_ty.rust_ty.span(),
+                &format!("{fn_name}: expected a path type for return type annotation"),
+            );
+        };
+        let Some(last_segment) = type_path.path.segments.last() else {
+            return self.jit_error_result(
+                &return_ty.rust_ty.span(),
+                &format!("{fn_name}: missing path segment in return type"),
+            );
+        };
+        let syn::PathArguments::AngleBracketed(args) = &last_segment.arguments else {
+            return self.jit_error_result(
+                &return_ty.rust_ty.span(),
+                &format!("{fn_name}: return type has no generic arguments"),
+            );
+        };
+        let Some(arg) = args.args.iter().nth(pos) else {
+            return self.jit_error_result(
+                &return_ty.rust_ty.span(),
+                &format!(
+                    "{fn_name}: return type missing `{param_name}` at generic argument {}",
+                    pos + 1
+                ),
+            );
+        };
+        let syn::GenericArgument::Const(expr) = arg else {
+            return self.jit_error_result(
+                &return_ty.rust_ty.span(),
+                &format!("{fn_name}: generic argument {pos} for `{param_name}` must be a const expression"),
+            );
+        };
+        Ok(parse_expr_as_i32(expr, generic_args))
+    }
+
+    /// Read an array const generic `[i32; N]` from a return-type annotation at
+    /// `pos` (0-indexed, lifetimes excluded). Used for params like
+    /// `TRAVERSAL_STRIDES` and `DIM_MAP` that must come from the let binding's
+    /// type annotation.
+    fn return_type_cga_generic_arg(
+        &self,
+        return_ty: &TileRustType,
+        generic_args: &GenericVars,
+        pos: usize,
+        fn_name: &str,
+        param_name: &str,
+    ) -> Result<Vec<i32>, JITError> {
+        let syn::Type::Path(type_path) = &return_ty.rust_ty else {
+            return self.jit_error_result(
+                &return_ty.rust_ty.span(),
+                &format!("{fn_name}: expected a path type for return type annotation"),
+            );
+        };
+        let Some(last_segment) = type_path.path.segments.last() else {
+            return self.jit_error_result(
+                &return_ty.rust_ty.span(),
+                &format!("{fn_name}: missing path segment in return type"),
+            );
+        };
+        let syn::PathArguments::AngleBracketed(args) = &last_segment.arguments else {
+            return self.jit_error_result(
+                &return_ty.rust_ty.span(),
+                &format!("{fn_name}: return type has no generic arguments"),
+            );
+        };
+        let Some(arg) = args.args.iter().nth(pos) else {
+            return self.jit_error_result(
+                &return_ty.rust_ty.span(),
+                &format!(
+                    "{fn_name}: return type missing `{param_name}` at generic argument {}",
+                    pos + 1
+                ),
+            );
+        };
+        get_cga_from_generic_argument(arg, generic_args).ok_or_else(|| {
+            self.jit_error(
+                &return_ty.rust_ty.span(),
+                &format!(
+                    "{fn_name}: failed to resolve `{param_name}` from return type argument {pos}"
+                ),
+            )
+        })
+    }
+
+    fn compile_make_gather_scatter_view(
+        &self,
+        module: &mut Module,
+        block_id: BlockId,
+        call_expr: &ExprCall,
+        generic_args: &GenericVars,
+        ctx: &mut CompilerContext,
+        return_type: Option<TileRustType>,
+    ) -> Result<Option<TileRustValue>, JITError> {
+        if call_expr.args.len() != 3 {
+            return self.jit_error_result(
+                &call_expr.span(),
+                &format!(
+                    "make_gather_scatter_view expects 3 arguments, got {}",
+                    call_expr.args.len()
+                ),
+            );
+        }
+        let Some(tensor_value) = self.compile_expression(
+            module,
+            block_id,
+            &call_expr.args[0],
+            generic_args,
+            ctx,
+            None,
+        )?
+        else {
+            return self.jit_error_result(
+                &call_expr.args[0].span(),
+                "failed to compile gather_scatter_view tensor argument",
+            );
+        };
+        let Some(tensor_view_value) = tensor_value.value else {
+            return self.jit_error_result(
+                &call_expr.args[0].span(),
+                "gather_scatter_view tensor must be an SSA value",
+            );
+        };
+        let Some(TileIrType::TensorView(tensor_view_ty)) = tensor_value.ty.tile_ir_ty.clone()
+        else {
+            return self.jit_error_result(
+                &call_expr.args[0].span(),
+                "gather_scatter_view source must be a tensor view",
+            );
+        };
+
+        let Some(shape_value) = self.compile_expression(
+            module,
+            block_id,
+            &call_expr.args[1],
+            generic_args,
+            ctx,
+            None,
+        )?
+        else {
+            return self.jit_error_result(
+                &call_expr.args[1].span(),
+                "failed to compile gather_scatter_view tile shape",
+            );
+        };
+        let tile_shape = match &shape_value.ty.type_instance {
+            TypeInstance::StructuredType(instance) => instance.shape.clone(),
+            _ => get_cga_from_type(&shape_value.ty.rust_ty, generic_args).ok_or_else(|| {
+                self.jit_error(
+                    &call_expr.args[1].span(),
+                    "gather_scatter_view tile shape must be static",
+                )
+            })?,
+        };
+        // SPARSE_DIM is not inferable from the function arguments; read it from
+        // the return-type annotation on the let binding (angle-bracket arg 2:
+        // GatherScatterView<E, TILE_SHAPE, SPARSE_DIM>).
+        let Some(return_ty) = return_type else {
+            return self.jit_error_result(
+                &call_expr.span(),
+                "make_gather_scatter_view: add a return type annotation to specify SPARSE_DIM \
+                (e.g. `let gsv: GatherScatterView<f32, {[8,64]}, 0> = ...`)",
+            );
+        };
+        let sparse_dim = self.return_type_scalar_generic_arg(
+            &return_ty,
+            generic_args,
+            2,
+            "make_gather_scatter_view",
+            "SPARSE_DIM",
+        )?;
+
+        let element_type = tensor_value
+            .ty
+            .get_instantiated_rust_element_type(&self.modules.primitives())
+            .ok_or_else(|| {
+                self.jit_error(
+                    &call_expr.args[0].span(),
+                    "failed to determine gather_scatter_view element type",
+                )
+            })?;
+        let shape_expr = format!(
+            "{{[{}]}}",
+            tile_shape
+                .iter()
+                .map(|d| d.to_string())
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+        let rust_ty: Type = syn::parse2(
+            format!("GatherScatterView<{element_type}, {shape_expr}, {sparse_dim}>")
+                .parse()
+                .unwrap(),
+        )
+        .unwrap();
+        let type_instance = generic_args.instantiate_type(&rust_ty, self.modules.primitives())?;
+        let return_type = TileRustType {
+            cuda_tile_ty_str: None,
+            tile_ir_ty: Some(TileIrType::GatherScatterView(GatherScatterViewType {
+                tile_shape: tile_shape.clone(),
+                tensor_view: tensor_view_ty,
+                sparse_dim,
+                padding_value: None,
+            })),
+            cuda_tile_name: Some("!cuda_tile.gather_scatter_view".to_string()),
+            params: vec![],
+            rust_ty,
+            type_instance,
+            kind: Kind::StructuredType,
+        };
+
+        let result_ir_ty = super::_type::convert_type(&return_type).ok_or_else(|| {
+            self.jit_error(
+                &call_expr.span(),
+                "failed to convert gather_scatter_view return type",
+            )
+        })?;
+        let (op_id, results) = OpBuilder::new(
+            Opcode::MakeGatherScatterView,
+            self.ir_location(&call_expr.span()),
+        )
+        .operand(tensor_view_value)
+        .result(result_ir_ty)
+        .build(module);
+        append_op(module, block_id, op_id);
+        let mut result = TileRustValue::new_structured_type(results[0], return_type, None);
+        result.tensor_origin = tensor_value.tensor_origin;
+        Ok(Some(result))
+    }
+
+    fn compile_make_strided_view(
+        &self,
+        module: &mut Module,
+        block_id: BlockId,
+        call_expr: &ExprCall,
+        generic_args: &GenericVars,
+        ctx: &mut CompilerContext,
+        return_type: Option<TileRustType>,
+    ) -> Result<Option<TileRustValue>, JITError> {
+        if call_expr.args.len() != 3 {
+            return self.jit_error_result(
+                &call_expr.span(),
+                &format!(
+                    "make_strided_view expects 3 arguments, got {}",
+                    call_expr.args.len()
+                ),
+            );
+        }
+        let Some(tensor_value) = self.compile_expression(
+            module,
+            block_id,
+            &call_expr.args[0],
+            generic_args,
+            ctx,
+            None,
+        )?
+        else {
+            return self.jit_error_result(
+                &call_expr.args[0].span(),
+                "failed to compile strided_view tensor argument",
+            );
+        };
+        let Some(tensor_view_value) = tensor_value.value else {
+            return self.jit_error_result(
+                &call_expr.args[0].span(),
+                "strided_view tensor must be an SSA value",
+            );
+        };
+        let Some(TileIrType::TensorView(tensor_view_ty)) = tensor_value.ty.tile_ir_ty.clone()
+        else {
+            return self.jit_error_result(
+                &call_expr.args[0].span(),
+                "strided_view source must be a tensor view",
+            );
+        };
+
+        let Some(shape_value) = self.compile_expression(
+            module,
+            block_id,
+            &call_expr.args[1],
+            generic_args,
+            ctx,
+            None,
+        )?
+        else {
+            return self.jit_error_result(
+                &call_expr.args[1].span(),
+                "failed to compile strided_view tile shape",
+            );
+        };
+        let tile_shape = match &shape_value.ty.type_instance {
+            TypeInstance::StructuredType(instance) => instance.shape.clone(),
+            _ => get_cga_from_type(&shape_value.ty.rust_ty, generic_args).ok_or_else(|| {
+                self.jit_error(
+                    &call_expr.args[1].span(),
+                    "strided_view tile shape must be static",
+                )
+            })?,
+        };
+        // TRAVERSAL_STRIDES and DIM_MAP are not inferable from the function
+        // arguments; read them from the return-type annotation on the let binding
+        // (angle-bracket args 2 and 3:
+        // StridedView<E, TILE_SHAPE, TRAVERSAL_STRIDES, DIM_MAP>).
+        let Some(return_ty) = return_type else {
+            return self.jit_error_result(
+                &call_expr.span(),
+                "make_strided_view: add a return type annotation to specify TRAVERSAL_STRIDES and \
+                DIM_MAP (e.g. `let sv: StridedView<f32, {[16,16]}, {[2,1]}, {[0,1]}> = ...`)",
+            );
+        };
+        let traversal_strides = self.return_type_cga_generic_arg(
+            &return_ty,
+            generic_args,
+            2,
+            "make_strided_view",
+            "TRAVERSAL_STRIDES",
+        )?;
+        let dim_map = self.return_type_cga_generic_arg(
+            &return_ty,
+            generic_args,
+            3,
+            "make_strided_view",
+            "DIM_MAP",
+        )?;
+
+        let element_type = tensor_value
+            .ty
+            .get_instantiated_rust_element_type(&self.modules.primitives())
+            .ok_or_else(|| {
+                self.jit_error(
+                    &call_expr.args[0].span(),
+                    "failed to determine strided_view element type",
+                )
+            })?;
+        let shape_expr = format!(
+            "{{[{}]}}",
+            tile_shape
+                .iter()
+                .map(|d| d.to_string())
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+        let strides_expr = format!(
+            "{{[{}]}}",
+            traversal_strides
+                .iter()
+                .map(|d| d.to_string())
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+        let dim_map_expr = format!(
+            "{{[{}]}}",
+            dim_map
+                .iter()
+                .map(|d| d.to_string())
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+        let rust_ty: Type = syn::parse2(
+            format!("StridedView<{element_type}, {shape_expr}, {strides_expr}, {dim_map_expr}>")
+                .parse()
+                .unwrap(),
+        )
+        .unwrap();
+        let type_instance = generic_args.instantiate_type(&rust_ty, self.modules.primitives())?;
+        let return_type = TileRustType {
+            cuda_tile_ty_str: None,
+            tile_ir_ty: Some(TileIrType::StridedView(StridedViewType {
+                tile_shape: tile_shape.clone(),
+                traversal_strides,
+                tensor_view: tensor_view_ty,
+                dim_map,
+                padding_value: None,
+            })),
+            cuda_tile_name: Some("!cuda_tile.strided_view".to_string()),
+            params: vec![],
+            rust_ty,
+            type_instance,
+            kind: Kind::StructuredType,
+        };
+
+        let result_ir_ty = super::_type::convert_type(&return_type).ok_or_else(|| {
+            self.jit_error(
+                &call_expr.span(),
+                "failed to convert strided_view return type",
+            )
+        })?;
+        let (op_id, results) =
+            OpBuilder::new(Opcode::MakeStridedView, self.ir_location(&call_expr.span()))
+                .operand(tensor_view_value)
+                .result(result_ir_ty)
+                .build(module);
+        append_op(module, block_id, op_id);
+        let mut result = TileRustValue::new_structured_type(results[0], return_type, None);
+        result.tensor_origin = tensor_value.tensor_origin;
+        Ok(Some(result))
+    }
+
+    fn compile_load_gather_scatter_view_tko(
+        &self,
+        module: &mut Module,
+        block_id: BlockId,
+        call_expr: &ExprCall,
+        fn_item: &ItemFn,
+        generic_args: &GenericVars,
+        ctx: &mut CompilerContext,
+        return_type: Option<TileRustType>,
+    ) -> Result<Option<TileRustValue>, JITError> {
+        let return_type_outer = match return_type {
+            Some(rt) => rt,
+            None => {
+                return self.jit_error_result(
+                    &call_expr.span(),
+                    "unable to infer call; add a return type annotation",
+                )
+            }
+        };
+        let Type::Tuple(tuple_type) = &return_type_outer.rust_ty else {
+            return self.jit_error_result(
+                &call_expr.span(),
+                "expected a tuple return type for load_gather_scatter_view_tko",
+            );
+        };
+        let tile_elem_ty = self
+            .compile_type(&tuple_type.elems[0], generic_args, &HashMap::new())?
+            .unwrap();
+        let token_elem_ty = self
+            .compile_type(&tuple_type.elems[1], generic_args, &HashMap::new())?
+            .unwrap();
+        let tile_result_ir_ty = super::_type::convert_type(&tile_elem_ty)
+            .expect("failed to convert tile result type for load_gather_scatter_view_tko");
+
+        let Some(view_value) = self.compile_expression(
+            module,
+            block_id,
+            &call_expr.args[0],
+            generic_args,
+            ctx,
+            None,
+        )?
+        else {
+            return self.jit_error_result(&call_expr.args[0].span(), "unable to compile view");
+        };
+        let Some(cuda_tile_view_value) = view_value.value else {
+            return self.jit_error_result(&call_expr.args[0].span(), "unable to compile view");
+        };
+
+        let Some(sparse_value) = self.compile_expression(
+            module,
+            block_id,
+            &call_expr.args[1],
+            generic_args,
+            ctx,
+            None,
+        )?
+        else {
+            return self
+                .jit_error_result(&call_expr.args[1].span(), "unable to compile sparse_index");
+        };
+        let Some(cuda_tile_sparse_index) = sparse_value.value else {
+            return self.jit_error_result(
+                &call_expr.args[1].span(),
+                "sparse_index must be an SSA value",
+            );
+        };
+
+        let Some(dense_value) = self.compile_expression(
+            module,
+            block_id,
+            &call_expr.args[2],
+            generic_args,
+            ctx,
+            None,
+        )?
+        else {
+            return self
+                .jit_error_result(&call_expr.args[2].span(), "unable to compile dense_index");
+        };
+        let Some(cuda_tile_dense_index) = dense_value.value else {
+            return self.jit_error_result(
+                &call_expr.args[2].span(),
+                "dense_index must be an SSA value",
+            );
+        };
+
+        let Some(token_value) = self.compile_expression(
+            module,
+            block_id,
+            &call_expr.args[3],
+            generic_args,
+            ctx,
+            None,
+        )?
+        else {
+            return self.jit_error_result(&call_expr.args[3].span(), "unable to compile token");
+        };
+        let Some(cuda_tile_token) = token_value.value else {
+            return self.jit_error_result(&call_expr.args[3].span(), "token must be an SSA value");
+        };
+
+        let fn_params = get_sig_param_names(&fn_item.sig);
+        let (memory_ordering_value, memory_scope_value, memory_ordering) = self
+            .read_view_ordering_scope(
+                &fn_params,
+                call_expr,
+                "load_gather_scatter_view_tko",
+                true,
+            )?;
+
+        let all_operands = vec![
+            cuda_tile_view_value,
+            cuda_tile_sparse_index,
+            cuda_tile_dense_index,
+            cuda_tile_token,
+        ];
+        let operand_segments: Vec<i64> = vec![1, 2, 1];
+
+        let mut op_builder =
+            OpBuilder::new(Opcode::LoadViewTko, self.ir_location(&call_expr.span()))
+                .result(tile_result_ir_ty)
+                .result(TileIrType::Token)
+                .operands(all_operands.iter().copied())
+                .attr(
+                    "memory_ordering_semantics",
+                    Attribute::i32(memory_ordering_value),
+                )
+                .attr(
+                    "operandSegmentSizes",
+                    Attribute::Array(
+                        operand_segments
+                            .iter()
+                            .map(|&x| Attribute::i32(x))
+                            .collect(),
+                    ),
+                );
+        if memory_ordering != "Weak" {
+            op_builder = op_builder.attr("memory_scope", Attribute::i32(memory_scope_value));
+        }
+        let (op_id, results) = op_builder.build(module);
+        append_op(module, block_id, op_id);
+        let mut values = vec![];
+        values.push(TileRustValue::new_structured_type(
+            results[0],
+            tile_elem_ty,
+            None,
+        ));
+        values.push(TileRustValue::new_primitive(
+            results[1],
+            token_elem_ty,
+            None,
+        ));
+        Ok(Some(TileRustValue::new_compound(values, return_type_outer)))
+    }
+
+    fn compile_load_strided_view_tko(
+        &self,
+        module: &mut Module,
+        block_id: BlockId,
+        call_expr: &ExprCall,
+        fn_item: &ItemFn,
+        generic_args: &GenericVars,
+        ctx: &mut CompilerContext,
+        return_type: Option<TileRustType>,
+    ) -> Result<Option<TileRustValue>, JITError> {
+        let return_type_outer = match return_type {
+            Some(rt) => rt,
+            None => {
+                return self.jit_error_result(
+                    &call_expr.span(),
+                    "unable to infer call; add a return type annotation",
+                )
+            }
+        };
+        let Type::Tuple(tuple_type) = &return_type_outer.rust_ty else {
+            return self.jit_error_result(
+                &call_expr.span(),
+                "expected a tuple return type for load_strided_view_tko",
+            );
+        };
+        let tile_elem_ty = self
+            .compile_type(&tuple_type.elems[0], generic_args, &HashMap::new())?
+            .unwrap();
+        let token_elem_ty = self
+            .compile_type(&tuple_type.elems[1], generic_args, &HashMap::new())?
+            .unwrap();
+        let tile_result_ir_ty = super::_type::convert_type(&tile_elem_ty)
+            .expect("failed to convert tile result type for load_strided_view_tko");
+
+        let Some(view_value) = self.compile_expression(
+            module,
+            block_id,
+            &call_expr.args[0],
+            generic_args,
+            ctx,
+            None,
+        )?
+        else {
+            return self.jit_error_result(&call_expr.args[0].span(), "unable to compile view");
+        };
+        let Some(cuda_tile_view_value) = view_value.value else {
+            return self.jit_error_result(&call_expr.args[0].span(), "unable to compile view");
+        };
+
+        let index_arg = &call_expr.args[1];
+        let index_arg_str = index_arg.to_token_stream().to_string();
+        let index_value = self
+            .compile_expression(module, block_id, index_arg, generic_args, ctx, None)?
+            .unwrap();
+        if index_value.values.is_none() {
+            return self.jit_error_result(&call_expr.args[1].span(), "expected values for index");
+        }
+        let mut index_value_elems = Vec::new();
+        for value in index_value.values.unwrap().into_iter() {
+            if value.value.is_none() {
+                return self.jit_error_result(
+                    &call_expr.args[1].span(),
+                    &format!("unexpected nested array {index_arg_str}"),
+                );
+            }
+            index_value_elems.push(value);
+        }
+        let index_values: Vec<Value> = index_value_elems
+            .iter()
+            .map(|v| v.value.expect("validated index value"))
+            .collect();
+
+        let Some(token_value) = self.compile_expression(
+            module,
+            block_id,
+            &call_expr.args[2],
+            generic_args,
+            ctx,
+            None,
+        )?
+        else {
+            return self.jit_error_result(&call_expr.args[2].span(), "unable to compile token");
+        };
+        let Some(cuda_tile_token) = token_value.value else {
+            return self.jit_error_result(&call_expr.args[2].span(), "token must be an SSA value");
+        };
+
+        let fn_params = get_sig_param_names(&fn_item.sig);
+        let (memory_ordering_value, memory_scope_value, memory_ordering) =
+            self.read_view_ordering_scope(&fn_params, call_expr, "load_strided_view_tko", true)?;
+
+        let mut all_operands = vec![cuda_tile_view_value];
+        all_operands.extend_from_slice(&index_values);
+        all_operands.push(cuda_tile_token);
+        let operand_segments: Vec<i64> = vec![1, index_values.len() as i64, 1];
+
+        let mut op_builder =
+            OpBuilder::new(Opcode::LoadViewTko, self.ir_location(&call_expr.span()))
+                .result(tile_result_ir_ty)
+                .result(TileIrType::Token)
+                .operands(all_operands.iter().copied())
+                .attr(
+                    "memory_ordering_semantics",
+                    Attribute::i32(memory_ordering_value),
+                )
+                .attr(
+                    "operandSegmentSizes",
+                    Attribute::Array(
+                        operand_segments
+                            .iter()
+                            .map(|&x| Attribute::i32(x))
+                            .collect(),
+                    ),
+                );
+        if memory_ordering != "Weak" {
+            op_builder = op_builder.attr("memory_scope", Attribute::i32(memory_scope_value));
+        }
+        let (op_id, results) = op_builder.build(module);
+        append_op(module, block_id, op_id);
+        let mut values = vec![];
+        values.push(TileRustValue::new_structured_type(
+            results[0],
+            tile_elem_ty,
+            None,
+        ));
+        values.push(TileRustValue::new_primitive(
+            results[1],
+            token_elem_ty,
+            None,
+        ));
+        Ok(Some(TileRustValue::new_compound(values, return_type_outer)))
     }
 }
 

--- a/cutile-compiler/src/compiler/compile_expression.rs
+++ b/cutile-compiler/src/compiler/compile_expression.rs
@@ -11,14 +11,14 @@
 
 use super::_function::CUDATileFunctionCompiler;
 use super::_value::{
-    BlockTerminator, CompilerContext, DimOrigin, PartitionAxisOrigin, TileRustValue,
+    BlockTerminator, CompilerContext, DimOrigin, LoopFrame, PartitionAxisOrigin, TileRustValue,
 };
 use super::shared_types::Kind;
 use super::shared_utils::{
     collect_mutated_variables, collect_mutated_variables_from_block,
     collect_mutated_variables_from_expr, collect_mutated_variables_loop,
     collect_mutated_variables_while, dedup, update_outer_block_type_meta, TileBinaryOp,
-    STACK_GROW_SIZE, STACK_RED_ZONE,
+    MAX_MAPPED_PARTITION_RANK, OWNED_MAP_DIM, STACK_GROW_SIZE, STACK_RED_ZONE,
 };
 use super::tile_rust_type::TileRustType;
 use crate::bounds::Bounds;
@@ -43,6 +43,31 @@ use syn::parse::Parser;
 use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
 use syn::{parse_quote, Expr, ExprForLoop, ExprMacro, Lit, Member, Pat, Token, UnOp};
+
+/// A per-tensor ordering-token accumulator threaded through a loop. The loop
+/// carries the tensor's token (a bare `token`, never the view); each store in
+/// the body joins its output into it; the loop result is published to the tensor
+/// at exit. Orders any later access to the tensor after all of the loop's writes.
+pub(crate) struct LoopTokenAcc {
+    /// Synthetic carry-var name holding the accumulator token.
+    acc_var: String,
+    /// The root tensor whose token the accumulator publishes.
+    root: String,
+    /// Views written in the body that root at `root`; rebound to the published
+    /// token after the loop so a trailing store through them stays ordered.
+    receivers: Vec<String>,
+    /// True if this loop created the accumulator; false if it inherited one from
+    /// an enclosing loop (nested loops writing the same tensor). Only the owner
+    /// publishes the result to the tensor and drops the carry variable — a
+    /// non-owner's result is left for the enclosing loop to carry further.
+    owner: bool,
+    /// True if some store to this tensor has a non-distinct index (a
+    /// constant/repeated address, not varying with the loop variable). Those
+    /// writes overlap, so the views are rebound to read the carried accumulator
+    /// token — the stores serialize (each ordered after the previous). Distinct
+    /// (branded) writes keep reading their invariant view token and fork.
+    serialize: bool,
+}
 
 impl<'m> CUDATileFunctionCompiler<'m> {
     /// Construct a ZST marker type placeholder from a path expression.
@@ -265,7 +290,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
         format!("{{ [{dims}] }}")
     }
 
-    fn mapped_partition_type_shapes(
+    pub(crate) fn mapped_partition_type_shapes(
         &self,
         value: &TileRustValue,
         generic_vars: &GenericVars,
@@ -308,13 +333,22 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                 "failed to resolve MappedPartitionMut map-shape const generic array",
             );
         };
-        if tile_shape.len() != 2 || map_shape.len() != 2 {
+        if tile_shape.len() != map_shape.len() {
             return self.jit_error_result(
                 span,
                 &format!(
-                    "`iter_indices()` currently supports rank-2 MappedPartitionMut values, got tile rank {} and map rank {}",
+                    "`iter_indices()` requires matching tile and map ranks, got tile rank {} and map rank {}",
                     tile_shape.len(),
                     map_shape.len()
+                ),
+            );
+        }
+        if tile_shape.is_empty() || tile_shape.len() > MAX_MAPPED_PARTITION_RANK {
+            return self.jit_error_result(
+                span,
+                &format!(
+                    "`iter_indices()` supports rank-1 through rank-{MAX_MAPPED_PARTITION_RANK} MappedPartitionMut values, got rank {}",
+                    tile_shape.len(),
                 ),
             );
         }
@@ -373,7 +407,20 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                         None
                     }
                 });
-                TileRustValue::new_primitive(value, i32_ty.clone(), bounds)
+                let mut result = TileRustValue::new_primitive(value, i32_ty.clone(), bounds);
+                // Tag the special-register value with its canonical atom so a
+                // partition-access obligation can discharge against the universal
+                // `TileBlockId(k) < NumTileBlocks(k)` hardware axiom.
+                if is_tile_block_id {
+                    result.term = Some(cuda_async::predicate::Term::atom(
+                        cuda_async::predicate::Atom::TileBlockId(axis),
+                    ));
+                } else if is_num_tile_blocks {
+                    result.term = Some(cuda_async::predicate::Term::atom(
+                        cuda_async::predicate::Atom::NumTileBlocks(axis),
+                    ));
+                }
+                result
             })
             .collect()
     }
@@ -400,10 +447,12 @@ impl<'m> CUDATileFunctionCompiler<'m> {
             );
         };
         let rank = pv.tile_shape.len();
-        if rank != 2 {
+        if rank == 0 || rank > MAX_MAPPED_PARTITION_RANK {
             return self.jit_error_result(
                 span,
-                &format!("`iter_indices()` currently supports rank-2 partitions, got rank {rank}"),
+                &format!(
+                    "`iter_indices()` supports rank-1 through rank-{MAX_MAPPED_PARTITION_RANK} partitions, got rank {rank}"
+                ),
             );
         }
 
@@ -633,7 +682,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                 "`Partition::with_bounds` expects exactly one tuple argument",
             );
         }
-        let mut partition = self
+        let partition = self
             .compile_expression(
                 module,
                 block_id,
@@ -666,29 +715,81 @@ impl<'m> CUDATileFunctionCompiler<'m> {
         let Some(bound_values) = bounds.values else {
             return self.jit_error_result(
                 &method_call.args[0].span(),
-                "`Partition::with_bounds` expects a rank-2 tuple",
+                "`Partition::with_bounds` expects a tuple of dimensions",
             );
         };
-        if bound_values.len() != 2 {
+        self.apply_with_bounds(
+            module,
+            block_id,
+            partition,
+            bound_values,
+            return_type,
+            generic_vars,
+            ctx,
+            &method_call.args[0].span(),
+        )
+        .map(Some)
+    }
+
+    /// Bind a `Dim` per axis to `partition`, verifying each binding and
+    /// retyping the result as the matching `Bounded*` partition.
+    ///
+    /// `with_bounds` is reachable two ways — as a method call, intercepted
+    /// before inlining, and as the `partition_with_bounds` compiler op, which
+    /// is `pub` and so callable directly. Both spellings must mean exactly the
+    /// same thing, so both route here. They previously carried separate copies
+    /// of this logic that had already drifted (differing diagnostics, and only
+    /// one of them was ever exercised).
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn apply_with_bounds(
+        &self,
+        module: &mut Module,
+        block_id: BlockId,
+        mut partition: TileRustValue,
+        bound_values: Vec<TileRustValue>,
+        return_type: Option<TileRustType>,
+        generic_vars: &GenericVars,
+        ctx: &mut CompilerContext,
+        span: &proc_macro2::Span,
+    ) -> Result<TileRustValue, JITError> {
+        let (static_tile, _, _) = self.partition_static_geometry(&partition, span)?;
+        if bound_values.len() != static_tile.len() {
             return self.jit_error_result(
-                &method_call.args[0].span(),
+                span,
                 &format!(
-                    "`Partition::with_bounds` expects rank-2 bounds, got rank {}",
+                    "`Partition::with_bounds` expects rank-{} bounds for this partition, got rank {}",
+                    static_tile.len(),
                     bound_values.len()
                 ),
             );
         }
         let mut dim_origins = Vec::with_capacity(bound_values.len());
+        // The partition's index-space shape is one op serving every axis. Built
+        // on first use (a binding that folds at JIT never needs it) and shared
+        // across the rest, so a rank-n `with_bounds` costs at most one query
+        // rather than n.
+        let mut index_space_shape: Option<Vec<cutile_ir::ir::Value>> = None;
         for (axis, value) in bound_values.into_iter().enumerate() {
-            let origin = Self::value_dim_origin(&value);
-            let Some(origin) = origin else {
+            let Some(origin) = Self::value_dim_origin(&value) else {
                 return self.jit_error_result(
-                    &method_call.args[0].span(),
+                    span,
                     &format!(
                         "`Partition::with_bounds` bound {axis} must come from `num_tiles`, `Dim::new`, or `IntoDim::into_dim`"
                     ),
                 );
             };
+            // The binding is a claim; verify it (see the helper's doc).
+            self.emit_with_bounds_binding_check(
+                module,
+                block_id,
+                &partition,
+                &value,
+                axis,
+                generic_vars,
+                ctx,
+                &mut index_space_shape,
+                span,
+            )?;
             dim_origins.push(origin);
         }
         let return_type = match return_type {
@@ -697,17 +798,21 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                 let mut bounded_ty = partition.ty.rust_ty.clone();
                 let syn::Type::Path(path_ty) = &mut bounded_ty else {
                     return self.jit_error_result(
-                        &method_call.receiver.span(),
+                        span,
                         "expected a partition type for `Partition::with_bounds`",
                     );
                 };
                 let Some(segment) = path_ty.path.segments.last_mut() else {
                     return self.jit_error_result(
-                        &method_call.receiver.span(),
+                        span,
                         "expected a partition type path for `Partition::with_bounds`",
                     );
                 };
-                segment.ident = syn::Ident::new("BoundedPartition", segment.ident.span());
+                // Derive the bounded name from the receiver's own ident rather
+                // than naming one target: `PartitionMut` must become
+                // `BoundedPartitionMut`, not `BoundedPartition`.
+                segment.ident =
+                    syn::Ident::new(&format!("Bounded{}", segment.ident), segment.ident.span());
                 let mut return_type = partition.ty.clone();
                 return_type.rust_ty = bounded_ty;
                 return_type
@@ -715,7 +820,321 @@ impl<'m> CUDATileFunctionCompiler<'m> {
         };
         partition.ty = return_type;
         partition.bounded_axes = Some(dim_origins);
-        Ok(Some(partition))
+        Ok(partition)
+    }
+
+    /// Reduce a `with_bounds` binding to a divisibility predicate, when the
+    /// bound `Dim` is `floor(e / t)` over exactly the extent and tile extent
+    /// this axis is partitioned by.
+    ///
+    /// The binding obliges `val(m) == tiles(P, axis) == ceil(e / t)`. With
+    /// `val(m) == floor(e / t)`, the two agree precisely when `t` divides `e`,
+    /// so the whole obligation collapses to `divisible_by(e, t)` — stated over
+    /// the extent atom that already exists, with no new vocabulary.
+    ///
+    /// Returns `None` whenever any part of that shape is not established: a
+    /// different divisor, an unlabelled extent, or a numerator the compiler
+    /// cannot relate to this axis's extent. The caller then falls through to
+    /// the device assert — fail closed (SC4). The extent atom's frame comes
+    /// from [`Self::extent_atom`] (SC1).
+    fn with_bounds_divisibility(
+        &self,
+        partition: &TileRustValue,
+        bound: &TileRustValue,
+        dim_map: &[i32],
+        axis: usize,
+        tile_dim: i64,
+    ) -> Option<cuda_async::predicate::Predicate> {
+        use crate::passes::obligation::{resolve, Obligation, Resolution};
+        use cuda_async::predicate::{Predicate, Term};
+        // The `Dim`'s scalar lives in a `size` field; look there too.
+        let floor_div = bound.floor_div.as_ref().or_else(|| {
+            bound
+                .fields
+                .as_ref()
+                .and_then(|fields| fields.get("size"))
+                .and_then(|size| size.floor_div.as_ref())
+        })?;
+        // The division must be by this axis's tile extent, or it says nothing
+        // about this axis's tile count.
+        if floor_div.divisor != tile_dim {
+            return None;
+        }
+        // ...and the numerator must be this axis's extent.
+        let param = *self.param_index.get(partition.tensor_origin.as_ref()?)?;
+        let tensor_axis = *dim_map.get(axis).filter(|&&d| d >= 0)? as usize;
+        let expected = Term::atom(self.extent_atom(param, tensor_axis));
+        if floor_div.numerator == expected {
+            return Predicate::divisible_by(expected, tile_dim);
+        }
+        // Cross-tensor binding (Theorem 2): the `Dim` divides a *different*
+        // tensor's extent — the GEMM contraction pattern, `k` derived from `x`
+        // but also bound to an axis of `y`. The reduction still applies when
+        // the two extents are equal, and that equality is precisely what a
+        // declared `preconditions` dim fact states — already verified by the
+        // launcher before the kernel runs. So the binding discharges from the
+        // *declared* equality plus the numerator's own divisibility check (the
+        // very predicate the sibling binding emits): one check decides both.
+        //
+        // Entailed-only, deliberately. An *unproven* equality here also ranges
+        // over launch-known operands, so `resolve` would happily hoist it — but
+        // extent equality is strictly stronger than tile-count equality
+        // (`ceil(100/64) == ceil(128/64)` with unequal extents), so hoisting it
+        // unasked would reject launches today's device assert accepts. The
+        // kernel must opt in by declaring the fact; otherwise fail closed.
+        let equality = Obligation::new(
+            Predicate::eq(&floor_div.numerator, &expected)?,
+            "with_bounds shared-extent binding",
+        );
+        if matches!(resolve(&equality, &self.assumptions), Resolution::Jit) {
+            return Predicate::divisible_by(floor_div.numerator.clone(), tile_dim);
+        }
+        None
+    }
+
+    /// Verify one `with_bounds` binding at run time: the declared `Dim` must
+    /// equal this partition's tile count for `axis`.
+    ///
+    /// `with_bounds` binds a symbolic extent (a `Dim`) to `(partition, axis)`.
+    /// Binding the *same* `Dim` to several partitions is how a kernel states
+    /// that those axes share an extent — a GEMM binds one `Dim` to `x`'s axis 1
+    /// and `y`'s axis 0 to name the contraction dimension. So a binding is a
+    /// **claim**, and nothing else verifies it: unchecked, a wrong `Dim`
+    /// discharges every branded access on that axis and admits an out-of-bounds
+    /// access from safe code (both on stores and on loads).
+    ///
+    /// Emitted once per binding at the `with_bounds` site — loop-invariant in
+    /// practice — never per access. The cost is therefore O(bindings), not
+    /// O(accesses): the per-access checks stay discharged by the brand, so the
+    /// register win on hot loops is unaffected.
+    ///
+    /// Static and launch-resolvable bindings are handled before this fallback.
+    /// The remaining dynamic forms deliberately keep this device comparison:
+    /// `with_bounds` is deprecated, and preserving its safety is more valuable
+    /// than expanding the solver solely to optimize its residual cases.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn emit_with_bounds_binding_check(
+        &self,
+        module: &mut Module,
+        block_id: BlockId,
+        partition: &TileRustValue,
+        bound: &TileRustValue,
+        axis: usize,
+        generic_vars: &GenericVars,
+        ctx: &mut CompilerContext,
+        index_space_shape: &mut Option<Vec<cutile_ir::ir::Value>>,
+        span: &proc_macro2::Span,
+    ) -> Result<(), JITError> {
+        // The declared extent: the `Dim`'s runtime value.
+        let declared = bound.value.or_else(|| {
+            bound
+                .fields
+                .as_ref()
+                .and_then(|fields| fields.get("size"))
+                .and_then(|size| size.value)
+        });
+        let (Some(declared), Some(view_value)) = (declared, partition.value) else {
+            return Ok(());
+        };
+        let view_ty = module.value_type(view_value).clone();
+        let cutile_ir::ir::Type::PartitionView(pv) = &view_ty else {
+            return Ok(());
+        };
+        let rank = pv.tile_shape.len();
+        if axis >= rank {
+            return Ok(());
+        }
+        // Discharge at JIT where possible — this is the zero-cost path.
+        //
+        // FRAME INVARIANT (SC2, and the reason this is sound): the declared
+        // parameter shape may stand in for the view extent only for parameter
+        // kinds where the two coincide. That holds for every kind that can reach
+        // here, because `with_bounds` exists solely on `Partition` and
+        // `PartitionMut`: an immutable `&Tensor` has view == root, and a
+        // `&mut Tensor`'s declared shape *is* its per-CTA slab. It does NOT hold
+        // for a `MappedPartitionMut`, whose declared shape is the *tile* shape —
+        // if `with_bounds` is ever added to that type, this fold becomes wrong
+        // and must first gate on the parameter kind. See
+        // `.internal/tasks/in_progress/check_hoisting/BOUNDS_HOISTING_ANALYSIS.md` §SC1 amendment.
+        //
+        // The *declared* parameter shape is enforced at launch (the generated
+        // launcher asserts `valid_shape == given_shape`), so the compiler may
+        // trust it as this view's extent. That matters because the partition
+        // view type carries `-1` for a `&mut Tensor` param by design, while the
+        // validator still knows the declared shape. If both that extent and the
+        // declared `Dim` are known, the binding is decided at compile time and
+        // costs nothing at run time.
+        let tile_dim = pv.tile_shape[axis] as i64;
+        let declared_extent = self.declared_view_extent(partition, &pv.dim_map, axis);
+        let declared_const = bound
+            .bounds
+            .filter(|b| b.is_exact())
+            .map(|b| b.start)
+            .or_else(|| {
+                bound
+                    .fields
+                    .as_ref()
+                    .and_then(|fields| fields.get("size"))
+                    .and_then(|size| size.bounds)
+                    .filter(|b| b.is_exact())
+                    .map(|b| b.start)
+            });
+        if let (Some(extent), Some(dim_value)) = (declared_extent, declared_const) {
+            if extent >= 0 && tile_dim > 0 {
+                let expected = (extent as i64 + tile_dim - 1) / tile_dim;
+                if dim_value == expected {
+                    return Ok(());
+                }
+                return self.jit_error_result(
+                    span,
+                    &format!(
+                        "`with_bounds` bound {axis} is {dim_value}, but this partition has {expected} tiles on axis {axis}"
+                    ),
+                );
+            }
+        }
+        // Launch rung. Neither side folded, so the binding is about to cost a
+        // device assert. But when the bound `Dim` is `floor(e / t)` for the very
+        // extent and tile this axis is partitioned by, the obligation
+        // `val(m) == ceil(e / t)` is exactly `t` divides `e` — a predicate the
+        // existing vocabulary can state over the extent atom itself.
+        //
+        // Reducing to divisibility rather than naming the division as an atom is
+        // what keeps this discharge-able: a declared `preconditions` fact
+        // asserting the divisibility entails it, so `resolve` can settle it at
+        // `Jit` and emit nothing. An opaque division atom would be evaluable but
+        // unrelatable, forcing a host check even for a kernel that proved the
+        // fact. (Same lever MLIR uses to simplify floordiv/ceildiv.)
+        //
+        // FRAME (SC1): the extent atom resolves against the host's *root* shape
+        // array, and `label_param_extents` only labels immutable parameters, so
+        // a slabbed `&mut Tensor` never reaches here — its `floor_div` carries
+        // no term. Fail closed to the device assert below (SC4).
+        if let Some(divisibility) =
+            self.with_bounds_divisibility(partition, bound, &pv.dim_map, axis, tile_dim)
+        {
+            let cause = format!(
+                "`with_bounds` bound {axis}: the partitioned extent must be divisible by the tile \
+                 extent {tile_dim}, or the declared bound undercounts the tiles on axis {axis}"
+            );
+            if self.lower_obligation(divisibility, cause) {
+                return Ok(());
+            }
+        }
+        // Constant rung, launch tier: a constant bound `c` on a dynamic-extent
+        // axis obliges `ceil(e / t) == c`, which is the pair of linear
+        // inequalities `(c-1)·t < e ≤ c·t` — both over the extent atom, both
+        // launch-known. The atom's frame comes from `extent_atom` (SC1): the
+        // root extent for an immutable param, the slab extent for a `&mut`.
+        if let (Some(c), Some(&param)) = (
+            declared_const,
+            partition
+                .tensor_origin
+                .as_ref()
+                .and_then(|name| self.param_index.get(name)),
+        ) {
+            let tensor_axis = pv.dim_map.get(axis).copied().filter(|&d| d >= 0);
+            if let (Some(tensor_axis), true, true) = (tensor_axis, c >= 1, tile_dim >= 1) {
+                use cuda_async::predicate::{Predicate, Term};
+                let e = Term::atom(self.extent_atom(param, tensor_axis as usize));
+                // `(c-1)·t < e` and `e < c·t + 1`; bail to the device assert on
+                // arithmetic overflow rather than weaken either side (the upper
+                // bound must stay ≤-inclusive or the exact-fit extent — the
+                // common case — would be rejected).
+                let bounds_pair = (|| {
+                    let lower = (c - 1).checked_mul(tile_dim)?;
+                    let upper_plus_one = c.checked_mul(tile_dim)?.checked_add(1)?;
+                    let above = Predicate::lt(&Term::constant(lower), &e)?;
+                    let not_above = Predicate::lt(&e, &Term::constant(upper_plus_one))?;
+                    Some((above, not_above))
+                })();
+                if let Some((above, not_above)) = bounds_pair {
+                    let cause = format!(
+                        "`with_bounds` bound {axis} declares {c} tiles of extent {tile_dim}, so \
+                         axis {axis}'s extent must be in ({}, {}]",
+                        (c - 1) * tile_dim,
+                        c * tile_dim
+                    );
+                    if self.lower_obligation(above, cause.clone())
+                        && self.lower_obligation(not_above, cause)
+                    {
+                        return Ok(());
+                    }
+                }
+            }
+        }
+        // This partition's real tile count on `axis`, read off the one
+        // index-space query shared by every axis of this binding.
+        let shape_results = match index_space_shape {
+            Some(cached) => cached,
+            slot => {
+                let i32_scalar_ty = cutile_ir::ir::Type::Tile(TileType {
+                    shape: vec![],
+                    element_type: TileElementType::Scalar(ScalarType::I32),
+                });
+                let mut op_builder =
+                    OpBuilder::new(Opcode::GetIndexSpaceShape, self.ir_location(span))
+                        .operand(view_value);
+                for _ in 0..rank {
+                    op_builder = op_builder.result(i32_scalar_ty.clone());
+                }
+                let (shape_op, results) = op_builder.build(module);
+                append_op(module, block_id, shape_op);
+                slot.insert(results)
+            }
+        };
+        let actual = shape_results[axis];
+
+        let i32_tr_type = self
+            .compile_type(&syn::parse_quote!(i32), generic_vars, &HashMap::new())?
+            .ok_or_else(|| self.jit_error(span, "failed to synthesize `i32` type"))?;
+        let eq = self.compile_binary_op_from_values(
+            module,
+            block_id,
+            TileRustValue::new_primitive(declared, i32_tr_type.clone(), None),
+            TileRustValue::new_primitive(actual, i32_tr_type, None),
+            &TileBinaryOp::Eq,
+            generic_vars,
+            ctx,
+            None,
+            span,
+        )?;
+        // Statically decidable: discharge at JIT and emit nothing (the common
+        // case when the view's extent and the declared `Dim` are both known), or
+        // reject outright when the bound is provably wrong.
+        if let Some(bounds) = eq.bounds {
+            if bounds.is_exact() {
+                if bounds.start != 0 {
+                    return Ok(());
+                }
+                return self.jit_error_result(
+                    span,
+                    &format!(
+                        "`with_bounds` bound {axis} does not equal this partition's tile count on axis {axis}"
+                    ),
+                );
+            }
+        }
+        let Some(eq_result) = eq.value else {
+            return Ok(());
+        };
+        self.deny_residual_check(
+            &format!("the `with_bounds` binding check for axis {axis}"),
+            "Declare the extent statically in the signature, or bind a `Dim` the \
+             compiler can relate to this partition's tile count",
+            span,
+        )?;
+        let (assert_op, _) = OpBuilder::new(Opcode::Assert, self.ir_location(span))
+            .attr(
+                "message",
+                Attribute::String(format!(
+                    "`with_bounds` bound {axis} does not equal this partition's tile count on axis {axis}"
+                )),
+            )
+            .operand(eq_result)
+            .build(module);
+        append_op(module, block_id, assert_op);
+        Ok(())
     }
 
     fn value_dim_origin(value: &TileRustValue) -> Option<DimOrigin> {
@@ -725,6 +1144,20 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                 .as_ref()
                 .and_then(|fields| fields.get("size"))
                 .and_then(|size| size.dim_origin.clone())
+        })
+    }
+
+    /// The tensor-named axis provenance of a loop bound, looking through a
+    /// `Dim` wrapper to the scalar it wraps (mirroring
+    /// [`Self::value_dim_origin`], which does the same for the view-valued
+    /// form).
+    fn value_partition_axis_origin(value: &TileRustValue) -> Option<PartitionAxisOrigin> {
+        value.partition_axis_origin.clone().or_else(|| {
+            value
+                .fields
+                .as_ref()
+                .and_then(|fields| fields.get("size"))
+                .and_then(|size| size.partition_axis_origin.clone())
         })
     }
 
@@ -764,15 +1197,26 @@ impl<'m> CUDATileFunctionCompiler<'m> {
         let Expr::MethodCall(method_call) = &*for_expr.expr else {
             return Ok(false);
         };
-        if method_call.method != "iter_indices" {
-            return Ok(false);
-        }
-        if !method_call.args.is_empty() {
+        let method_name = method_call.method.to_string();
+        let (has_ranges, is_shared) = match method_name.as_str() {
+            "iter_indices" => (false, false),
+            "iter_indices_with" => (false, true),
+            "iter_indices_within" => (true, false),
+            "iter_indices_within_with" => (true, true),
+            _ => return Ok(false),
+        };
+        let expected_args = usize::from(has_ranges) + usize::from(is_shared);
+        if method_call.args.len() != expected_args {
             return self.jit_error_result(
                 &method_call.args.span(),
-                "MappedPartitionMut::iter_indices does not take arguments",
+                &format!(
+                    "MappedPartitionMut::{method_name} expects {expected_args} argument(s), got {}",
+                    method_call.args.len()
+                ),
             );
         }
+        let ranges_arg = has_ranges.then(|| &method_call.args[0]);
+        let other_arg_index = usize::from(has_ranges);
         let Pat::Ident(iterand_ident) = &*for_expr.pat else {
             return self.jit_error_result(
                 &for_expr.pat.span(),
@@ -806,6 +1250,37 @@ impl<'m> CUDATileFunctionCompiler<'m> {
             generic_vars,
             &method_call.receiver.span(),
         )?;
+        let rank = tile_shape.len();
+        // Owned axes (map dim OWNED = 0) are not traversed by the stream: each
+        // stream item owns the axis's full extent (subtensor-per-CTA
+        // exclusivity), and in-kernel loops traverse it with bounds-proven
+        // indices. Only the streamed axes participate in the flat tile-id
+        // schedule.
+        if let Some(axis) = map_shape.iter().position(|&dim| dim < 0) {
+            return self.jit_error_result(
+                &method_call.receiver.span(),
+                &format!(
+                    "mapped partition map dimensions must be OWNED (0) or positive: axis {axis} is {}",
+                    map_shape[axis]
+                ),
+            );
+        }
+        let streamed_axes: Vec<usize> = (0..rank)
+            .filter(|&axis| map_shape[axis] != OWNED_MAP_DIM)
+            .collect();
+        if streamed_axes.is_empty() {
+            return self.jit_error_result(
+                &method_call.receiver.span(),
+                "mapped partition requires at least one streamed (non-OWNED) map axis",
+            );
+        }
+        let has_owned_axes = streamed_axes.len() != rank;
+        if has_owned_axes && has_ranges {
+            return self.jit_error_result(
+                &method_call.args.span(),
+                "sub-range iteration over a map with OWNED axes is not supported yet",
+            );
+        }
         let i32_ty = self.compile_i32_type(generic_vars, &for_expr.span())?;
         let index_space = self.compile_index_space_shape_values(
             module,
@@ -814,19 +1289,400 @@ impl<'m> CUDATileFunctionCompiler<'m> {
             &i32_ty,
             &method_call.receiver.span(),
         )?;
-        let num_bid_m = index_space[0].clone();
-        let num_bid_n = index_space[1].clone();
-        let total_tiles = self.compile_binary_op_from_values(
-            module,
-            block_id,
-            num_bid_m.clone(),
-            num_bid_n.clone(),
-            &TileBinaryOp::Mul,
-            generic_vars,
-            ctx,
-            None,
-            &for_expr.span(),
-        )?;
+
+        // Shared maps: a second mapped partition whose stores accept the same
+        // indices. The type already forces equal tile/map shapes; the logical
+        // partition grids must also match so every minted index is in bounds
+        // for both partitions. Static grids are compared here; dynamic grids
+        // get a runtime assert per axis.
+        let mut extra_origins: Vec<cutile_ir::ir::Value> = vec![];
+        if is_shared {
+            let other_arg = &method_call.args[other_arg_index];
+            let other_expr: &Expr = match other_arg {
+                Expr::Reference(reference) => &reference.expr,
+                other => other,
+            };
+            let other_value = self
+                .compile_expression(module, block_id, other_expr, generic_vars, ctx, None)?
+                .ok_or_else(|| {
+                    self.jit_error(
+                        &other_arg.span(),
+                        "failed to compile shared mapped partition argument",
+                    )
+                })?;
+            let other_origin = other_value.value.ok_or_else(|| {
+                self.jit_error(
+                    &other_arg.span(),
+                    "shared mapped partition argument did not produce a direct value",
+                )
+            })?;
+            let (other_tile_shape, other_map_shape) =
+                self.mapped_partition_type_shapes(&other_value, generic_vars, &other_arg.span())?;
+            if other_tile_shape != tile_shape || other_map_shape != map_shape {
+                return self.jit_error_result(
+                    &other_arg.span(),
+                    "iter_indices_with requires both mapped partitions to share tile and map shapes",
+                );
+            }
+            let other_index_space = self.compile_index_space_shape_values(
+                module,
+                block_id,
+                &other_value,
+                &i32_ty,
+                &other_arg.span(),
+            )?;
+            // Declared `dim(a, i) == dim(b, i)` preconditions discharge the
+            // per-axis grid-equality asserts: equal tensor extents with
+            // type-equal tile shapes (checked above) give equal tile grids.
+            let receiver_name = Self::simple_path_name(&method_call.receiver)
+                .or_else(|| partition_value.tensor_origin.clone());
+            let other_name =
+                Self::simple_path_name(other_expr).or_else(|| other_value.tensor_origin.clone());
+            for axis in 0..rank {
+                let lhs = &index_space[axis];
+                let rhs = &other_index_space[axis];
+                if let (Some(lhs_bounds), Some(rhs_bounds)) = (lhs.bounds, rhs.bounds) {
+                    if lhs_bounds.is_exact() && rhs_bounds.is_exact() {
+                        if lhs_bounds.start != rhs_bounds.start {
+                            return self.jit_error_result(
+                                &other_arg.span(),
+                                &format!(
+                                    "iter_indices_with requires equal logical partition grids: axis {axis} has {} vs {} tiles",
+                                    lhs_bounds.start, rhs_bounds.start
+                                ),
+                            );
+                        }
+                        continue;
+                    }
+                }
+                if let (Some(receiver_name), Some(other_name)) = (&receiver_name, &other_name) {
+                    if self.resolve_dim_eq(receiver_name, axis, other_name, axis) {
+                        self.check_stats
+                            .discharged
+                            .set(self.check_stats.discharged.get() + 1);
+                        continue;
+                    }
+                }
+                let eq_value = self.compile_binary_op_from_values(
+                    module,
+                    block_id,
+                    lhs.clone(),
+                    rhs.clone(),
+                    &TileBinaryOp::Eq,
+                    generic_vars,
+                    ctx,
+                    None,
+                    &other_arg.span(),
+                )?;
+                let eq_result = eq_value.value.ok_or_else(|| {
+                    self.jit_error(
+                        &other_arg.span(),
+                        "failed to compile shared mapped partition grid comparison",
+                    )
+                })?;
+                let message = format!(
+                    "shared mapped partitions require equal logical partition grids: axis {axis}"
+                );
+                self.deny_residual_check(
+                    &format!("the shared mapped-partition grid check for axis {axis}"),
+                    "Declare the two tensors' extents equal with a `preconditions` fact so \
+                     the equality discharges at compile time or at launch",
+                    &other_arg.span(),
+                )?;
+                let (assert_op_id, _) =
+                    OpBuilder::new(Opcode::Assert, self.ir_location(&other_arg.span()))
+                        .attr("message", Attribute::String(message))
+                        .operand(eq_result)
+                        .build(module);
+                append_op(module, block_id, assert_op_id);
+            }
+            extra_origins.push(other_origin);
+        }
+
+        // Sub-range iteration: per-axis (start_tile, num_tiles) pairs narrow
+        // the traversed grid. The schedule below runs over the effective
+        // lengths and the axis starts are added to the minted coordinates.
+        // Each range is validated against the grid — statically when bounds
+        // prove it, otherwise with a runtime assert — so indices keep the
+        // in-bounds store proof.
+        let mut axis_starts: Vec<Option<TileRustValue>> = vec![None; rank];
+        let mut axis_lens: Vec<TileRustValue> = index_space.clone();
+        // Tensor-axis provenance means "this coordinate ranges over the
+        // source tensor's whole axis" and can therefore justify a
+        // cross-tensor `tiles(source) <= tiles(target)` obligation. A
+        // validated sub-range still proves stores into its mapped partition,
+        // but its coordinates range over only `[start, start + len)`: using
+        // the full source axis there is conservative yet needlessly rejects
+        // consumers such as a `[heads, max_seq, d]` cache updated from a
+        // `[seq, heads, d]` source. Track the two proofs separately.
+        let mut axis_covers_full_grid = vec![true; rank];
+        if let Some(ranges_expr) = ranges_arg {
+            let ranges_value = self
+                .compile_expression(module, block_id, ranges_expr, generic_vars, ctx, None)?
+                .ok_or_else(|| {
+                    self.jit_error(
+                        &ranges_expr.span(),
+                        "failed to compile mapped partition sub-range argument",
+                    )
+                })?;
+            let Some(range_tuples) = &ranges_value.values else {
+                return self.jit_error_result(
+                    &ranges_expr.span(),
+                    "sub-range iteration expects an array of (start_tile, num_tiles) pairs",
+                );
+            };
+            if range_tuples.len() != rank {
+                return self.jit_error_result(
+                    &ranges_expr.span(),
+                    &format!(
+                        "sub-range iteration expects {rank} (start_tile, num_tiles) pairs, got {}",
+                        range_tuples.len()
+                    ),
+                );
+            }
+            for axis in 0..rank {
+                let Some(parts) = &range_tuples[axis].values else {
+                    return self.jit_error_result(
+                        &ranges_expr.span(),
+                        &format!("sub-range axis {axis} must be a (start_tile, num_tiles) pair"),
+                    );
+                };
+                if parts.len() != 2 {
+                    return self.jit_error_result(
+                        &ranges_expr.span(),
+                        &format!("sub-range axis {axis} must be a (start_tile, num_tiles) pair"),
+                    );
+                }
+                let start = parts[0].clone();
+                let len = parts[1].clone();
+                let num_bid = index_space[axis].clone();
+
+                let start_exact = start.bounds.filter(|bounds| bounds.is_exact());
+                let len_exact = len.bounds.filter(|bounds| bounds.is_exact());
+                let grid_exact = num_bid.bounds.filter(|bounds| bounds.is_exact());
+
+                // Reject provably-bad ranges at compile time.
+                if let Some(bounds) = start_exact {
+                    if bounds.start < 0 {
+                        return self.jit_error_result(
+                            &ranges_expr.span(),
+                            &format!("sub-range axis {axis} start {} is negative", bounds.start),
+                        );
+                    }
+                }
+                if let Some(bounds) = len_exact {
+                    if bounds.start < -1 {
+                        return self.jit_error_result(
+                            &ranges_expr.span(),
+                            &format!(
+                                "sub-range axis {axis} length {} is negative (-1 means the rest of the axis)",
+                                bounds.start
+                            ),
+                        );
+                    }
+                }
+
+                // `num_tiles = -1`: the rest of the axis from `start_tile`.
+                // The resulting length is in bounds by construction, so only
+                // the start needs validation.
+                let is_remainder = len_exact.is_some_and(|bounds| bounds.start == -1);
+                axis_covers_full_grid[axis] = start_exact.is_some_and(|bounds| bounds.start == 0)
+                    && (is_remainder
+                        || matches!(
+                            (len_exact, grid_exact),
+                            (Some(len_bounds), Some(grid_bounds))
+                                if len_bounds.start == grid_bounds.start
+                        ));
+                let len = if is_remainder {
+                    self.compile_binary_op_from_values(
+                        module,
+                        block_id,
+                        num_bid.clone(),
+                        start.clone(),
+                        &TileBinaryOp::Sub,
+                        generic_vars,
+                        ctx,
+                        None,
+                        &ranges_expr.span(),
+                    )?
+                } else {
+                    len
+                };
+
+                let emit_range_assert = |compiler: &Self,
+                                         module: &mut Module,
+                                         ctx: &mut CompilerContext,
+                                         lhs: TileRustValue,
+                                         rhs: TileRustValue,
+                                         op: TileBinaryOp,
+                                         detail: &str|
+                 -> Result<(), JITError> {
+                    let cmp = compiler.compile_binary_op_from_values(
+                        module,
+                        block_id,
+                        lhs,
+                        rhs,
+                        &op,
+                        generic_vars,
+                        ctx,
+                        None,
+                        &ranges_expr.span(),
+                    )?;
+                    let cmp_value = cmp.value.ok_or_else(|| {
+                        compiler.jit_error(
+                            &ranges_expr.span(),
+                            "failed to compile sub-range bounds comparison",
+                        )
+                    })?;
+                    let message =
+                        format!("mapped partition sub-range out of bounds: axis {axis}: {detail}");
+                    compiler.deny_residual_check(
+                        &format!("the mapped-partition sub-range check for axis {axis} ({detail})"),
+                        "Use compile-time-constant sub-range bounds so the check discharges \
+                         at compile time",
+                        &ranges_expr.span(),
+                    )?;
+                    let (assert_op_id, _) =
+                        OpBuilder::new(Opcode::Assert, compiler.ir_location(&ranges_expr.span()))
+                            .attr("message", Attribute::String(message))
+                            .operand(cmp_value)
+                            .build(module);
+                    append_op(module, block_id, assert_op_id);
+                    Ok(())
+                };
+
+                // start >= 0, unless proven above.
+                if start_exact.is_none() {
+                    let zero = self.compile_constant(module, block_id, generic_vars, 0)?;
+                    emit_range_assert(
+                        self,
+                        module,
+                        ctx,
+                        start.clone(),
+                        zero,
+                        TileBinaryOp::Ge,
+                        "start is negative",
+                    )?;
+                }
+                if is_remainder {
+                    // Remainder length: assert start <= grid so the length is
+                    // non-negative, unless both are static.
+                    let statically_ok = match (start_exact, grid_exact) {
+                        (Some(start_bounds), Some(grid_bounds)) => {
+                            if start_bounds.start > grid_bounds.start {
+                                return self.jit_error_result(
+                                    &ranges_expr.span(),
+                                    &format!(
+                                        "sub-range axis {axis} start {} exceeds the {}-tile grid",
+                                        start_bounds.start, grid_bounds.start
+                                    ),
+                                );
+                            }
+                            true
+                        }
+                        // `(0, -1)` spells "the whole axis": in bounds for any
+                        // grid, no assert needed.
+                        (Some(start_bounds), None) => start_bounds.start == 0,
+                        _ => false,
+                    };
+                    if !statically_ok {
+                        emit_range_assert(
+                            self,
+                            module,
+                            ctx,
+                            start.clone(),
+                            num_bid.clone(),
+                            TileBinaryOp::Le,
+                            "start exceeds the logical grid",
+                        )?;
+                    }
+                } else {
+                    // Explicit length: len >= 0 and start + len <= grid,
+                    // unless both are static.
+                    if len_exact.is_none() {
+                        let zero = self.compile_constant(module, block_id, generic_vars, 0)?;
+                        emit_range_assert(
+                            self,
+                            module,
+                            ctx,
+                            len.clone(),
+                            zero,
+                            TileBinaryOp::Ge,
+                            "length is negative (the -1 rest-of-axis spelling must be a literal)",
+                        )?;
+                    }
+                    let statically_ok = match (start_exact, len_exact, grid_exact) {
+                        (Some(start_bounds), Some(len_bounds), Some(grid_bounds)) => {
+                            if start_bounds.start + len_bounds.start > grid_bounds.start {
+                                return self.jit_error_result(
+                                    &ranges_expr.span(),
+                                    &format!(
+                                        "sub-range axis {axis} [{}, {}) exceeds the {}-tile grid",
+                                        start_bounds.start,
+                                        start_bounds.start + len_bounds.start,
+                                        grid_bounds.start
+                                    ),
+                                );
+                            }
+                            true
+                        }
+                        _ => false,
+                    };
+                    if !statically_ok {
+                        // Overflow-free form of `start + len <= grid`:
+                        // `start <= grid - len`. Both operands of the
+                        // subtraction are asserted nonnegative above, so the
+                        // difference is representable in i32, whereas the sum
+                        // wraps for `start = i32::MAX, len = 1` — and the
+                        // wrapped value passed this assert and got the
+                        // resulting coordinate branded as proven (issue #214).
+                        let grid_minus_len = self.compile_binary_op_from_values(
+                            module,
+                            block_id,
+                            num_bid.clone(),
+                            len.clone(),
+                            &TileBinaryOp::Sub,
+                            generic_vars,
+                            ctx,
+                            None,
+                            &ranges_expr.span(),
+                        )?;
+                        emit_range_assert(
+                            self,
+                            module,
+                            ctx,
+                            start.clone(),
+                            grid_minus_len,
+                            TileBinaryOp::Le,
+                            "range end exceeds the logical grid",
+                        )?;
+                    }
+                }
+
+                // A statically-zero start needs no coordinate offset.
+                if start_exact.is_none_or(|bounds| bounds.start != 0) {
+                    axis_starts[axis] = Some(start);
+                }
+                axis_lens[axis] = len;
+            }
+        }
+
+        // The persistent loop runs over the streamed tile count only; owned
+        // axes contribute no work items.
+        let mut total_tiles = axis_lens[streamed_axes[0]].clone();
+        for &axis in streamed_axes.iter().skip(1) {
+            total_tiles = self.compile_binary_op_from_values(
+                module,
+                block_id,
+                total_tiles,
+                axis_lens[axis].clone(),
+                &TileBinaryOp::Mul,
+                generic_vars,
+                ctx,
+                None,
+                &for_expr.span(),
+            )?;
+        }
         let total_tiles_value = total_tiles.value.ok_or_else(|| {
             self.jit_error(
                 &for_expr.span(),
@@ -855,9 +1711,25 @@ impl<'m> CUDATileFunctionCompiler<'m> {
             self.jit_error(&for_expr.span(), "failed to compute tile-block grid size")
         })?;
 
-        let loop_carry_vars = collect_mutated_variables(for_expr)?
+        let mut loop_carry_vars = collect_mutated_variables(for_expr)?
             .into_iter()
             .collect::<Vec<_>>();
+        // Thread each written tensor's ordering token across the loop boundary.
+        // The iterand (a branded `PartitionIndex`) makes every mapped store
+        // distinct per iteration, so these fork.
+        let persistent_loop_var = match &*for_expr.pat {
+            syn::Pat::Ident(p) => Some(p.ident.to_string()),
+            _ => None,
+        };
+        let token_accumulators = self.setup_loop_token_accumulators(
+            &for_expr.body,
+            persistent_loop_var.as_deref(),
+            ctx,
+            generic_vars,
+        )?;
+        for acc in &token_accumulators {
+            loop_carry_vars.push(acc.acc_var.clone());
+        }
         let loop_carry_args = ctx.unpack_some_vars(&loop_carry_vars)?;
         let loop_carry_arg_tys = loop_carry_args
             .iter()
@@ -866,28 +1738,34 @@ impl<'m> CUDATileFunctionCompiler<'m> {
 
         let for_iterand_type = Self::scalar_i32_ir_type();
         let loop_block_arg_tys = [&[for_iterand_type][..], loop_carry_arg_tys.as_slice()].concat();
+        let value_watermark = module.num_values() as u32;
         let (loop_block_id, loop_block_args) = build_block(module, &loop_block_arg_tys);
 
         let mut for_variables = ctx.clone();
         let block_args: Vec<cutile_ir::ir::Value> = loop_block_args[1..].to_vec();
         for_variables.repack_some_vars(&loop_carry_vars, &block_args, true)?;
+        self.bind_serialized_views(&token_accumulators, &mut for_variables);
         for_variables.carry_vars = Some(loop_carry_vars.clone());
         for_variables.default_terminator = Some(BlockTerminator::Continue);
+        // Persistent tile-id loop: the step is the physical grid size, so
+        // induction-substitution hoisting stays off (unit_step = false), but
+        // loop-invariant checks in the body can still move to the preheader.
+        for_variables.loop_frames.push(LoopFrame {
+            preheader_block: block_id,
+            body_block: loop_block_id,
+            value_watermark,
+            induction_values: vec![loop_block_args[0]],
+            lower: lower_bound,
+            upper: total_tiles_value,
+            unit_step: false,
+            // Non-unit step: `[lower, upper - 1]` is not the induction range.
+            induction_range: None,
+            known_non_empty: false,
+        });
 
-        let tile_id_name = "__cutile_mapped_partition_tile_id";
-        let num_bid_m_name = "__cutile_mapped_partition_num_bid_m";
-        let num_bid_n_name = "__cutile_mapped_partition_num_bid_n";
         let tile_id = TileRustValue::new_primitive(loop_block_args[0], i32_ty.clone(), None);
-        for_variables.vars.insert(tile_id_name.to_string(), tile_id);
-        for_variables
-            .vars
-            .insert(num_bid_m_name.to_string(), num_bid_m);
-        for_variables
-            .vars
-            .insert(num_bid_n_name.to_string(), num_bid_n);
 
         let tile_shape_arg = Self::cga_type_arg(&tile_shape);
-        let map_shape_arg = Self::cga_type_arg(&map_shape);
         let index_ty: syn::Type = syn::parse_str(&format!("PartitionIndex<{tile_shape_arg}>"))
             .map_err(|err| {
                 self.jit_error(
@@ -900,47 +1778,95 @@ impl<'m> CUDATileFunctionCompiler<'m> {
             .ok_or_else(|| {
                 self.jit_error(&for_expr.span(), "failed to compile PartitionIndex type")
             })?;
-        let swizzle_expr: Expr = syn::parse_str(&format!(
-            "swizzle_partition_index_2d::<{tile_shape_arg}, {map_shape_arg}>({tile_id_name}, {num_bid_m_name}, {num_bid_n_name})"
-        ))
-        .map_err(|err| {
-            self.jit_error(
-                &for_expr.span(),
-                &format!("failed to build mapped partition index expression: {err}"),
-            )
-        })?;
-        let mut index_value = self
-            .compile_expression(
+        // The schedule decomposes the flat tile id over the streamed axes
+        // only; owned axes take a constant 0 coordinate (the base of the
+        // owned subtensor), so the all-minted store path remains valid.
+        let streamed_lens: Vec<TileRustValue> = streamed_axes
+            .iter()
+            .map(|&axis| axis_lens[axis].clone())
+            .collect();
+        let streamed_map: Vec<i32> = streamed_axes.iter().map(|&axis| map_shape[axis]).collect();
+        let streamed_bids = self.emit_mapped_partition_schedule(
+            module,
+            loop_block_id,
+            &tile_id,
+            &streamed_lens,
+            &streamed_map,
+            generic_vars,
+            &mut for_variables,
+            &for_expr.span(),
+        )?;
+        let mut streamed_bids = streamed_bids.into_iter();
+        let mut bids: Vec<TileRustValue> = Vec::with_capacity(rank);
+        for axis in 0..rank {
+            if map_shape[axis] != OWNED_MAP_DIM {
+                bids.push(streamed_bids.next().ok_or_else(|| {
+                    self.jit_error(
+                        &for_expr.span(),
+                        "mapped partition schedule produced too few streamed coordinates",
+                    )
+                })?);
+            } else {
+                let zero = self.compile_constant(module, loop_block_id, generic_vars, 0i32)?;
+                bids.push(zero);
+            }
+        }
+        // Sub-range iteration: offset the minted coordinates by the axis
+        // starts. Bounds propagate through the add, so downstream proofs see
+        // [start, start + len - 1].
+        for (axis, start) in axis_starts.iter().enumerate() {
+            let Some(start) = start else {
+                continue;
+            };
+            bids[axis] = self.compile_binary_op_from_values(
                 module,
                 loop_block_id,
-                &swizzle_expr,
+                start.clone(),
+                bids[axis].clone(),
+                &TileBinaryOp::Add,
                 generic_vars,
                 &mut for_variables,
-                Some(index_return_ty),
-            )?
-            .ok_or_else(|| {
-                self.jit_error(&for_expr.span(), "failed to compile mapped partition index")
-            })?;
-        index_value.partition_origin = Some(partition_origin);
+                None,
+                &for_expr.span(),
+            )?;
+        }
+        let coords_ty = self.array_i32_type(rank, generic_vars, &for_expr.span())?;
+        let coords = TileRustValue::new_compound(bids, coords_ty);
+        let mut index_fields = BTreeMap::new();
+        index_fields.insert("coords".to_string(), coords);
+        let mut index_value = TileRustValue::new_struct(index_fields, index_return_ty);
+        let mut origins = vec![partition_origin];
+        origins.extend(extra_origins);
+        index_value.partition_origins = Some(origins.clone());
         let index_tensor_origin = Self::simple_path_name(&method_call.receiver)
             .or_else(|| partition_value.tensor_origin.clone());
-        if let (Some(tensor_origin), Some(fields)) =
-            (index_tensor_origin, index_value.fields.as_mut())
-        {
+        if let Some(fields) = index_value.fields.as_mut() {
             if let Some(coords) = fields.get_mut("coords") {
                 if let Some(values) = coords.values.as_mut() {
                     for (axis, value) in values.iter_mut().enumerate() {
-                        let dim_origin = DimOrigin::PartitionAxis {
+                        // Per-axis branding: each projected component records
+                        // the minting stream (all shared origins) and its
+                        // axis, so composite store indices can prove
+                        // streamed-axis provenance component-wise.
+                        value.index_origin = Some(DimOrigin::PartitionAxis {
                             view: partition_origin,
                             axis,
                             tile_dim: tile_shape[axis],
-                        };
-                        value.partition_axis_origin = Some(PartitionAxisOrigin {
-                            tensor: tensor_origin.clone(),
-                            axis,
-                            tile_dim: tile_shape[axis],
                         });
-                        value.index_origin = Some(dim_origin);
+                        value.partition_origins = Some(origins.clone());
+                        // Whole-axis provenance is stronger than the private
+                        // mapped-store brand above. A narrowed axis cannot
+                        // inherit it: downstream cross-tensor loads must test
+                        // the actual sub-range coordinate instead.
+                        if axis_covers_full_grid[axis] {
+                            if let Some(tensor_origin) = &index_tensor_origin {
+                                value.partition_axis_origin = Some(PartitionAxisOrigin {
+                                    tensor: tensor_origin.clone(),
+                                    axis,
+                                    tile_dim: tile_shape[axis],
+                                });
+                            }
+                        }
                     }
                 }
             }
@@ -981,6 +1907,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
             );
         }
         ctx.repack_some_vars(&loop_carry_vars, &result_values, true)?;
+        self.finish_loop_token_accumulators(&token_accumulators, ctx);
         Ok(true)
     }
 
@@ -990,6 +1917,193 @@ impl<'m> CUDATileFunctionCompiler<'m> {
     /// to `for idx in 0..dim`, while the loop variable is tagged as an index
     /// produced by that dimension. Plain `i32` values, including `num_tiles`
     /// results, continue through normal range lowering.
+    /// Set up per-tensor ordering-token accumulators for a loop body: for each
+    /// tensor written in the body, a synthetic carry variable holding the
+    /// tensor's token, seeded from its current value. Threaded as a loop iter-arg
+    /// (a bare `token`, never the view — a `partition_view` is not a valid
+    /// iter-arg), joined per store (see `accumulate_loop_token`), and published
+    /// to the tensor at exit (see `finish_loop_token_accumulators`). This is the
+    /// loop-scope case of resource token threading: a view roots at its tensor,
+    /// and the tensor's token must survive the loop boundary so a later access
+    /// (a second `partition_mut`, a store after the loop) is ordered after the
+    /// loop's writes.
+    fn setup_loop_token_accumulators(
+        &self,
+        body: &syn::Block,
+        loop_var: Option<&str>,
+        ctx: &mut CompilerContext,
+        generic_vars: &GenericVars,
+    ) -> Result<Vec<LoopTokenAcc>, JITError> {
+        use std::collections::BTreeMap;
+        let stores = super::shared_utils::collect_store_calls(body, loop_var);
+        // Group the written views by the root tensor they store to, tracking
+        // whether every store to that tensor is distinct per iteration.
+        struct RootInfo {
+            receivers: Vec<String>,
+            all_distinct: bool,
+        }
+        let mut by_root: BTreeMap<String, RootInfo> = BTreeMap::new();
+        for store in &stores {
+            let Some(view) = ctx.vars.get(&store.receiver) else {
+                continue;
+            };
+            let Some(root) = view.tensor_origin.clone() else {
+                continue;
+            };
+            let has_token = ctx
+                .vars
+                .get(&root)
+                .and_then(|t| t.type_meta.as_ref())
+                .and_then(|m| m.fields.get("token"))
+                .and_then(|f| f.value)
+                .is_some();
+            if has_token {
+                let entry = by_root.entry(root).or_insert(RootInfo {
+                    receivers: Vec::new(),
+                    all_distinct: true,
+                });
+                if !entry.receivers.contains(&store.receiver) {
+                    entry.receivers.push(store.receiver.clone());
+                }
+                entry.all_distinct &= store.index_distinct;
+            }
+        }
+        if by_root.is_empty() {
+            return Ok(vec![]);
+        }
+        let token_ty = self.token_type(generic_vars)?;
+        let mut accumulators = Vec::new();
+        for (root, info) in by_root {
+            let acc_var = format!("__loop_token_acc__{root}");
+            let serialize = !info.all_distinct;
+            if ctx.vars.contains_key(&acc_var) {
+                // An enclosing loop already threads this tensor's token; carry
+                // the same accumulator through this loop so its writes compose
+                // into it. The enclosing (owner) loop publishes the final result.
+                accumulators.push(LoopTokenAcc {
+                    acc_var,
+                    root,
+                    receivers: info.receivers,
+                    owner: false,
+                    serialize,
+                });
+            } else {
+                let seed = ctx.vars[&root]
+                    .type_meta
+                    .as_ref()
+                    .and_then(|m| m.fields.get("token"))
+                    .and_then(|f| f.value)
+                    .expect("root tensor token checked above");
+                ctx.vars.insert(
+                    acc_var.clone(),
+                    TileRustValue::new_primitive(seed, token_ty.clone(), None),
+                );
+                accumulators.push(LoopTokenAcc {
+                    acc_var,
+                    root,
+                    receivers: info.receivers,
+                    owner: true,
+                    serialize,
+                });
+            }
+        }
+        Ok(accumulators)
+    }
+
+    /// For accumulators whose writes overlap (serialize), rebind the receiver
+    /// views' tokens to the carried accumulator so the stores read it and chain
+    /// (each ordered after the previous). Called after the loop block args are
+    /// bound. Distinct (fork) accumulators are left alone — their stores keep
+    /// reading their invariant view token.
+    fn bind_serialized_views(
+        &self,
+        accumulators: &[LoopTokenAcc],
+        for_variables: &mut CompilerContext,
+    ) {
+        for acc in accumulators {
+            if !acc.serialize {
+                continue;
+            }
+            let Some(acc_token) = for_variables.vars.get(&acc.acc_var).and_then(|v| v.value) else {
+                continue;
+            };
+            for receiver in &acc.receivers {
+                super::shared_utils::set_view_token(receiver, acc_token, for_variables);
+            }
+        }
+    }
+
+    /// Join a store's output token into its tensor's loop accumulator, if the
+    /// enclosing loop is threading one. Called at the method-inline boundary
+    /// after the store advanced the view's token. The stores themselves keep
+    /// reading their (loop-invariant) view token — they fork, disjoint writes
+    /// stay parallel — while the accumulator collects `join(acc, output)` so the
+    /// loop result dominates every write.
+    pub(crate) fn accumulate_loop_token(
+        &self,
+        module: &mut Module,
+        block_id: BlockId,
+        ctx: &mut CompilerContext,
+        view_var: &str,
+        generic_vars: &GenericVars,
+    ) -> Result<(), JITError> {
+        let Some(view) = ctx.vars.get(view_var) else {
+            return Ok(());
+        };
+        let Some(root) = view.tensor_origin.clone() else {
+            return Ok(());
+        };
+        let acc_var = format!("__loop_token_acc__{root}");
+        let Some(acc_token) = ctx.vars.get(&acc_var).and_then(|v| v.value) else {
+            return Ok(());
+        };
+        let Some(view_token) = view
+            .type_meta
+            .as_ref()
+            .and_then(|m| m.fields.get("token"))
+            .and_then(|f| f.value)
+        else {
+            return Ok(());
+        };
+        let token_ty = self.token_type(generic_vars)?;
+        let (op_id, results) = OpBuilder::new(Opcode::JoinTokens, Location::Unknown)
+            .result(TileIrType::Token)
+            .operand(acc_token)
+            .operand(view_token)
+            .build(module);
+        append_op(module, block_id, op_id);
+        ctx.vars.insert(
+            acc_var,
+            TileRustValue::new_primitive(results[0], token_ty, None),
+        );
+        Ok(())
+    }
+
+    /// Publish each loop accumulator's result (repacked from the loop op) to its
+    /// tensor and to the views written in the body, then drop the synthetic
+    /// carry variables. After this, a later `partition_mut` of the tensor or a
+    /// store through one of those views is ordered after the loop's writes.
+    fn finish_loop_token_accumulators(
+        &self,
+        accumulators: &[LoopTokenAcc],
+        ctx: &mut CompilerContext,
+    ) {
+        for acc in accumulators {
+            // A non-owner inherited the accumulator from an enclosing loop: leave
+            // its result in place for that loop to carry and publish.
+            if !acc.owner {
+                continue;
+            }
+            if let Some(result_token) = ctx.vars.get(&acc.acc_var).and_then(|v| v.value) {
+                super::shared_utils::set_view_token(&acc.root, result_token, ctx);
+                for receiver in &acc.receivers {
+                    super::shared_utils::set_view_token(receiver, result_token, ctx);
+                }
+            }
+            ctx.vars.remove(&acc.acc_var);
+        }
+    }
+
     fn try_compile_dim_for_loop(
         &self,
         module: &mut Module,
@@ -1035,9 +2149,20 @@ impl<'m> CUDATileFunctionCompiler<'m> {
             self.jit_error(&for_expr.span(), "failed to compile dimension loop step")
         })?;
 
-        let loop_carry_vars = collect_mutated_variables(for_expr)?
+        let mut loop_carry_vars = collect_mutated_variables(for_expr)?
             .into_iter()
             .collect::<Vec<_>>();
+        // Thread each written tensor's ordering token across the loop boundary.
+        let loop_var_name = maybe_iterand_ident.map(|p| p.ident.to_string());
+        let token_accumulators = self.setup_loop_token_accumulators(
+            &for_expr.body,
+            loop_var_name.as_deref(),
+            ctx,
+            generic_vars,
+        )?;
+        for acc in &token_accumulators {
+            loop_carry_vars.push(acc.acc_var.clone());
+        }
         let loop_carry_args = ctx.unpack_some_vars(&loop_carry_vars)?;
         let loop_carry_arg_tys = loop_carry_args
             .iter()
@@ -1051,6 +2176,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
         let mut for_variables = ctx.clone();
         let block_args: Vec<cutile_ir::ir::Value> = loop_block_args[1..].to_vec();
         for_variables.repack_some_vars(&loop_carry_vars, &block_args, true)?;
+        self.bind_serialized_views(&token_accumulators, &mut for_variables);
         if let Some(iterand_ident) = maybe_iterand_ident {
             let iterand_name = iterand_ident.ident.to_string();
             let i32_type = self
@@ -1085,6 +2211,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                 TileRustValue::new_value_kind_like(loop_block_args[0], i32_type.clone())
             };
             iterand_val.index_origin = Some(dim_origin);
+            iterand_val.partition_axis_origin = Self::value_partition_axis_origin(&dim_value);
             for_variables.vars.insert(iterand_name, iterand_val);
         }
         for_variables.carry_vars = Some(loop_carry_vars.clone());
@@ -1122,6 +2249,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
             );
         }
         ctx.repack_some_vars(&loop_carry_vars, &result_values, true)?;
+        self.finish_loop_token_accumulators(&token_accumulators, ctx);
         Ok(true)
     }
 
@@ -1298,6 +2426,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                     // Add iterand as first argument.
                     let loop_block_arg_tys =
                         [&[for_iterand_type][..], loop_carry_arg_tys.as_slice()].concat();
+                    let value_watermark = module.num_values() as u32;
                     let (loop_block_id, loop_block_args) = build_block(module, &loop_block_arg_tys);
 
                     let mut for_variables = ctx.clone();
@@ -1355,13 +2484,71 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                                 start_val.ty.clone(),
                             ),
                         };
+                        // A loop from exactly 0 up to a partition-axis count
+                        // ranges over precisely that axis's tiles, so the
+                        // iterand inherits the bound's axis provenance in both
+                        // its forms. This is what makes `for i in 0..num_tiles(
+                        // &p, a)` prove its own accesses safe, with no
+                        // `with_bounds` annotation: an ordinary integer loop
+                        // over a count the compiler minted carries the same
+                        // evidence the annotation used to supply by hand.
                         if start_val
                             .bounds
                             .as_ref()
                             .is_some_and(|bounds| bounds.is_exact() && bounds.start == 0)
                         {
                             iterand_val.index_origin = Self::value_dim_origin(&end_val);
+                            iterand_val.partition_axis_origin =
+                                Self::value_partition_axis_origin(&end_val);
                         }
+                        let mut induction_values = vec![loop_block_args[0]];
+                        if let Some(alias) = iterand_val.value {
+                            induction_values.push(alias);
+                        }
+                        // Static bounds prove the loop non-empty when the
+                        // largest possible lower bound is below the smallest
+                        // possible upper bound.
+                        let known_non_empty = match (&start_val.bounds, &end_val.bounds) {
+                            (Some(lower), Some(upper)) => lower.end < upper.start,
+                            _ => false,
+                        };
+                        if let Some(alias) = iterand_val.value {
+                            // Seed the induction variable's symbolic form: `1 *
+                            // iv + 0`. Term arithmetic propagates it through the
+                            // loop body (replaces the former AffineForm seed).
+                            iterand_val.term = Some(cuda_async::predicate::Term::atom(
+                                cuda_async::predicate::Atom::Iv(alias.index()),
+                            ));
+                        }
+                        let unit_step = maybe_step_expr.is_none();
+                        // When both bounds are compile-time constants and the
+                        // step is unit, the induction variable's inclusive range
+                        // is `[lower, upper - 1]` — used to derive an affine
+                        // index's static range from its term.
+                        let induction_range = if unit_step {
+                            match (&start_val.bounds, &end_val.bounds) {
+                                (Some(lo), Some(hi)) if lo.is_exact() && hi.is_exact() => {
+                                    hi.start.checked_sub(1).map(|max| crate::bounds::Bounds {
+                                        start: lo.start,
+                                        end: max,
+                                    })
+                                }
+                                _ => None,
+                            }
+                        } else {
+                            None
+                        };
+                        for_variables.loop_frames.push(LoopFrame {
+                            preheader_block: block_id,
+                            body_block: loop_block_id,
+                            value_watermark,
+                            induction_values,
+                            lower: lower_bound,
+                            upper: upper_bound,
+                            unit_step,
+                            induction_range,
+                            known_non_empty,
+                        });
                         for_variables.vars.insert(iterand_name, iterand_val);
                     }
                     for_variables.carry_vars = Some(loop_carry_vars.clone());
@@ -1630,8 +2817,13 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                                     return Ok(None);
                                 }
                             };
-                            let result_values = block_vars.unpack_some_vars(&carry_vars)?;
-                            ctx.repack_some_vars(&carry_vars, &result_values, true)?;
+                            // The exact condition was inlined into this block,
+                            // so there is no join and no competing definition.
+                            // Publish the taken path's complete values —
+                            // including facts established by its RHS — instead
+                            // of reconstructing from the pre-branch templates
+                            // and invalidating them (2026-08-12 review, P1).
+                            ctx.replace_some_vars_from(&carry_vars, &block_vars)?;
                             return Ok(res);
                         }
                     }
@@ -2633,7 +3825,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                     }
                 }
                 Expr::Cast(cast_expr) => {
-                    let src_expr = self
+                    let mut src_expr = self
                         .compile_expression(
                             module,
                             block_id,
@@ -2660,6 +3852,18 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                                     "unsupported cast from `{src_elem_ty}` to `{dst_elem_ty}`"
                                 ),
                             )
+                        }
+                    }
+                    // The cast is a relabel — same bits, new value domain. An
+                    // interval is a claim about the machine value under the
+                    // NEW interpretation, so it survives only if it fits the
+                    // destination's domain (e.g. a possibly-negative `i32`
+                    // range says nothing about the value read as `u32`).
+                    if let Some(b) = src_expr.bounds {
+                        let keep = crate::value_facts::int_value_domain(&dst_elem_ty)
+                            .is_some_and(|d| d.start <= b.start && b.end <= d.end);
+                        if !keep {
+                            src_expr.bounds = None;
                         }
                     }
                     Ok(Some(src_expr))
@@ -2706,7 +3910,10 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                                 as i64;
                             (str, Some(Bounds::exact(val)))
                         }
-                        Lit::Bool(bool_lit) => (format!("{}", bool_lit.value as i32), None),
+                        Lit::Bool(bool_lit) => (
+                            format!("{}", bool_lit.value as i32),
+                            Some(Bounds::exact(bool_lit.value as i64)),
+                        ),
                         _ => {
                             return self.jit_error_result(
                                 &lit_expr.span(),

--- a/cutile-compiler/src/compiler/compile_global.rs
+++ b/cutile-compiler/src/compiler/compile_global.rs
@@ -572,7 +572,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
         })
     }
 
-    fn token_type(&self, generic_vars: &GenericVars) -> Result<TileRustType, JITError> {
+    pub(crate) fn token_type(&self, generic_vars: &GenericVars) -> Result<TileRustType, JITError> {
         let token_ty: Type = syn::parse_quote!(Token);
         self.compile_type(&token_ty, generic_vars, &HashMap::new())?
             .ok_or_else(|| self.jit_error(&token_ty.span(), "failed to compile Token type"))

--- a/cutile-compiler/src/compiler/compile_inline.rs
+++ b/cutile-compiler/src/compiler/compile_inline.rs
@@ -48,6 +48,12 @@ fn update_type_meta(
                         let mut new_val = outer_val.clone();
                         new_val.type_meta = inner_val.type_meta.clone();
                         outer_block_vars.vars.insert(outer_key.clone(), new_val);
+                        // The callee advanced this resource's token; propagate it
+                        // up the borrow link to the root tensor, so a later view
+                        // of the same tensor is ordered after these writes. Here
+                        // (the caller boundary) both the view and its root tensor
+                        // are in scope, unlike inside the callee frame.
+                        super::shared_utils::propagate_token_to_root(outer_key, outer_block_vars);
                     }
                 }
             }
@@ -122,7 +128,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                 .map(|arg| arg.ty.rust_ty.clone())
                 .collect::<Vec<_>>();
             // println!("{call_arg_rust_tys:#?}");
-            generic_arg_inference.map_args_to_params(&call_arg_rust_tys, None);
+            generic_arg_inference.map_args_to_params(&call_arg_rust_tys, None, generic_vars)?;
             // Bind new variables.
             // The variables must:
             // - Have the names of the parameters in the callee.
@@ -130,6 +136,9 @@ impl<'m> CUDATileFunctionCompiler<'m> {
             let param_names = get_sig_param_names(&fn_item.sig);
             let (input_params, _output_param) = get_sig_types(&fn_item.sig, None);
             let mut call_variables = CompilerContext::empty();
+            // The callee body is compiled into the caller's current block, so
+            // the caller's loop context governs check hoisting inside it.
+            call_variables.loop_frames = ctx.loop_frames.clone();
             call_variables.module_scope.push(module_name.clone());
             let mut outer2inner_map = HashMap::new();
             let sig_param_mutability = get_sig_param_mutability(&fn_item.sig);
@@ -166,7 +175,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                     .iter()
                     .map(|arg| arg.ty.rust_ty.clone())
                     .collect::<Vec<_>>();
-                generic_arg_inference.map_args_to_params(&call_arg_rust_tys, None);
+                generic_arg_inference.map_args_to_params(&call_arg_rust_tys, None, generic_vars)?;
                 // println!("inline_function_call {:#?}: generic_vars={generic_vars:#?} \nexpr_generic_args={expr_generic_args:#?} \ngeneric_arg_inference={generic_arg_inference:#?}", fn_item.sig.ident.to_string());
                 generic_arg_inference
                     .get_generic_vars_instance(&generic_vars, &self.modules.primitives())
@@ -343,6 +352,9 @@ impl<'m> CUDATileFunctionCompiler<'m> {
             let param_names = get_sig_param_names(&impl_method.sig);
             let (input_params, _output_param) = get_sig_types(&impl_method.sig, Some(self_ty));
             let mut call_variables = CompilerContext::empty();
+            // The callee body is compiled into the caller's current block, so
+            // the caller's loop context governs check hoisting inside it.
+            call_variables.loop_frames = ctx.loop_frames.clone();
             call_variables.module_scope.push(module_name.clone());
             let mut outer2inner_map = HashMap::new();
             let sig_param_mutability = get_sig_param_mutability(&impl_method.sig);
@@ -457,6 +469,25 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                 &outer2inner_map,
                 "token".to_string(),
             );
+            // If this method advanced a mutable view's token (a store) inside a
+            // loop threading that tensor's token, join the output into the loop
+            // accumulator. A no-op outside such a loop.
+            for outer_key in outer2inner_map.keys() {
+                let is_mutable = ctx
+                    .vars
+                    .get(outer_key)
+                    .map(|v| v.mutability == Mutability::Mutable)
+                    .unwrap_or(false);
+                if is_mutable {
+                    self.accumulate_loop_token(
+                        module,
+                        block_id,
+                        ctx,
+                        outer_key,
+                        &call_generic_vars,
+                    )?;
+                }
+            }
             // println!("exit_method_call: {}", method_call_expr.to_token_stream().to_string());
             if let Some(mut res) = result {
                 if let Some(rt) = return_type {

--- a/cutile-compiler/src/compiler/compile_intrinsic.rs
+++ b/cutile-compiler/src/compiler/compile_intrinsic.rs
@@ -12,9 +12,8 @@ use syn::spanned::Spanned;
 
 use super::_function::CUDATileFunctionCompiler;
 use super::_type as types;
-use super::_value::{CompilerContext, DimOrigin, Mutability, TileRustValue};
-use super::shared_types::Kind;
-use super::shared_utils::{get_binary_op_from_op_str, get_const_hex, TileBinaryOp};
+use super::_value::{CompilerContext, DimOrigin, Mutability, PartitionAxisOrigin, TileRustValue};
+use super::shared_utils::{get_binary_op_from_op_str, get_const_hex, TileBinaryOp, OWNED_MAP_DIM};
 use super::tile_rust_type::TileRustType;
 use super::utils::{int_attr, rounding_mode_attr, signedness_attr};
 use crate::bounds::Bounds;
@@ -68,13 +67,16 @@ fn tile_ir_type_from_trt(
 }
 
 impl<'m> CUDATileFunctionCompiler<'m> {
-    fn scalar_i32_type(&self, span: &proc_macro2::Span) -> Result<TileRustType, JITError> {
+    pub(super) fn scalar_i32_type(
+        &self,
+        span: &proc_macro2::Span,
+    ) -> Result<TileRustType, JITError> {
         let rust_ty = syn::parse2::<syn::Type>("i32".parse()?).unwrap();
         self.compile_type(&rust_ty, &GenericVars::empty_unchecked(), &HashMap::new())?
             .ok_or_else(|| self.jit_error(span, "failed to compile i32 type"))
     }
 
-    fn array_i32_type(
+    pub(crate) fn array_i32_type(
         &self,
         rank: usize,
         generic_vars: &GenericVars,
@@ -83,6 +85,56 @@ impl<'m> CUDATileFunctionCompiler<'m> {
         let rust_ty = syn::parse_str::<syn::Type>(&format!("[i32; {rank}]")).unwrap();
         self.compile_type(&rust_ty, generic_vars, &HashMap::new())?
             .ok_or_else(|| self.jit_error(span, "failed to compile i32 array type"))
+    }
+
+    /// Static per-axis geometry of a partition-view value: tile extents,
+    /// tensor extents (-1 where dynamic), and the dim-map remap.
+    pub(crate) fn partition_static_geometry(
+        &self,
+        partition: &TileRustValue,
+        span: &proc_macro2::Span,
+    ) -> Result<(Vec<i32>, Vec<i32>, Vec<i32>), JITError> {
+        let Some(TypeParam::Tile(tile)) = partition.ty.params.first() else {
+            return Err(self.jit_error(span, "partition type is missing its Tile parameter"));
+        };
+        let Some(TypeInstance::StructuredType(tile_inst)) = tile.type_instance.as_ref() else {
+            return Err(self.jit_error(span, "the Tile parameter must be instantiated"));
+        };
+        let static_tile = tile_inst.shape.clone();
+        let tensor = partition
+            .ty
+            .params
+            .iter()
+            .find_map(|p| match p {
+                TypeParam::TensorView(tv) => Some(tv),
+                _ => None,
+            })
+            .ok_or_else(|| self.jit_error(span, "partition type is missing a TensorView param"))?;
+        let Some(TypeInstance::StructuredType(tensor_inst)) = tensor.type_instance.as_ref() else {
+            return Err(self.jit_error(
+                span,
+                "expected a structured type instance for the tensor_view parameter",
+            ));
+        };
+        let static_shape = tensor_inst.shape.clone();
+        let dim_map = match partition.ty.params.iter().find_map(|p| match p {
+            TypeParam::DimMap(dm) => Some(dm),
+            _ => None,
+        }) {
+            Some(dim_map) => {
+                let Some(TypeInstance::StructuredType(dim_map_inst)) =
+                    dim_map.type_instance.as_ref()
+                else {
+                    return Err(self.jit_error(
+                        span,
+                        "expected a structured type instance for the dimension map",
+                    ));
+                };
+                dim_map_inst.shape.clone()
+            }
+            None => (0..static_shape.len() as i32).collect(),
+        };
+        Ok((static_tile, static_shape, dim_map))
     }
 
     fn static_shape_from_value(
@@ -906,15 +958,29 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                         &format!("`coord` expects 1 argument, got {}", call_expr.args.len()),
                     );
                 }
-                let tuple_type = self
-                    .compile_type(
-                        &syn::parse_quote!((i32, i32)),
-                        generic_vars,
-                        &HashMap::new(),
-                    )?
-                    .ok_or_else(|| {
-                        self.jit_error(&call_expr.span(), "failed to synthesize coordinate type")
-                    })?;
+                // The tuple's arity fixes the coordinate rank; the matching
+                // `Coord{rank}` shadow type is resolved below.
+                let tuple_type = match &call_expr.args[0] {
+                    syn::Expr::Tuple(tuple) if tuple.elems.len() >= 2 => {
+                        let tuple_src = format!("({})", vec!["i32"; tuple.elems.len()].join(", "));
+                        let tuple_ty = syn::parse_str::<syn::Type>(&tuple_src).map_err(|_| {
+                            self.jit_error(
+                                &call_expr.span(),
+                                "failed to synthesize coordinate type",
+                            )
+                        })?;
+                        Some(
+                            self.compile_type(&tuple_ty, generic_vars, &HashMap::new())?
+                                .ok_or_else(|| {
+                                    self.jit_error(
+                                        &call_expr.span(),
+                                        "failed to synthesize coordinate type",
+                                    )
+                                })?,
+                        )
+                    }
+                    _ => None,
+                };
                 let index = self
                     .compile_expression(
                         module,
@@ -922,7 +988,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                         &call_expr.args[0],
                         generic_vars,
                         ctx,
-                        Some(tuple_type),
+                        tuple_type,
                     )?
                     .ok_or_else(|| {
                         self.jit_error(&call_expr.args[0].span(), "failed to compile coordinate")
@@ -930,30 +996,31 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                 let Some(values) = index.values else {
                     return self.jit_error_result(
                         &call_expr.args[0].span(),
-                        "`coord` expects a 2D tuple coordinate",
+                        "`coord` expects a tuple coordinate",
                     );
                 };
-                if values.len() != 2 {
-                    return self.jit_error_result(
-                        &call_expr.args[0].span(),
-                        &format!(
-                            "`coord` expects a 2D tuple coordinate, got rank {}",
-                            values.len()
-                        ),
-                    );
-                }
+                let rank = values.len();
                 let return_type = match return_type {
                     Some(return_type) => return_type,
-                    None => self
-                        .compile_type(&syn::parse_quote!(Coord2), generic_vars, &HashMap::new())?
-                        .ok_or_else(|| {
+                    None => {
+                        let coord_ty = syn::parse_str::<syn::Type>(&format!("Coord{rank}"))
+                            .ok()
+                            .and_then(|ty| {
+                                self.compile_type(&ty, generic_vars, &HashMap::new())
+                                    .ok()
+                                    .flatten()
+                            });
+                        coord_ty.ok_or_else(|| {
                             self.jit_error(
-                                &call_expr.span(),
-                                "unable to infer return type for `coord`",
+                                &call_expr.args[0].span(),
+                                &format!(
+                                    "`coord` does not support rank-{rank} coordinates (no `Coord{rank}` type)"
+                                ),
                             )
-                        })?,
+                        })?
+                    }
                 };
-                let array_ty = self.array_i32_type(2, generic_vars, &call_expr.span())?;
+                let array_ty = self.array_i32_type(rank, generic_vars, &call_expr.span())?;
                 let coords = TileRustValue::new_compound(values, array_ty);
                 let mut fields = BTreeMap::new();
                 fields.insert("coords".to_string(), coords);
@@ -975,13 +1042,13 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                 let Some(fields) = coord.fields else {
                     return self.jit_error_result(
                         &call_expr.args[0].span(),
-                        "`coord_as_array` expects a compiler-created Coord2",
+                        "`coord_as_array` expects a coordinate created by `coord(...)`",
                     );
                 };
                 let Some(coords) = fields.get("coords").cloned() else {
                     return self.jit_error_result(
                         &call_expr.args[0].span(),
-                        "Coord2 is missing coordinate metadata",
+                        "coordinate is missing its metadata",
                     );
                 };
                 Ok(Some(coords))
@@ -998,141 +1065,35 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                 }
                 let mut args =
                     self.compile_call_args(module, block_id, &call_expr.args, generic_vars, ctx)?;
-                let mut partition = args.remove(0);
+                let partition = args.remove(0);
                 let bounds = args.remove(0);
                 let Some(bound_values) = bounds.values else {
                     return self.jit_error_result(
                         &call_expr.args[1].span(),
-                        "`Partition::with_bounds` expects a 2D tuple of dimensions",
+                        "`Partition::with_bounds` expects a tuple of dimensions",
                     );
                 };
-                if bound_values.len() != 2 {
-                    return self.jit_error_result(
-                        &call_expr.args[1].span(),
-                        &format!(
-                            "`Partition::with_bounds` expects rank-2 bounds, got rank {}",
-                            bound_values.len()
-                        ),
-                    );
-                }
-                let mut dim_origins = Vec::with_capacity(bound_values.len());
-                for (axis, value) in bound_values.into_iter().enumerate() {
-                    let origin = value.dim_origin.or_else(|| {
-                        value
-                            .fields
-                            .as_ref()
-                            .and_then(|fields| fields.get("size"))
-                            .and_then(|size| size.dim_origin.clone())
-                    });
-                    let Some(origin) = origin else {
-                        return self.jit_error_result(
-                            &call_expr.args[1].span(),
-                            &format!(
-                                "`Partition::with_bounds` bound {axis} must come from `num_tiles` or `Dim::new`"
-                            ),
-                        );
-                    };
-                    dim_origins.push(origin);
-                }
-                let return_type = match return_type {
-                    Some(return_type) => return_type,
-                    None => {
-                        let mut bounded_ty = partition.ty.rust_ty.clone();
-                        let syn::Type::Path(path_ty) = &mut bounded_ty else {
-                            return self.jit_error_result(
-                                &call_expr.args[0].span(),
-                                "expected a partition type for `Partition::with_bounds`",
-                            );
-                        };
-                        let Some(segment) = path_ty.path.segments.last_mut() else {
-                            return self.jit_error_result(
-                                &call_expr.args[0].span(),
-                                "expected a partition type path for `Partition::with_bounds`",
-                            );
-                        };
-                        segment.ident = syn::Ident::new("BoundedPartition", segment.ident.span());
-                        let mut return_type = partition.ty.clone();
-                        return_type.rust_ty = bounded_ty;
-                        return_type
-                    }
-                };
-                partition.ty = return_type;
-                partition.bounded_axes = Some(dim_origins);
-                Ok(Some(partition))
+                // Same operation as the `with_bounds` method call, so the same
+                // body: see `apply_with_bounds`.
+                self.apply_with_bounds(
+                    module,
+                    block_id,
+                    partition,
+                    bound_values,
+                    return_type,
+                    generic_vars,
+                    ctx,
+                    &call_expr.args[1].span(),
+                )
+                .map(Some)
             }
-            "check_bounded_partition_access" => {
-                if call_expr.args.len() != 2 {
-                    return self.jit_error_result(
-                        &call_expr.span(),
-                        &format!(
-                            "`check_bounded_partition_access` expects 2 arguments, got {}",
-                            call_expr.args.len()
-                        ),
-                    );
-                }
-                let mut args =
-                    self.compile_call_args(module, block_id, &call_expr.args, generic_vars, ctx)?;
-                let partition = args.remove(0);
-                let coord = args.remove(0);
-                let Some(bound_axes) = partition.bounded_axes else {
-                    return self.jit_error_result(
-                        &call_expr.args[0].span(),
-                        "bounded partition load requires bounds established by `Partition::with_bounds`",
-                    );
-                };
-                let Some(fields) = coord.fields else {
-                    return self.jit_error_result(
-                        &call_expr.args[1].span(),
-                        "bounded partition load requires a coordinate created by `coord(...)`",
-                    );
-                };
-                let Some(coords) = fields.get("coords") else {
-                    return self.jit_error_result(
-                        &call_expr.args[1].span(),
-                        "Coord2 is missing coordinate metadata",
-                    );
-                };
-                let Some(coord_values) = coords.values.as_ref() else {
-                    return self.jit_error_result(
-                        &call_expr.args[1].span(),
-                        "Coord2 coordinates must be a compound value",
-                    );
-                };
-                if coord_values.len() != bound_axes.len() {
-                    return self.jit_error_result(
-                        &call_expr.args[1].span(),
-                        &format!(
-                            "coordinate rank {} does not match bounded partition rank {}",
-                            coord_values.len(),
-                            bound_axes.len()
-                        ),
-                    );
-                }
-                for (axis, (coord_value, bound_origin)) in
-                    coord_values.iter().zip(bound_axes.iter()).enumerate()
-                {
-                    match coord_value.index_origin.as_ref() {
-                        Some(index_origin) if index_origin == bound_origin => {}
-                        Some(_) => {
-                            return self.jit_error_result(
-                                &call_expr.args[1].span(),
-                                &format!(
-                                    "bounded partition coordinate axis {axis} was produced by a different dimension"
-                                ),
-                            );
-                        }
-                        None => {
-                            return self.jit_error_result(
-                                &call_expr.args[1].span(),
-                                &format!(
-                                    "bounded partition coordinate axis {axis} must come from iterating the matching dimension"
-                                ),
-                            );
-                        }
-                    }
-                }
-                Ok(None)
-            }
+            "check_bounded_partition_access" => self.compile_check_bounded_partition_access(
+                module,
+                block_id,
+                call_expr,
+                generic_vars,
+                ctx,
+            ),
             "num_tiles" => {
                 // Signature: fn num_tiles(view: &V, axis: i32) -> i32
                 //
@@ -1294,6 +1255,29 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                     axis,
                     tile_dim: tile_dim as i32,
                 });
+                // Name the axis by TENSOR as well as by view value. The view
+                // value identifies this exact partition, which proves accesses
+                // back into it; the tensor name is what declared `dim(t, a)`
+                // facts speak about, so it is what lets a count taken here
+                // bound an access into a *different* partition whose extent a
+                // precondition relates to this one. Both describe one axis;
+                // they differ only in who can match them.
+                //
+                // The axis recorded is the ROOT axis `dim_map[axis]`, since
+                // that is the axis declared facts name. Minted only for a
+                // root-framed parameter: for a slabbed `&mut` the count above
+                // is per-CTA, which no `dim(t, a)` fact describes.
+                if let Some(tensor) = view
+                    .tensor_origin
+                    .as_ref()
+                    .filter(|tensor| self.root_framed_param(tensor).is_some())
+                {
+                    tr_value.partition_axis_origin = Some(PartitionAxisOrigin {
+                        tensor: tensor.clone(),
+                        axis: parent_axis,
+                        tile_dim: tile_dim as i32,
+                    });
+                }
                 Ok(Some(tr_value))
             }
             "partition_index_coords" => {
@@ -1323,12 +1307,12 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                 };
                 Ok(Some(coords))
             }
-            "validate_partition_index" => {
+            "validate_partition_store" => {
                 if call_expr.args.len() != 2 {
                     return self.jit_error_result(
                         &call_expr.span(),
                         &format!(
-                            "`validate_partition_index` expects 2 arguments, got {}",
+                            "`validate_partition_store` expects 2 arguments, got {}",
                             call_expr.args.len()
                         ),
                     );
@@ -1343,19 +1327,181 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                         "expected a direct value for mapped partition index validation",
                     )
                 })?;
-                let Some(origin_value) = index.partition_origin else {
+                let coords = index
+                    .fields
+                    .as_ref()
+                    .and_then(|fields| fields.get("coords"))
+                    .cloned()
+                    .ok_or_else(|| {
+                        self.jit_error(
+                            &call_expr.args[1].span(),
+                            "MappedPartitionMut::store requires an index produced by this partition's iter_indices() iterator or built with coord(...)",
+                        )
+                    })?;
+
+                // Degenerate case: a whole minted PartitionIndex. Every axis
+                // is proven by stream provenance.
+                if let Some(origin_values) = &index.partition_origins {
+                    if !origin_values.contains(&view_value) {
+                        return self.jit_error_result(
+                            &call_expr.args[1].span(),
+                            "MappedPartitionMut::store index was produced by a different mapped partition",
+                        );
+                    }
+                    return Ok(Some(coords));
+                }
+
+                // Composite coordinate: per-axis proofs. Streamed axes need a
+                // component minted by this partition's stream on that axis;
+                // owned axes (OWNED map dim) need a Dim proof bound to this
+                // partition's axis (or a shared-stream partner's, since
+                // iter_indices_with establishes grid equality), or a constant
+                // within the statically-known tile grid.
+                let coord_values = coords.values.as_ref().ok_or_else(|| {
+                    self.jit_error(
+                        &call_expr.args[1].span(),
+                        "coordinates must be a compound value",
+                    )
+                })?;
+                let (tile_shape, map_shape) = self.mapped_partition_type_shapes(
+                    &view,
+                    generic_vars,
+                    &call_expr.args[0].span(),
+                )?;
+                let rank = tile_shape.len();
+                if coord_values.len() != rank {
+                    return self.jit_error_result(
+                        &call_expr.args[1].span(),
+                        &format!(
+                            "store coordinate rank {} does not match mapped partition rank {rank}",
+                            coord_values.len()
+                        ),
+                    );
+                }
+                // On a fully-streamed map, every axis needs stream provenance,
+                // so only the minted index is acceptable.
+                if map_shape.iter().all(|&dim| dim != OWNED_MAP_DIM) {
                     return self.jit_error_result(
                         &call_expr.args[1].span(),
                         "MappedPartitionMut::store requires an index produced by this partition's iter_indices() iterator",
                     );
+                }
+
+                // First pass — streamed axes: provenance, and collect the
+                // shared-stream partner views the minted components carry.
+                let mut shared_views: Vec<cutile_ir::ir::Value> = vec![view_value];
+                for axis in 0..rank {
+                    if map_shape[axis] == OWNED_MAP_DIM {
+                        continue;
+                    }
+                    let coord_value = &coord_values[axis];
+                    let minted_here = match coord_value.index_origin.as_ref() {
+                        Some(DimOrigin::PartitionAxis {
+                            view: origin_view,
+                            axis: origin_axis,
+                            ..
+                        }) if *origin_axis == axis => {
+                            *origin_view == view_value
+                                || coord_value
+                                    .partition_origins
+                                    .as_ref()
+                                    .is_some_and(|origins| origins.contains(&view_value))
+                        }
+                        _ => false,
+                    };
+                    if !minted_here {
+                        return self.jit_error_result(
+                            &call_expr.args[1].span(),
+                            &format!(
+                                "streamed axis {axis} of a composite store index must be the component minted by this partition's iter_indices() (owned axes may use Dim indices instead)"
+                            ),
+                        );
+                    }
+                    if let Some(origins) = coord_value.partition_origins.as_ref() {
+                        for origin in origins {
+                            if !shared_views.contains(origin) {
+                                shared_views.push(*origin);
+                            }
+                        }
+                    }
+                    self.check_stats
+                        .discharged
+                        .set(self.check_stats.discharged.get() + 1);
+                }
+
+                // Second pass — owned axes: Dim proof or constant rung. The
+                // static geometry comes from the view's IR type (works for
+                // kernel-parameter views, whose Rust type carries no
+                // structured params).
+                let view_ir_ty = module.value_type(view_value).clone();
+                let Type::PartitionView(pv) = &view_ir_ty else {
+                    return self.jit_error_result(
+                        &call_expr.args[0].span(),
+                        &format!("expected a mapped partition view, got `{view_ir_ty:?}`"),
+                    );
                 };
-                if origin_value != view_value {
+                for axis in 0..rank {
+                    if map_shape[axis] != OWNED_MAP_DIM {
+                        continue;
+                    }
+                    let coord_value = &coord_values[axis];
+                    if let Some(DimOrigin::PartitionAxis {
+                        view: origin_view,
+                        axis: origin_axis,
+                        ..
+                    }) = coord_value.index_origin.as_ref()
+                    {
+                        if *origin_axis == axis && shared_views.contains(origin_view) {
+                            self.check_stats
+                                .discharged
+                                .set(self.check_stats.discharged.get() + 1);
+                            continue;
+                        }
+                        return self.jit_error_result(
+                            &call_expr.args[1].span(),
+                            &format!(
+                                "owned axis {axis} of a composite store index was produced by a different dimension"
+                            ),
+                        );
+                    }
+                    // Constant rung: a coordinate with known constant bounds
+                    // checks statically against a statically-known axis grid.
+                    let static_tile_dim = pv.tile_shape[axis];
+                    let parent_axis = pv.dim_map.get(axis).copied().unwrap_or(axis as i32);
+                    let static_shape_dim = if parent_axis >= 0 {
+                        pv.tensor_view
+                            .shape
+                            .get(parent_axis as usize)
+                            .copied()
+                            .unwrap_or(-1)
+                    } else {
+                        -1
+                    };
+                    if let (Some(bounds), true) = (coord_value.bounds, static_shape_dim != -1) {
+                        let num_partitions = (static_shape_dim as i64 + static_tile_dim as i64 - 1)
+                            / static_tile_dim as i64;
+                        if !(0 <= bounds.start && bounds.end < num_partitions) {
+                            return self.jit_error_result(
+                                &call_expr.args[1].span(),
+                                &format!(
+                                    "owned axis {axis}: constant range [{}, {}] is not within the {num_partitions}-tile grid",
+                                    bounds.start, bounds.end
+                                ),
+                            );
+                        }
+                        self.check_stats
+                            .discharged
+                            .set(self.check_stats.discharged.get() + 1);
+                        continue;
+                    }
                     return self.jit_error_result(
                         &call_expr.args[1].span(),
-                        "MappedPartitionMut::store index was produced by a different mapped partition",
+                        &format!(
+                            "owned axis {axis} of a composite store index must come from iterating the axis's Dim (num_tiles(&view, {axis})) or be a constant within the axis's static tile grid"
+                        ),
                     );
                 }
-                Ok(None)
+                Ok(Some(coords))
             }
             "swizzle_partition_index_2d" => {
                 if call_expr.args.len() != 3 {
@@ -1448,327 +1594,18 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                 let tile_id = args.remove(0);
                 let num_bid_m = args.remove(0);
                 let num_bid_n = args.remove(0);
-                let (mut bid_m, mut bid_n) = if swizzle_m_value == 1 && swizzle_n_value == 1 {
-                    let bid_m = self.compile_binary_op_from_values(
-                        module,
-                        block_id,
-                        tile_id.clone(),
-                        num_bid_n.clone(),
-                        &TileBinaryOp::Div,
-                        generic_vars,
-                        ctx,
-                        None,
-                        &call_expr.span(),
-                    )?;
-                    let bid_n = self.compile_binary_op_from_values(
-                        module,
-                        block_id,
-                        tile_id.clone(),
-                        num_bid_n.clone(),
-                        &TileBinaryOp::Rem,
-                        generic_vars,
-                        ctx,
-                        None,
-                        &call_expr.span(),
-                    )?;
-                    (bid_m, bid_n)
-                } else if swizzle_n_value == 1 {
-                    let swizzle_m =
-                        self.compile_constant(module, block_id, generic_vars, swizzle_m_value)?;
-                    let num_bid_in_m_band = self.compile_binary_op_from_values(
-                        module,
-                        block_id,
-                        swizzle_m.clone(),
-                        num_bid_n.clone(),
-                        &TileBinaryOp::Mul,
-                        generic_vars,
-                        ctx,
-                        None,
-                        &call_expr.span(),
-                    )?;
-                    let group_m_id = self.compile_binary_op_from_values(
-                        module,
-                        block_id,
-                        tile_id.clone(),
-                        num_bid_in_m_band.clone(),
-                        &TileBinaryOp::Div,
-                        generic_vars,
-                        ctx,
-                        None,
-                        &call_expr.span(),
-                    )?;
-                    let first_bid_m = self.compile_binary_op_from_values(
-                        module,
-                        block_id,
-                        group_m_id.clone(),
-                        swizzle_m.clone(),
-                        &TileBinaryOp::Mul,
-                        generic_vars,
-                        ctx,
-                        None,
-                        &call_expr.span(),
-                    )?;
-                    let remaining_m = self.compile_binary_op_from_values(
-                        module,
-                        block_id,
-                        num_bid_m.clone(),
-                        first_bid_m.clone(),
-                        &TileBinaryOp::Sub,
-                        generic_vars,
-                        ctx,
-                        None,
-                        &call_expr.span(),
-                    )?;
-                    let actual_group_size_m = self.compile_binary_op_from_values(
-                        module,
-                        block_id,
-                        remaining_m,
-                        swizzle_m,
-                        &TileBinaryOp::Min,
-                        generic_vars,
-                        ctx,
-                        None,
-                        &call_expr.span(),
-                    )?;
-                    let m_band_start = self.compile_binary_op_from_values(
-                        module,
-                        block_id,
-                        group_m_id,
-                        num_bid_in_m_band,
-                        &TileBinaryOp::Mul,
-                        generic_vars,
-                        ctx,
-                        None,
-                        &call_expr.span(),
-                    )?;
-                    let tile_in_m_band = self.compile_binary_op_from_values(
-                        module,
-                        block_id,
-                        tile_id.clone(),
-                        m_band_start,
-                        &TileBinaryOp::Sub,
-                        generic_vars,
-                        ctx,
-                        None,
-                        &call_expr.span(),
-                    )?;
-                    let tile_in_group_m = self.compile_binary_op_from_values(
-                        module,
-                        block_id,
-                        tile_in_m_band.clone(),
-                        actual_group_size_m.clone(),
-                        &TileBinaryOp::Rem,
-                        generic_vars,
-                        ctx,
-                        None,
-                        &call_expr.span(),
-                    )?;
-                    let bid_m = self.compile_binary_op_from_values(
-                        module,
-                        block_id,
-                        first_bid_m,
-                        tile_in_group_m,
-                        &TileBinaryOp::Add,
-                        generic_vars,
-                        ctx,
-                        None,
-                        &call_expr.span(),
-                    )?;
-                    let bid_n = self.compile_binary_op_from_values(
-                        module,
-                        block_id,
-                        tile_in_m_band,
-                        actual_group_size_m,
-                        &TileBinaryOp::Div,
-                        generic_vars,
-                        ctx,
-                        None,
-                        &call_expr.span(),
-                    )?;
-                    (bid_m, bid_n)
-                } else {
-                    let swizzle_m =
-                        self.compile_constant(module, block_id, generic_vars, swizzle_m_value)?;
-                    let swizzle_n =
-                        self.compile_constant(module, block_id, generic_vars, swizzle_n_value)?;
-                    let num_bid_in_m_band = self.compile_binary_op_from_values(
-                        module,
-                        block_id,
-                        swizzle_m.clone(),
-                        num_bid_n.clone(),
-                        &TileBinaryOp::Mul,
-                        generic_vars,
-                        ctx,
-                        None,
-                        &call_expr.span(),
-                    )?;
-                    let group_m_id = self.compile_binary_op_from_values(
-                        module,
-                        block_id,
-                        tile_id.clone(),
-                        num_bid_in_m_band.clone(),
-                        &TileBinaryOp::Div,
-                        generic_vars,
-                        ctx,
-                        None,
-                        &call_expr.span(),
-                    )?;
-                    let first_bid_m = self.compile_binary_op_from_values(
-                        module,
-                        block_id,
-                        group_m_id.clone(),
-                        swizzle_m.clone(),
-                        &TileBinaryOp::Mul,
-                        generic_vars,
-                        ctx,
-                        None,
-                        &call_expr.span(),
-                    )?;
-                    let remaining_m = self.compile_binary_op_from_values(
-                        module,
-                        block_id,
-                        num_bid_m.clone(),
-                        first_bid_m.clone(),
-                        &TileBinaryOp::Sub,
-                        generic_vars,
-                        ctx,
-                        None,
-                        &call_expr.span(),
-                    )?;
-                    let actual_group_size_m = self.compile_binary_op_from_values(
-                        module,
-                        block_id,
-                        remaining_m,
-                        swizzle_m,
-                        &TileBinaryOp::Min,
-                        generic_vars,
-                        ctx,
-                        None,
-                        &call_expr.span(),
-                    )?;
-                    let m_band_start = self.compile_binary_op_from_values(
-                        module,
-                        block_id,
-                        group_m_id,
-                        num_bid_in_m_band,
-                        &TileBinaryOp::Mul,
-                        generic_vars,
-                        ctx,
-                        None,
-                        &call_expr.span(),
-                    )?;
-                    let tile_in_m_band = self.compile_binary_op_from_values(
-                        module,
-                        block_id,
-                        tile_id.clone(),
-                        m_band_start,
-                        &TileBinaryOp::Sub,
-                        generic_vars,
-                        ctx,
-                        None,
-                        &call_expr.span(),
-                    )?;
-                    let n_group_capacity = self.compile_binary_op_from_values(
-                        module,
-                        block_id,
-                        actual_group_size_m.clone(),
-                        swizzle_n.clone(),
-                        &TileBinaryOp::Mul,
-                        generic_vars,
-                        ctx,
-                        None,
-                        &call_expr.span(),
-                    )?;
-                    let group_n_id = self.compile_binary_op_from_values(
-                        module,
-                        block_id,
-                        tile_in_m_band.clone(),
-                        n_group_capacity.clone(),
-                        &TileBinaryOp::Div,
-                        generic_vars,
-                        ctx,
-                        None,
-                        &call_expr.span(),
-                    )?;
-                    let first_bid_n = self.compile_binary_op_from_values(
-                        module,
-                        block_id,
-                        group_n_id,
-                        swizzle_n,
-                        &TileBinaryOp::Mul,
-                        generic_vars,
-                        ctx,
-                        None,
-                        &call_expr.span(),
-                    )?;
-                    let tile_in_n_group = self.compile_binary_op_from_values(
-                        module,
-                        block_id,
-                        tile_in_m_band,
-                        n_group_capacity,
-                        &TileBinaryOp::Rem,
-                        generic_vars,
-                        ctx,
-                        None,
-                        &call_expr.span(),
-                    )?;
-                    let tile_in_group_m = self.compile_binary_op_from_values(
-                        module,
-                        block_id,
-                        tile_in_n_group.clone(),
-                        actual_group_size_m.clone(),
-                        &TileBinaryOp::Rem,
-                        generic_vars,
-                        ctx,
-                        None,
-                        &call_expr.span(),
-                    )?;
-                    let bid_m = self.compile_binary_op_from_values(
-                        module,
-                        block_id,
-                        first_bid_m,
-                        tile_in_group_m,
-                        &TileBinaryOp::Add,
-                        generic_vars,
-                        ctx,
-                        None,
-                        &call_expr.span(),
-                    )?;
-                    let tile_in_group_n = self.compile_binary_op_from_values(
-                        module,
-                        block_id,
-                        tile_in_n_group,
-                        actual_group_size_m,
-                        &TileBinaryOp::Div,
-                        generic_vars,
-                        ctx,
-                        None,
-                        &call_expr.span(),
-                    )?;
-                    let bid_n = self.compile_binary_op_from_values(
-                        module,
-                        block_id,
-                        first_bid_n,
-                        tile_in_group_n,
-                        &TileBinaryOp::Add,
-                        generic_vars,
-                        ctx,
-                        None,
-                        &call_expr.span(),
-                    )?;
-                    (bid_m, bid_n)
-                };
-
-                if let Some(bounds) = num_bid_m.bounds {
-                    if bounds.is_exact() && bounds.start > 0 {
-                        bid_m.bounds = Some(Bounds::new(0, bounds.start - 1));
-                    }
-                }
-                if let Some(bounds) = num_bid_n.bounds {
-                    if bounds.is_exact() && bounds.start > 0 {
-                        bid_n.bounds = Some(Bounds::new(0, bounds.start - 1));
-                    }
-                }
+                let (bid_m, bid_n) = self.emit_swizzle_2d(
+                    module,
+                    block_id,
+                    &tile_id,
+                    &num_bid_m,
+                    &num_bid_n,
+                    swizzle_m_value,
+                    swizzle_n_value,
+                    generic_vars,
+                    ctx,
+                    &call_expr.span(),
+                )?;
 
                 let return_type = return_type.ok_or_else(|| {
                     self.jit_error(
@@ -2389,7 +2226,11 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                         &format!("undefined type metadata field `{type_meta_field}` on this value"),
                     );
                 };
-                Ok(Some(return_value.clone()))
+                let mut return_value = return_value.clone();
+                if type_meta_field == "shape" {
+                    self.label_param_extents(&mut return_value, &value);
+                }
+                Ok(Some(return_value))
             }
             "set_nested_mutable_partition_access_offset" => {
                 if call_expr.args.len() != 2 {
@@ -2562,14 +2403,17 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                 }
                 let compiler_op_function = ident.to_string();
                 match compiler_op_function.as_str() {
-                    "check_partition_access" => Ok(self.compile_check_partition_access(
-                        module,
-                        block_id,
-                        call_expr,
-                        &call_expr_func_str,
-                        generic_vars,
-                        ctx,
-                    )?),
+                    // Both view types walk the same ladder over the same
+                    // goals; they differ only in the Rust type of the
+                    // receiver, which the checker never inspects.
+                    "check_partition_access" | "check_partition_access_mut" => self
+                        .compile_check_partition_access(
+                            module,
+                            block_id,
+                            call_expr,
+                            generic_vars,
+                            ctx,
+                        ),
                     _ => {
                         return self.jit_error_result(
                             &call_expr.span(),
@@ -2592,313 +2436,504 @@ impl<'m> CUDATileFunctionCompiler<'m> {
         }
     }
 
-    /// Compiles a check_partition_access compiler_op call.
-    fn compile_check_partition_access(
+    /// Emits the flat-tile-id → `(bid_m, bid_n)` schedule math for one 2-D
+    /// (sub-)grid: linear traversal for a `[1, 1]` map, grouped-M bands for
+    /// `[GM, 1]`, and grouped-MN for `[GM, GN]`. Shared by the
+    /// `swizzle_partition_index_2d` intrinsic and the rank-N `iter_indices()`
+    /// loop lowering (which applies it to the trailing two axes).
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn emit_swizzle_2d(
         &self,
         module: &mut Module,
         block_id: BlockId,
-        call_expr: &ExprCall,
-        call_expr_func_str: &str,
+        tile_id: &TileRustValue,
+        num_bid_m: &TileRustValue,
+        num_bid_n: &TileRustValue,
+        swizzle_m_value: i32,
+        swizzle_n_value: i32,
         generic_vars: &GenericVars,
         ctx: &mut CompilerContext,
-    ) -> Result<Option<TileRustValue>, JITError> {
-        let mut args =
-            self.compile_call_args(module, block_id, &call_expr.args, generic_vars, ctx)?;
-        let partition_value = args.remove(0);
-        let index_value = args.remove(0);
-        if partition_value.kind != Kind::StructuredType {
-            return self.jit_error_result(
-                &call_expr.span(),
-                &format!(
-                    "expected a structured or primitive type for first argument of `{}`, got {:?}",
-                    &call_expr.to_token_stream().to_string(),
-                    partition_value.kind
-                ),
-            );
-        }
-        if index_value.kind != Kind::Compound {
-            return self.jit_error_result(
-                &call_expr.span(),
-                &format!(
-                    "Unexpected kind for arg 1 in {}",
-                    &call_expr.to_token_stream().to_string()
-                ),
-            );
-        }
-        if partition_value.ty.params.len() < 2 {
-            return self.jit_error_result(
-                &call_expr.span(),
-                &format!(
-                    "Unable to obtain type parameters for arg 0 in {}",
-                    call_expr_func_str
-                ),
-            );
-        }
-
-        // Get static tile values.
-        let TypeParam::Tile(partition_tile) = &partition_value.ty.params[0] else {
-            return self
-                .jit_error_result(&call_expr.span(), "the type parameter must be a Tile type");
-        };
-        let Some(TypeInstance::StructuredType(tile_param_inst)) =
-            partition_tile.type_instance.as_ref()
-        else {
-            return self
-                .jit_error_result(&call_expr.span(), "the Tile parameter must be instantiated");
-        };
-        let static_tile = tile_param_inst.shape.clone(); // This is const.
-
-        // Get static shape values.
-        // Search for the TensorView param by variant (not by index), since
-        // optional params like padding_value may shift the positions.
-        let partition_tensor = partition_value
-            .ty
-            .params
-            .iter()
-            .find_map(|p| match p {
-                TypeParam::TensorView(tv) => Some(tv),
-                _ => None,
-            })
-            .ok_or_else(|| {
-                self.jit_error(
-                    &call_expr.span(),
-                    &format!(
-                        "partition type is missing a TensorView param; found: {:?}",
-                        partition_value
-                            .ty
-                            .params
-                            .iter()
-                            .map(|p| p.name().unwrap_or_else(|| "?".to_string()))
-                            .collect::<Vec<_>>()
-                    ),
-                )
-            })?;
-        let Some(TypeInstance::StructuredType(tensor_param_inst)) =
-            partition_tensor.type_instance.as_ref()
-        else {
-            return self.jit_error_result(
-                &call_expr.span(),
-                &format!(
-                    "expected a structured type instance for tensor_view parameter, got {:?}",
-                    &partition_tensor.type_instance
-                ),
-            );
-        };
-        let static_shape = tensor_param_inst.shape.clone(); // This *may* be const. Any field that is not const is -1.
-
-        // Get optional dim_map by searching for the DimMap variant.
-        let dim_map = match partition_value.ty.params.iter().find_map(|p| match p {
-            TypeParam::DimMap(dm) => Some(dm),
-            _ => None,
-        }) {
-            Some(dim_map) => {
-                let Some(TypeInstance::StructuredType(dim_map_param_inst)) =
-                    dim_map.type_instance.as_ref()
-                else {
-                    return self.jit_error_result(
-                        &call_expr.span(),
-                        &format!(
-                            "expected a structured type instance for dimension map, got `{}`",
-                            dim_map.rust_ty.to_token_stream().to_string()
-                        ),
-                    );
-                };
-                dim_map_param_inst.shape.clone()
-            }
-            None => {
-                let mut r = vec![];
-                for i in 0..static_shape.len() {
-                    r.push(i as i32);
-                }
-                r
-            }
-        };
-        let partition_tensor_origin = partition_value.tensor_origin.clone();
-        let partition_view_value = partition_value.value;
-
-        // Get dynamic shape values.
-        let tensor_shape_value = partition_value
-            .take_type_meta_field("tensor_view.shape()")
-            .ok_or_else(|| {
-                self.jit_error(
-                    &call_expr.span(),
-                    "Failed to obtain type meta field tensor_view.shape().",
-                )
-            })?;
-        let Some(tensor_shape_values) = tensor_shape_value.fields.as_ref() else {
-            return self.jit_error_result(
-                &call_expr.span(),
-                "Expected fields for tensor shape expression.",
-            );
-        };
-        let Some(shape_dims) = tensor_shape_values.get("dims") else {
-            return self.jit_error_result(
-                &call_expr.span(),
-                "Expected dims field for shape expression.",
-            );
-        };
-        let Some(dynamic_shape) = shape_dims.values.clone() else {
-            return self.jit_error_result(&call_expr.span(), "expected a compound (tuple) value");
-        };
-
-        // Get index values.
-        let Some(mut indexes) = index_value.values else {
-            return self.jit_error_result(&call_expr.span(), "expected a compound (tuple) value");
-        };
-        let len = static_tile.len();
-        if len != indexes.len() || len != static_shape.len() {
-            return self.jit_error_result(
-                &call_expr.span(),
-                &format!(
-                    "Unexpected tile ({}), shape ({}), or index ({}) length mismatch.",
-                    len,
-                    static_shape.len(),
-                    indexes.len()
-                ),
-            );
-        }
-        for i in 0..len {
-            // Because the indices may be remapped via a permutation of the tile
-            // dimensions, we need to remap the tensor's shape as well.
-            let remapped_i = dim_map[i] as usize;
-            let static_tile_dim = static_tile[i];
-            let static_shape_dim = static_shape[remapped_i];
-            let is_static_shape_dim = static_shape_dim != -1;
-            let index_value = indexes.remove(0);
-            if let (Some(index_origin), Some(target_origin)) = (
-                index_value.partition_axis_origin.as_ref(),
-                partition_tensor_origin.as_ref(),
-            ) {
-                if self.proof_results.proves_partition_axis_access(
-                    index_origin,
-                    target_origin,
-                    i,
-                    static_tile_dim,
-                ) {
-                    continue;
-                }
-            }
-            if let (
-                Some(DimOrigin::PartitionAxis {
-                    view,
-                    axis,
-                    tile_dim,
-                }),
-                Some(partition_view_value),
-            ) = (index_value.index_origin.as_ref(), partition_view_value)
-            {
-                if *view == partition_view_value && *axis == i && *tile_dim == static_tile_dim {
-                    continue;
-                }
-            }
-            if index_value.bounds.is_some() && is_static_shape_dim {
-                // We can do a static bounds check.
-                let bounds = index_value.bounds.unwrap();
-                let num_partitions =
-                    (static_shape_dim as i64 + static_tile_dim as i64 - 1) / static_tile_dim as i64;
-                if !(0 <= bounds.start && bounds.end < num_partitions) {
-                    return self.jit_error_result(
-                        &call_expr.span(),
-                        &format!(
-                            "Bounds check failed: 0 <= {} && {} < {}",
-                            bounds.start, bounds.end, num_partitions
-                        ),
-                    );
-                }
-                continue;
-            }
-            // In the rest of the cases, we need to generate a dynamic bounds check.
-            let tile_dim_value =
-                self.compile_constant(module, block_id, generic_vars, static_tile_dim)?;
-            let index_value = if let Some(bounds) = index_value.bounds {
-                let index_upper_bound = bounds.end;
-                self.compile_constant(module, block_id, generic_vars, index_upper_bound as i32)?
-            } else {
-                index_value
-            };
-            let shape_dim_value = if is_static_shape_dim {
-                self.compile_constant(module, block_id, generic_vars, static_shape_dim)?
-            } else {
-                let dynamic_shape_index = static_shape
-                    .iter()
-                    .take(remapped_i + 1)
-                    .filter(|&&dim| dim == -1)
-                    .count()
-                    .checked_sub(1)
-                    .ok_or_else(|| {
-                        self.jit_error(
-                            &call_expr.span(),
-                            "internal: dynamic partition dimension was not found in tensor shape metadata",
-                        )
-                    })?;
-                dynamic_shape.get(dynamic_shape_index).cloned().ok_or_else(|| {
-                    self.jit_error(
-                        &call_expr.span(),
-                        &format!(
-                            "internal: tensor shape metadata is missing dynamic dimension {dynamic_shape_index}"
-                        ),
-                    )
-                })?
-            };
-            // Compute ceil_div(shape, tile) as (shape + tile - 1) / tile
-            // using floor division. This avoids positive_inf rounding which
-            // can be misoptimized when the dividend carries assume hints.
-            let tile_minus_one =
-                self.compile_constant(module, block_id, generic_vars, static_tile_dim - 1)?;
-            let shape_plus_tile_minus_one = self.compile_binary_op_from_values(
+        span: &proc_macro2::Span,
+    ) -> Result<(TileRustValue, TileRustValue), JITError> {
+        let tile_id = tile_id.clone();
+        let num_bid_m = num_bid_m.clone();
+        let num_bid_n = num_bid_n.clone();
+        let (mut bid_m, mut bid_n) = if swizzle_m_value == 1 && swizzle_n_value == 1 {
+            let bid_m = self.compile_binary_op_from_values(
                 module,
                 block_id,
-                shape_dim_value.clone(),
-                tile_minus_one,
-                &TileBinaryOp::Add,
-                generic_vars,
-                ctx,
-                None,
-                &call_expr.span(),
-            )?;
-            let div_result_value = self.compile_binary_op_from_values(
-                module,
-                block_id,
-                shape_plus_tile_minus_one,
-                tile_dim_value,
+                tile_id.clone(),
+                num_bid_n.clone(),
                 &TileBinaryOp::Div,
                 generic_vars,
                 ctx,
                 None,
-                &call_expr.span(),
+                span,
             )?;
-            let ineq_result_value = self.compile_binary_op_from_values(
+            let bid_n = self.compile_binary_op_from_values(
                 module,
                 block_id,
-                index_value,
-                div_result_value,
-                &TileBinaryOp::Lt,
+                tile_id.clone(),
+                num_bid_n.clone(),
+                &TileBinaryOp::Rem,
                 generic_vars,
                 ctx,
                 None,
-                &call_expr.span(),
+                span,
             )?;
-            let result_value = ineq_result_value.value.ok_or_else(|| {
-                self.jit_error(
-                    &call_expr.span(),
-                    "failed to compile a binary expression operand",
-                )
-            })?;
-            let shape_desc = if is_static_shape_dim {
-                format!("{}", static_shape_dim)
-            } else {
-                "?".to_string()
-            };
-            let message = format!(
-                "partition access out of bounds: dim {i}, block index >= ceil({shape_desc}/{static_tile_dim})"
-            );
-            let (assert_op_id, _) =
-                OpBuilder::new(Opcode::Assert, self.ir_location(&call_expr.span()))
-                    .attr("message", cutile_ir::ir::Attribute::String(message))
-                    .operand(result_value)
-                    .build(module);
-            append_op(module, block_id, assert_op_id);
+            (bid_m, bid_n)
+        } else if swizzle_n_value == 1 {
+            let swizzle_m =
+                self.compile_constant(module, block_id, generic_vars, swizzle_m_value)?;
+            let num_bid_in_m_band = self.compile_binary_op_from_values(
+                module,
+                block_id,
+                swizzle_m.clone(),
+                num_bid_n.clone(),
+                &TileBinaryOp::Mul,
+                generic_vars,
+                ctx,
+                None,
+                span,
+            )?;
+            let group_m_id = self.compile_binary_op_from_values(
+                module,
+                block_id,
+                tile_id.clone(),
+                num_bid_in_m_band.clone(),
+                &TileBinaryOp::Div,
+                generic_vars,
+                ctx,
+                None,
+                span,
+            )?;
+            let first_bid_m = self.compile_binary_op_from_values(
+                module,
+                block_id,
+                group_m_id.clone(),
+                swizzle_m.clone(),
+                &TileBinaryOp::Mul,
+                generic_vars,
+                ctx,
+                None,
+                span,
+            )?;
+            let remaining_m = self.compile_binary_op_from_values(
+                module,
+                block_id,
+                num_bid_m.clone(),
+                first_bid_m.clone(),
+                &TileBinaryOp::Sub,
+                generic_vars,
+                ctx,
+                None,
+                span,
+            )?;
+            let actual_group_size_m = self.compile_binary_op_from_values(
+                module,
+                block_id,
+                remaining_m,
+                swizzle_m,
+                &TileBinaryOp::Min,
+                generic_vars,
+                ctx,
+                None,
+                span,
+            )?;
+            let m_band_start = self.compile_binary_op_from_values(
+                module,
+                block_id,
+                group_m_id,
+                num_bid_in_m_band,
+                &TileBinaryOp::Mul,
+                generic_vars,
+                ctx,
+                None,
+                span,
+            )?;
+            let tile_in_m_band = self.compile_binary_op_from_values(
+                module,
+                block_id,
+                tile_id.clone(),
+                m_band_start,
+                &TileBinaryOp::Sub,
+                generic_vars,
+                ctx,
+                None,
+                span,
+            )?;
+            let tile_in_group_m = self.compile_binary_op_from_values(
+                module,
+                block_id,
+                tile_in_m_band.clone(),
+                actual_group_size_m.clone(),
+                &TileBinaryOp::Rem,
+                generic_vars,
+                ctx,
+                None,
+                span,
+            )?;
+            let bid_m = self.compile_binary_op_from_values(
+                module,
+                block_id,
+                first_bid_m,
+                tile_in_group_m,
+                &TileBinaryOp::Add,
+                generic_vars,
+                ctx,
+                None,
+                span,
+            )?;
+            let bid_n = self.compile_binary_op_from_values(
+                module,
+                block_id,
+                tile_in_m_band,
+                actual_group_size_m,
+                &TileBinaryOp::Div,
+                generic_vars,
+                ctx,
+                None,
+                span,
+            )?;
+            (bid_m, bid_n)
+        } else {
+            let swizzle_m =
+                self.compile_constant(module, block_id, generic_vars, swizzle_m_value)?;
+            let swizzle_n =
+                self.compile_constant(module, block_id, generic_vars, swizzle_n_value)?;
+            let num_bid_in_m_band = self.compile_binary_op_from_values(
+                module,
+                block_id,
+                swizzle_m.clone(),
+                num_bid_n.clone(),
+                &TileBinaryOp::Mul,
+                generic_vars,
+                ctx,
+                None,
+                span,
+            )?;
+            let group_m_id = self.compile_binary_op_from_values(
+                module,
+                block_id,
+                tile_id.clone(),
+                num_bid_in_m_band.clone(),
+                &TileBinaryOp::Div,
+                generic_vars,
+                ctx,
+                None,
+                span,
+            )?;
+            let first_bid_m = self.compile_binary_op_from_values(
+                module,
+                block_id,
+                group_m_id.clone(),
+                swizzle_m.clone(),
+                &TileBinaryOp::Mul,
+                generic_vars,
+                ctx,
+                None,
+                span,
+            )?;
+            let remaining_m = self.compile_binary_op_from_values(
+                module,
+                block_id,
+                num_bid_m.clone(),
+                first_bid_m.clone(),
+                &TileBinaryOp::Sub,
+                generic_vars,
+                ctx,
+                None,
+                span,
+            )?;
+            let actual_group_size_m = self.compile_binary_op_from_values(
+                module,
+                block_id,
+                remaining_m,
+                swizzle_m,
+                &TileBinaryOp::Min,
+                generic_vars,
+                ctx,
+                None,
+                span,
+            )?;
+            let m_band_start = self.compile_binary_op_from_values(
+                module,
+                block_id,
+                group_m_id,
+                num_bid_in_m_band,
+                &TileBinaryOp::Mul,
+                generic_vars,
+                ctx,
+                None,
+                span,
+            )?;
+            let tile_in_m_band = self.compile_binary_op_from_values(
+                module,
+                block_id,
+                tile_id.clone(),
+                m_band_start,
+                &TileBinaryOp::Sub,
+                generic_vars,
+                ctx,
+                None,
+                span,
+            )?;
+            let n_group_capacity = self.compile_binary_op_from_values(
+                module,
+                block_id,
+                actual_group_size_m.clone(),
+                swizzle_n.clone(),
+                &TileBinaryOp::Mul,
+                generic_vars,
+                ctx,
+                None,
+                span,
+            )?;
+            let group_n_id = self.compile_binary_op_from_values(
+                module,
+                block_id,
+                tile_in_m_band.clone(),
+                n_group_capacity.clone(),
+                &TileBinaryOp::Div,
+                generic_vars,
+                ctx,
+                None,
+                span,
+            )?;
+            let first_bid_n = self.compile_binary_op_from_values(
+                module,
+                block_id,
+                group_n_id,
+                swizzle_n,
+                &TileBinaryOp::Mul,
+                generic_vars,
+                ctx,
+                None,
+                span,
+            )?;
+            let tile_in_n_group = self.compile_binary_op_from_values(
+                module,
+                block_id,
+                tile_in_m_band,
+                n_group_capacity,
+                &TileBinaryOp::Rem,
+                generic_vars,
+                ctx,
+                None,
+                span,
+            )?;
+            let tile_in_group_m = self.compile_binary_op_from_values(
+                module,
+                block_id,
+                tile_in_n_group.clone(),
+                actual_group_size_m.clone(),
+                &TileBinaryOp::Rem,
+                generic_vars,
+                ctx,
+                None,
+                span,
+            )?;
+            let bid_m = self.compile_binary_op_from_values(
+                module,
+                block_id,
+                first_bid_m,
+                tile_in_group_m,
+                &TileBinaryOp::Add,
+                generic_vars,
+                ctx,
+                None,
+                span,
+            )?;
+            let tile_in_group_n = self.compile_binary_op_from_values(
+                module,
+                block_id,
+                tile_in_n_group,
+                actual_group_size_m,
+                &TileBinaryOp::Div,
+                generic_vars,
+                ctx,
+                None,
+                span,
+            )?;
+            let bid_n = self.compile_binary_op_from_values(
+                module,
+                block_id,
+                first_bid_n,
+                tile_in_group_n,
+                &TileBinaryOp::Add,
+                generic_vars,
+                ctx,
+                None,
+                span,
+            )?;
+            (bid_m, bid_n)
+        };
+
+        if let Some(bounds) = num_bid_m.bounds {
+            if bounds.is_exact() && bounds.start > 0 {
+                bid_m.bounds = Some(Bounds::new(0, bounds.start - 1));
+            }
         }
-        return Ok(None);
+        if let Some(bounds) = num_bid_n.bounds {
+            if bounds.is_exact() && bounds.start > 0 {
+                bid_n.bounds = Some(Bounds::new(0, bounds.start - 1));
+            }
+        }
+        Ok((bid_m, bid_n))
+    }
+
+    /// Emits the rank-N flat-tile-id → per-axis block-id schedule for
+    /// `iter_indices()`. Leading axes traverse linearly (their map dims must
+    /// be 1) via row-major decomposition; the trailing two axes reuse
+    /// [`Self::emit_swizzle_2d`]. Rank-1 is a direct linear traversal.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn emit_mapped_partition_schedule(
+        &self,
+        module: &mut Module,
+        block_id: BlockId,
+        tile_id: &TileRustValue,
+        num_bids: &[TileRustValue],
+        map_shape: &[i32],
+        generic_vars: &GenericVars,
+        ctx: &mut CompilerContext,
+        span: &proc_macro2::Span,
+    ) -> Result<Vec<TileRustValue>, JITError> {
+        let rank = map_shape.len();
+        debug_assert_eq!(rank, num_bids.len());
+        for (axis, &dim) in map_shape.iter().enumerate().take(rank.saturating_sub(2)) {
+            if dim != 1 {
+                return self.jit_error_result(
+                    span,
+                    &format!(
+                        "mapped partition schedules group only the trailing two axes: leading map axis {axis} must be 1, got {dim}"
+                    ),
+                );
+            }
+        }
+        let exact_axis_bounds = |num_bid: &TileRustValue| {
+            num_bid.bounds.and_then(|bounds| {
+                if bounds.is_exact() && bounds.start > 0 {
+                    Some(Bounds::new(0, bounds.start - 1))
+                } else {
+                    None
+                }
+            })
+        };
+        if rank == 1 {
+            if map_shape[0] != 1 {
+                return self.jit_error_result(
+                    span,
+                    &format!(
+                        "rank-1 mapped partition maps must be [1], got [{}]",
+                        map_shape[0]
+                    ),
+                );
+            }
+            let mut bid = tile_id.clone();
+            bid.bounds = exact_axis_bounds(&num_bids[0]);
+            return Ok(vec![bid]);
+        }
+
+        let m_axis = rank - 2;
+        let n_axis = rank - 1;
+        let mut bids: Vec<TileRustValue> = Vec::with_capacity(rank);
+        let mut inner_tile_id = tile_id.clone();
+        if rank > 2 {
+            let inner_total = self.compile_binary_op_from_values(
+                module,
+                block_id,
+                num_bids[m_axis].clone(),
+                num_bids[n_axis].clone(),
+                &TileBinaryOp::Mul,
+                generic_vars,
+                ctx,
+                None,
+                span,
+            )?;
+            let mut lead = self.compile_binary_op_from_values(
+                module,
+                block_id,
+                tile_id.clone(),
+                inner_total.clone(),
+                &TileBinaryOp::Div,
+                generic_vars,
+                ctx,
+                None,
+                span,
+            )?;
+            inner_tile_id = self.compile_binary_op_from_values(
+                module,
+                block_id,
+                tile_id.clone(),
+                inner_total,
+                &TileBinaryOp::Rem,
+                generic_vars,
+                ctx,
+                None,
+                span,
+            )?;
+            // Row-major decomposition of the leading flat id: the last leading
+            // axis varies fastest.
+            for axis in 0..rank - 2 {
+                let mut bid = if axis + 1 < rank - 2 {
+                    let mut stride = num_bids[axis + 1].clone();
+                    for num_bid in &num_bids[axis + 2..rank - 2] {
+                        stride = self.compile_binary_op_from_values(
+                            module,
+                            block_id,
+                            stride,
+                            num_bid.clone(),
+                            &TileBinaryOp::Mul,
+                            generic_vars,
+                            ctx,
+                            None,
+                            span,
+                        )?;
+                    }
+                    let bid = self.compile_binary_op_from_values(
+                        module,
+                        block_id,
+                        lead.clone(),
+                        stride.clone(),
+                        &TileBinaryOp::Div,
+                        generic_vars,
+                        ctx,
+                        None,
+                        span,
+                    )?;
+                    lead = self.compile_binary_op_from_values(
+                        module,
+                        block_id,
+                        lead,
+                        stride,
+                        &TileBinaryOp::Rem,
+                        generic_vars,
+                        ctx,
+                        None,
+                        span,
+                    )?;
+                    bid
+                } else {
+                    lead.clone()
+                };
+                bid.bounds = exact_axis_bounds(&num_bids[axis]);
+                bids.push(bid);
+            }
+        }
+        let (bid_m, bid_n) = self.emit_swizzle_2d(
+            module,
+            block_id,
+            &inner_tile_id,
+            &num_bids[m_axis],
+            &num_bids[n_axis],
+            map_shape[m_axis],
+            map_shape[n_axis],
+            generic_vars,
+            ctx,
+            span,
+        )?;
+        bids.push(bid_m);
+        bids.push(bid_n);
+        Ok(bids)
     }
 }

--- a/cutile-compiler/src/compiler/compile_type.rs
+++ b/cutile-compiler/src/compiler/compile_type.rs
@@ -223,7 +223,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                         None,
                         type_instance.clone(),
                     )),
-                    "strides" => return Ok(None),
+                    "strides" | "traversal_strides" => return Ok(None),
                     "tensor_view" => return Ok(None),
                     _ => {
                         return self.jit_error_result(

--- a/cutile-compiler/src/compiler/mod.rs
+++ b/cutile-compiler/src/compiler/mod.rs
@@ -13,6 +13,7 @@ pub mod _function;
 pub mod _module;
 pub mod _type;
 pub(crate) mod _value;
+mod checks;
 mod compile_assume;
 mod compile_binary_op;
 mod compile_block;

--- a/cutile-compiler/src/compiler/shared_utils.rs
+++ b/cutile-compiler/src/compiler/shared_utils.rs
@@ -31,6 +31,17 @@ pub(crate) const STACK_RED_ZONE: usize = 4 * 1024 * 1024;
 /// Size of each new stack segment when growth is needed (10 MiB).
 pub(crate) const STACK_GROW_SIZE: usize = 10 * 1024 * 1024;
 
+/// Maximum rank of a mapped partition (`MappedPartitionMut` / `iter_indices`).
+/// Matches the DSL's `variadic_struct(N = 6)` expansion ceiling.
+pub(crate) const MAX_MAPPED_PARTITION_RANK: usize = 6;
+
+/// Map-shape sentinel marking an owned axis (mirrors `cutile::tensor::OWNED`).
+///
+/// An owned axis is not traversed by the mapped work-item stream: each stream
+/// item owns the axis's full extent (subtensor-per-CTA exclusivity), and
+/// in-kernel loops traverse it with bounds-proven indices.
+pub(crate) const OWNED_MAP_DIM: i32 = 0;
+
 // ---------------------------------------------------------------------------
 // AtomicMode
 // ---------------------------------------------------------------------------
@@ -600,6 +611,175 @@ pub fn collect_mutated_variables(
     Ok(result)
 }
 
+/// Set a variable's ordering token directly. A no-op if the variable is absent
+/// or carries no token field. Used to publish a loop's accumulated token to the
+/// tensor and to views written in the loop body.
+pub fn set_view_token(var: &str, token: cutile_ir::ir::Value, ctx: &mut CompilerContext) {
+    let Some(value) = ctx.vars.get(var) else {
+        return;
+    };
+    let mut new_value = value.clone();
+    let Some(meta) = new_value.type_meta.as_mut() else {
+        return;
+    };
+    let Some(field) = meta.fields.get_mut("token") else {
+        return;
+    };
+    field.value = Some(token);
+    ctx.vars.insert(var.to_string(), new_value);
+}
+
+/// Method names that write to a mutable partition/tensor view (advance its
+/// ordering token). Used to find which resources a loop body stores to, so the
+/// loop can thread and publish their tokens (token-ordering across the loop
+/// scope boundary).
+const STORE_METHOD_NAMES: &[&str] = &["store", "store_index"];
+
+/// A `.store(...)` call found in a loop body: the receiver view and whether its
+/// index varies with the loop variable (distinct per iteration → the writes are
+/// disjoint and may fork; otherwise the same address is written each iteration
+/// and the writes must be serialized).
+pub struct StoreCall {
+    pub receiver: String,
+    pub index_distinct: bool,
+}
+
+/// Collects the `.store(...)` / `.store_index(...)` calls anywhere in `block`
+/// (descending through nested control flow and `unsafe` blocks), with the
+/// receiver view and whether the store's index references `loop_var`. When
+/// `loop_var` is `None` (no simple loop variable), indices are treated as
+/// non-distinct (conservative: serialize).
+pub fn collect_store_calls(block: &syn::Block, loop_var: Option<&str>) -> Vec<StoreCall> {
+    let mut out = Vec::new();
+    for stmt in &block.stmts {
+        collect_store_calls_stmt(stmt, loop_var, &mut out);
+    }
+    out
+}
+
+fn collect_store_calls_stmt(stmt: &Stmt, loop_var: Option<&str>, out: &mut Vec<StoreCall>) {
+    match stmt {
+        Stmt::Local(local) => {
+            if let Some(init) = &local.init {
+                collect_store_calls_expr(&init.expr, loop_var, out);
+            }
+        }
+        Stmt::Expr(expr, _) => collect_store_calls_expr(expr, loop_var, out),
+        _ => {}
+    }
+}
+
+fn collect_store_calls_expr(expr: &Expr, loop_var: Option<&str>, out: &mut Vec<StoreCall>) {
+    match expr {
+        Expr::MethodCall(mc) => {
+            if STORE_METHOD_NAMES.contains(&mc.method.to_string().as_str()) {
+                if let Expr::Path(path) = &*mc.receiver {
+                    if let Some(ident) = path.path.get_ident() {
+                        // The index is the second argument: `store(tile, index)`.
+                        let index_distinct = match (loop_var, mc.args.iter().nth(1)) {
+                            (Some(lv), Some(index)) => expr_references_ident(index, lv),
+                            _ => false,
+                        };
+                        out.push(StoreCall {
+                            receiver: ident.to_string(),
+                            index_distinct,
+                        });
+                    }
+                }
+            }
+            collect_store_calls_expr(&mc.receiver, loop_var, out);
+            for arg in &mc.args {
+                collect_store_calls_expr(arg, loop_var, out);
+            }
+        }
+        Expr::Block(b) => collect_store_calls_block(&b.block, loop_var, out),
+        Expr::Unsafe(u) => collect_store_calls_block(&u.block, loop_var, out),
+        Expr::ForLoop(f) => collect_store_calls_block(&f.body, loop_var, out),
+        Expr::While(w) => collect_store_calls_block(&w.body, loop_var, out),
+        Expr::Loop(l) => collect_store_calls_block(&l.body, loop_var, out),
+        Expr::If(i) => {
+            collect_store_calls_block(&i.then_branch, loop_var, out);
+            if let Some((_, else_expr)) = &i.else_branch {
+                collect_store_calls_expr(else_expr, loop_var, out);
+            }
+        }
+        Expr::Call(c) => {
+            for arg in &c.args {
+                collect_store_calls_expr(arg, loop_var, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn collect_store_calls_block(block: &syn::Block, loop_var: Option<&str>, out: &mut Vec<StoreCall>) {
+    for stmt in &block.stmts {
+        collect_store_calls_stmt(stmt, loop_var, out);
+    }
+}
+
+/// Whether `expr` syntactically references the identifier `name` anywhere. Used
+/// to decide whether a store's index varies with the loop variable (fork —
+/// distinct per iteration) or not (serialize — a constant/repeated address must
+/// be ordered).
+pub fn expr_references_ident(expr: &Expr, name: &str) -> bool {
+    let mut found = false;
+    references_ident_expr(expr, name, &mut found);
+    found
+}
+
+fn references_ident_expr(expr: &Expr, name: &str, found: &mut bool) {
+    if *found {
+        return;
+    }
+    if let Expr::Path(path) = expr {
+        if path.path.is_ident(name) {
+            *found = true;
+            return;
+        }
+    }
+    // Descend into the common sub-expression carriers for index expressions.
+    match expr {
+        Expr::MethodCall(mc) => {
+            references_ident_expr(&mc.receiver, name, found);
+            for arg in &mc.args {
+                references_ident_expr(arg, name, found);
+            }
+        }
+        Expr::Call(c) => {
+            references_ident_expr(&c.func, name, found);
+            for arg in &c.args {
+                references_ident_expr(arg, name, found);
+            }
+        }
+        Expr::Binary(b) => {
+            references_ident_expr(&b.left, name, found);
+            references_ident_expr(&b.right, name, found);
+        }
+        Expr::Unary(u) => references_ident_expr(&u.expr, name, found),
+        Expr::Paren(p) => references_ident_expr(&p.expr, name, found),
+        Expr::Group(g) => references_ident_expr(&g.expr, name, found),
+        Expr::Reference(r) => references_ident_expr(&r.expr, name, found),
+        Expr::Tuple(t) => {
+            for e in &t.elems {
+                references_ident_expr(e, name, found);
+            }
+        }
+        Expr::Array(a) => {
+            for e in &a.elems {
+                references_ident_expr(e, name, found);
+            }
+        }
+        Expr::Cast(c) => references_ident_expr(&c.expr, name, found),
+        Expr::Index(i) => {
+            references_ident_expr(&i.expr, name, found);
+            references_ident_expr(&i.index, name, found);
+        }
+        Expr::Field(f) => references_ident_expr(&f.base, name, found),
+        _ => {}
+    }
+}
+
 /// Collects mutated outer-scope variables from a while-loop body.
 pub fn collect_mutated_variables_while(
     while_expr: &syn::ExprWhile,
@@ -699,6 +879,49 @@ pub fn update_token(
     };
     new_token_value.value = Some(new_token);
     Ok(ctx.vars.insert(var_name, new_value))
+}
+
+/// Propagate a resource's current ordering token up its borrow link to the root
+/// tensor it views. A view roots at its tensor (`tensor_origin`), so advancing
+/// the view's token must advance the tensor's: a *later* view of the same tensor
+/// seeds its token from `get_tensor_token`, and this is what makes that later
+/// view happen-after this one's writes (the epoch boundary of the token model).
+///
+/// This runs at scope boundaries (where the view and its root tensor are both in
+/// scope), not at the store site — inside a method frame the root tensor is out
+/// of scope, so the propagation is deferred to the boundary that reconciles the
+/// view back to its caller. A no-op when the resource has no root, roots at
+/// itself (a tensor), or the root is not a live variable here.
+pub fn propagate_token_to_root(resource_var: &str, ctx: &mut CompilerContext) {
+    let Some(resource) = ctx.vars.get(resource_var) else {
+        return;
+    };
+    let Some(root) = resource.tensor_origin.clone() else {
+        return;
+    };
+    if root == resource_var {
+        return; // A tensor roots at itself; there is nothing above it to walk to.
+    }
+    let token = resource
+        .type_meta
+        .as_ref()
+        .and_then(|meta| meta.fields.get("token"))
+        .and_then(|field| field.value);
+    let Some(token) = token else {
+        return;
+    };
+    let Some(root_value) = ctx.vars.get(&root) else {
+        return;
+    };
+    let mut new_root = root_value.clone();
+    let Some(meta) = new_root.type_meta.as_mut() else {
+        return;
+    };
+    let Some(token_field) = meta.fields.get_mut("token") else {
+        return;
+    };
+    token_field.value = Some(token);
+    ctx.vars.insert(root, new_root);
 }
 
 /// Retrieves the ordering token from a variable expression's type metadata.

--- a/cutile-compiler/src/cuda_tile_runtime_utils.rs
+++ b/cutile-compiler/src/cuda_tile_runtime_utils.rs
@@ -36,6 +36,37 @@ pub fn get_compiler_version() -> String {
     env!("CARGO_PKG_VERSION").to_string()
 }
 
+/// Ablation switch: `CUTILE_DISABLE_CHECK_HOISTING=1` keeps every dynamic
+/// partition-access bounds check at its access site instead of hoisting to
+/// loop preheaders. Read uncached so A/B toggling never needs a rebuild —
+/// this is a compile-time (JIT) knob, not a kernel-time one.
+pub fn check_hoisting_disabled() -> bool {
+    env::var("CUTILE_DISABLE_CHECK_HOISTING").is_ok_and(|v| v == "1") || force_device_checks()
+}
+
+/// `CUTILE_FORCE_DEVICE_CHECKS=1`: full placement ablation for differential
+/// testing. Every plain-family access check is emitted at its access site,
+/// two-sided, over the actual runtime values — no preheader hoisting
+/// (implies `CUTILE_DISABLE_CHECK_HOISTING`), no launch relocation, and no
+/// JIT discharge: provenance, static folds, entailment, and inferred lower
+/// bounds are all skipped. The ablated build is the differential harness's
+/// semantic REFERENCE, and a reference that inherits the compiler's proofs
+/// cannot catch one that is wrong (2026-08-12 review, S2) — earlier this
+/// knob kept "verified" proofs, and a wrap-tainted static fold sailed
+/// through both builds identically. The bounded (`with_bounds`) family is
+/// unaffected — its undischarged checks are compile errors, so it has no
+/// device placement to ablate to.
+pub fn force_device_checks() -> bool {
+    env::var("CUTILE_FORCE_DEVICE_CHECKS").is_ok_and(|v| v == "1")
+}
+
+/// `CUTILE_JIT_LOG=1` also reports every bounds check that stays inside a
+/// loop body with the reason it could not hoist.
+pub fn jit_hoist_log_enabled() -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| env::var("CUTILE_JIT_LOG").is_ok_and(|v| v == "1"))
+}
+
 /// Queries the CUDA driver to determine the SM architecture name (e.g. `"sm_90"`) for a device.
 ///
 /// Cached per device: the driver is queried once per device and cache hits are
@@ -395,12 +426,145 @@ fn clamp_bytecode_version(version: BytecodeVersion) -> BytecodeVersion {
         .min(BytecodeVersion::CURRENT)
 }
 
+/// Builds the version-probe module: one entry with a pointer parameter, a
+/// token, a tensor/partition view, and a `cuda_tile.for` region whose body
+/// loads through the view. An EMPTY module is not a valid probe — an older
+/// `tileiras` accepted a newer version's empty bytecode while rejecting the
+/// same version's region encoding, so the probe selected a version real
+/// kernels could not compile at (grout B200 evaluation, 2026-08). The probe
+/// must contain the independently versioned encodings a real kernel has:
+/// regions were the construct that caught it, and view/token types are the
+/// other independently versioned family (2026-08-18 review, R1). If a
+/// version-gated encoding is ever added outside these families, extend this
+/// module alongside it.
+fn build_probe_module() -> cutile_ir::Module {
+    use cutile_ir::builder::{append_op, build_single_block_region, OpBuilder};
+    use cutile_ir::bytecode::Opcode;
+    use cutile_ir::ir::{
+        Attribute, DenseElements, FuncType, Location, Module, PartitionViewType, PointerType,
+        ScalarType, TensorViewType, TileElementType, TileType, Type,
+    };
+
+    let tile_i32 = Type::Tile(TileType {
+        element_type: TileElementType::Scalar(ScalarType::I32),
+        shape: vec![],
+    });
+    let tile_ptr_f32 = Type::Tile(TileType {
+        element_type: TileElementType::Pointer(Box::new(PointerType {
+            pointee: ScalarType::F32,
+        })),
+        shape: vec![],
+    });
+    let tv_ty = Type::TensorView(TensorViewType {
+        element_type: ScalarType::F32,
+        shape: vec![128],
+        strides: vec![1],
+    });
+    let pv_ty = Type::PartitionView(PartitionViewType {
+        tile_shape: vec![16],
+        tensor_view: TensorViewType {
+            element_type: ScalarType::F32,
+            shape: vec![128],
+            strides: vec![1],
+        },
+        dim_map: vec![0],
+        padding_value: None,
+    });
+    let tile_16_f32 = Type::Tile(TileType {
+        element_type: TileElementType::Scalar(ScalarType::F32),
+        shape: vec![16],
+    });
+    let mut module = Module::new("__cutile_probe");
+    let (region_id, block_id, entry_args) =
+        build_single_block_region(&mut module, std::slice::from_ref(&tile_ptr_f32));
+    let const_i32 = |module: &mut Module, val: i32| {
+        let (op, res) = OpBuilder::new(Opcode::Constant, Location::Unknown)
+            .attr(
+                "value",
+                Attribute::DenseElements(DenseElements {
+                    element_type: tile_i32.clone(),
+                    shape: vec![],
+                    data: val.to_le_bytes().to_vec(),
+                }),
+            )
+            .result(tile_i32.clone())
+            .build(module);
+        append_op(module, block_id, op);
+        res[0]
+    };
+    let (tok_op, tok_res) = OpBuilder::new(Opcode::MakeToken, Location::Unknown)
+        .result(Type::Token)
+        .build(&mut module);
+    append_op(&mut module, block_id, tok_op);
+    let seg_i32 = |n: i64| Attribute::Integer(n, tile_i32.clone());
+    let (mtv, mtv_res) = OpBuilder::new(Opcode::MakeTensorView, Location::Unknown)
+        .operand(entry_args[0])
+        .result(tv_ty)
+        .attr(
+            "operandSegmentSizes",
+            Attribute::Array(vec![seg_i32(1), seg_i32(0), seg_i32(0)]),
+        )
+        .build(&mut module);
+    append_op(&mut module, block_id, mtv);
+    let (mpv, mpv_res) = OpBuilder::new(Opcode::MakePartitionView, Location::Unknown)
+        .operand(mtv_res[0])
+        .result(pv_ty)
+        .build(&mut module);
+    append_op(&mut module, block_id, mpv);
+    let lb = const_i32(&mut module, 0);
+    let ub = const_i32(&mut module, 4);
+    let step = const_i32(&mut module, 1);
+    let (body_region, body_blk, body_args) =
+        build_single_block_region(&mut module, &[tile_i32.clone()]);
+    // The load sits INSIDE the region and references parent-scope values
+    // (view, token) plus the block argument — the cross-region encoding a
+    // real kernel exercises.
+    let (load, _) = OpBuilder::new(Opcode::LoadViewTko, Location::Unknown)
+        .operand(mpv_res[0])
+        .operand(body_args[0])
+        .operand(tok_res[0])
+        .attr("memory_ordering_semantics", seg_i32(0))
+        .attr(
+            "operandSegmentSizes",
+            Attribute::Array(vec![seg_i32(1), seg_i32(1), seg_i32(1)]),
+        )
+        .result(tile_16_f32)
+        .result(Type::Token)
+        .build(&mut module);
+    append_op(&mut module, body_blk, load);
+    let (cont, _) = OpBuilder::new(Opcode::Continue, Location::Unknown).build(&mut module);
+    append_op(&mut module, body_blk, cont);
+    let (for_op, _) = OpBuilder::new(Opcode::For, Location::Unknown)
+        .operand(lb)
+        .operand(ub)
+        .operand(step)
+        .region(body_region)
+        .build(&mut module);
+    append_op(&mut module, block_id, for_op);
+    let (ret, _) = OpBuilder::new(Opcode::Return, Location::Unknown).build(&mut module);
+    append_op(&mut module, block_id, ret);
+    let (entry, _) = OpBuilder::new(Opcode::Entry, Location::Unknown)
+        .attr("sym_name", Attribute::String("__cutile_probe_entry".into()))
+        .attr(
+            "function_type",
+            Attribute::Type(Type::Func(FuncType {
+                inputs: vec![tile_ptr_f32],
+                results: vec![],
+            })),
+        )
+        .region(region_id)
+        .build(&mut module);
+    module.functions.push(entry);
+    module
+}
+
 /// Probes `tileiras` for the newest bytecode version it accepts by compiling a
-/// tiny empty module at each candidate version, newest first.
+/// tiny but REPRESENTATIVE module (an entry with a `for` region) at each
+/// candidate version, newest first.
 fn probe_max_supported_bytecode_version(tileiras: &Path) -> BytecodeVersion {
     let tmp_dir = env::temp_dir();
     for &version in BytecodeVersion::SUPPORTED.iter().rev() {
-        let module = cutile_ir::Module::new("__cutile_probe");
+        let module = build_probe_module();
         let Ok(bytes) = write_bytecode_version(&module, version) else {
             continue;
         };
@@ -926,6 +1090,43 @@ mod tests {
     use std::sync::Mutex;
 
     static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    /// The probe module must be a valid, encodable kernel at every supported
+    /// version, and it must contain a `for` region — an EMPTY probe passed a
+    /// version the installed tileiras then rejected on real kernels (grout
+    /// B200 evaluation, 2026-08).
+    #[test]
+    fn probe_module_is_representative_and_valid() {
+        // Reads the tileiras env resolution: serialize with the tests that
+        // mutate it.
+        let _guard = ENV_LOCK.lock().unwrap();
+        let module = build_probe_module();
+        module.verify_dominance().expect("probe module dominance");
+        module
+            .verify_bytecode_indices()
+            .expect("probe module bytecode indices");
+        assert!(
+            !module.functions.is_empty() && module.num_values() >= 4,
+            "the probe must carry an entry with real ops (a `for` region), not \
+             be the empty module that once passed a version real kernels failed at"
+        );
+        for &version in BytecodeVersion::SUPPORTED.iter() {
+            write_bytecode_version(&module, version)
+                .unwrap_or_else(|e| panic!("probe must encode at {version}: {e}"));
+        }
+        // When a real tileiras is reachable, the probe must find SOME
+        // accepted version (i.e. real-construct bytecode compiles, not just
+        // an empty module).
+        let tileiras = tileiras_binary();
+        if Command::new(&tileiras).arg("--version").output().is_ok() {
+            let version = probe_max_supported_bytecode_version(&tileiras);
+            assert!(
+                version >= BytecodeVersion::MIN_SUPPORTED,
+                "probe found no accepted version against {}",
+                tileiras.display()
+            );
+        }
+    }
 
     #[test]
     fn tileiras_binary_defaults_to_path_lookup() {

--- a/cutile-compiler/src/generics.rs
+++ b/cutile-compiler/src/generics.rs
@@ -918,7 +918,7 @@ impl Instantiable for TypeInstanceStructuredType {
         let structured_type_name = get_type_ident(maybe_generic_ty).map(|ident| ident.to_string());
         let allows_extra_cga = matches!(
             structured_type_name.as_deref(),
-            Some("MappedPartitionMut" | "PartitionIndices")
+            Some("MappedPartitionMut" | "PartitionIndices" | "GatherScatterView" | "StridedView")
         );
 
         let inst_mut_ref = if let Type::Reference(inner_elem) = &mut instance_ty {
@@ -1248,6 +1248,12 @@ pub struct GenericArgInference {
     pub params: Vec<String>,
     pub param2arg: HashMap<String, Option<(GenericArgType, String)>>,
     pub param2cga: HashMap<String, Type>,
+    /// Caller-side const-generic instances (`D` → `128`), used to normalize
+    /// symbolic shape elements before unification: argument types reaching
+    /// inline inference mix entry-substituted literals with unsubstituted
+    /// caller symbols, and both forms of the same dimension must unify.
+    /// Populated by [`Self::map_args_to_params`]; empty otherwise.
+    caller_scalars: HashMap<String, i32>,
 }
 
 // TODO (hme): Separate generic parameter inference from type inference procedure.
@@ -1291,6 +1297,7 @@ impl GenericArgInference {
             param2arg,
             params,
             method_params: Some(method_params),
+            caller_scalars: HashMap::new(),
         }
     }
 
@@ -1312,22 +1319,31 @@ impl GenericArgInference {
             param2arg,
             params,
             method_params: None,
+            caller_scalars: HashMap::new(),
         }
     }
 
     /// Maps positional call arguments to their corresponding parameter names.
+    ///
+    /// `caller_generic_vars` supplies the caller's const-generic instances so
+    /// symbolic shape elements normalize before unification: argument types
+    /// mix entry-substituted literals (`128`) with unsubstituted caller
+    /// symbols (`D`) for the same dimension.
     pub fn map_args_to_params(
         &mut self,
         call_arg_rust_tys: &Vec<syn::Type>,
         self_ty: Option<&Type>,
-    ) -> () {
+        caller_generic_vars: &GenericVars,
+    ) -> Result<(), JITError> {
+        self.caller_scalars = caller_generic_vars.inst_i32.clone();
         let (fn_arg_types, _return_type) = get_sig_types(&self.sig, self_ty);
         // Get the generic parameters in this function signature.
         for i in 0..call_arg_rust_tys.len() {
             let call_arg_rust_ty = &call_arg_rust_tys[i];
             let fn_arg_types = &fn_arg_types[i];
-            self.add_generic_args(fn_arg_types, call_arg_rust_ty);
+            self.add_generic_args(fn_arg_types, call_arg_rust_ty)?;
         }
+        Ok(())
     }
     /// Applies explicitly provided generic arguments from a function call expression.
     pub fn apply_provided_generics_fn_call(
@@ -1450,9 +1466,11 @@ impl GenericArgInference {
             )
         };
         assert_eq!(expr_generic_args.args.len(), method_params.len());
-        for i in 0..expr_generic_args.args.len() {
-            let param = &self.params[i];
-            let arg = &expr_generic_args.args[i];
+        // A method turbofish names the METHOD generics only (Rust semantics);
+        // impl generics come from the receiver. `self.params` is impl params
+        // followed by method params, so pair against the latter.
+        let method_params = method_params.clone();
+        for (param, arg) in method_params.iter().zip(expr_generic_args.args.iter()) {
             if let Some(Some(_)) = self.param2arg.get(param) {
                 // The type for this has already been inferred.
                 // Our compiler doesn't need to check anything. Rust already has.
@@ -1568,7 +1586,12 @@ impl GenericArgInference {
         // arg_map keys are target param names, and values are their values.
         for (name, v) in &self.param2arg {
             let Some((ast_name, ast_string)) = v else {
-                panic!("Unexpected None value for key={name}");
+                // Not inferable from the argument types — e.g. a method const
+                // generic supplied only via turbofish (`load_pipelined::<4>`).
+                // Leave it unresolved; callers merge explicit turbofish args
+                // afterward, and a genuinely missing param still fails with a
+                // spanned "no resolved value" error at its use site.
+                continue;
             };
             match *ast_name {
                 GenericArgType::Type => {
@@ -1697,11 +1720,19 @@ impl GenericArgInference {
         to_generic_vars
     }
 
-    pub(crate) fn add_type_constraints(&mut self, type_param: &syn::Type, type_arg: &syn::Type) {
-        self.add_generic_args(type_param, type_arg);
+    pub(crate) fn add_type_constraints(
+        &mut self,
+        type_param: &syn::Type,
+        type_arg: &syn::Type,
+    ) -> Result<(), JITError> {
+        self.add_generic_args(type_param, type_arg)
     }
 
-    fn add_generic_args(&mut self, type_param: &syn::Type, type_arg: &syn::Type) -> () {
+    fn add_generic_args(
+        &mut self,
+        type_param: &syn::Type,
+        type_arg: &syn::Type,
+    ) -> Result<(), JITError> {
         // Adds generic arguments to arg_map.
         // arg_map maps generic parameters (present in arg_map upon initialization) to various GenericArgument patterns (see below).
         // Each key in arg_map specifies the set of generic parameters in a function / method signature.
@@ -1721,12 +1752,12 @@ impl GenericArgInference {
         if let (syn::Type::Tuple(param_tuple), syn::Type::Tuple(arg_tuple)) = (type_param, type_arg)
         {
             if param_tuple.elems.len() != arg_tuple.elems.len() {
-                return;
+                return Ok(());
             }
             for (param_elem, arg_elem) in param_tuple.elems.iter().zip(arg_tuple.elems.iter()) {
-                self.add_generic_args(param_elem, arg_elem);
+                self.add_generic_args(param_elem, arg_elem)?;
             }
-            return;
+            return Ok(());
         }
 
         let (Some(mut param_generic_args), Some(mut arg_generic_args)) =
@@ -1734,7 +1765,7 @@ impl GenericArgInference {
         else {
             // Check if type itself is a generic param.
             self.add_generic_type(type_param, type_arg);
-            return;
+            return Ok(());
         };
         strip_generic_args_lifetimes(&mut param_generic_args);
         strip_generic_args_lifetimes(&mut arg_generic_args);
@@ -1771,7 +1802,7 @@ impl GenericArgInference {
                             if maybe_generic_args(param_type).is_some()
                                 && maybe_generic_args(arg_type).is_some()
                             {
-                                self.add_generic_args(param_type, arg_type);
+                                self.add_generic_args(param_type, arg_type)?;
                             }
                             // Something like (Tensor<f32, ...>, Tensor<E, ...>)
                             let param_ident = &param_type_path
@@ -1812,7 +1843,7 @@ impl GenericArgInference {
                             }
                         }
                         (syn::Type::Reference(arg_ref), syn::Type::Reference(param_ref)) => {
-                            self.add_generic_args(&param_ref.elem, &arg_ref.elem);
+                            self.add_generic_args(&param_ref.elem, &arg_ref.elem)?;
                         }
                         _ => {}
                     }
@@ -1880,6 +1911,15 @@ impl GenericArgInference {
                                                 },
                                                 _ => unimplemented!("Unexpected array element {arg_elem:#?} in {arg_array_expr:#?}"),
                                             };
+                                            // Normalize symbolic elements through the
+                                            // caller's generics: argument types mix
+                                            // entry-substituted literals with caller
+                                            // symbols for the same dimension (`128` vs
+                                            // `D`), and both must unify.
+                                            let arg_val = match self.caller_scalars.get(&arg_val) {
+                                                Some(value) => value.to_string(),
+                                                None => arg_val,
+                                            };
                                             // Skip inference from dynamic dims (-1): they
                                             // carry no information about the generic param.
                                             if arg_val == "- 1" || arg_val == "-1" {
@@ -1887,11 +1927,18 @@ impl GenericArgInference {
                                             }
                                             let replaced_arg = self.param2arg.insert(param_var.to_string(), Some((GenericArgType::GenericConstExpr, arg_val.to_string())));
                                             if let Some(Some((_arg_type, arg))) = replaced_arg {
+                                                let arg = match self.caller_scalars.get(&arg) {
+                                                    Some(value) => value.to_string(),
+                                                    None => arg,
+                                                };
                                                 // Allow overriding a previous -1 (dynamic)
                                                 // inference with a concrete value, but
                                                 // two different concrete values conflict.
-                                                if arg != "- 1" && arg != "-1" {
-                                                    assert_eq!(arg, arg_val.to_string());
+                                                if arg != "- 1" && arg != "-1" && arg != arg_val {
+                                                    return Err(JITError::Generic(format!(
+                                                        "conflicting const-generic inference for `{param_var}` in call to `{callee}`: one argument implies `{arg}`, another implies `{arg_val}`",
+                                                        callee = self.sig.ident,
+                                                    )));
                                                 }
                                             }
                                         }
@@ -1905,10 +1952,14 @@ impl GenericArgInference {
                             }
                         }
                         (Expr::Lit(arg_lit), Expr::Lit(param_lit)) => {
-                            assert_eq!(
-                                arg_lit.to_token_stream().to_string(),
-                                param_lit.to_token_stream().to_string()
-                            );
+                            let arg_lit_str = arg_lit.to_token_stream().to_string();
+                            let param_lit_str = param_lit.to_token_stream().to_string();
+                            if arg_lit_str != param_lit_str {
+                                return Err(JITError::Generic(format!(
+                                    "const-generic mismatch in call to `{callee}`: the signature fixes `{param_lit_str}` but the argument provides `{arg_lit_str}`",
+                                    callee = self.sig.ident,
+                                )));
+                            }
                         }
                         _ => unimplemented!(
                             "Unsupported Const inference {param_const:#?} {arg_const:#?}"
@@ -1918,6 +1969,7 @@ impl GenericArgInference {
                 _ => {}
             }
         }
+        Ok(())
     }
 
     fn add_generic_type(&mut self, param_type: &Type, arg_type: &Type) {
@@ -2439,5 +2491,86 @@ pub fn parse_expr_as_i32(expr: &Expr, generic_args: &GenericVars) -> i32 {
             *dim
         }
         _ => unimplemented!("Unexpected expression {expr:#?}"),
+    }
+}
+
+#[cfg(test)]
+mod inference_tests {
+    use super::*;
+
+    fn mma_like_inference() -> GenericArgInference {
+        let sig: Signature = syn::parse_quote! {
+            fn mma_like<const M: i32, const N: i32, const K: i32>(
+                lhs: Tile<f32, { [M, K] }>,
+                rhs: Tile<f32, { [K, N] }>,
+            ) -> Tile<f32, { [M, N] }>
+        };
+        GenericArgInference::new_function(sig)
+    }
+
+    /// Two arguments implying different concrete values for the same shape
+    /// param is a genuine conflict: it must produce the named JIT error,
+    /// never silently unify.
+    #[test]
+    fn conflicting_concrete_dims_error_instead_of_unifying() {
+        let mut inference = mma_like_inference();
+        let args: Vec<Type> = vec![
+            syn::parse_quote!(Tile<f32, { [16, 128] }>),
+            syn::parse_quote!(Tile<f32, { [64, 32] }>),
+        ];
+        let err = inference
+            .map_args_to_params(&args, None, &GenericVars::empty_unchecked())
+            .expect_err("K = 128 vs K = 64 must conflict");
+        let message = err.to_string();
+        assert!(
+            message.contains("conflicting const-generic inference")
+                && message.contains("`K`")
+                && message.contains("mma_like")
+                && message.contains("128")
+                && message.contains("64"),
+            "conflict error must name the param, callee, and both values: {message}"
+        );
+    }
+
+    /// Normalization is evaluation under the caller's instantiation: a
+    /// symbol and its instance are the same dimension and must unify.
+    #[test]
+    fn symbolic_and_substituted_forms_of_one_dim_unify() {
+        let mut inference = mma_like_inference();
+        let mut caller = GenericVars::empty_unchecked();
+        caller.inst_i32.insert("D".to_string(), 128);
+        let args: Vec<Type> = vec![
+            syn::parse_quote!(Tile<f32, { [16, D] }>),
+            syn::parse_quote!(Tile<f32, { [128, 32] }>),
+        ];
+        inference
+            .map_args_to_params(&args, None, &caller)
+            .expect("D (=128) and 128 are the same dimension");
+        let vars = inference.get_generic_vars_instance(&caller, &HashMap::new());
+        assert_eq!(vars.inst_i32.get("K"), Some(&128));
+        assert_eq!(vars.inst_i32.get("M"), Some(&16));
+        assert_eq!(vars.inst_i32.get("N"), Some(&32));
+    }
+
+    /// Normalization cannot over-normalize: two different symbols with
+    /// different instances still conflict after resolution.
+    #[test]
+    fn distinct_symbols_with_distinct_instances_still_conflict() {
+        let mut inference = mma_like_inference();
+        let mut caller = GenericVars::empty_unchecked();
+        caller.inst_i32.insert("D".to_string(), 128);
+        caller.inst_i32.insert("E".to_string(), 64);
+        let args: Vec<Type> = vec![
+            syn::parse_quote!(Tile<f32, { [16, D] }>),
+            syn::parse_quote!(Tile<f32, { [E, 32] }>),
+        ];
+        let err = inference
+            .map_args_to_params(&args, None, &caller)
+            .expect_err("D (=128) vs E (=64) must conflict after normalization");
+        assert!(
+            err.to_string()
+                .contains("conflicting const-generic inference"),
+            "unexpected error: {err}"
+        );
     }
 }

--- a/cutile-compiler/src/kernel_entry_generator.rs
+++ b/cutile-compiler/src/kernel_entry_generator.rs
@@ -120,9 +120,12 @@ impl TensorInput {
 
     pub fn validate(&self) -> Result<(), JITError> {
         if let TensorParamKind::MappedPartitionMut { .. } = &self.param_kind {
-            if self.rank != 2 {
+            // Mutable partitions are capped at rank 3 below; rank-1 and rank-2
+            // mapped partitions traverse linearly or with a grouped 2-D
+            // swizzle, rank-3 adds a linear leading axis.
+            if self.rank < 1 || self.rank > 3 {
                 return SourceLocation::unknown()
-                    .jit_error_result("swizzled MappedPartitionMut parameters must have rank 2.");
+                    .jit_error_result("MappedPartitionMut parameters must have rank 1 through 3.");
             }
         }
         if self.mutable {
@@ -659,6 +662,7 @@ pub fn generate_entry_point(
         fn_entry,
         Validator {
             params: fn_params_concrete_types,
+            launch_checks: Vec::new(),
         },
     ))
 }

--- a/cutile-compiler/src/lib.rs
+++ b/cutile-compiler/src/lib.rs
@@ -24,6 +24,7 @@ pub mod train_map;
 pub mod type_aliases;
 pub mod types;
 pub mod use_classifier;
+mod value_facts;
 
 pub mod compiler;
 pub mod dump;

--- a/cutile-compiler/src/passes/mod.rs
+++ b/cutile-compiler/src/passes/mod.rs
@@ -38,6 +38,7 @@
 
 pub mod name_resolution;
 pub mod node_ids;
+pub mod obligation;
 pub mod proof_analysis;
 pub mod type_inference;
 pub mod typed_dispatch_lowering;

--- a/cutile-compiler/src/passes/obligation.rs
+++ b/cutile-compiler/src/passes/obligation.rs
@@ -1,0 +1,270 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Staged obligation resolution: the solver seam for launch-time check hoisting.
+//!
+//! The predicate vocabulary itself lives in [`cuda_async::predicate`] (a
+//! canonical [`Term`]/[`Predicate`] shared with the host launcher). This module
+//! adds the *solver* around it:
+//! - [`Obligation`] — a predicate to prove, with a diagnostic `cause` (rustc
+//!   `Obligation`).
+//! - [`Assumptions`] — the set of predicates believed in scope (rustc
+//!   `ParamEnv.caller_bounds`).
+//! - [`resolve`] — picks the earliest [`Stage`] that discharges an obligation:
+//!   [`Resolution::Jit`] if a dominating assumption entails it, else
+//!   [`Resolution::Launch`] if the predicate ranges only over launch-known
+//!   operands (`predicate.stage() <= Launch`), else [`Resolution::Device`].
+//!
+//! Because [`Predicate`] is canonical (see `cuda_async::predicate`), assumption
+//! entailment is set membership and the launch-known test is `stage()` over the
+//! predicate's atoms — no per-variant special-casing.
+
+use std::collections::HashSet;
+
+use cuda_async::predicate::{LaunchCheck, Predicate, Stage};
+
+use crate::passes::proof_analysis::ProofResults;
+
+/// A predicate to prove, carrying a diagnostic `cause` for the eventual launch
+/// or in-kernel failure message.
+#[derive(Debug, Clone)]
+pub(crate) struct Obligation {
+    pub(crate) predicate: Predicate,
+    pub(crate) cause: String,
+}
+
+impl Obligation {
+    pub(crate) fn new(predicate: Predicate, cause: impl Into<String>) -> Self {
+        Self {
+            predicate,
+            cause: cause.into(),
+        }
+    }
+}
+
+/// Where an obligation was discharged. [`Resolution::Jit`] costs zero registers
+/// and zero host work; [`Resolution::Launch`] costs one host compare per launch;
+/// [`Resolution::Device`] is an in-kernel assert (the existing path).
+#[derive(Debug, Clone)]
+pub(crate) enum Resolution {
+    Jit,
+    #[allow(dead_code)] // accepted once a client collects launch checks (RMSNorm wiring).
+    Launch(LaunchCheck),
+    Device,
+}
+
+/// The set of predicates believed in scope (rustc `ParamEnv.caller_bounds`).
+/// Membership is exact because [`Predicate`] is canonical.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct Assumptions {
+    believed: HashSet<Predicate>,
+}
+
+impl Assumptions {
+    /// Seed from declared `preconditions`: `dim(a, i) == dim(b, j)` becomes an
+    /// entry-scoped `Predicate::eq` over the two axis extents, and
+    /// `dim(t, k) % d == 0` becomes `Predicate::divisible_by` over one extent,
+    /// resolving tensor names to param indices via `param_index`. Each fact's
+    /// truth is verified by the generated launcher before the kernel runs — a
+    /// violating launch is rejected — which is what makes believing it here
+    /// sound. A fact naming a non-parameter (or that fails to canonicalize) is
+    /// skipped — conservative.
+    pub(crate) fn from_preconditions(
+        proof: &ProofResults,
+        param_index: &std::collections::HashMap<String, usize>,
+    ) -> Self {
+        use crate::passes::proof_analysis::MetadataExpr;
+        use crate::passes::proof_analysis::MetadataFact;
+        use cuda_async::predicate::{Atom, Term};
+        let mut believed = HashSet::new();
+        for fact in &proof.metadata_facts {
+            match fact {
+                MetadataFact::DimEq {
+                    lhs:
+                        MetadataExpr::Dim {
+                            tensor: lt,
+                            axis: la,
+                        },
+                    rhs:
+                        MetadataExpr::Dim {
+                            tensor: rt,
+                            axis: ra,
+                        },
+                } => {
+                    let (Some(&lp), Some(&rp)) = (param_index.get(lt), param_index.get(rt)) else {
+                        continue;
+                    };
+                    let lhs = Term::atom(Atom::Dim {
+                        param: lp,
+                        axis: *la,
+                    });
+                    let rhs = Term::atom(Atom::Dim {
+                        param: rp,
+                        axis: *ra,
+                    });
+                    if let Some(pred) = Predicate::eq(&lhs, &rhs) {
+                        believed.insert(pred);
+                    }
+                }
+                MetadataFact::DimDivisible {
+                    tensor,
+                    axis,
+                    divisor,
+                } => {
+                    let Some(&param) = param_index.get(tensor) else {
+                        continue;
+                    };
+                    let term = Term::atom(Atom::Dim { param, axis: *axis });
+                    if let Some(pred) = Predicate::divisible_by(term, *divisor) {
+                        believed.insert(pred);
+                    }
+                }
+            }
+        }
+        Self { believed }
+    }
+
+    // NOTE: the assumption set deliberately holds NOTHING besides declared,
+    // launch-verified `preconditions`. It used to be seeded with the hardware
+    // register axioms (`TileBlockId(k) < NumTileBlocks(k)`): universally true,
+    // but their only consumer was a rung that formed the axiom as its own goal
+    // and discharged it against itself — a tautology that admitted
+    // out-of-bounds stores (reverted). Live-looking machinery with no sound
+    // consumer is how that bug shipped, so the axioms are gone until a rung
+    // exists that (a) forms the real proposition `TileBlockId(k) <
+    // num_partitions(view, k)` and (b) obtains `NumTileBlocks(k) ==
+    // num_partitions(view, k)` as a *verified* Launch obligation. Every set
+    // member being launch-verified is also what keeps `entails` sound as plain
+    // membership without a dominance test.
+
+    /// Does an assumption in scope entail `predicate`? Exact set membership,
+    /// since predicates are canonical.
+    ///
+    /// **There is no dominance check here.** The design (`staged dominance`)
+    /// requires an assumption to dominate the obligation it discharges; this is
+    /// vacuously satisfied today because the only assumption source is
+    /// kernel-scoped and unconditional — declared entry `preconditions` hold at
+    /// every program point. The moment a
+    /// *flow-sensitive* assumption is minted (a loop-body fact, an `if`-arm
+    /// fact, a point `require`), this must become a real dominance test or it
+    /// will discharge obligations from facts that do not reach them.
+    fn entails(&self, predicate: &Predicate) -> bool {
+        self.believed.contains(predicate)
+    }
+}
+
+/// The solver: pick the earliest [`Stage`] that discharges `obligation` given
+/// the dominating `assumptions`.
+///
+/// - [`Resolution::Jit`] — a dominating assumption entails the predicate.
+/// - [`Resolution::Launch`] — the predicate ranges only over launch-known
+///   operands (`stage() <= Launch`), so the host decides it once per launch.
+/// - [`Resolution::Device`] — otherwise; fall to the existing in-kernel check.
+///
+/// A client that has not opted into launch-check collection simply treats any
+/// non-`Jit` resolution as "not discharged here" and keeps its existing
+/// (device) path — so introducing the `Launch` tier is behavior-preserving
+/// until a client collects it.
+pub(crate) fn resolve(obligation: &Obligation, assumptions: &Assumptions) -> Resolution {
+    // A predicate over no atoms is already decided: its term is a constant, so
+    // evaluate it rather than shipping a host compare of two known numbers.
+    // `dim(x, 1) == dim(x, 1)` canonicalizes to `Zero(0)` and lands here — a
+    // goal worth recognising, since asking whether an axis matches *itself* is
+    // the degenerate case of every cross-tensor query. A constant-false
+    // predicate falls through to the stage rungs, which will place a check
+    // that fails: conservative, and it keeps the reporting of a real violation
+    // in one place.
+    if obligation.predicate.eval(&|_| None) == Some(true) {
+        return Resolution::Jit;
+    }
+    if assumptions.entails(&obligation.predicate) {
+        Resolution::Jit
+    } else if obligation.predicate.stage() <= Stage::Launch {
+        Resolution::Launch(LaunchCheck {
+            predicate: obligation.predicate.clone(),
+            cause: obligation.cause.clone(),
+        })
+    } else {
+        Resolution::Device
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cuda_async::predicate::{Atom, Term};
+
+    fn dim_term(param: usize, axis: usize) -> Term {
+        Term::atom(Atom::Dim { param, axis })
+    }
+
+    fn assumptions(preds: Vec<Predicate>) -> Assumptions {
+        Assumptions {
+            believed: preds.into_iter().collect(),
+        }
+    }
+
+    #[test]
+    fn dim_eq_entailed_resolves_at_jit() {
+        let env = assumptions(vec![
+            Predicate::eq(&dim_term(0, 0), &dim_term(1, 0)).unwrap()
+        ]);
+        // Symmetric: the goal states the equality the other way round.
+        let obl = Obligation::new(
+            Predicate::eq(&dim_term(1, 0), &dim_term(0, 0)).unwrap(),
+            "test",
+        );
+        assert!(matches!(resolve(&obl, &env), Resolution::Jit));
+    }
+
+    #[test]
+    fn dim_eq_unentailed_but_launch_known_resolves_at_launch() {
+        // Both operands are tensor extents (Launch-known), so an unproven
+        // equality is a launch check rather than a device assert.
+        let env = assumptions(vec![]);
+        let obl = Obligation::new(
+            Predicate::eq(&dim_term(0, 0), &dim_term(1, 1)).unwrap(),
+            "test",
+        );
+        assert!(matches!(resolve(&obl, &env), Resolution::Launch(_)));
+    }
+
+    #[test]
+    fn device_stage_predicate_falls_to_device() {
+        // An induction variable is Device-stage, so a predicate over it cannot
+        // be hoisted.
+        let env = assumptions(vec![]);
+        let obl = Obligation::new(Predicate::nonzero(Term::atom(Atom::Iv(3))), "iv");
+        assert!(matches!(resolve(&obl, &env), Resolution::Device));
+    }
+
+    #[test]
+    fn dim_nonzero_resolves_at_launch() {
+        let env = assumptions(vec![]);
+        let obl = Obligation::new(Predicate::nonzero(dim_term(0, 0)), "extent > 0");
+        assert!(matches!(resolve(&obl, &env), Resolution::Launch(_)));
+    }
+
+    #[test]
+    fn no_axiom_is_believed_without_a_declared_precondition() {
+        // The assumption set holds nothing but declared, launch-verified facts.
+        // In particular the hardware register axioms are NOT seeded: their only
+        // consumer was a rung that formed the axiom as its own goal and
+        // discharged it against itself — a tautology that admitted
+        // out-of-bounds stores (reverted). A block-id bound is Device-stage, so
+        // with nothing believed it falls to Device — fail closed.
+        let env = Assumptions::from_preconditions(
+            &ProofResults::default(),
+            &std::collections::HashMap::new(),
+        );
+        let goal = Predicate::lt(
+            &Term::atom(Atom::TileBlockId(0)),
+            &Term::atom(Atom::NumTileBlocks(0)),
+        )
+        .unwrap();
+        let obl = Obligation::new(goal, "block id in grid");
+        assert!(matches!(resolve(&obl, &env), Resolution::Device));
+    }
+}

--- a/cutile-compiler/src/passes/proof_analysis.rs
+++ b/cutile-compiler/src/passes/proof_analysis.rs
@@ -11,7 +11,6 @@
 //! source-level predicates directly.
 
 use crate::ast::SourceLocation;
-use crate::compiler::_value::PartitionAxisOrigin;
 use crate::compiler::shared_types::EntryAttrs;
 use crate::error::{JITError, SpannedJITError};
 use syn::{BinOp, Expr, ExprBinary, ExprCall};
@@ -22,9 +21,21 @@ pub(crate) enum MetadataExpr {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub(crate) struct MetadataFact {
-    pub(crate) lhs: MetadataExpr,
-    pub(crate) rhs: MetadataExpr,
+pub(crate) enum MetadataFact {
+    /// `dim(a, i) == dim(b, j)` — two axis extents are equal.
+    DimEq {
+        lhs: MetadataExpr,
+        rhs: MetadataExpr,
+    },
+    /// `dim(t, k) % divisor == 0` — an axis extent is a multiple of a constant.
+    /// The divisor must be a positive integer literal: it is embedded in the
+    /// generated launcher's verification, which runs before any const-generic
+    /// value exists.
+    DimDivisible {
+        tensor: String,
+        axis: usize,
+        divisor: i64,
+    },
 }
 
 #[derive(Debug, Clone, Default)]
@@ -42,42 +53,6 @@ impl ProofResults {
             metadata_facts.push(parse_metadata_fact(expr)?);
         }
         Ok(Self { metadata_facts })
-    }
-
-    pub(crate) fn has_dim_equality(
-        &self,
-        lhs: &str,
-        lhs_axis: usize,
-        rhs: &str,
-        rhs_axis: usize,
-    ) -> bool {
-        let lhs = MetadataExpr::Dim {
-            tensor: lhs.to_string(),
-            axis: lhs_axis,
-        };
-        let rhs = MetadataExpr::Dim {
-            tensor: rhs.to_string(),
-            axis: rhs_axis,
-        };
-        self.metadata_facts.iter().any(|fact| {
-            (fact.lhs == lhs && fact.rhs == rhs) || (fact.lhs == rhs && fact.rhs == lhs)
-        })
-    }
-
-    pub(crate) fn proves_partition_axis_access(
-        &self,
-        index_origin: &PartitionAxisOrigin,
-        target_tensor: &str,
-        target_axis: usize,
-        target_tile_dim: i32,
-    ) -> bool {
-        index_origin.tile_dim == target_tile_dim
-            && self.has_dim_equality(
-                &index_origin.tensor,
-                index_origin.axis,
-                target_tensor,
-                target_axis,
-            )
     }
 }
 
@@ -112,10 +87,59 @@ fn parse_metadata_equality(binary: &ExprBinary) -> Result<MetadataFact, JITError
     if !matches!(binary.op, BinOp::Eq(_)) {
         return SourceLocation::unknown().jit_error_result("precondition predicates must use `==`");
     }
-    Ok(MetadataFact {
+    // Divisibility spelling: `dim(t, k) % divisor == 0`.
+    if let Expr::Binary(rem) = binary.left.as_ref() {
+        if matches!(rem.op, BinOp::Rem(_)) {
+            if !is_zero_literal(&binary.right) {
+                return SourceLocation::unknown().jit_error_result(
+                    "a `%` precondition must compare against literal `0`: `dim(t, k) % d == 0`",
+                );
+            }
+            let MetadataExpr::Dim { tensor, axis } = parse_metadata_expr(&rem.left)?;
+            let divisor = parse_divisor_literal(&rem.right)?;
+            return Ok(MetadataFact::DimDivisible {
+                tensor,
+                axis,
+                divisor,
+            });
+        }
+    }
+    Ok(MetadataFact::DimEq {
         lhs: parse_metadata_expr(&binary.left)?,
         rhs: parse_metadata_expr(&binary.right)?,
     })
+}
+
+fn is_zero_literal(expr: &Expr) -> bool {
+    match expr {
+        Expr::Lit(lit) => match &lit.lit {
+            syn::Lit::Int(i) => i.base10_parse::<i64>().map(|v| v == 0).unwrap_or(false),
+            _ => false,
+        },
+        _ => false,
+    }
+}
+
+fn parse_divisor_literal(expr: &Expr) -> Result<i64, JITError> {
+    let Expr::Lit(lit) = expr else {
+        return SourceLocation::unknown().jit_error_result(
+            "a `%` precondition divisor must be a positive integer literal (a const generic \
+             cannot be verified by the launcher, which runs before monomorphization)",
+        );
+    };
+    let syn::Lit::Int(int_lit) = &lit.lit else {
+        return SourceLocation::unknown()
+            .jit_error_result("a `%` precondition divisor must be a positive integer literal");
+    };
+    let divisor = int_lit.base10_parse::<i64>().map_err(|err| {
+        SourceLocation::unknown().jit_error(&format!("invalid `%` precondition divisor: {err}"))
+    })?;
+    if divisor < 1 {
+        return SourceLocation::unknown().jit_error_result(&format!(
+            "a `%` precondition divisor must be >= 1, got {divisor}"
+        ));
+    }
+    Ok(divisor)
 }
 
 fn parse_metadata_expr(expr: &Expr) -> Result<MetadataExpr, JITError> {

--- a/cutile-compiler/src/passes/type_inference.rs
+++ b/cutile-compiler/src/passes/type_inference.rs
@@ -2036,7 +2036,17 @@ impl<'a, 'm> TypeInferenceCx<'a, 'm> {
 
     fn infer_for_iter_ty(&mut self, iter_expr: &Expr) -> Result<Option<TileRustType>, JITError> {
         if let Expr::MethodCall(method_call) = iter_expr {
-            if method_call.method == "iter_indices" && method_call.args.is_empty() {
+            let is_mapped_indices_iter = matches!(
+                (
+                    method_call.method.to_string().as_str(),
+                    method_call.args.len()
+                ),
+                ("iter_indices", 0)
+                    | ("iter_indices_with", 1)
+                    | ("iter_indices_within", 1)
+                    | ("iter_indices_within_with", 2)
+            );
+            if is_mapped_indices_iter {
                 if let Some(receiver_ty) = self.infer_expr_syn_type(&method_call.receiver, None)? {
                     if get_type_ident(&receiver_ty)
                         .is_some_and(|ident| ident.to_string().starts_with("MappedPartitionMut"))
@@ -2370,6 +2380,25 @@ impl<'a, 'm> TypeInferenceCx<'a, 'm> {
             }
         }
         let ident = get_ident_from_path_expr(path).to_string();
+        // `coord((a, b, ...))` returns the arity-matched `Coord{N}`. The
+        // declared return type is the associated `C::Coord`, which bottom-up
+        // inference cannot project, so resolve it from the tuple arity here
+        // (needed when the expected type is not supplied by a concrete
+        // parameter, e.g. the generic `MappedPartitionMut::store` index).
+        if ident == "coord" && call.args.len() == 1 {
+            if let Some(tuple) = self.tuple_expr_or_origin(&call.args[0]) {
+                let rank = tuple.elems.len();
+                let _ = self.infer_call_arg_types(call.args.iter())?;
+                if let Ok(coord_ty) = syn::parse_str::<Type>(&format!("Coord{rank}")) {
+                    if let Some(ty) =
+                        self.compiler
+                            .compile_type(&coord_ty, self.generic_vars, &HashMap::new())?
+                    {
+                        return Ok(Some(ty));
+                    }
+                }
+            }
+        }
         if ident == "Some" && call.args.len() == 1 {
             if let Some(expected) = expected {
                 let payload_expected =
@@ -2439,7 +2468,9 @@ impl<'a, 'm> TypeInferenceCx<'a, 'm> {
 
         let mut generic_arg_inf = GenericArgInference::new_function(fn_item.sig.clone());
         if let Some(expected_return) = expected_return {
-            generic_arg_inf.add_type_constraints(&return_type, &expected_return.rust_ty);
+            // Speculative seed from the expected type: a conflict just means
+            // the hint doesn't apply, the strict check runs at inline time.
+            let _ = generic_arg_inf.add_type_constraints(&return_type, &expected_return.rust_ty);
         }
         generic_arg_inf.apply_provided_generics_fn_call(call, self.generic_vars);
 
@@ -2479,7 +2510,7 @@ impl<'a, 'm> TypeInferenceCx<'a, 'm> {
                 if type_mentions_any_name(param_type, &closure_generics)
                     && can_add_type_constraint(param_type, &arg_ty)
                 {
-                    generic_arg_inf.add_type_constraints(param_type, &arg_ty);
+                    let _ = generic_arg_inf.add_type_constraints(param_type, &arg_ty);
                 }
             }
         }
@@ -2676,7 +2707,9 @@ impl<'a, 'm> TypeInferenceCx<'a, 'm> {
         let (param_types, return_type) = get_sig_types(&fn_item.sig, None);
         let mut generic_arg_inf = GenericArgInference::new_function(fn_item.sig.clone());
         if let Some(expected_return) = expected_return {
-            generic_arg_inf.add_type_constraints(&return_type, &expected_return.rust_ty);
+            // Speculative seed from the expected type: a conflict just means
+            // the hint doesn't apply, the strict check runs at inline time.
+            let _ = generic_arg_inf.add_type_constraints(&return_type, &expected_return.rust_ty);
         }
         generic_arg_inf.apply_provided_generics_fn_call(call, self.generic_vars);
 
@@ -2916,6 +2949,14 @@ impl<'a, 'm> TypeInferenceCx<'a, 'm> {
         let method_name = method_call.method.to_string();
         let mut matches = Vec::new();
 
+        // Same-named methods defined per rank (e.g. `BoundedPartition::load`
+        // for rank 2 and rank 3) stay unique after filtering impls whose
+        // const-generic array rank cannot match the receiver.
+        let receiver_lookup_ty = crate::compiler::_module::instantiate_type_for_lookup(
+            receiver_ty,
+            self.generic_vars,
+            self.compiler.modules.primitives(),
+        );
         for (_module_name, item_impl) in self
             .compiler
             .modules
@@ -2923,6 +2964,13 @@ impl<'a, 'm> TypeInferenceCx<'a, 'm> {
             .get(&receiver_type)?
             .iter()
         {
+            if !crate::compiler::_module::impl_self_type_rank_matches(
+                item_impl,
+                &receiver_lookup_ty,
+                self.generic_vars,
+            ) {
+                continue;
+            }
             for item in &item_impl.items {
                 let syn::ImplItem::Fn(method) = item else {
                     continue;
@@ -2939,7 +2987,8 @@ impl<'a, 'm> TypeInferenceCx<'a, 'm> {
         let self_ty = &*item_impl.self_ty;
         let (param_types, _return_type) = get_sig_types(&method.sig, Some(self_ty));
         let mut generic_arg_inf = GenericArgInference::new_method(item_impl, method);
-        generic_arg_inf.add_type_constraints(self_ty, receiver_ty);
+        // Probing for a unique method match: constraint conflicts mean no match.
+        let _ = generic_arg_inf.add_type_constraints(self_ty, receiver_ty);
         let receiver_rank = rank_from_type_shape_arg(receiver_ty, self.generic_vars);
         Some(
             param_types
@@ -3015,7 +3064,11 @@ impl<'a, 'm> TypeInferenceCx<'a, 'm> {
             return Ok(None);
         }
         let mut generic_arg_inf = GenericArgInference::new_method(impl_item, impl_method);
-        generic_arg_inf.map_args_to_params(&call_arg_rust_tys.to_vec(), Some(self_ty));
+        generic_arg_inf.map_args_to_params(
+            &call_arg_rust_tys.to_vec(),
+            Some(self_ty),
+            self.generic_vars,
+        )?;
         generic_arg_inf.apply_provided_generics_method_call(method_call, self.generic_vars);
         if !generic_arg_inf.verify() {
             return Ok(None);
@@ -3069,7 +3122,7 @@ impl<'a, 'm> TypeInferenceCx<'a, 'm> {
             return Ok(expected);
         }
         let mut generic_arg_inf = GenericArgInference::new_function(fn_item.sig.clone());
-        generic_arg_inf.map_args_to_params(&call_arg_rust_tys, None);
+        generic_arg_inf.map_args_to_params(&call_arg_rust_tys, None, self.generic_vars)?;
         generic_arg_inf.apply_provided_generics_fn_call(call, self.generic_vars);
         if !generic_arg_inf.verify() {
             return Ok(expected);
@@ -4430,7 +4483,11 @@ pub fn infer_method_generics(
     }
 
     let mut generic_arg_inference = GenericArgInference::new_method(impl_item, impl_method);
-    generic_arg_inference.map_args_to_params(&call_arg_rust_tys.to_vec(), Some(self_ty));
+    generic_arg_inference.map_args_to_params(
+        &call_arg_rust_tys.to_vec(),
+        Some(self_ty),
+        caller_generic_vars,
+    )?;
     let inferred = generic_arg_inference.get_generic_vars_instance(caller_generic_vars, primitives);
 
     if method_call.turbofish.is_some() {

--- a/cutile-compiler/src/syn_utils.rs
+++ b/cutile-compiler/src/syn_utils.rs
@@ -119,14 +119,23 @@ fn expr_attrs_mut(expr: &mut Expr) -> Option<&mut Vec<Attribute>> {
 impl SingleMetaList {
     /// Construct from a `syn::Attribute` that contains a meta list.
     pub fn from_attribute(attr: Attribute) -> Self {
-        let Meta::List(meta_list) = attr.meta else {
-            panic!("Unexpected attribute list {:#?}", attr.meta)
-        };
-        let tokens = proc_macro2::TokenStream::from(meta_list.tokens.clone());
-        let mut result = syn::parse2::<SingleMetaList>(tokens).unwrap();
-        result.name = Some(meta_list.path.to_token_stream().to_string());
-        result.meta_list = Some(meta_list);
-        return result;
+        match attr.meta {
+            Meta::List(meta_list) => {
+                let tokens = proc_macro2::TokenStream::from(meta_list.tokens.clone());
+                let mut result = syn::parse2::<SingleMetaList>(tokens).unwrap();
+                result.name = Some(meta_list.path.to_token_stream().to_string());
+                result.meta_list = Some(meta_list);
+                result
+            }
+            // The bare form (`#[cutile::entry]`): no arguments, every
+            // knob at its default.
+            Meta::Path(path) => Self {
+                name: Some(path.to_token_stream().to_string()),
+                meta_list: None,
+                variables: Vec::new(),
+            },
+            other => panic!("Unexpected attribute list {other:#?}"),
+        }
     }
     /// Returns the attribute path as a single string.
     pub fn name_as_str(&self) -> Option<String> {
@@ -280,26 +289,26 @@ pub fn clear_attributes(attr_names: HashSet<&str>, attrs: &mut Vec<Attribute>) -
         .collect::<Vec<Attribute>>();
 }
 
-/// Finds an attribute by path string, optionally matching only the last segment.
+/// Finds an attribute by path string, optionally matching only the last
+/// segment. Matches both the argument-list form (`#[cutile::entry(...)]`)
+/// and the bare-path form (`#[cutile::entry]`) — every argument has a
+/// default, so the bare form is the documented spelling for a kernel that
+/// needs none.
 pub fn get_attribute(
     lookup_str: &str,
     outer_attrs: &Vec<Attribute>,
     last_seg_only: bool,
 ) -> Option<Attribute> {
     for attr in outer_attrs {
-        let Meta::List(meta_list) = &attr.meta else {
-            continue;
+        let path = match &attr.meta {
+            Meta::List(meta_list) => &meta_list.path,
+            Meta::Path(path) => path,
+            _ => continue,
         };
         let parsed_str = if last_seg_only {
-            meta_list
-                .path
-                .segments
-                .last()
-                .unwrap()
-                .to_token_stream()
-                .to_string()
+            path.segments.last().unwrap().to_token_stream().to_string()
         } else {
-            meta_list.path.to_token_stream().to_string()
+            path.to_token_stream().to_string()
         };
         if parsed_str == lookup_str {
             return Some(attr.clone());

--- a/cutile-compiler/src/value_facts.rs
+++ b/cutile-compiler/src/value_facts.rs
@@ -1,0 +1,267 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Per-value dataflow facts: the forward, monotone abstract-interpretation
+//! lattices the compiler propagates over scalar values, gathered in one place.
+//!
+//! Two lattices, propagated together by [`transfer`]:
+//! - **interval** — [`Bounds`] (`crate::bounds`), a concrete inclusive
+//!   `[start, end]` range. The constant / static rung of bounds checks consumes
+//!   it, and an *exact* range folds to a compile-time constant.
+//! - **symbolic** — [`Term`] (`cuda_async::predicate`), a canonical linear form
+//!   `sum(coeff·atom) + constant`. Loop check-hoisting consumes it via
+//!   `Term::as_single_affine`; launch-time check hoisting consumes it via the
+//!   obligation solver (`passes::obligation::resolve`).
+//!
+//! The two are not independent: **an interval is the range-abstraction of the
+//! symbolic term.** [`term_range`] computes a `Bounds` from a `Term` given a
+//! range per atom — the constant case (a term with no atoms) is just its
+//! constant folded to an exact range. This is LLVM SCEV's `getRange` / MLIR's
+//! `IntegerRangeAnalysis` reduction, and it is why the two lattices can share a
+//! module rather than duplicate interval arithmetic.
+//!
+//! (Provenance brands — `PartitionAxisOrigin` / `DimOrigin` in
+//! `compiler::_value` — are the third, origin, facet of a value's facts; they
+//! propagate structurally rather than arithmetically and are categorized here
+//! by reference until they move in.)
+
+use crate::bounds::{bounds_from_bop, Bounds, TileBinaryOp};
+use crate::compiler::_value::TileRustValue;
+use cuda_async::predicate::{Atom, Term};
+
+/// The arithmetic facts produced for a binary op's result value.
+pub(crate) struct ScalarFacts {
+    pub(crate) bounds: Option<Bounds<i64>>,
+    pub(crate) term: Option<Term>,
+    pub(crate) floor_div: Option<FloorDiv>,
+}
+
+/// `floor(numerator / divisor)` with a compile-time-constant `divisor`.
+///
+/// Integer division is not linear, so it cannot live in [`Term`]. It is kept
+/// here, on the *analysis* side, instead of being added to the predicate
+/// vocabulary as an opaque atom. That distinction matters: an opaque atom would
+/// be evaluable but not reasonable-about — nothing could relate it to the
+/// operands it was built from, so an obligation naming it could only ever be
+/// shipped to the host, never discharged by a declared `preconditions` fact.
+///
+/// Keeping the residue here lets an obligation site reduce it to a predicate
+/// over the *existing* vocabulary. The reduction that matters:
+/// `floor(e/d) == ceil(e/d)` iff `d` divides `e`, so an equality against a tile
+/// count becomes [`cuda_async::predicate::Predicate::divisible_by`] over `e` —
+/// which a precondition can entail, and the host can decide. This mirrors MLIR,
+/// where `floordiv`/`ceildiv` simplification is driven by known divisibility
+/// rather than by treating the division as an opaque leaf.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct FloorDiv {
+    pub(crate) numerator: Term,
+    pub(crate) divisor: i64,
+}
+
+/// The value domain of a runtime integer type — the range every machine
+/// value of that type inhabits. `None` means the domain is unknown (or not
+/// an integer), and interval facts must not be kept for it.
+///
+/// `usize` is deliberately `None`: the DSL relabels it against `i32` and
+/// `u32` freely, so no single domain is trustworthy. 64-bit types are also
+/// `None`: interval composition saturates at `i64` while the machine wraps,
+/// and saturated endpoints cannot be told apart from genuine ones.
+pub(crate) fn int_value_domain(elem_ty: &str) -> Option<Bounds<i64>> {
+    match elem_ty {
+        "bool" | "i1" => Some(Bounds::new(0, 1)),
+        "i32" => Some(Bounds::new(i32::MIN as i64, i32::MAX as i64)),
+        "u32" => Some(Bounds::new(0, u32::MAX as i64)),
+        _ => None,
+    }
+}
+
+/// The arithmetic transfer function: given an op, its two operands, and the
+/// result's value domain, produce the result value's facts (interval +
+/// symbolic). One place for both lattices; the caller still owns IR-emission
+/// control flow (the exact-range → constant fold and the operand-kind check).
+///
+/// The interval is kept only when it proves this op cannot wrap: interval
+/// composition is mathematical, the machine op wraps at the type width, and
+/// the two agree exactly when the mathematical result range fits the type's
+/// value domain. A range that escapes the domain — or a domain we cannot
+/// name — yields NO interval, because after a wrap the machine value can be
+/// anything in the type. Checking only a downstream consumer's final range
+/// is not enough: a later `max`/`%`/`min` narrows the mathematical range
+/// back into the domain while the wrapped machine value stays outside it
+/// (2026-08-12 review, S1).
+pub(crate) fn transfer(
+    op: &TileBinaryOp,
+    lhs: &TileRustValue,
+    rhs: &TileRustValue,
+    result_domain: Option<Bounds<i64>>,
+) -> ScalarFacts {
+    let bounds = propagate_bounds(op, lhs, rhs).filter(|b| {
+        result_domain.is_some_and(|domain| domain.start <= b.start && b.end <= domain.end)
+    });
+    ScalarFacts {
+        bounds,
+        term: propagate_term(op, lhs, rhs),
+        floor_div: propagate_floor_div(op, lhs, rhs),
+    }
+}
+
+/// Record an integer division by a compile-time constant as a [`FloorDiv`]
+/// residue. Only a truncating/floor `Div` qualifies, and only when the
+/// numerator has a symbolic term to name — otherwise there is nothing an
+/// obligation could later reduce it against.
+pub(crate) fn propagate_floor_div(
+    op: &TileBinaryOp,
+    lhs: &TileRustValue,
+    rhs: &TileRustValue,
+) -> Option<FloorDiv> {
+    if !matches!(op, TileBinaryOp::Div) {
+        return None;
+    }
+    let divisor = rhs.bounds.filter(|b| b.is_exact()).map(|b| b.start)?;
+    if divisor <= 0 {
+        return None;
+    }
+    Some(FloorDiv {
+        numerator: lhs.term.clone()?,
+        divisor,
+    })
+}
+
+/// Interval transfer: propagate `[start, end]` ranges through the op. `None`
+/// unless both operands carry a range.
+pub(crate) fn propagate_bounds(
+    op: &TileBinaryOp,
+    lhs: &TileRustValue,
+    rhs: &TileRustValue,
+) -> Option<Bounds<i64>> {
+    match (lhs.bounds, rhs.bounds) {
+        (Some(a), Some(b)) => bounds_from_bop(op, &a, &b),
+        _ => None,
+    }
+}
+
+/// Symbolic transfer: propagate the canonical linear [`Term`] through the op.
+///
+/// Each operand contributes its own `term`, or a constant term synthesized from
+/// an exact range (so `i + 3` keeps propagating). A product stays linear only
+/// when one side is constant; other ops (division, remainder) and `i64`
+/// overflow yield `None` — the term algebra's bail-to-weaker policy. The
+/// single-variable affine fragment the loop hoister needs is recovered via
+/// [`Term::as_single_affine`].
+pub(crate) fn propagate_term(
+    op: &TileBinaryOp,
+    lhs: &TileRustValue,
+    rhs: &TileRustValue,
+) -> Option<Term> {
+    // Each operand's term: an explicit symbolic form, or a constant from an
+    // exact range.
+    let term_of = |v: &TileRustValue| -> Option<Term> {
+        v.term.clone().or_else(|| {
+            v.bounds
+                .filter(|b| b.is_exact())
+                .map(|b| Term::constant(b.start))
+        })
+    };
+    let lt = term_of(lhs)?;
+    let rt = term_of(rhs)?;
+    match op {
+        TileBinaryOp::Add => lt.add(&rt),
+        TileBinaryOp::Sub => lt.sub(&rt),
+        TileBinaryOp::Mul => {
+            // Linearity: a product stays affine only if one side is constant.
+            if let Some(c) = rt.as_constant() {
+                lt.mul_const(c)
+            } else if let Some(c) = lt.as_constant() {
+                rt.mul_const(c)
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+/// The interval-from-symbolic reduction (LLVM SCEV `getRange`): the range of an
+/// affine `Term = sum(coeff·atom) + constant`, given a range per atom, is
+/// `constant + sum(coeff · [lo, hi])` with interval arithmetic (a negative
+/// coefficient swaps the endpoints). `None` if any atom lacks a range or the
+/// arithmetic overflows `i64`.
+///
+/// This makes the interval derivable from the symbolic term wherever the term
+/// is affine — the const-rung bounds we track today are the special case where
+/// the term has no atoms.
+///
+/// The live consumer is the hoisting classifier: when a loop's induction range
+/// is a compile-time constant, an affine index's static range follows from its
+/// term via this reduction, so the check discharges as a constant instead of a
+/// runtime strongest-instance substitution.
+pub(crate) fn term_range(
+    term: &Term,
+    atom_range: &impl Fn(&Atom) -> Option<Bounds<i64>>,
+) -> Option<Bounds<i64>> {
+    let mut lo = term.constant_part();
+    let mut hi = term.constant_part();
+    for (atom, &coeff) in term.coeffs() {
+        let r = atom_range(atom)?;
+        let (a, b) = (coeff.checked_mul(r.start)?, coeff.checked_mul(r.end)?);
+        let (add_lo, add_hi) = if a <= b { (a, b) } else { (b, a) };
+        lo = lo.checked_add(add_lo)?;
+        hi = hi.checked_add(add_hi)?;
+    }
+    Some(Bounds { start: lo, end: hi })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dim(param: usize, axis: usize) -> Atom {
+        Atom::Dim { param, axis }
+    }
+
+    #[test]
+    fn term_range_of_a_constant_is_the_exact_range() {
+        let range = term_range(&Term::constant(7), &|_| None).unwrap();
+        assert_eq!(range, Bounds { start: 7, end: 7 });
+        assert!(range.is_exact());
+    }
+
+    #[test]
+    fn term_range_of_affine_uses_atom_ranges() {
+        // 2*i + 3, with i in [0, 4]  ->  [3, 11].
+        let term = Term::affine(dim(0, 0), 2, 3);
+        let env = |_: &Atom| Some(Bounds { start: 0, end: 4 });
+        assert_eq!(term_range(&term, &env), Some(Bounds { start: 3, end: 11 }));
+    }
+
+    #[test]
+    fn term_range_negative_coefficient_swaps_endpoints() {
+        // -1*i + 10, with i in [0, 4]  ->  [6, 10].
+        let term = Term::affine(dim(0, 0), -1, 10);
+        let env = |_: &Atom| Some(Bounds { start: 0, end: 4 });
+        assert_eq!(term_range(&term, &env), Some(Bounds { start: 6, end: 10 }));
+    }
+
+    #[test]
+    fn term_range_is_none_when_an_atom_has_no_range() {
+        let term = Term::atom(dim(9, 9));
+        assert_eq!(term_range(&term, &|_| None), None);
+    }
+
+    #[test]
+    fn runtime_domains_cover_boolean_and_32_bit_integer_results() {
+        assert_eq!(int_value_domain("bool"), Some(Bounds::new(0, 1)));
+        assert_eq!(
+            int_value_domain("i32"),
+            Some(Bounds::new(i32::MIN as i64, i32::MAX as i64))
+        );
+        assert_eq!(
+            int_value_domain("u32"),
+            Some(Bounds::new(0, u32::MAX as i64))
+        );
+        assert_eq!(int_value_domain("i64"), None);
+        assert_eq!(int_value_domain("usize"), None);
+    }
+}

--- a/cutile-examples/examples/cuda_graphs.rs
+++ b/cutile-examples/examples/cuda_graphs.rs
@@ -60,7 +60,7 @@ mod kernels {
         for j in 0i32..tiles {
             let t: Tile<f32, { [1, BS] }> = x_part.load([row, j]);
             let tw: Tile<f32, { [1, BS] }> = w_part.load([j]).reshape(shape);
-            unsafe { out_part.store(t * scale * tw, [0i32, j]) };
+            out_part.store(t * scale * tw, [0i32, j]);
         }
     }
 

--- a/cutile-examples/examples/cuda_graphs_deviceop.rs
+++ b/cutile-examples/examples/cuda_graphs_deviceop.rs
@@ -58,7 +58,7 @@ mod kernels {
         for j in 0i32..tiles {
             let t: Tile<f32, { [1, BS] }> = x_part.load([row, j]);
             let tw: Tile<f32, { [1, BS] }> = w_part.load([j]).reshape(shape);
-            unsafe { out_part.store(t * scale * tw, [0i32, j]) };
+            out_part.store(t * scale * tw, [0i32, j]);
         }
     }
 

--- a/cutile-examples/examples/mxfp8.rs
+++ b/cutile-examples/examples/mxfp8.rs
@@ -11,6 +11,9 @@
  * Run with: cargo run -p cutile-examples --example mxfp8
  */
 
+// Still on the deprecated `Dim::new` spelling; migrate with the examples pass.
+#![allow(deprecated)]
+
 use cutile::cuda_core::{f8e4m3fn, f8e8m0fnu};
 use cutile::prelude::*;
 use cutile_compiler::cuda_tile_runtime_utils::get_gpu_name;

--- a/cutile-examples/examples/nvfp4.rs
+++ b/cutile-examples/examples/nvfp4.rs
@@ -10,6 +10,9 @@
  * Run with: cargo run -p cutile-examples --example nvfp4
  */
 
+// Still on the deprecated `Dim::new` spelling; migrate with the examples pass.
+#![allow(deprecated)]
+
 use cutile::cuda_core::{f4e2m1fnx2, f8e4m3fn};
 use cutile::prelude::*;
 use cutile_compiler::cuda_tile_runtime_utils::get_gpu_name;

--- a/cutile-examples/examples/persistent_gemm.rs
+++ b/cutile-examples/examples/persistent_gemm.rs
@@ -17,12 +17,19 @@ use std::sync::Arc;
 mod persistent_gemm_kernels {
     use cutile::core::*;
 
+    /// No annotations and no declared contract: the compiler derives every
+    /// safety fact from how the kernel walks its inputs — the mapped
+    /// components range over `z`'s axes, `k_tile` over `x`'s k axis — and
+    /// verifies the cross-tensor ties as launch checks (for example
+    /// `ceil(dim(x, 1)/BK) <= ceil(dim(y, 0)/BK)`) before any GPU work.
+    /// `deny_in_kernel_checks` makes any check that would remain in the
+    /// kernel a compile error, so the body is assert-free by construction.
     #[cutile::entry(
         optimization_hints = (
             sm_120 = (num_cta_in_cga = 2,),
             sm_100 = (num_cta_in_cga = 2,),
         ),
-        unchecked_accesses = false,
+        deny_in_kernel_checks = true,
     )]
     fn gemm_persistent<
         T: ElementType,
@@ -35,20 +42,16 @@ mod persistent_gemm_kernels {
         x: &Tensor<T, { [-1, -1] }>,
         y: &Tensor<T, { [-1, -1] }>,
     ) {
-        let m = num_tiles(&z, 0);
-        let n = num_tiles(&z, 1);
-        let k = Dim::new(x.shape()[1] / BK);
-
-        let part_x = x.partition(const_shape![BM, BK]).with_bounds((m, k));
-        let part_y = y.partition(const_shape![BK, BN]).with_bounds((k, n));
+        let part_x = x.partition(const_shape![BM, BK]);
+        let part_y = y.partition(const_shape![BK, BN]);
 
         for out_idx in z.iter_indices() {
             let (bid_m, bid_n) = out_idx.components();
 
             let mut tile_z: Tile<T, { [BM, BN] }> = constant(T::ZERO, const_shape![BM, BN]);
-            for k_tile in k {
-                let tile_x = part_x.load(coord((bid_m, k_tile)));
-                let tile_y = part_y.load(coord((k_tile, bid_n)));
+            for k_tile in 0i32..num_tiles(&part_x, 1) {
+                let tile_x = part_x.load([bid_m, k_tile]);
+                let tile_y = part_y.load([k_tile, bid_n]);
                 tile_z = mma(tile_x, tile_y, tile_z);
             }
             z.store(tile_z, out_idx);

--- a/cutile-examples/examples/rms_norm.rs
+++ b/cutile-examples/examples/rms_norm.rs
@@ -56,7 +56,7 @@ mod my_module {
             let tx: Tile<f32, { [1, BLOCK_SIZE] }> = x_part.load([row, j]);
             let tw: Tile<f32, { [1, BLOCK_SIZE] }> = w_part.load([j]).reshape(tile_shape);
             let tout: Tile<f32, { [1, BLOCK_SIZE] }> = tx * rms * tw;
-            unsafe { out_part.store(tout, [0i32, j]) };
+            out_part.store(tout, [0i32, j]);
         }
     }
 }

--- a/cutile-ir/src/ir/module.rs
+++ b/cutile-ir/src/ir/module.rs
@@ -87,6 +87,13 @@ impl Module {
         id
     }
 
+    /// Number of values allocated so far. Usable as a dominance watermark:
+    /// a value with `index() < num_values()` taken at some program point was
+    /// allocated before that point.
+    pub fn num_values(&self) -> usize {
+        self.values.len()
+    }
+
     pub fn value_data(&self, v: Value) -> &ValueData {
         &self.values[v.0 as usize]
     }

--- a/cutile-ir/tests/bytecode_validate.rs
+++ b/cutile-ir/tests/bytecode_validate.rs
@@ -235,6 +235,49 @@ fn for_loop_with_iter_args() {
 }
 
 #[test]
+fn for_loop_with_token_iter_arg() {
+    // Feasibility probe for token-ordering loop-carry: a for-loop that carries a
+    // `!cuda_tile.token` as an iter-arg (seeded by make_token, yielded back). If
+    // this validates through tileiras, a token is a legal loop-carried value —
+    // which is what the mutable-store token threading needs (carry the token, not
+    // the partition_view, which is a restricted iter-arg type).
+    let module = build_kernel("for_token_iter_arg", &[], |m, blk, _args| {
+        let lb = const_i32(m, blk, 0);
+        let ub = const_i32(m, blk, 10);
+        let step = const_i32(m, blk, 1);
+
+        // Seed token.
+        let (tok_op, tok_res) = OpBuilder::new(Opcode::MakeToken, Location::Unknown)
+            .result(token_ty())
+            .build(m);
+        append_op(m, blk, tok_op);
+        let init = tok_res[0];
+
+        // for %iv, %tok = lb to ub step step iter(%init) { continue %tok }
+        // The body threads the carried token straight through (identity), the
+        // minimal shape that puts a token on the loop's block-arg + result.
+        let (body_region, body_blk, body_args) =
+            build_single_block_region(m, &[tile_i32(), token_ty()]); // iv, tok
+
+        let (cont, _) = OpBuilder::new(Opcode::Continue, Location::Unknown)
+            .operand(body_args[1]) // yield the carried token
+            .build(m);
+        append_op(m, body_blk, cont);
+
+        let (for_op, _) = OpBuilder::new(Opcode::For, Location::Unknown)
+            .operand(lb)
+            .operand(ub)
+            .operand(step)
+            .operand(init)
+            .result(token_ty()) // carried token result
+            .region(body_region)
+            .build(m);
+        append_op(m, blk, for_op);
+    });
+    validate_module(&module);
+}
+
+#[test]
 fn nested_for_loops() {
     // Outer for containing an inner for.
     let module = build_kernel("nested_for", &[tile_i32()], |m, blk, args| {

--- a/cutile-kernels/src/experimental/attention.rs
+++ b/cutile-kernels/src/experimental/attention.rs
@@ -365,9 +365,7 @@ pub mod fmha_prefill_gqa_lpt_module {
 
         let mut out_part: PartitionMut<f16, { [BM, GROUP, D] }> =
             unsafe { out_tv.partition_full_mut(const_shape![BM, GROUP, D]) };
-        unsafe {
-            out_part.store(out_tile, [q_m_idx, q_head_group_idx, 0i32]);
-        }
+        out_part.store(out_tile, [q_m_idx, q_head_group_idx, 0i32]);
     }
 }
 

--- a/cutile-kernels/src/experimental/moe.rs
+++ b/cutile-kernels/src/experimental/moe.rs
@@ -118,9 +118,7 @@ pub mod group_gemm_f16_nt_desc_module {
                 }
 
                 let out: Tile<f16, { [BM, BN] }> = convert_tile(acc);
-                unsafe {
-                    c_part.store(out, [tile_m_idx, tile_n_idx]);
-                }
+                c_part.store(out, [tile_m_idx, tile_n_idx]);
 
                 tile_idx = tile_idx + NUM_SM;
             }

--- a/cutile-kernels/src/kv_cache.rs
+++ b/cutile-kernels/src/kv_cache.rs
@@ -33,8 +33,8 @@ pub mod kv_cache_update_seq_f16_module {
 
         let new_k_part = new_k.partition(const_shape![1, 1, BLOCK_SIZE]);
         let new_v_part = new_v.partition(const_shape![1, 1, BLOCK_SIZE]);
-        let mut k_cache_part = unsafe { k_cache.partition_mut(const_shape![1, 1, BLOCK_SIZE]) };
-        let mut v_cache_part = unsafe { v_cache.partition_mut(const_shape![1, 1, BLOCK_SIZE]) };
+        let mut k_cache_part = k_cache.partition_mut(const_shape![1, 1, BLOCK_SIZE]);
+        let mut v_cache_part = v_cache.partition_mut(const_shape![1, 1, BLOCK_SIZE]);
 
         let s_start: i32 = s_tile_idx * BM_S;
         // Skip trailing CTAs that are entirely beyond seq_len. The
@@ -52,10 +52,8 @@ pub mod kv_cache_update_seq_f16_module {
                         .reshape(const_shape![1, 1, BLOCK_SIZE]);
                     // Local index within per-CTA tile; position_start
                     // is assumed 0 (see function docstring).
-                    unsafe {
-                        k_cache_part.store(k_tile, [0i32, s_local, 0i32]);
-                        v_cache_part.store(v_tile, [0i32, s_local, 0i32]);
-                    }
+                    k_cache_part.store(k_tile, [0i32, s_local, 0i32]);
+                    v_cache_part.store(v_tile, [0i32, s_local, 0i32]);
                 }
             }
         }
@@ -98,8 +96,8 @@ pub mod kv_cache_update_seq_dynpos_f16_module {
 
         let new_k_part = new_k.partition(const_shape![1, 1, BLOCK_SIZE]);
         let new_v_part = new_v.partition(const_shape![1, 1, BLOCK_SIZE]);
-        let mut k_cache_part = unsafe { k_cache.partition_mut(const_shape![1, 1, BLOCK_SIZE]) };
-        let mut v_cache_part = unsafe { v_cache.partition_mut(const_shape![1, 1, BLOCK_SIZE]) };
+        let mut k_cache_part = k_cache.partition_mut(const_shape![1, 1, BLOCK_SIZE]);
+        let mut v_cache_part = v_cache.partition_mut(const_shape![1, 1, BLOCK_SIZE]);
 
         for s in 0i32..seq_len {
             let k_tile = new_k_part
@@ -109,10 +107,8 @@ pub mod kv_cache_update_seq_dynpos_f16_module {
                 .load([s, head, d_block])
                 .reshape(const_shape![1, 1, BLOCK_SIZE]);
             let cache_pos = pos_start + s;
-            unsafe {
-                k_cache_part.store(k_tile, [0i32, cache_pos, 0i32]);
-                v_cache_part.store(v_tile, [0i32, cache_pos, 0i32]);
-            }
+            k_cache_part.store(k_tile, [0i32, cache_pos, 0i32]);
+            v_cache_part.store(v_tile, [0i32, cache_pos, 0i32]);
         }
     }
 }

--- a/cutile-kernels/src/norms.rs
+++ b/cutile-kernels/src/norms.rs
@@ -47,8 +47,7 @@ pub mod rms_norm_f16_module {
         let inv_rms: Tile<f32, { [1, BLOCK_SIZE] }> = inv_rms.broadcast(tile_shape);
 
         let w_part: Partition<f16, { [BLOCK_SIZE] }> = w.partition(const_shape![BLOCK_SIZE]);
-        let mut out_part: PartitionMut<f16, { [1, BLOCK_SIZE] }> =
-            unsafe { out.partition_mut(tile_shape) };
+        let mut out_part: PartitionMut<f16, { [1, BLOCK_SIZE] }> = out.partition_mut(tile_shape);
         for j in 0i32..num_tiles {
             let tx_f16: Tile<f16, { [1, BLOCK_SIZE] }> = x_part.load([row, j]);
             let tw_f16: Tile<f16, { [1, BLOCK_SIZE] }> = w_part.load([j]).reshape(tile_shape);
@@ -56,7 +55,7 @@ pub mod rms_norm_f16_module {
             let tw: Tile<f32, { [1, BLOCK_SIZE] }> = convert_tile(tw_f16);
             let tout: Tile<f32, { [1, BLOCK_SIZE] }> = tx * inv_rms * tw;
             let tout_f16: Tile<f16, { [1, BLOCK_SIZE] }> = convert_tile(tout);
-            unsafe { out_part.store(tout_f16, [0i32, j]) };
+            out_part.store(tout_f16, [0i32, j]);
         }
     }
 }
@@ -116,10 +115,9 @@ pub mod add_rms_norm_f16_module {
 
         // Second pass: write normalized output and updated residual.
         let w_part: Partition<f16, { [BLOCK_SIZE] }> = w.partition(const_shape![BLOCK_SIZE]);
-        let mut out_part: PartitionMut<f16, { [1, BLOCK_SIZE] }> =
-            unsafe { out.partition_mut(tile_shape) };
+        let mut out_part: PartitionMut<f16, { [1, BLOCK_SIZE] }> = out.partition_mut(tile_shape);
         let mut res_out_part: PartitionMut<f16, { [1, BLOCK_SIZE] }> =
-            unsafe { residual_out.partition_mut(tile_shape) };
+            residual_out.partition_mut(tile_shape);
         for j in 0i32..num_tiles {
             let tr_f16: Tile<f16, { [1, BLOCK_SIZE] }> = residual_part.load([row, j]);
             let tx_f16: Tile<f16, { [1, BLOCK_SIZE] }> = x_part.load([row, j]);
@@ -131,10 +129,8 @@ pub mod add_rms_norm_f16_module {
             let normed: Tile<f32, { [1, BLOCK_SIZE] }> = combined * inv_rms * tw;
             let normed_f16: Tile<f16, { [1, BLOCK_SIZE] }> = convert_tile(normed);
             let combined_f16: Tile<f16, { [1, BLOCK_SIZE] }> = convert_tile(combined);
-            unsafe {
-                out_part.store(normed_f16, [0i32, j]);
-                res_out_part.store(combined_f16, [0i32, j]);
-            }
+            out_part.store(normed_f16, [0i32, j]);
+            res_out_part.store(combined_f16, [0i32, j]);
         }
     }
 }
@@ -198,8 +194,7 @@ pub mod qk_norm_f16_module {
             q_weight.partition(const_shape![BLOCK_SIZE]);
         let kw_part: Partition<f16, { [BLOCK_SIZE] }> =
             k_weight.partition(const_shape![BLOCK_SIZE]);
-        let mut out_part: PartitionMut<f16, { [1, BLOCK_SIZE] }> =
-            unsafe { out.partition_mut(tile_shape) };
+        let mut out_part: PartitionMut<f16, { [1, BLOCK_SIZE] }> = out.partition_mut(tile_shape);
         for j in 0i32..num_tiles {
             let tx_f16: Tile<f16, { [1, BLOCK_SIZE] }> = if is_q {
                 q_part.load([local_row, j])
@@ -215,7 +210,7 @@ pub mod qk_norm_f16_module {
             let tw: Tile<f32, { [1, BLOCK_SIZE] }> = convert_tile(tw_f16);
             let tout: Tile<f32, { [1, BLOCK_SIZE] }> = tx * inv_rms * tw;
             let tout_f16: Tile<f16, { [1, BLOCK_SIZE] }> = convert_tile(tout);
-            unsafe { out_part.store(tout_f16, [0i32, j]) };
+            out_part.store(tout_f16, [0i32, j]);
         }
     }
 }

--- a/cutile-macro/src/kernel_launcher_generator.rs
+++ b/cutile-macro/src/kernel_launcher_generator.rs
@@ -926,6 +926,21 @@ pub fn generate_kernel_launcher(
     .block
     .stmts;
     launcher_method.block.stmts.extend(compile_stmts);
+    // Per-parameter runtime extents for launch-time check hoisting; the
+    // per-arg validator statements fill in each tensor param's shape by
+    // signature index (non-tensor params stay empty).
+    launcher_method.block.stmts.push(parse_stmt(
+        "let mut param_shapes: Vec<Vec<i32>> = vec![Vec::new(); validator.params.len()];"
+            .to_string(),
+    ));
+    // The kernel-visible view per parameter: the partition slab for a
+    // `&mut Tensor` output, the whole tensor otherwise. Resolves the
+    // view-frame atoms in hoisted checks, while `param_shapes` (the root
+    // frame) resolves `dim(...)` atoms and declared preconditions.
+    launcher_method.block.stmts.push(parse_stmt(
+        "let mut view_shapes: Vec<Vec<i32>> = vec![Vec::new(); validator.params.len()];"
+            .to_string(),
+    ));
     launcher_method.block.stmts.extend(validator_statements);
 
     // Above the `!_compile_only` gate so warmup validates the grid too.
@@ -933,6 +948,12 @@ pub fn generate_kernel_launcher(
         "let launch_grid: (u32, u32, u32) = self.infer_launch_grid(&[{}])?;",
         launch_grid_expr_strs.join(",")
     )));
+    // Run the compiler-emitted launch checks (safety checks hoisted out of the
+    // kernel) against the runtime extents, before the kernel is launched.
+    launcher_method.block.stmts.push(parse_stmt(
+        "validate_launch_checks(&validator.launch_checks, &param_shapes, &view_shapes, launch_grid)?;"
+            .to_string(),
+    ));
 
     let mut launch_only_stmts: Vec<Stmt> = vec![parse_stmt(
         "let mut kernel_launch = AsyncKernelLaunch::new(function.clone());".to_string(),
@@ -1272,7 +1293,17 @@ struct DimEqualityPrecondition {
     rhs_axis: usize,
 }
 
-fn parse_metadata_preconditions(item: &ItemFn) -> Result<Vec<DimEqualityPrecondition>, Error> {
+enum Precondition {
+    DimEq(DimEqualityPrecondition),
+    /// `dim(tensor, axis) % divisor == 0`, divisor a positive integer literal.
+    DimDivisible {
+        tensor: String,
+        axis: usize,
+        divisor: i64,
+    },
+}
+
+fn parse_metadata_preconditions(item: &ItemFn) -> Result<Vec<Precondition>, Error> {
     let Some(entry_attrs) = get_meta_list_by_last_segment("entry", &item.attrs) else {
         return Ok(Vec::new());
     };
@@ -1305,9 +1336,59 @@ fn parse_metadata_preconditions(item: &ItemFn) -> Result<Vec<DimEqualityPrecondi
                 .ident
                 .err("each `preconditions` entry must be a metadata equality");
         };
-        preconditions.push(parse_dim_equality_precondition(binary)?);
+        preconditions.push(parse_precondition(binary)?);
     }
     Ok(preconditions)
+}
+
+fn parse_precondition(binary: &syn::ExprBinary) -> Result<Precondition, Error> {
+    if !matches!(binary.op, syn::BinOp::Eq(_)) {
+        return binary.err("precondition predicates must use `==`");
+    }
+    // Divisibility spelling: `dim(t, k) % divisor == 0`.
+    if let Expr::Binary(rem) = binary.left.as_ref() {
+        if matches!(rem.op, syn::BinOp::Rem(_)) {
+            let is_zero = match binary.right.as_ref() {
+                Expr::Lit(lit) => match &lit.lit {
+                    Lit::Int(i) => i.base10_parse::<i64>().map(|v| v == 0).unwrap_or(false),
+                    _ => false,
+                },
+                _ => false,
+            };
+            if !is_zero {
+                return binary.err(
+                    "a `%` precondition must compare against literal `0`: `dim(t, k) % d == 0`",
+                );
+            }
+            let (tensor, axis) = parse_dim_precondition_expr(&rem.left)?;
+            let Expr::Lit(lit) = rem.right.as_ref() else {
+                return rem.right.err(
+                    "a `%` precondition divisor must be a positive integer literal (a const \
+                     generic cannot be verified by the launcher, which runs before \
+                     monomorphization)",
+                );
+            };
+            let Lit::Int(int_lit) = &lit.lit else {
+                return rem
+                    .right
+                    .err("a `%` precondition divisor must be a positive integer literal");
+            };
+            let divisor = int_lit
+                .base10_parse::<i64>()
+                .map_err(|err| crate::error::syn_err(int_lit.span(), &err.to_string()))?;
+            if divisor < 1 {
+                return rem.right.err(&format!(
+                    "a `%` precondition divisor must be >= 1, got {divisor}"
+                ));
+            }
+            return Ok(Precondition::DimDivisible {
+                tensor,
+                axis,
+                divisor,
+            });
+        }
+    }
+    parse_dim_equality_precondition(binary).map(Precondition::DimEq)
 }
 
 fn parse_dim_equality_precondition(
@@ -1395,11 +1476,51 @@ fn precondition_shape_expr(name: &str, kind: TensorParamKind) -> TokenStream2 {
 }
 
 fn metadata_precondition_validation_stmts(
-    preconditions: &[DimEqualityPrecondition],
+    preconditions: &[Precondition],
     tensor_param_kinds: &HashMap<String, TensorParamKind>,
 ) -> Result<Vec<Stmt>, Error> {
     let mut statements = Vec::new();
     for precondition in preconditions {
+        let precondition = match precondition {
+            Precondition::DimEq(eq) => eq,
+            Precondition::DimDivisible {
+                tensor,
+                axis,
+                divisor,
+            } => {
+                let Some(&kind) = tensor_param_kinds.get(tensor) else {
+                    return Err(crate::error::syn_err(
+                        Span::call_site(),
+                        &format!("precondition references unknown tensor parameter `{tensor}`"),
+                    ));
+                };
+                let shape_expr = precondition_shape_expr(tensor, kind);
+                let axis = *axis;
+                let divisor = *divisor;
+                let validation = syn::parse2::<ExprBlock>(quote! {{
+                    {
+                        let shape: Vec<i32> = #shape_expr;
+                        kernel_launch_assert(
+                            #axis < shape.len(),
+                            format!(
+                                "dim({}, {}) % {} == 0 failed: axis is out of range for shape {:?}",
+                                #tensor, #axis, #divisor, shape
+                            ).as_str(),
+                        )?;
+                        kernel_launch_assert(
+                            (shape[#axis] as i64).rem_euclid(#divisor) == 0,
+                            format!(
+                                "dim({}, {}) % {} == 0 failed: extent is {}",
+                                #tensor, #axis, #divisor, shape[#axis]
+                            ).as_str(),
+                        )?;
+                    }
+                }})
+                .unwrap();
+                statements.extend(validation.block.stmts);
+                continue;
+            }
+        };
         let Some(&lhs_kind) = tensor_param_kinds.get(&precondition.lhs) else {
             return Err(crate::error::syn_err(
                 Span::call_site(),
@@ -1588,7 +1709,7 @@ fn get_tensor_code(
         builder_statements.push(parse_stmt(format!(
             "KernelOutputStored::push_kernel_args(&{var_name}, &mut kernel_launch);"
         )));
-        launch_grid_expr_strs.push(format!("KernelOutputStored::grid(&{var_name})?"));
+        launch_grid_expr_strs.push(format!("KernelOutputStored::grid_bound(&{var_name})?"));
         syn::parse2::<ExprBlock>(quote! {{
             {
                 let ValidParamType::Tensor(tensor_validator) = &validator.params[#var_idx] else {
@@ -1600,6 +1721,12 @@ fn get_tensor_code(
                     format!("{} rank mismatch: Expected {}, got {}", #var_name, valid_shape.len(), given_shape.len()).as_str())?;
                 kernel_launch_assert(valid_shape == &given_shape,
                     format!("{} partition shape mismatch. Expected {:?}, got {:?}", #var_name, valid_shape, given_shape).as_str())?;
+                // Runtime extents for launch-time check hoisting (indexed by
+                // signature position): root shape resolves `Dim` atoms, and the
+                // partition slab -- this param's kernel-visible view -- resolves
+                // `ViewExtent` atoms.
+                param_shapes[#var_idx] = KernelOutputStored::shape_as_i32(&#var_ident);
+                view_shapes[#var_idx] = given_shape;
             }
         }})
         .unwrap()
@@ -1626,6 +1753,11 @@ fn get_tensor_code(
                 kernel_launch_assert(pred,
                     format!("{} partition shape mismatch. Expected {:?}, got {:?}", #var_name, valid_shape_mixed, given_shape).as_str())?;
                 // TODO (hme): add validation for strides here too.
+                // Runtime extents for launch-time check hoisting (indexed by
+                // signature position). An immutable tensor is passed whole, so
+                // its view is its root shape.
+                param_shapes[#var_idx] = #var_ident.shape().to_vec();
+                view_shapes[#var_idx] = param_shapes[#var_idx].clone();
             }
         }})
         .unwrap()

--- a/cutile-macro/src/shadow_dispatch.rs
+++ b/cutile-macro/src/shadow_dispatch.rs
@@ -1379,7 +1379,16 @@ fn replace_lifetimes_with(ty: &Type, dead: &[String], replacement: &syn::Lifetim
 /// When `rewrite_ty_for_rank` rewrites `Shape<...>` → `Shape_N<...>`, we must
 /// prepend `'_` to the rank-instance form because `Shape_N<'a, const D_0: i32, ...>`
 /// has a lifetime that is NOT elidable in impl header positions (E0726).
-const LIFETIME_BEARING_BASES: &[&str] = &["Shape", "Array", "Partition", "PartitionMut"];
+const LIFETIME_BEARING_BASES: &[&str] = &[
+    "Shape",
+    "Array",
+    "Partition",
+    "PartitionMut",
+    "BoundedPartition",
+    "BoundedPartitionMut",
+    "GatherScatterView",
+    "StridedView",
+];
 
 fn base_has_lifetime(base: &Ident) -> bool {
     let s = base.to_string();

--- a/cutile/src/_core.rs
+++ b/cutile/src/_core.rs
@@ -620,6 +620,22 @@ pub mod core {
         }
     }
 
+    #[cuda_tile::variadic_impl(N = 6)]
+    impl<E: ElementType, const D: [i32; N]> ops::Shl<Tile<E, D>> for Tile<E, D> {
+        type Output = Tile<E, D>;
+        fn shl(self, _rhs: Tile<E, D>) -> Tile<E, D> {
+            unreachable!()
+        }
+    }
+
+    #[cuda_tile::variadic_impl(N = 6)]
+    impl<E: ElementType, const D: [i32; N]> ops::Shr<Tile<E, D>> for Tile<E, D> {
+        type Output = Tile<E, D>;
+        fn shr(self, _rhs: Tile<E, D>) -> Tile<E, D> {
+            unreachable!()
+        }
+    }
+
     /// Kernel-side view into GPU global memory. `-1` in `D` marks a dynamic dim.
     #[cuda_tile::ty(name="!cuda_tile.tensor_view",
                     type_params=["{D}xE", "strides"],
@@ -650,13 +666,23 @@ pub mod core {
                 make_partition_view(self, tile, padding::Zero, dim_map, tensor_token);
             p
         }
-        pub unsafe fn partition_mut<'a, const R: [i32; N]>(
+        /// Build a mutable tiled view of this tensor.
+        ///
+        /// Safe: constructing the view is not itself UB — the `&mut self` borrow
+        /// gives exclusive access for the view's lifetime, and *every* store
+        /// through the view is independently gated. The raw unchecked store
+        /// ([`PartitionMut::store`]) is `unsafe`; the proof-carrying stores
+        /// ([`PartitionMut::with_bounds`] → branded/block-id `coord`, and
+        /// [`PartitionMut::store_index`] via a minted `PartitionIndex`) are safe.
+        /// So no *unproven* store is reachable without `unsafe`. Mirrors the
+        /// immutable [`Tensor::partition`], which is likewise safe.
+        pub fn partition_mut<'a, const R: [i32; N]>(
             &'a mut self,
             tile: Shape<R>,
         ) -> PartitionMut<'a, E, R> {
-            // TODO (hme): Bounds checks.
             let tensor_token: Token = get_tensor_token(self);
             let outer_tile: Shape<S> = Shape::<S> { dims: &[] };
+            // TODO (hme): document safety
             let mut p: PartitionMut<E, R> =
                 unsafe { make_nested_partition_view_mut(self, tile, padding::None, tensor_token) };
             set_nested_mutable_partition_access_offset(&mut p, outer_tile);
@@ -704,10 +730,20 @@ pub mod core {
         }
     }
 
+    #[cuda_tile::variadic_impl(N = 6)]
+    impl<const D: [i32; N]> StoreIndex for PartitionIndex<D> {}
+
     impl<const D: [i32; 2]> PartitionIndex<D> {
         pub fn components(self) -> (i32, i32) {
             let coords = self.coords();
             (coords[0], coords[1])
+        }
+    }
+
+    impl<const D: [i32; 3]> PartitionIndex<D> {
+        pub fn components(self) -> (i32, i32, i32) {
+            let coords = self.coords();
+            (coords[0], coords[1], coords[2])
         }
     }
 
@@ -719,6 +755,12 @@ pub mod core {
     pub struct Dim {}
 
     impl Dim {
+        #[deprecated(
+            since = "0.3.0",
+            note = "a hand-computed tile count carries no axis provenance. Use \
+                    `num_tiles(&partition, axis)`, which names the axis it counts, \
+                    and iterate it directly as `0..num_tiles(&p, axis)`."
+        )]
         pub fn new(size: i32) -> Dim {
             dim_new(size)
         }
@@ -775,10 +817,45 @@ pub mod core {
         _type: PhantomData<()>,
     }
 
+    /// Proof-carrying 3D coordinate produced from branded dimension indices.
+    #[derive(Copy, Clone)]
+    pub struct Coord3 {
+        _type: PhantomData<()>,
+    }
+
+    /// Tuple of indices convertible into a proof-carrying coordinate.
+    ///
+    /// Each component must either be produced by iterating the `Dim` bound to
+    /// the matching partition axis, or be a constant provably inside the
+    /// axis's statically-known tile grid.
+    pub trait CoordTuple {
+        type Coord;
+    }
+
+    impl CoordTuple for (i32, i32) {
+        type Coord = Coord2;
+    }
+
+    impl CoordTuple for (i32, i32, i32) {
+        type Coord = Coord3;
+    }
+
     #[cuda_tile::compiler_op(name = "coord")]
-    pub fn coord(index: (i32, i32)) -> Coord2 {
+    pub fn coord<C: CoordTuple>(index: C) -> C::Coord {
         unreachable!()
     }
+
+    /// Index forms accepted by [`MappedPartitionMut::store`].
+    ///
+    /// Either the whole minted [`PartitionIndex`] (every axis proven by the
+    /// stream), or a [`coord`]-built composite whose streamed-axis components
+    /// were minted by this partition's `iter_indices()` and whose owned-axis
+    /// (`OWNED` map dim) components carry a `Dim` or constant bounds proof.
+    pub trait StoreIndex {}
+
+    impl StoreIndex for Coord2 {}
+
+    impl StoreIndex for Coord3 {}
 
     /// Iterator marker for mapped partition indices.
     ///
@@ -792,7 +869,8 @@ pub mod core {
         _type: PhantomData<()>,
     }
 
-    impl<const D: [i32; 2], const M: [i32; 2]> Iterator for PartitionIndices<D, M> {
+    #[cuda_tile::variadic_impl(N = 6)]
+    impl<const D: [i32; N], const M: [i32; N]> Iterator for PartitionIndices<D, M> {
         type Item = PartitionIndex<D>;
 
         fn next(&mut self) -> Option<Self::Item> {
@@ -814,12 +892,78 @@ pub mod core {
         _type: PhantomData<E>,
     }
 
-    impl<E: ElementType, const D: [i32; 2], const M: [i32; 2]> MappedPartitionMut<E, D, M> {
+    #[cuda_tile::variadic_impl(N = 6)]
+    impl<E: ElementType, const D: [i32; N], const M: [i32; N]> MappedPartitionMut<E, D, M> {
         /// Iterate the private disjoint indices generated by this partition map.
         pub fn iter_indices(&self) -> PartitionIndices<D, M> {
             unreachable!()
         }
 
+        /// Iterate indices accepted by stores into both this partition and `other`.
+        ///
+        /// Multi-output kernels write several tensors at the same logical tile
+        /// index. Both partitions must share the tile and map shapes (enforced
+        /// by the type), and their logical partition grids must match: static
+        /// mismatches are compile errors, dynamic grids are checked at runtime.
+        pub fn iter_indices_with<E2: ElementType>(
+            &self,
+            other: &MappedPartitionMut<E2, D, M>,
+        ) -> PartitionIndices<D, M> {
+            unreachable!()
+        }
+
+        /// Iterate a sub-range of the logical partition grid.
+        ///
+        /// `ranges` gives one `(start_tile, num_tiles)` pair per axis in tile
+        /// units; a **literal** `num_tiles = -1` means "the rest of the axis
+        /// from `start_tile`" — the spelling is resolved at compile time, so
+        /// a runtime value of -1 is a negative length and fails the range
+        /// assert. Only the covered tiles are visited, so a kernel
+        /// updating `seq_len` rows of a `max_seq` cache iterates exactly the
+        /// written tiles instead of the whole grid. Starts and lengths are
+        /// runtime values (a start read from device memory works); each range
+        /// is checked against the grid — statically when provable, otherwise
+        /// with a runtime assert — so minted indices keep the in-bounds store
+        /// proof.
+        pub fn iter_indices_within(&self, ranges: [(i32, i32); N]) -> PartitionIndices<D, M> {
+            unreachable!()
+        }
+
+        /// Sub-range iteration whose indices are also accepted by `other`:
+        /// [`Self::iter_indices_within`] composed with
+        /// [`Self::iter_indices_with`].
+        pub fn iter_indices_within_with<E2: ElementType>(
+            &self,
+            ranges: [(i32, i32); N],
+            other: &MappedPartitionMut<E2, D, M>,
+        ) -> PartitionIndices<D, M> {
+            unreachable!()
+        }
+
+        /// Store `tile` at a proven-disjoint partition index.
+        ///
+        /// Accepts the whole minted [`PartitionIndex`], or — on partitions
+        /// with `OWNED` map axes — a [`coord`]-built composite: streamed-axis
+        /// components must be minted by this partition's `iter_indices()`
+        /// stream; owned-axis components carry a `Dim` or constant bounds
+        /// proof (the stream item owns the whole axis, so bounds suffice).
+        pub fn store<I: StoreIndex>(&mut self, tile: Tile<E, D>, index: I) -> Token {
+            let coords: [i32; N] = validate_partition_store(self, index);
+            unsafe {
+                store_view_tko_mapped_mut(
+                    self,
+                    tile,
+                    coords,
+                    ordering::Weak,
+                    scope::TileBlock,
+                    None,
+                    tma::Enabled,
+                )
+            }
+        }
+    }
+
+    impl<E: ElementType, const D: [i32; 2], const M: [i32; 2]> MappedPartitionMut<E, D, M> {
         /// Map a flat persistent tile id into this partition's swizzled index.
         ///
         /// # Safety
@@ -834,22 +978,6 @@ pub mod core {
             num_bid_n: i32,
         ) -> PartitionIndex<D> {
             unsafe { swizzle_partition_index_2d::<D, M>(tile_id, num_bid_m, num_bid_n) }
-        }
-
-        /// Store `tile` at a map-produced disjoint partition index.
-        pub fn store(&mut self, tile: Tile<E, D>, index: PartitionIndex<D>) -> Token {
-            validate_partition_index(self, index);
-            unsafe {
-                store_view_tko_mapped_mut(
-                    self,
-                    tile,
-                    index.coords(),
-                    ordering::Weak,
-                    scope::TileBlock,
-                    None,
-                    tma::Enabled,
-                )
-            }
         }
     }
 
@@ -878,9 +1006,42 @@ pub mod core {
             );
             result
         }
+
+        /// Checked load with a software-pipelining latency hint.
+        ///
+        /// Identical bounds checking to [`Self::load`]; `LATENCY` only feeds
+        /// the Tile IR `optimization_hints.latency` knob and has no safety
+        /// interaction. Use for loads on the critical path of pipelined
+        /// loops, e.g. `part_k.load_pipelined::<4>([i, j])`.
+        ///
+        /// The cost of the bounds check depends on where the compiler can
+        /// place it: see the book's "Bounds-Check Placement" chapter for the
+        /// placement rules and how to inspect them (`CUTILE_JIT_LOG=1`).
+        pub fn load_pipelined<const LATENCY: i32>(&self, index: [i32; N]) -> Tile<E, D> {
+            check_partition_access(self, index);
+            let result: Tile<E, D> = load_view_tko(
+                self,
+                index,
+                ordering::Weak,
+                scope::TileBlock,
+                Some(LATENCY),
+                tma::Enabled,
+            );
+            result
+        }
     }
 
     impl<'a, E: ElementType, const D: [i32; 2]> Partition<'a, E, D> {
+        #[deprecated(
+            since = "0.3.0",
+            note = "iterate `0..num_tiles(&p, axis)` and index with plain arrays; \
+                    the compiler infers the same bounds, and an index walked from \
+                    another tensor's axis is verified against this one at launch \
+                    automatically. Migrate `Dim::new(expr)` loops to `num_tiles` \
+                    rather than just dropping this call: a hand-computed count \
+                    carries no axis provenance, so the access would fall back to \
+                    a runtime check."
+        )]
         pub fn with_bounds<A: IntoDim, B: IntoDim>(
             self,
             bounds: (A, B),
@@ -890,6 +1051,32 @@ pub mod core {
 
         pub fn load_index(&self, index: PartitionIndex<D>) -> Tile<E, D> {
             self.load(index.coords())
+        }
+    }
+
+    impl<'a, E: ElementType, const D: [i32; 3]> Partition<'a, E, D> {
+        #[deprecated(
+            since = "0.3.0",
+            note = "iterate `0..num_tiles(&p, axis)` and index with plain arrays; \
+                    the compiler infers the same bounds, and an index walked from \
+                    another tensor's axis is verified against this one at launch \
+                    automatically. Migrate `Dim::new(expr)` loops to `num_tiles` \
+                    rather than just dropping this call: a hand-computed count \
+                    carries no axis provenance, so the access would fall back to \
+                    a runtime check."
+        )]
+        pub fn with_bounds<A: IntoDim, B: IntoDim, C: IntoDim>(
+            self,
+            bounds: (A, B, C),
+        ) -> BoundedPartition<'a, E, D> {
+            partition_with_bounds3(
+                self,
+                (
+                    bounds.0.into_dim(),
+                    bounds.1.into_dim(),
+                    bounds.2.into_dim(),
+                ),
+            )
         }
     }
 
@@ -910,24 +1097,77 @@ pub mod core {
     impl<'a, E: ElementType, const D: [i32; 2]> BoundedPartition<'a, E, D> {
         pub fn load(&self, index: Coord2) -> Tile<E, D> {
             check_bounded_partition_access(self, index);
-            load_view_tko_bounded(
+            let result: Tile<E, D> = load_view_tko_bounded(
                 self,
                 coord2_as_array(index),
                 ordering::Weak,
                 scope::TileBlock,
                 None,
                 tma::Enabled,
-            )
+            );
+            result
+        }
+
+        /// Checked load with a software-pipelining latency hint.
+        ///
+        /// Identical proof requirements to [`Self::load`]; `LATENCY` only
+        /// feeds the Tile IR `optimization_hints.latency` knob and has no
+        /// safety interaction.
+        pub fn load_pipelined<const LATENCY: i32>(&self, index: Coord2) -> Tile<E, D> {
+            check_bounded_partition_access(self, index);
+            let result: Tile<E, D> = load_view_tko_bounded(
+                self,
+                coord2_as_array(index),
+                ordering::Weak,
+                scope::TileBlock,
+                Some(LATENCY),
+                tma::Enabled,
+            );
+            result
         }
     }
 
-    /// Mutable partition view. Loads/stores are unordered (hence `unsafe`);
-    /// prefer `Tensor::load`/`store` for ordered access.
+    impl<'a, E: ElementType, const D: [i32; 3]> BoundedPartition<'a, E, D> {
+        pub fn load(&self, index: Coord3) -> Tile<E, D> {
+            check_bounded_partition_access3(self, index);
+            let result: Tile<E, D> = load_view_tko_bounded(
+                self,
+                coord3_as_array(index),
+                ordering::Weak,
+                scope::TileBlock,
+                None,
+                tma::Enabled,
+            );
+            result
+        }
+
+        /// Checked load with a software-pipelining latency hint.
+        ///
+        /// Identical proof requirements to [`Self::load`]; `LATENCY` only
+        /// feeds the Tile IR `optimization_hints.latency` knob and has no
+        /// safety interaction.
+        pub fn load_pipelined<const LATENCY: i32>(&self, index: Coord3) -> Tile<E, D> {
+            check_bounded_partition_access3(self, index);
+            let result: Tile<E, D> = load_view_tko_bounded(
+                self,
+                coord3_as_array(index),
+                ordering::Weak,
+                scope::TileBlock,
+                Some(LATENCY),
+                tma::Enabled,
+            );
+            result
+        }
+    }
+
+    /// Mutable partition view. `store` is bounds-checked and safe; `load` is
+    /// unordered and stays `unsafe` (a load may race a store to the same
+    /// region, which bounds checking does not address).
     // TODO (hme): consolidate Partition + PartitionMut into a single type.
     #[cuda_tile::ty(name="!cuda_tile.partition_view",
                     type_params=["tile"],
                     type_params_optional=["padding_value", "tensor_view"],
-                    type_meta=["token"])]
+                    type_meta=["token", "tensor_view.shape()"])]
     #[cuda_tile::variadic_struct(N = 6)]
     pub struct PartitionMut<'a, E: ElementType, const D: [i32; N]> {
         _type: PhantomData<E>,
@@ -953,12 +1193,39 @@ pub mod core {
 
         /// Stores a tile to this mutable partition at the specified index.
         ///
+        /// The index is bounds-checked: the compiler proves it lies inside the
+        /// partition grid, or emits a check that traps if it does not. An
+        /// index the compiler can relate to the axis it indexes — one iterating
+        /// `num_tiles(&p, a)`, or a constant inside a known extent — costs
+        /// nothing at runtime. See the book's "Bounds-Check Placement" chapter
+        /// for the placement rules and how to inspect them (`CUTILE_JIT_LOG=1`).
+        ///
         /// Returns a token representing the completion of the store operation.
+        pub fn store(&mut self, tile: Tile<E, D>, index: [i32; N]) -> Token {
+            check_partition_access_mut(self, index);
+            let token: Token = unsafe {
+                store_view_tko_mut(
+                    self,
+                    tile,
+                    index,
+                    ordering::Weak,
+                    scope::TileBlock,
+                    None,
+                    tma::Enabled,
+                )
+            };
+            token
+        }
+
+        /// [`Self::store`] without the bounds check.
         ///
         /// ## Safety
         ///
-        /// This is unsafe because it uses unordered memory operations.
-        pub unsafe fn store(&mut self, tile: Tile<E, D>, index: [i32; N]) -> Token {
+        /// The caller must guarantee `index` is within this partition's grid
+        /// on every axis. An out-of-range index writes memory outside the
+        /// partition. Prefer [`Self::store`], which proves the same property
+        /// and costs nothing when the compiler can discharge it.
+        pub unsafe fn store_unchecked(&mut self, tile: Tile<E, D>, index: [i32; N]) -> Token {
             let token: Token = unsafe {
                 store_view_tko_mut(
                     self,
@@ -976,7 +1243,106 @@ pub mod core {
 
     impl<'a, E: ElementType, const D: [i32; 2]> PartitionMut<'a, E, D> {
         pub fn store_index(&mut self, tile: Tile<E, D>, index: PartitionIndex<D>) -> Token {
-            unsafe { self.store(tile, index.coords()) }
+            self.store(tile, index.coords())
+        }
+    }
+
+    /// Mutable partition whose valid axes have been tied to `Dim` values.
+    ///
+    /// The mutable mirror of [`BoundedPartition`]: safe stores require
+    /// `coord((...))` built from indices produced by those dimensions.
+    #[cuda_tile::ty(name="!cuda_tile.partition_view",
+                    type_params=["tile"],
+                    type_params_optional=["padding_value", "tensor_view", "dim_map"],
+                    type_meta=["token", "tensor_view.shape()"])]
+    #[cuda_tile::variadic_struct(N = 6)]
+    pub struct BoundedPartitionMut<'a, E: ElementType, const D: [i32; N]> {
+        _type: PhantomData<E>,
+        _tensor: PhantomData<&'a mut ()>,
+    }
+
+    impl<'a, E: ElementType, const D: [i32; 2]> PartitionMut<'a, E, D> {
+        /// Tie this mutable partition's axes to `Dim` bounds, mirroring
+        /// [`Partition::with_bounds`]. Stores then require branded coords.
+        #[deprecated(
+            since = "0.3.0",
+            note = "iterate `0..num_tiles(&p, axis)` and index with plain arrays; \
+                    the compiler infers the same bounds, and an index walked from \
+                    another tensor's axis is verified against this one at launch \
+                    automatically. Migrate `Dim::new(expr)` loops to `num_tiles` \
+                    rather than just dropping this call: a hand-computed count \
+                    carries no axis provenance, so the access would fall back to \
+                    a runtime check."
+        )]
+        pub fn with_bounds<A: IntoDim, B: IntoDim>(
+            self,
+            bounds: (A, B),
+        ) -> BoundedPartitionMut<'a, E, D> {
+            partition_with_bounds_mut(self, (bounds.0.into_dim(), bounds.1.into_dim()))
+        }
+    }
+
+    impl<'a, E: ElementType, const D: [i32; 3]> PartitionMut<'a, E, D> {
+        #[deprecated(
+            since = "0.3.0",
+            note = "iterate `0..num_tiles(&p, axis)` and index with plain arrays; \
+                    the compiler infers the same bounds, and an index walked from \
+                    another tensor's axis is verified against this one at launch \
+                    automatically. Migrate `Dim::new(expr)` loops to `num_tiles` \
+                    rather than just dropping this call: a hand-computed count \
+                    carries no axis provenance, so the access would fall back to \
+                    a runtime check."
+        )]
+        pub fn with_bounds<A: IntoDim, B: IntoDim, C: IntoDim>(
+            self,
+            bounds: (A, B, C),
+        ) -> BoundedPartitionMut<'a, E, D> {
+            partition_with_bounds_mut3(
+                self,
+                (
+                    bounds.0.into_dim(),
+                    bounds.1.into_dim(),
+                    bounds.2.into_dim(),
+                ),
+            )
+        }
+    }
+
+    impl<'a, E: ElementType, const D: [i32; 2]> BoundedPartitionMut<'a, E, D> {
+        /// Checked store. Mirrors [`BoundedPartition::load`]: the index must be
+        /// a `coord((...))` branded by this partition's bound `Dim`s.
+        pub fn store(&mut self, tile: Tile<E, D>, index: Coord2) -> Token {
+            check_bounded_partition_access_mut(self, index);
+            let token: Token = unsafe {
+                store_view_tko_bounded(
+                    self,
+                    tile,
+                    coord2_as_array(index),
+                    ordering::Weak,
+                    scope::TileBlock,
+                    None,
+                    tma::Enabled,
+                )
+            };
+            token
+        }
+    }
+
+    impl<'a, E: ElementType, const D: [i32; 3]> BoundedPartitionMut<'a, E, D> {
+        pub fn store(&mut self, tile: Tile<E, D>, index: Coord3) -> Token {
+            check_bounded_partition_access_mut3(self, index);
+            let token: Token = unsafe {
+                store_view_tko_bounded(
+                    self,
+                    tile,
+                    coord3_as_array(index),
+                    ordering::Weak,
+                    scope::TileBlock,
+                    None,
+                    tma::Enabled,
+                )
+            };
+            token
         }
     }
 
@@ -1139,6 +1505,18 @@ pub mod core {
         unreachable!()
     }
 
+    /// [`check_partition_access`] for a mutable partition. Same check, same
+    /// compiler handler; a separate declaration only because the view type
+    /// differs.
+    #[cuda_tile::compiler_op(name = "check")]
+    #[cuda_tile::variadic_op(N = 6)]
+    pub fn check_partition_access_mut<E: ElementType, const S: [i32; N]>(
+        part: &PartitionMut<E, S>,
+        index: [i32; N],
+    ) {
+        unreachable!()
+    }
+
     #[cuda_tile::compiler_op(name = "dim_new")]
     pub fn dim_new(size: i32) -> Dim {
         unreachable!()
@@ -1159,10 +1537,23 @@ pub mod core {
         unreachable!()
     }
 
+    #[cuda_tile::compiler_op(name = "coord_as_array")]
+    pub fn coord3_as_array(index: Coord3) -> [i32; 3] {
+        unreachable!()
+    }
+
     #[cuda_tile::compiler_op(name = "partition_with_bounds")]
     pub fn partition_with_bounds<'a, E: ElementType, const S: [i32; 2]>(
         part: Partition<'a, E, S>,
         bounds: (Dim, Dim),
+    ) -> BoundedPartition<'a, E, S> {
+        unreachable!()
+    }
+
+    #[cuda_tile::compiler_op(name = "partition_with_bounds")]
+    pub fn partition_with_bounds3<'a, E: ElementType, const S: [i32; 3]>(
+        part: Partition<'a, E, S>,
+        bounds: (Dim, Dim, Dim),
     ) -> BoundedPartition<'a, E, S> {
         unreachable!()
     }
@@ -1175,18 +1566,68 @@ pub mod core {
         unreachable!()
     }
 
+    #[cuda_tile::compiler_op(name = "check_bounded_partition_access")]
+    pub fn check_bounded_partition_access3<E: ElementType, const S: [i32; 3]>(
+        part: &BoundedPartition<E, S>,
+        index: Coord3,
+    ) {
+        unreachable!()
+    }
+
+    #[cuda_tile::compiler_op(name = "partition_with_bounds")]
+    pub fn partition_with_bounds_mut<'a, E: ElementType, const S: [i32; 2]>(
+        part: PartitionMut<'a, E, S>,
+        bounds: (Dim, Dim),
+    ) -> BoundedPartitionMut<'a, E, S> {
+        unreachable!()
+    }
+
+    #[cuda_tile::compiler_op(name = "partition_with_bounds")]
+    pub fn partition_with_bounds_mut3<'a, E: ElementType, const S: [i32; 3]>(
+        part: PartitionMut<'a, E, S>,
+        bounds: (Dim, Dim, Dim),
+    ) -> BoundedPartitionMut<'a, E, S> {
+        unreachable!()
+    }
+
+    #[cuda_tile::compiler_op(name = "check_bounded_partition_access")]
+    pub fn check_bounded_partition_access_mut<E: ElementType, const S: [i32; 2]>(
+        part: &BoundedPartitionMut<E, S>,
+        index: Coord2,
+    ) {
+        unreachable!()
+    }
+
+    #[cuda_tile::compiler_op(name = "check_bounded_partition_access")]
+    pub fn check_bounded_partition_access_mut3<E: ElementType, const S: [i32; 3]>(
+        part: &BoundedPartitionMut<E, S>,
+        index: Coord3,
+    ) {
+        unreachable!()
+    }
+
     #[cuda_tile::compiler_op(name = "partition_index_coords")]
     #[cuda_tile::variadic_op(N = 6)]
     pub fn partition_index_coords<const D: [i32; N]>(index: PartitionIndex<D>) -> [i32; N] {
         unreachable!()
     }
 
-    #[cuda_tile::compiler_op(name = "validate_partition_index")]
+    /// Validate a store index against a mapped partition and return its
+    /// coordinates. Whole minted `PartitionIndex` values pass on stream
+    /// provenance; `coord(...)` composites are checked per axis (streamed
+    /// axes need minted components, owned axes need `Dim`/constant bounds
+    /// proofs).
+    #[cuda_tile::compiler_op(name = "validate_partition_store")]
     #[cuda_tile::variadic_op(N = 6)]
-    pub fn validate_partition_index<E: ElementType, const D: [i32; N], const M: [i32; N]>(
+    pub fn validate_partition_store<
+        E: ElementType,
+        const D: [i32; N],
+        const M: [i32; N],
+        I: StoreIndex,
+    >(
         view: &MappedPartitionMut<E, D, M>,
-        index: PartitionIndex<D>,
-    ) {
+        index: I,
+    ) -> [i32; N] {
         unreachable!()
     }
 
@@ -2340,15 +2781,16 @@ pub mod core {
 
     /// `load_view_tko` for a proof-bounded read-only partition.
     #[cuda_tile::op(name = "load_view_tko", params = ["view", "index"])]
+    #[cuda_tile::variadic_op(N = 6)]
     pub fn load_view_tko_bounded<
         E: ElementType,
-        const D: [i32; 2],
+        const D: [i32; N],
         O: ordering::LoadMode,
         Sc: scope::Mode,
         T: tma::Mode,
     >(
         view: &BoundedPartition<E, D>,
-        index: [i32; 2],
+        index: [i32; N],
         memory_ordering: O,
         memory_scope: Sc,
         latency: Option<i32>,
@@ -2375,6 +2817,29 @@ pub mod core {
         latency: Option<i32>,
         tma: T,
     ) -> Tile<E, D> {
+        unreachable!()
+    }
+
+    /// Store a tile into a `BoundedPartitionMut` at a branded `index`. The
+    /// mutable mirror of `load_view_tko_bounded`; lowers via the same
+    /// `store_view_tko` op as `store_view_tko_mut`.
+    #[cuda_tile::op(name = "store_view_tko", params = ["view", "tile", "index"])]
+    #[cuda_tile::variadic_op(N = 6)]
+    pub unsafe fn store_view_tko_bounded<
+        E: ElementType,
+        const D: [i32; N],
+        O: ordering::StoreMode,
+        Sc: scope::Mode,
+        T: tma::Mode,
+    >(
+        view: &mut BoundedPartitionMut<E, D>,
+        tile: Tile<E, D>,
+        index: [i32; N],
+        memory_ordering: O,
+        memory_scope: Sc,
+        latency: Option<i32>,
+        tma: T,
+    ) -> Token {
         unreachable!()
     }
 
@@ -2483,7 +2948,7 @@ pub mod core {
     #[cuda_tile::op(name="cuda_tile.make_partition_view",
                     params=["tensor_view"],
                     output_type_params=["tensor_view", "padding_value"],
-                    output_type_meta=["token"]
+                    output_type_meta=["token", "tensor_view.shape()"]
     )]
     #[cuda_tile::variadic_op(N = 6)]
     pub unsafe fn make_partition_view_mut<
@@ -2532,7 +2997,7 @@ pub mod core {
     #[cuda_tile::op(name="cuda_tile.make_partition_view",
                     params=["tensor_view"],
                     output_type_params=["tensor_view", "padding_value"],
-                    output_type_meta=["token"]
+                    output_type_meta=["token", "tensor_view.shape()"]
     )]
     #[cuda_tile::variadic_op(N = 6)]
     pub unsafe fn make_nested_partition_view_mut<

--- a/cutile/src/_tileir.rs
+++ b/cutile/src/_tileir.rs
@@ -1,0 +1,187 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/// Raw 1:1 Tile IR op surface.
+///
+/// Every item here mirrors an op in the Tile IR specification
+/// (<https://docs.nvidia.com/cuda/tile-ir/latest/sections/operations.html>)
+/// under its `Ops.td` name, declared `unsafe` wholesale: the contract is
+/// bit-for-bit Tile IR semantics with the caller owning every
+/// precondition. New Tile IR features land here first, mechanically;
+/// their safe/idiomatic exposure in [`crate::core`] follows separately.
+/// See `.internal/tasks/in_progress/dsl_improvements/op_cleanup_v0.0.2/OP_CLEANUP.md`
+/// Phase 2.
+#[cutile_macro::module(tile_rust_crate = true)]
+pub mod tileir {
+    use crate::_core::core::*;
+
+    /// View-based atomic reduction: element-wise
+    /// `view[index] := mode(view[index], value)` without returning old
+    /// values (use `atomic_rmw_tko` when old values are needed). `mode`
+    /// selects the op (`atomic::*`): integer modes for `i32`/`i64`, `AddF`
+    /// for `f16`/`bf16`/`f32`/`f64`. `memory_ordering` must be `Relaxed`;
+    /// `memory_scope` ⊆ {TileBlock, Device}. Returns the completion token.
+    // TODO (hme): document safety
+    #[cuda_tile::op(name="cuda_tile.atomic_red_view_tko", params=["view", "value", "index"])]
+    #[cuda_tile::variadic_op(N = 6)]
+    pub unsafe fn atomic_red_view_tko<
+        E: ElementType,
+        const D: [i32; N],
+        M: atomic::Mode,
+        O: ordering::AtomicMode,
+        Sc: scope::Mode,
+    >(
+        view: &mut PartitionMut<E, D>,
+        value: Tile<E, D>,
+        index: [i32; N],
+        mode: M,
+        memory_ordering: O,
+        memory_scope: Sc,
+    ) -> Token {
+        unreachable!()
+    }
+
+    // ── GatherScatterView ────────────────────────────────────────────────────
+
+    /// Sparse-indexed view into a tensor.
+    ///
+    /// One dimension (`SPARSE_DIM`) uses a 1D tile of integer indices for
+    /// gather/scatter; all other dimensions are traversed densely.
+    /// Created by [`make_gather_scatter_view`]; loaded with
+    /// [`load_gather_scatter_view_tko`].
+    // TODO (hme): document safety
+    #[cuda_tile::ty(name="!cuda_tile.gather_scatter_view",
+                    type_params=["tile"],
+                    type_params_optional=["padding_value"])]
+    #[cuda_tile::variadic_struct(N = 6)]
+    pub struct GatherScatterView<
+        'a,
+        E: ElementType,
+        const TILE_SHAPE: [i32; N],
+        const SPARSE_DIM: i32,
+    > {
+        _marker: ::core::marker::PhantomData<(&'a (), E)>,
+    }
+
+    /// Build a `GatherScatterView` from a tensor.
+    ///
+    /// `_tile` encodes the output tile shape (a `Shape<TILE_SHAPE>` witness).
+    /// `SPARSE_DIM` selects which tensor dimension uses sparse indexing.
+    /// `_padding` selects out-of-bounds fill (currently only `padding::None`
+    /// is wired through).
+    // TODO (hme): document safety
+    #[cuda_tile::op(name = "cuda_tile.make_gather_scatter_view")]
+    #[cuda_tile::variadic_op(N = 6)]
+    pub unsafe fn make_gather_scatter_view<
+        'a,
+        E: ElementType,
+        const TENSOR_SHAPE: [i32; N],
+        const TILE_SHAPE: [i32; N],
+        const SPARSE_DIM: i32,
+        P: padding::Mode,
+    >(
+        tensor_view: &'a Tensor<E, TENSOR_SHAPE>,
+        _tile: Shape<TILE_SHAPE>,
+        _padding: P,
+    ) -> GatherScatterView<'a, E, TILE_SHAPE, SPARSE_DIM> {
+        unreachable!()
+    }
+
+    /// Load a tile from a `GatherScatterView`.
+    ///
+    /// `sparse_index`: 1-D tile of integer indices into the sparse dimension.
+    /// `dense_index`: scalar index for the dense dimension.
+    /// Returns `(Tile<E, TILE_SHAPE>, Token)` with a fresh completion token.
+    // TODO (hme): document safety
+    #[cuda_tile::op(name = "cuda_tile.load_gather_scatter_view_tko")]
+    #[cuda_tile::variadic_op(N = 6)]
+    pub unsafe fn load_gather_scatter_view_tko<
+        E: ElementType,
+        const TILE_SHAPE: [i32; N],
+        const SPARSE_DIM: i32,
+        const SPARSE_IDX_SIZE: i32,
+        O: ordering::AtomicMode,
+        Sc: scope::Mode,
+    >(
+        view: &GatherScatterView<'_, E, TILE_SHAPE, SPARSE_DIM>,
+        sparse_index: Tile<i32, { [SPARSE_IDX_SIZE] }>,
+        dense_index: i32,
+        token: Token,
+        memory_ordering: O,
+        memory_scope: Sc,
+    ) -> (Tile<E, TILE_SHAPE>, Token) {
+        unreachable!()
+    }
+
+    // ── StridedView ──────────────────────────────────────────────────────────
+
+    /// Strided view into a tensor with configurable per-dimension traversal.
+    ///
+    /// `TRAVERSAL_STRIDES` controls how far to step per tile along each
+    /// dimension; `DIM_MAP` maps tile axes to tensor axes. Created by
+    /// [`make_strided_view`]; loaded with [`load_strided_view_tko`].
+    // TODO (hme): document safety
+    #[cuda_tile::ty(name="!cuda_tile.strided_view",
+                    type_params=["tile"],
+                    type_params_optional=["traversal_strides", "dim_map", "padding_value"])]
+    #[cuda_tile::variadic_struct(N = 6)]
+    pub struct StridedView<
+        'a,
+        E: ElementType,
+        const TILE_SHAPE: [i32; N],
+        const TRAVERSAL_STRIDES: [i32; N],
+        const DIM_MAP: [i32; N],
+    > {
+        _marker: ::core::marker::PhantomData<(&'a (), E)>,
+    }
+
+    /// Build a `StridedView` from a tensor.
+    ///
+    /// `TRAVERSAL_STRIDES` and `DIM_MAP` are encoded as const generic
+    /// parameters on the return type; pass them via a turbofish or return-type
+    /// annotation. `_tile` is a shape witness for `TILE_SHAPE`.
+    // TODO (hme): document safety
+    #[cuda_tile::op(name = "cuda_tile.make_strided_view")]
+    #[cuda_tile::variadic_op(N = 6)]
+    pub unsafe fn make_strided_view<
+        'a,
+        E: ElementType,
+        const TENSOR_SHAPE: [i32; N],
+        const TILE_SHAPE: [i32; N],
+        const TRAVERSAL_STRIDES: [i32; N],
+        const DIM_MAP: [i32; N],
+        P: padding::Mode,
+    >(
+        tensor_view: &'a Tensor<E, TENSOR_SHAPE>,
+        _tile: Shape<TILE_SHAPE>,
+        _padding: P,
+    ) -> StridedView<'a, E, TILE_SHAPE, TRAVERSAL_STRIDES, DIM_MAP> {
+        unreachable!()
+    }
+
+    /// Load a tile from a `StridedView`.
+    ///
+    /// `index` is an N-element array of scalar indices, one per tile
+    /// dimension. Returns `(Tile<E, TILE_SHAPE>, Token)`.
+    // TODO (hme): document safety
+    #[cuda_tile::op(name = "cuda_tile.load_strided_view_tko")]
+    #[cuda_tile::variadic_op(N = 6)]
+    pub unsafe fn load_strided_view_tko<
+        E: ElementType,
+        const TILE_SHAPE: [i32; N],
+        const TRAVERSAL_STRIDES: [i32; N],
+        const DIM_MAP: [i32; N],
+        O: ordering::AtomicMode,
+        Sc: scope::Mode,
+    >(
+        view: &StridedView<'_, E, TILE_SHAPE, TRAVERSAL_STRIDES, DIM_MAP>,
+        index: [i32; N],
+        token: Token,
+        memory_ordering: O,
+        memory_scope: Sc,
+    ) -> (Tile<E, TILE_SHAPE>, Token) {
+        unreachable!()
+    }
+}

--- a/cutile/src/lib.rs
+++ b/cutile/src/lib.rs
@@ -160,8 +160,10 @@
 //! - **Architecture & Design** - How cutile works under the hood
 
 pub mod _core;
+pub mod _tileir;
 pub mod error;
 pub use _core::core;
+pub use _tileir::tileir;
 
 // LINKING Phase B: register an additional registry entry at the public
 // `cutile::core` path so kernel `use cutile::core::*` statements resolve
@@ -177,6 +179,12 @@ static __CUTILE_REEXPORT_CORE: cutile_compiler::registry::CutileModuleEntry =
     cutile_compiler::registry::CutileModuleEntry {
         absolute_path: "cutile::core",
         build: _core::core::__module_ast_self,
+    };
+#[linkme::distributed_slice(cutile_compiler::registry::CUTILE_MODULES)]
+static __CUTILE_REEXPORT_TILEIR: cutile_compiler::registry::CutileModuleEntry =
+    cutile_compiler::registry::CutileModuleEntry {
+        absolute_path: "cutile::tileir",
+        build: _tileir::tileir::__module_ast_self,
     };
 pub mod api;
 pub mod bench;

--- a/cutile/src/prelude.rs
+++ b/cutile/src/prelude.rs
@@ -22,7 +22,7 @@ pub use crate::error::Error;
 pub use crate::tensor::{
     IntoPartition, KernelInput, KernelInputStored, KernelOutput, KernelOutputStored,
     MappedLaunchPartition, Partition, PartitionMut, Reshape, SpecializationBits, Tensor,
-    TensorView, ToHostVec, TryPartition, Unpartition,
+    TensorView, ToHostVec, TryPartition, Unpartition, OWNED,
 };
 
 // Tile kernel traits

--- a/cutile/src/tensor.rs
+++ b/cutile/src/tensor.rs
@@ -253,9 +253,30 @@ pub struct Partition<T> {
     pub(crate) object: T,
     pub partition_shape: Vec<usize>,
     pub partition_strides: Vec<usize>,
+    /// `true` iff this binding opted into partial coverage
+    /// ([`IntoPartition::partition_prefix`]): the launch grid may be a
+    /// per-axis PREFIX of this partition's block grid instead of equal to
+    /// it. Launched blocks embed identically; blocks beyond the launch grid
+    /// are simply never visited (they keep their prior contents).
+    pub(crate) prefix_coverage: bool,
 }
 
 impl<T> Partition<T> {
+    /// Opts this binding into partial coverage: the launch grid may be a
+    /// per-axis PREFIX of the inferred block grid (`launch <= inferred` on
+    /// every axis) instead of equal to it. Launched blocks map to exactly
+    /// the blocks they would under full coverage — a per-axis prefix is the
+    /// identity embedding into the block grid, so exclusivity and
+    /// disjointness are unchanged — and blocks beyond the launch grid are
+    /// never visited, keeping their prior contents. Exceeding the inferred
+    /// grid on ANY axis remains a hard launch error: that direction is
+    /// genuine out-of-bounds. Prefer the [`IntoPartition::partition_prefix`]
+    /// spelling at call sites.
+    pub fn prefix(mut self) -> Self {
+        self.prefix_coverage = true;
+        self
+    }
+
     /// Unwraps the partition to retrieve the underlying object.
     ///
     /// This consumes the partition and returns the original tensor or value.
@@ -279,11 +300,27 @@ impl<T> Partition<T> {
     /// // Launch 8 tile blocks to traverse the mapped output tiles.
     /// let output = z.partition([32, 64]).map([4, 1], 8);
     /// ```
+    ///
+    /// A map dimension of [`OWNED`] marks an owned axis: the axis is not
+    /// traversed by the work-item stream; each stream item owns the axis's
+    /// full extent (subtensor-per-CTA exclusivity). `iter_indices()` then
+    /// yields one item per streamed-axes coordinate, and the owned axes are
+    /// traversed by in-kernel loops:
+    ///
+    /// ```rust,ignore
+    /// // One stream item per axis-0 tile; each item owns all of axis 1.
+    /// let output = z.partition([1, 2048]).map([1, OWNED], rows);
+    /// ```
     pub fn map<const RANK: usize>(
         self,
         map_shape: [usize; RANK],
         num_tile_blocks: u32,
     ) -> MappedLaunchPartition<Self> {
+        assert!(
+            !self.prefix_coverage,
+            "a partial-coverage (prefix) partition cannot be mapped: a mapped \
+             schedule covers its full index space by construction"
+        );
         MappedLaunchPartition {
             partition: self,
             map_shape: map_shape.to_vec(),
@@ -291,6 +328,14 @@ impl<T> Partition<T> {
         }
     }
 }
+
+/// Map-shape sentinel marking an owned axis.
+///
+/// An owned axis is not traversed by the mapped work-item stream: each stream
+/// item owns the axis's full extent, so in-kernel loops traverse it with
+/// plain (`Dim`-bounded) indices while the minted stream index proves
+/// disjointness on the streamed axes only.
+pub const OWNED: usize = 0;
 
 /// Host-side mapped partition launch argument.
 ///
@@ -310,29 +355,45 @@ impl<P> MappedLaunchPartition<P> {
         partition_grid: (u32, u32, u32),
         num_tile_blocks: u32,
     ) -> Result<(u32, u32, u32), Error> {
-        if self.map_shape.len() != 2 {
-            return tensor_error_result("mapped partitions currently require a 2D map shape.");
-        }
-        if self.map_shape.iter().any(|&dim| dim == 0) {
-            return tensor_error_result("mapped partition requires positive map dimensions.");
-        }
-        if partition_grid.0 == 0 || partition_grid.1 == 0 || partition_grid.2 != 1 {
+        let map_rank = self.map_shape.len();
+        if map_rank == 0 || map_rank > 3 {
             return tensor_error_result(
-                "mapped partition requires a non-empty 2D logical partition grid.",
+                "mapped partitions require a rank-1 through rank-3 map shape.",
             );
         }
-        let total_tiles = partition_grid
-            .0
-            .checked_mul(partition_grid.1)
+        // A map dimension of OWNED (0) marks an owned axis: not traversed by
+        // the stream, so it contributes nothing to the streamed tile count.
+        if self.map_shape.iter().all(|&dim| dim == OWNED) {
+            return tensor_error_result(
+                "mapped partition requires at least one streamed (non-OWNED) map axis.",
+            );
+        }
+        let grid_axes = [partition_grid.0, partition_grid.1, partition_grid.2];
+        if grid_axes.iter().take(map_rank).any(|&axis| axis == 0) {
+            return tensor_error_result(
+                "mapped partition requires a non-empty logical partition grid.",
+            );
+        }
+        if grid_axes.iter().skip(map_rank).any(|&axis| axis != 1) {
+            return tensor_error_result(
+                "mapped partition map rank must match the logical partition grid rank.",
+            );
+        }
+        let streamed_tiles = grid_axes
+            .iter()
+            .zip(self.map_shape.iter())
+            .filter(|&(_, &map_dim)| map_dim != OWNED)
+            .map(|(&axis, _)| axis)
+            .try_fold(1u32, |total, axis| total.checked_mul(axis))
             .ok_or_else(|| {
                 crate::error::tensor_error("mapped partition logical grid is too large")
             })?;
         if num_tile_blocks == 0 {
             return tensor_error_result("mapped partition requires num_tile_blocks > 0.");
         }
-        if num_tile_blocks > total_tiles {
+        if num_tile_blocks > streamed_tiles {
             return tensor_error_result(
-                "mapped partition num_tile_blocks cannot exceed the logical partition tile count.",
+                "mapped partition num_tile_blocks cannot exceed the streamed logical tile count.",
             );
         }
         Ok((num_tile_blocks, 1, 1))
@@ -429,6 +490,19 @@ pub trait IntoPartition {
     fn partition<const RANK: usize>(self, partition_shape: [usize; RANK]) -> Partition<Self>
     where
         Self: Sized;
+
+    /// Partitions with PARTIAL coverage: the launch grid may be a per-axis
+    /// prefix of the block grid instead of equal to it (see
+    /// [`Partition::prefix`] for the contract). The strict-equality
+    /// diagnostic of [`Self::partition`] remains the default; this spelling
+    /// is the explicit opt-in for kernels that deliberately cover only an
+    /// aligned prefix and leave the remainder to another kernel.
+    fn partition_prefix<const RANK: usize>(self, partition_shape: [usize; RANK]) -> Partition<Self>
+    where
+        Self: Sized,
+    {
+        self.partition(partition_shape).prefix()
+    }
 }
 
 /// Enables partitioning an `Arc`-wrapped value into tiles.
@@ -1182,6 +1256,7 @@ impl<T: DType> IntoPartitionArc for Tensor<T> {
             object: tensor,
             partition_shape,
             partition_strides,
+            prefix_coverage: false,
         }
     }
 }
@@ -1195,6 +1270,7 @@ impl<T: DType> IntoPartition for Tensor<T> {
             object: self,
             partition_shape,
             partition_strides,
+            prefix_coverage: false,
         }
     }
 }
@@ -1208,6 +1284,18 @@ pub trait PartitionMut<'a, T: DType> {
         self,
         partition_shape: [usize; RANK],
     ) -> Partition<&'a mut Tensor<T>>;
+
+    /// Partial-coverage variant of [`Self::partition`]; see
+    /// [`IntoPartition::partition_prefix`].
+    fn partition_prefix<const RANK: usize>(
+        self,
+        partition_shape: [usize; RANK],
+    ) -> Partition<&'a mut Tensor<T>>
+    where
+        Self: Sized,
+    {
+        self.partition(partition_shape).prefix()
+    }
 }
 
 impl<'a, T: DType> PartitionMut<'a, T> for &'a mut Tensor<T> {
@@ -1221,6 +1309,7 @@ impl<'a, T: DType> PartitionMut<'a, T> for &'a mut Tensor<T> {
             object: self,
             partition_shape,
             partition_strides,
+            prefix_coverage: false,
         }
     }
 }
@@ -1430,9 +1519,27 @@ use cuda_async::launch::AsyncKernelLaunch;
 /// |---|---|---|
 /// | `Partition<Tensor<T>>` | `Partition<Tensor<T>>` | `Partition<Tensor<T>>` |
 /// | `Partition<&'a mut Tensor<T>>` | `Partition<&'a mut Tensor<T>>` | `Partition<&'a mut Tensor<T>>` |
+/// A partition binding's constraint on the launch grid.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GridBound {
+    /// The launch grid must EQUAL this per axis — full coverage, the
+    /// default, and the diagnostic that catches accidental mismatches.
+    Exact((u32, u32, u32)),
+    /// The launch grid may be a per-axis PREFIX of this (opt-in via
+    /// `partition_prefix`). `launch > bound` on any axis is a launch error:
+    /// that direction is genuine out-of-bounds.
+    AtMost((u32, u32, u32)),
+}
+
 pub trait KernelOutputStored<T: DType>: Send {
     fn push_kernel_args(&self, launcher: &mut AsyncKernelLaunch);
     fn grid(&self) -> Result<(u32, u32, u32), Error>;
+    /// This binding's launch-grid constraint. Defaults to exact coverage;
+    /// only bindings that explicitly opted into partial coverage return
+    /// [`GridBound::AtMost`].
+    fn grid_bound(&self) -> Result<GridBound, Error> {
+        Ok(GridBound::Exact(self.grid()?))
+    }
     fn map_shape_as_i32(&self) -> Option<Vec<i32>> {
         None
     }
@@ -1451,6 +1558,15 @@ pub trait KernelOutput<T: DType>: Send + Sized {
 }
 
 impl<T: DType> KernelOutputStored<T> for Partition<Tensor<T>> {
+    fn grid_bound(&self) -> Result<GridBound, Error> {
+        let grid = KernelOutputStored::grid(self)?;
+        Ok(if self.prefix_coverage {
+            GridBound::AtMost(grid)
+        } else {
+            GridBound::Exact(grid)
+        })
+    }
+
     fn push_kernel_args(&self, launcher: &mut AsyncKernelLaunch) {
         unsafe {
             launcher.push_device_ptr(self.object.cu_deviceptr());
@@ -1513,6 +1629,15 @@ impl<T: DType> KernelOutputStored<T> for Partition<Tensor<T>> {
 }
 
 impl<'a, T: DType> KernelOutputStored<T> for Partition<&'a mut Tensor<T>> {
+    fn grid_bound(&self) -> Result<GridBound, Error> {
+        let grid = KernelOutputStored::grid(self)?;
+        Ok(if self.prefix_coverage {
+            GridBound::AtMost(grid)
+        } else {
+            GridBound::Exact(grid)
+        })
+    }
+
     fn push_kernel_args(&self, launcher: &mut AsyncKernelLaunch) {
         unsafe {
             launcher.push_device_ptr(self.object.cu_deviceptr());
@@ -1884,7 +2009,55 @@ mod tests {
         let err = partition.validate((2, 3, 1), 7).unwrap_err();
         assert!(err
             .to_string()
-            .contains("num_tile_blocks cannot exceed the logical partition tile count"));
+            .contains("num_tile_blocks cannot exceed the streamed logical tile count"));
+    }
+
+    #[test]
+    fn owned_axis_excluded_from_streamed_tile_count() {
+        // Axis 1 is OWNED: only the 2-tile axis 0 is streamed, so
+        // num_tile_blocks is capped at 2 rather than 2*3.
+        let partition = MappedLaunchPartition {
+            partition: (),
+            map_shape: vec![1, OWNED],
+            num_tile_blocks: 2,
+        };
+        let launch_grid = partition.validate((2, 3, 1), 2).unwrap();
+        assert_eq!(launch_grid, (2, 1, 1));
+
+        let partition = MappedLaunchPartition {
+            partition: (),
+            map_shape: vec![1, OWNED],
+            num_tile_blocks: 3,
+        };
+        let err = partition.validate((2, 3, 1), 3).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("num_tile_blocks cannot exceed the streamed logical tile count"));
+    }
+
+    #[test]
+    fn owned_axis_rejects_all_owned_map() {
+        let partition = MappedLaunchPartition {
+            partition: (),
+            map_shape: vec![OWNED, OWNED],
+            num_tile_blocks: 1,
+        };
+        let err = partition.validate((2, 3, 1), 1).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("at least one streamed (non-OWNED) map axis"));
+    }
+
+    #[test]
+    fn owned_axis_accepts_leading_owned() {
+        // Owned axes may sit at any position: axis 0 owned, axis 1 streamed.
+        let partition = MappedLaunchPartition {
+            partition: (),
+            map_shape: vec![OWNED, 1],
+            num_tile_blocks: 3,
+        };
+        let launch_grid = partition.validate((2, 3, 1), 3).unwrap();
+        assert_eq!(launch_grid, (3, 1, 1));
     }
 
     #[test]
@@ -1899,7 +2072,7 @@ mod tests {
     }
 
     #[test]
-    fn swizzle_rejects_non_2d_partition_grid() {
+    fn swizzle_rejects_grid_rank_above_map_rank() {
         let partition = MappedLaunchPartition {
             partition: (),
             map_shape: vec![4, 1],
@@ -1908,6 +2081,52 @@ mod tests {
         let err = partition.validate((2, 3, 4), 3).unwrap_err();
         assert!(err
             .to_string()
-            .contains("requires a non-empty 2D logical partition grid"));
+            .contains("map rank must match the logical partition grid rank"));
+    }
+
+    #[test]
+    fn swizzle_accepts_rank1_map() {
+        let partition = MappedLaunchPartition {
+            partition: (),
+            map_shape: vec![1],
+            num_tile_blocks: 4,
+        };
+        let launch_grid = partition.validate((8, 1, 1), 4).unwrap();
+        assert_eq!(launch_grid, (4, 1, 1));
+    }
+
+    #[test]
+    fn swizzle_accepts_rank3_map() {
+        let partition = MappedLaunchPartition {
+            partition: (),
+            map_shape: vec![1, 4, 1],
+            num_tile_blocks: 6,
+        };
+        let launch_grid = partition.validate((2, 3, 4), 6).unwrap();
+        assert_eq!(launch_grid, (6, 1, 1));
+    }
+
+    #[test]
+    fn swizzle_rejects_rank1_map_with_2d_grid() {
+        let partition = MappedLaunchPartition {
+            partition: (),
+            map_shape: vec![1],
+            num_tile_blocks: 2,
+        };
+        let err = partition.validate((2, 3, 1), 2).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("map rank must match the logical partition grid rank"));
+    }
+
+    #[test]
+    fn swizzle_rejects_map_rank_above_3() {
+        let partition = MappedLaunchPartition {
+            partition: (),
+            map_shape: vec![1, 1, 1, 1],
+            num_tile_blocks: 2,
+        };
+        let err = partition.validate((2, 3, 4), 2).unwrap_err();
+        assert!(err.to_string().contains("rank-1 through rank-3 map shape"));
     }
 }

--- a/cutile/src/tile_kernel.rs
+++ b/cutile/src/tile_kernel.rs
@@ -5,7 +5,7 @@
 
 //! Tile kernel compilation, caching, launching, and partitioning for CUDA device operations.
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use cuda_async::error::DeviceError;
 use cuda_core::DType;
 use cuda_core::{memcpy_dtoh_async, Function};
@@ -62,11 +62,11 @@ fn record_jit_compile() {
 }
 
 use crate::error::*;
-use crate::tensor::{IntoPartition, IntoPartitionArc, Partition, Tensor};
+use crate::tensor::{GridBound, IntoPartition, IntoPartitionArc, Partition, Tensor};
 
 pub use cuda_async::{
     device_buffer::*, device_context::*, device_future::*, device_operation::*, launch::*,
-    scheduling_policies::*,
+    predicate::*, scheduling_policies::*,
 };
 
 pub use cutile_compiler::compiler::utils::CompileOptions;
@@ -498,7 +498,7 @@ fn compile_and_load_kernel(
         scalar_hints.iter().map(|x| (x.0.as_str(), &x.1)).collect();
 
     let stage1_start = std::time::Instant::now();
-    let (tile_module, validator) = {
+    let (tile_module, validator, check_stats) = {
         let compiler = CUDATileFunctionCompiler::new(
             modules,
             module_name,
@@ -511,9 +511,21 @@ fn compile_and_load_kernel(
             gpu_name.to_string(),
             compile_options,
         )?;
-        let validator = Arc::new(compiler.get_validator());
         let tile_module = compiler.compile()?;
-        (tile_module, validator)
+        // AFTER compile, not before: the launch-check accumulator fills
+        // DURING compilation, and this snapshot is the one the generated
+        // launcher enforces. Taken early, every hoisted check is silently
+        // dropped at launch while the compiler has already discharged the
+        // in-kernel assert on its promise — out-of-bounds accesses then run
+        // unchecked (caught by the differential placement harness; pinned by
+        // `launch_checks_are_enforced_at_launch`).
+        let validator = Arc::new(compiler.get_validator());
+        let check_stats = (
+            compiler.check_stats.discharged.get(),
+            compiler.check_stats.hoisted.get(),
+            compiler.check_stats.in_place.get(),
+        );
+        (tile_module, validator, check_stats)
     };
     let stage1_ms = stage1_start.elapsed().as_secs_f64() * 1000.0;
 
@@ -602,7 +614,10 @@ fn compile_and_load_kernel(
             Stage2Source::DiskCache { .. } => "disk",
         };
         eprintln!(
-            "CUTILE_JIT_TIMING module={module_name} function={function_name} key={key_str} stage1_ms={stage1_ms:.3} stage2_ms={stage2_ms:.3} stage2_source={stage2_source} stage3_ms={stage3_ms:.3} generics={}",
+            "CUTILE_JIT_TIMING module={module_name} function={function_name} key={key_str} stage1_ms={stage1_ms:.3} stage2_ms={stage2_ms:.3} stage2_source={stage2_source} stage3_ms={stage3_ms:.3} checks_discharged={} checks_hoisted={} checks_in_place={} generics={}",
+            check_stats.0,
+            check_stats.1,
+            check_stats.2,
             generics.join(","),
         );
     }
@@ -756,6 +771,156 @@ pub fn validate_grids(
     }
 }
 
+/// Validates the launch grid against every binding's [`GridBound`]:
+/// exact-coverage bindings must equal the grid; partial-coverage
+/// (`partition_prefix`) bindings must bound it per axis. `launch <= bound`
+/// per axis is the sound direction — a per-axis prefix embeds identically
+/// into the block grid, uncovered blocks are simply never visited — while
+/// `launch > bound` on ANY axis is genuine out-of-bounds and always an
+/// error. Per-axis, never total-count: delinearizing against a different
+/// grid shape would remap CTAs to the wrong blocks.
+pub fn validate_grid_bounds(grid: (u32, u32, u32), bounds: &[GridBound]) -> Result<(), Error> {
+    for bound in bounds {
+        let GridBound::Exact(expected) = bound else {
+            continue;
+        };
+        if *expected != grid {
+            return Err(Error::KernelLaunch(KernelLaunchError(format!(
+                "launch grid {:?} does not match the inferred partition grid {:?}",
+                grid, expected
+            ))));
+        }
+    }
+    for bound in bounds {
+        let GridBound::AtMost(max) = bound else {
+            continue;
+        };
+        let launch = [grid.0, grid.1, grid.2];
+        let max_axes = [max.0, max.1, max.2];
+        if let Some(axis) = (0..3).find(|&k| launch[k] > max_axes[k]) {
+            return Err(Error::KernelLaunch(KernelLaunchError(format!(
+                "launch grid {:?} exceeds the partial-coverage partition grid {:?} on axis {axis}",
+                grid, max
+            ))));
+        }
+    }
+    Ok(())
+}
+
+/// Runs the full set of launch-time checks before `cuLaunchKernel`: the
+/// built-in grid family (all partition grids match the launch grid) plus any
+/// compiler-emitted checks hoisted out of the device kernel.
+///
+/// `param_shapes[i]` is the runtime extent vector of the i-th kernel parameter
+/// (empty for non-tensor params). This is the host end of launch-time check
+/// hoisting: the compiler evacuated these checks from the kernel, so they run
+/// here once per launch instead of per-thread on the device. `validate_grids`
+/// is folded in as the first, always-present family; compiler-emitted checks
+/// are canonical [`Predicate`]s evaluated against the parameter extents.
+pub fn validate_launch(
+    launch_checks: &[LaunchCheck],
+    grid: (u32, u32, u32),
+    partition_bounds: &[GridBound],
+    param_shapes: &[Vec<i32>],
+    view_shapes: &[Vec<i32>],
+) -> Result<(), Error> {
+    // Built-in family: launch grid vs. partition grid bounds.
+    validate_grid_bounds(grid, partition_bounds)?;
+    // Compiler-emitted families (empty unless a kernel hoisted a check).
+    for check in launch_checks {
+        evaluate_launch_check(check, param_shapes, view_shapes, grid)?;
+    }
+    Ok(())
+}
+
+/// Runs only the compiler-emitted launch checks (the grid family is already
+/// validated by `infer_launch_grid`). Called from the generated launcher after
+/// grid inference, both arrays indexed in signature order (empty for
+/// non-tensor params):
+/// - `param_shapes[i]` — the i-th parameter's *root* extents (the whole
+///   tensor). Resolves [`Atom::Dim`], the frame declared `preconditions` are
+///   stated in.
+/// - `view_shapes[i]` — the i-th parameter's *kernel-visible view* extents:
+///   the partition slab for a `&mut Tensor` output, the whole tensor
+///   otherwise. Resolves [`Atom::ViewExtent`].
+/// - `launch_grid` — the grid the kernel will actually be launched with.
+///   Resolves [`Atom::NumTileBlocks`]: the block-id axiom rung discharges
+///   `tile_block_id(k)` accesses in the kernel against a launch check over
+///   this exact grid, so validating any other grid would unsound the rung.
+pub fn validate_launch_checks(
+    launch_checks: &[LaunchCheck],
+    param_shapes: &[Vec<i32>],
+    view_shapes: &[Vec<i32>],
+    launch_grid: (u32, u32, u32),
+) -> Result<(), Error> {
+    for check in launch_checks {
+        evaluate_launch_check(check, param_shapes, view_shapes, launch_grid)?;
+    }
+    Ok(())
+}
+
+/// Evaluates one hoisted [`LaunchCheck`] by interpreting its canonical
+/// [`Predicate`] against the runtime parameter extents, each atom against the
+/// array holding its frame. Fails closed: a predicate whose atoms cannot be
+/// resolved (a missing parameter/axis, or a non-launch-known `Iv` atom that
+/// should never appear here) is an error, not a silent skip.
+fn evaluate_launch_check(
+    check: &LaunchCheck,
+    param_shapes: &[Vec<i32>],
+    view_shapes: &[Vec<i32>],
+    launch_grid: (u32, u32, u32),
+) -> Result<(), Error> {
+    // Resolve each atom to its runtime value, in the atom's own frame.
+    let resolve_atom = |atom: &Atom| -> Option<i64> {
+        match atom {
+            Atom::Dim { param, axis } => param_shapes
+                .get(*param)
+                .and_then(|shape| shape.get(*axis))
+                .map(|&extent| extent as i64),
+            Atom::ViewExtent { param, axis } => view_shapes
+                .get(*param)
+                .and_then(|shape| shape.get(*axis))
+                .map(|&extent| extent as i64),
+            // ceil(root extent / tile). The mint site guarantees tile >= 1;
+            // fail closed on a malformed atom rather than dividing by zero.
+            Atom::TileCount { param, axis, tile } => {
+                if *tile < 1 {
+                    return None;
+                }
+                param_shapes
+                    .get(*param)
+                    .and_then(|shape| shape.get(*axis))
+                    .map(|&extent| (extent as i64 + *tile as i64 - 1) / *tile as i64)
+            }
+            // The grid axis extents: the host fixes the grid before launch,
+            // and the block-id axiom rung's checks are stated over it. Only
+            // three grid axes exist; anything else fails closed.
+            Atom::NumTileBlocks(k) => match k {
+                0 => Some(launch_grid.0 as i64),
+                1 => Some(launch_grid.1 as i64),
+                2 => Some(launch_grid.2 as i64),
+                _ => None,
+            },
+            // A device-runtime induction variable and the block-id register
+            // are not launch-known; they never appear in a launch check (the
+            // axiom rung replaces the block id with its grid bound), so fail
+            // closed if one somehow does.
+            Atom::Iv(_) | Atom::TileBlockId(_) => None,
+        }
+    };
+    match check.predicate.eval(&resolve_atom) {
+        Some(true) => Ok(()),
+        Some(false) => Err(Error::KernelLaunch(KernelLaunchError(format!(
+            "launch check failed: {}",
+            check.cause
+        )))),
+        None => Err(Error::KernelLaunch(KernelLaunchError(format!(
+            "launch check has unresolved operands (extent unavailable at launch): {}",
+            check.cause
+        )))),
+    }
+}
+
 /// Infers the launch grid for a kernel from partitioned tensor inputs.
 ///
 /// If a grid is explicitly specified (non-zero), it is used directly. Otherwise, the grid
@@ -768,24 +933,36 @@ pub fn validate_grids(
 /// grids from different inputs don't match.
 pub fn infer_launch_grid(
     grid: (u32, u32, u32),
-    inferred_grids: &[(u32, u32, u32)],
+    bounds: &[GridBound],
 ) -> Result<(u32, u32, u32), Error> {
+    let exact: Vec<(u32, u32, u32)> = bounds
+        .iter()
+        .filter_map(|b| match b {
+            GridBound::Exact(g) => Some(*g),
+            GridBound::AtMost(_) => None,
+        })
+        .collect();
     if grid != (0, 0, 0) {
         // A launch grid was specified.
-        if !inferred_grids.is_empty() {
-            validate_grids(grid, inferred_grids).with_context(|| {
-                "Specified launch grid does not match inferred tensor partition grid"
-            })?;
-        }
+        validate_grid_bounds(grid, bounds)?;
         return Ok(grid);
     }
-    // Try to infer launch grid.
-    if inferred_grids.is_empty() {
-        return kernel_launch_error_result("Launch grid required.");
+    // Try to infer the launch grid. Only an EXACT binding can define it: a
+    // partial-coverage binding is an upper bound, and inferring the bound
+    // itself would silently reconstruct full coverage — the thing the
+    // caller opted out of.
+    if exact.is_empty() {
+        if bounds.is_empty() {
+            return kernel_launch_error_result("Launch grid required.");
+        }
+        return kernel_launch_error_result(
+            "Launch grid required: a partial-coverage (partition_prefix) binding \
+             only bounds the grid; specify the grid explicitly or bind with \
+             partition().",
+        );
     }
-    let grid = inferred_grids[0];
-    validate_grids(grid, inferred_grids)
-        .with_context(|| "Inferred tensor partition grids do not match")?;
+    let grid = exact[0];
+    validate_grid_bounds(grid, bounds)?;
     Ok(grid)
 }
 
@@ -913,12 +1090,9 @@ where
     /// Sets the runtime compile options (occupancy, num_cta_in_cga).
     fn compile_options(self, options: CompileOptions) -> Self;
     /// Infers the launch grid from partitioned tensor inputs, or uses the explicit grid.
-    fn infer_launch_grid(
-        &self,
-        inferred_grids: &[(u32, u32, u32)],
-    ) -> Result<(u32, u32, u32), Error> {
+    fn infer_launch_grid(&self, bounds: &[GridBound]) -> Result<(u32, u32, u32), Error> {
         let grid = self.get_launch_grid();
-        infer_launch_grid(grid, inferred_grids)
+        infer_launch_grid(grid, bounds)
     }
     /// Returns the currently configured launch grid dimensions.
     fn get_launch_grid(&self) -> (u32, u32, u32);
@@ -1313,6 +1487,112 @@ pub trait ToHostVecOp<T: DType> {
 }
 
 impl<T: DType, DI> ToHostVecOp<T> for DI where DI: DeviceOp<Output = Tensor<T>> {}
+
+#[cfg(test)]
+mod launch_check_tests {
+    use super::*;
+
+    fn nonzero(param: usize, axis: usize) -> LaunchCheck {
+        LaunchCheck {
+            predicate: Predicate::nonzero(Term::atom(Atom::Dim { param, axis })),
+            cause: "extent > 0".to_string(),
+        }
+    }
+
+    fn view_nonzero(param: usize, axis: usize) -> LaunchCheck {
+        LaunchCheck {
+            predicate: Predicate::nonzero(Term::atom(Atom::ViewExtent { param, axis })),
+            cause: "view extent > 0".to_string(),
+        }
+    }
+
+    #[test]
+    fn empty_checks_run_only_the_grid_family() {
+        // Matching grids pass; no compiler checks means no extent evaluation.
+        assert!(validate_launch(&[], (4, 1, 1), &[GridBound::Exact((4, 1, 1))], &[], &[]).is_ok());
+    }
+
+    #[test]
+    fn grid_family_still_rejects_mismatched_partition_grid() {
+        assert!(validate_launch(&[], (4, 1, 1), &[GridBound::Exact((2, 1, 1))], &[], &[]).is_err());
+    }
+
+    #[test]
+    fn dim_nonzero_passes_for_positive_extent() {
+        let shapes = vec![vec![128, 256]];
+        assert!(validate_launch(&[nonzero(0, 0)], (1, 1, 1), &[], &shapes, &[]).is_ok());
+    }
+
+    #[test]
+    fn dim_nonzero_rejects_zero_extent() {
+        let shapes = vec![vec![0, 256]];
+        assert!(validate_launch(&[nonzero(0, 0)], (1, 1, 1), &[], &shapes, &[]).is_err());
+    }
+
+    #[test]
+    fn dim_nonzero_fails_closed_on_missing_parameter() {
+        // Check references param 1 axis 0, but only one param was supplied.
+        let shapes = vec![vec![128]];
+        assert!(validate_launch(&[nonzero(1, 0)], (1, 1, 1), &[], &shapes, &[]).is_err());
+    }
+
+    #[test]
+    fn each_atom_resolves_against_its_own_frame() {
+        // Root says 256 rows; the kernel-visible view (the per-CTA slab) says
+        // zero. A root-frame check passes while the view-frame check rejects:
+        // the frames are not interchangeable, and the atom picks the array.
+        let roots = vec![vec![256, 256]];
+        let views = vec![vec![0, 256]];
+        assert!(validate_launch(&[nonzero(0, 0)], (1, 1, 1), &[], &roots, &views).is_ok());
+        assert!(validate_launch(&[view_nonzero(0, 0)], (1, 1, 1), &[], &roots, &views).is_err());
+    }
+
+    #[test]
+    fn view_atoms_fail_closed_without_view_shapes() {
+        let roots = vec![vec![256, 256]];
+        assert!(validate_launch(&[view_nonzero(0, 0)], (1, 1, 1), &[], &roots, &[]).is_err());
+    }
+
+    #[test]
+    fn prefix_bound_admits_a_per_axis_prefix_and_nothing_more() {
+        use GridBound::{AtMost, Exact};
+        // Equal and per-axis-smaller launches pass; exceeding ANY axis fails.
+        assert!(validate_grid_bounds((3, 2, 1), &[AtMost((3, 2, 1))]).is_ok());
+        assert!(validate_grid_bounds((2, 2, 1), &[AtMost((3, 2, 1))]).is_ok());
+        assert!(validate_grid_bounds((2, 1, 1), &[AtMost((3, 2, 1))]).is_ok());
+        assert!(validate_grid_bounds((4, 1, 1), &[AtMost((3, 2, 1))]).is_err());
+        assert!(validate_grid_bounds((1, 3, 1), &[AtMost((3, 2, 1))]).is_err());
+        // Per-axis, never total-count: 6 = 3*2 total blocks but the wrong
+        // shape must be rejected (delinearization would remap CTAs).
+        assert!(validate_grid_bounds((6, 1, 1), &[AtMost((3, 2, 1))]).is_err());
+        // Exact bindings keep strict equality even alongside a prefix one.
+        assert!(validate_grid_bounds((2, 1, 1), &[Exact((3, 1, 1)), AtMost((3, 1, 1))]).is_err());
+        assert!(validate_grid_bounds((3, 1, 1), &[Exact((3, 1, 1)), AtMost((4, 1, 1))]).is_ok());
+    }
+
+    #[test]
+    fn prefix_bound_cannot_define_the_launch_grid() {
+        use GridBound::{AtMost, Exact};
+        // Inference needs an exact binding; a bound alone is not a grid.
+        let err = infer_launch_grid((0, 0, 0), &[AtMost((3, 1, 1))]).unwrap_err();
+        assert!(
+            err.to_string().contains("partial-coverage"),
+            "the error should say why inference refused: {err}"
+        );
+        // With an exact sibling, inference works and the bound still gates.
+        assert_eq!(
+            infer_launch_grid((0, 0, 0), &[Exact((3, 1, 1)), AtMost((4, 1, 1))]).unwrap(),
+            (3, 1, 1)
+        );
+        assert!(infer_launch_grid((0, 0, 0), &[Exact((3, 1, 1)), AtMost((2, 1, 1))]).is_err());
+        // An explicit grid validates against both kinds.
+        assert_eq!(
+            infer_launch_grid((2, 1, 1), &[AtMost((3, 1, 1))]).unwrap(),
+            (2, 1, 1)
+        );
+        assert!(infer_launch_grid((4, 1, 1), &[AtMost((3, 1, 1))]).is_err());
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/cutile/tests/basics_and_inlining.rs
+++ b/cutile/tests/basics_and_inlining.rs
@@ -23,7 +23,7 @@ mod basics_and_inlining_module {
         reshape(y, shape)
     }
 
-    #[cutile::entry()]
+    #[cutile::entry]
     fn inlining_kernel<E: ElementType, const X: i32, const S: [i32; 3], const Y: i32>(
         x: f32,
         y: &mut Tensor<E, S>,
@@ -34,7 +34,7 @@ mod basics_and_inlining_module {
         other_function(tile_x, shape);
     }
 
-    #[cutile::entry()]
+    #[cutile::entry]
     fn scalar_bool_condition_kernel<const CAUSAL: i32, const EVEN_K: i32>(
         output: &mut Tensor<i32, { [1] }>,
         mask_start: i32,
@@ -77,12 +77,12 @@ mod basics_and_inlining_module {
         make_tensor_view(ptr_tile, shape, strides, new_token_unordered())
     }
 
-    #[cutile::entry()]
+    #[cutile::entry]
     unsafe fn inline_tensor_from_ptr_kernel<T: ElementType>(ptr: *mut T, len: i32) {
         let _tensor: Tensor<T, { [-1] }> = tensor_from_ptr(ptr, len);
     }
 
-    #[cutile::entry()]
+    #[cutile::entry]
     unsafe fn ptr_partition_load_kernel<T: ElementType>(ptr: *mut T, len: i32) {
         let tensor: Tensor<T, { [-1] }> = tensor_from_ptr(ptr, len);
         let pid: (i32, i32, i32) = get_tile_block_id();
@@ -90,7 +90,20 @@ mod basics_and_inlining_module {
         let _tile = tensor.partition(tile_shape).load([pid.0]);
     }
 
-    #[cutile::entry()]
+    /// Nibble unpacking shape: shifts and masks on integer tiles and scalars.
+    #[cutile::entry]
+    unsafe fn shift_ops_kernel(x: &Tensor<i32, { [-1] }>, z: &mut Tensor<i32, { [-1] }>, s: i32) {
+        let tile: Tile<i32, { [64] }> = x.partition(const_shape![64]).load([0]);
+        let four: Tile<i32, { [64] }> = constant(4i32, const_shape![64]);
+        let mask: Tile<i32, { [64] }> = constant(0xFi32, const_shape![64]);
+        let lo = tile & mask;
+        let hi = (tile >> four) & mask;
+        let scaled = lo << four;
+        let _scalar_shift: i32 = s >> 1;
+        z.partition_mut(const_shape![64]).store(hi + scaled, [0]);
+    }
+
+    #[cutile::entry]
     unsafe fn ptr_partition_mut_store_kernel(ptr: *mut f32, len: i32) {
         let mut tensor: Tensor<f32, { [-1] }> = tensor_from_ptr(ptr, len);
         let pid: (i32, i32, i32) = get_tile_block_id();
@@ -99,18 +112,21 @@ mod basics_and_inlining_module {
         tensor.partition_mut(tile_shape).store(tile, [pid.0]);
     }
 
-    #[cutile::entry()]
+    #[cutile::entry]
     unsafe fn partition_mut_store_rank3_loop_kernel<const S: [i32; 3]>(out: &mut Tensor<f32, S>) {
-        let tile_shape = const_shape![1i32, 4i32, 8i32];
-        let mut out_part: PartitionMut<f32, { [1, 4, 8] }> =
-            unsafe { out.partition_mut(tile_shape) };
+        // The tile is one slice of the `[1, 4, 8]` slab along axis 1, so the
+        // loop below sweeps that axis's four tiles exactly. Tiling by the whole
+        // slab (as this kernel once did) makes the same sweep write four times
+        // past it — silently, until stores became checked.
+        let tile_shape = const_shape![1i32, 1i32, 8i32];
+        let mut out_part: PartitionMut<f32, { [1, 1, 8] }> = out.partition_mut(tile_shape);
         for s_local in 0i32..4i32 {
-            let tile: Tile<f32, { [1, 4, 8] }> = constant(1.0, tile_shape);
-            unsafe { out_part.store(tile, [0i32, s_local, 0i32]) };
+            let tile: Tile<f32, { [1, 1, 8] }> = constant(1.0, tile_shape);
+            out_part.store(tile, [0i32, s_local, 0i32]);
         }
     }
 
-    #[cutile::entry()]
+    #[cutile::entry]
     unsafe fn partition_mut_store_loaded_rank3_loop_kernel<
         const BLOCK_SIZE: i32,
         const BM_S: i32,
@@ -125,7 +141,7 @@ mod basics_and_inlining_module {
         let d_block = pid.2;
 
         let source_part = source.partition(const_shape![1, 1, BLOCK_SIZE]);
-        let mut out_part = unsafe { out.partition_mut(const_shape![1, 1, BLOCK_SIZE]) };
+        let mut out_part = out.partition_mut(const_shape![1, 1, BLOCK_SIZE]);
 
         let s_start: i32 = s_tile_idx * BM_S;
         if s_start < seq_len {
@@ -135,13 +151,13 @@ mod basics_and_inlining_module {
                     let tile = source_part
                         .load([s_global, head, d_block])
                         .reshape(const_shape![1, 1, BLOCK_SIZE]);
-                    unsafe { out_part.store(tile, [0i32, s_local, 0i32]) };
+                    out_part.store(tile, [0i32, s_local, 0i32]);
                 }
             }
         }
     }
 
-    #[cutile::entry()]
+    #[cutile::entry]
     unsafe fn basics_kernel<const S: [i32; 3]>(
         y: &mut Tensor<f32, { [128, -1] }>,
         #[allow(unused_variables)] w: &Tensor<f32, S>,
@@ -389,7 +405,7 @@ mod basics_and_inlining_module {
         }
     }
 
-    #[cutile::entry()]
+    #[cutile::entry]
     unsafe fn ptr_tile_reshape_kernel(ptr: *mut f32) {
         let ptr_tile: PointerTile<*mut f32, { [] }> = pointer_to_tile(ptr);
         let offset_ptr_tile: PointerTile<*mut f32, { [] }> = pointer_to_tile(ptr).offset(1);
@@ -399,12 +415,55 @@ mod basics_and_inlining_module {
         let _broadcast: PointerTile<*mut f32, { [128] }> = reshaped.broadcast(const_shape![128]);
     }
 
-    #[cutile::entry()]
+    #[cutile::entry]
     fn negative_constant_kernel<const S: [i32; 1]>(output: &mut Tensor<f32, S>) {
         let shape = output.shape();
         let _neg_float: Tile<f32, S> = constant(-1.0, shape);
         let _neg_int: Tile<i32, S> = constant(-42i32, shape);
         let _neg_suffixed: Tile<f32, S> = constant(-2.5f32, shape);
+    }
+
+    // Distilled from grout's fmha_prefill_causal_mapped: `mma` unifies its
+    // shared shape params against a mix of annotation-typed values (symbolic
+    // `D`) and op-computed values (substituted `128`). Inline inference must
+    // normalize both forms of the same dimension before unifying.
+    #[cutile::entry]
+    fn symbolic_dim_mma_kernel<
+        const BM: i32,
+        const BN: i32,
+        const D: i32,
+        const MAP_SHAPE: [i32; 3],
+    >(
+        mut out: MappedPartitionMut<f16, { [BM, 1, D] }, MAP_SHAPE>,
+        q: &Tensor<f16, { [-1, -1, D] }>,
+        k: &Tensor<f16, { [-1, -1, D] }>,
+    ) {
+        let q_part: Partition<f16, { [BM, 1, D] }> = q.partition(const_shape![BM, 1, D]);
+        let k_part = k.partition(const_shape![1, BN, D]);
+        let transpose: Array<{ [1, 0] }> = Array::<{ [1, 0] }> {
+            dims: &[1i32, 0i32],
+        };
+        for index in out.iter_indices() {
+            let [q_m_idx, q_head_idx, _d0] = index.coords();
+            let mut acc: Tile<f32, { [BM, D] }> = constant(0.0f32, const_shape![BM, D]);
+            let tq_raw: Tile<f16, { [BM, 1, D] }> = q_part.load([q_m_idx, q_head_idx, 0i32]);
+            let tq: Tile<f16, { [BM, D] }> = tq_raw.reshape(const_shape![BM, D]);
+            for j in 0i32..2i32 {
+                let k_tile: Tile<f16, { [1, BN, D] }> = k_part.load([q_head_idx, j, 0i32]);
+                let k_tile: Tile<f16, { [BN, D] }> = k_tile.reshape(const_shape![BN, D]);
+                let k_trans: Tile<f16, { [D, BN] }> = permute(k_tile, transpose);
+                let mut qk: Tile<f32, { [BM, BN] }> = constant(0.0f32, const_shape![BM, BN]);
+                qk = mma(tq, k_trans, qk);
+                let p: Tile<f16, { [BM, BN] }> = convert_tile(qk);
+                let v_tile: Tile<f16, { [BN, D] }> = k_part
+                    .load([q_head_idx, j, 0i32])
+                    .reshape(const_shape![BN, D]);
+                acc = mma(p, v_tile, acc);
+            }
+            let out_tile: Tile<f16, { [BM, 1, D] }> =
+                convert_tile(acc.reshape(const_shape![BM, 1, D]));
+            out.store(out_tile, index);
+        }
     }
 }
 
@@ -448,6 +507,22 @@ fn compile_ptr_partition_load_helper() -> () {
         assert!(
             module_op_str.contains("load_view_tko"),
             "Expected partition load helper to emit load_view_tko.\n{module_op_str}"
+        );
+    });
+}
+
+#[test]
+fn compile_shift_ops_kernel() -> () {
+    common::with_test_stack(|| {
+        let module_op_str =
+            compile_ir("shift_ops_kernel", &[], &[("x", &[1][..]), ("z", &[1][..])]);
+        assert!(
+            module_op_str.contains("shri"),
+            "Expected `>>` to lower to shri.\n{module_op_str}"
+        );
+        assert!(
+            module_op_str.contains("shli"),
+            "Expected `<<` to lower to shli.\n{module_op_str}"
         );
     });
 }
@@ -565,6 +640,32 @@ fn compile_ptr_tile_reshape() -> () {
         assert!(
             module_op_str.contains("broadcast"),
             "Expected broadcast operation on pointer tile type"
+        );
+    });
+}
+
+#[test]
+fn symbolic_dim_mma_unifies_substituted_and_symbolic_shapes() {
+    common::with_test_stack(|| {
+        let mlir = compile_ir(
+            "symbolic_dim_mma_kernel",
+            &[
+                "16".to_string(),
+                "32".to_string(),
+                "128".to_string(),
+                "1".to_string(),
+                "1".to_string(),
+                "1".to_string(),
+            ],
+            &[
+                ("out", &[128, 128, 1]),
+                ("q", &[512, 128, 1]),
+                ("k", &[512, 128, 1]),
+            ],
+        );
+        assert!(
+            mlir.contains("mma"),
+            "expected an mma op in the symbolic-dim kernel:\n{mlir}"
         );
     });
 }

--- a/cutile/tests/check_placement_ratchet.rs
+++ b/cutile/tests/check_placement_ratchet.rs
@@ -1,0 +1,264 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// The `branded_*` families measure the deprecated annotation path against
+// the plain one; that is the point of the corpus.
+#![allow(deprecated)]
+
+//! The check-placement ratchet: a fixed corpus of kernels, one per access
+//! family, with EXACT placement counts pinned per kernel.
+//!
+//! This is the merge gate for the check-framework unification (phases A-D of
+//! the plan approved 2026-08-04): across any refactor of the checkers, a
+//! kernel's `(discharged, hoisted, in_place)` triple and its launch-check
+//! count may only improve — `in_place` may move to `hoisted`/launch,
+//! `hoisted` may move to `discharged`/launch, and nothing may regress toward
+//! the device. A count change in the good direction is re-pinned consciously
+//! in the same commit that causes it; a change in the bad direction fails
+//! this suite.
+//!
+//! Keep this corpus FROZEN: it is a measurement instrument, not a feature
+//! test. New behavior gets new tests elsewhere.
+
+use cutile;
+use cutile_compiler::compiler::utils::CompileOptions;
+
+mod common;
+
+#[cutile::module]
+mod ratchet_module {
+    use cutile::core::*;
+
+    /// Family: branded loop over a `with_bounds` binding, static extents.
+    /// Everything discharges at JIT.
+    #[cutile::entry]
+    fn branded_static<const N: i32, const B: i32>(out: &mut Tensor<f32, { [1, N] }>) {
+        let cols = Dim::new(N / B);
+        let mut p = out
+            .partition_mut(const_shape![1, B])
+            .with_bounds((Dim::new(1), cols));
+        for j in cols {
+            let t: Tile<f32, { [1, B] }> = constant(0.0, const_shape![1, B]);
+            p.store(t, coord((0i32, j)));
+        }
+    }
+
+    /// Family: branded loop over dynamic extents; bindings reduce to
+    /// divisibility launch checks, accesses discharge by brand.
+    #[cutile::entry]
+    fn branded_dynamic<const BM: i32, const BN: i32>(
+        z: &mut Tensor<f32, { [BM, BN] }>,
+        x: &Tensor<f32, { [-1, -1] }>,
+    ) {
+        let m = Dim::new(x.shape()[0] / BM);
+        let n = Dim::new(x.shape()[1] / BN);
+        let p = x.partition(const_shape![BM, BN]).with_bounds((m, n));
+        for i in m {
+            for j in n {
+                let t = p.load(coord((i, j)));
+                z.store(t);
+            }
+        }
+    }
+
+    /// Family: plain partition, affine loop index, static extents. The
+    /// constant/static rung discharges everything.
+    #[cutile::entry]
+    fn plain_static_loop<const B: i32>(z: &mut Tensor<f32, { [B] }>, x: &Tensor<f32, { [256] }>) {
+        let p = x.partition(const_shape![B]);
+        for j in 0i32..4i32 {
+            let t = p.load([j]);
+            z.store(t);
+        }
+    }
+
+    /// Family: plain partition, affine loop index, dynamic extent. The check
+    /// hoists to the loop preheader (upper), lower discharges statically.
+    #[cutile::entry]
+    fn plain_dynamic_loop<const B: i32>(
+        z: &mut Tensor<f32, { [B] }>,
+        x: &Tensor<f32, { [-1] }>,
+        n: i32,
+    ) {
+        let p = x.partition(const_shape![B]);
+        for j in 0i32..n {
+            let t = p.load([j]);
+            z.store(t);
+        }
+    }
+
+    /// Family: plain partition, raw runtime scalar, dynamic extent. Fully
+    /// in-place check, both directions.
+    #[cutile::entry]
+    fn plain_runtime_scalar<const B: i32>(
+        z: &mut Tensor<f32, { [B] }>,
+        x: &Tensor<f32, { [-1] }>,
+        idx: i32,
+    ) {
+        let p = x.partition(const_shape![B]);
+        let t = p.load([idx]);
+        z.store(t);
+    }
+
+    /// Family: mapped partition streaming a GEMM, foreign mapped components
+    /// into plain partitions, discharged by declared equalities.
+    #[cutile::entry(
+        preconditions = (
+            dim(z, 0) == dim(x, 0),
+            dim(z, 1) == dim(y, 1),
+        )
+    )]
+    fn mapped_gemm<const BM: i32, const BN: i32, const BK: i32, const MAP_SHAPE: [i32; 2]>(
+        mut z: MappedPartitionMut<f32, { [BM, BN] }, MAP_SHAPE>,
+        x: &Tensor<f32, { [-1, -1] }>,
+        y: &Tensor<f32, { [-1, -1] }>,
+    ) {
+        let px = x.partition(const_shape![BM, BK]);
+        let py = y.partition(const_shape![BK, BN]);
+        for index in z.iter_indices() {
+            let (bid_m, bid_n) = index.components();
+            let mut acc: Tile<f32, { [BM, BN] }> = constant(0.0, const_shape![BM, BN]);
+            for k in 0i32..4i32 {
+                let tx = px.load([bid_m, k]);
+                let ty = py.load([k, bid_n]);
+                acc = mma(tx, ty, acc);
+            }
+            z.store(acc, index);
+        }
+    }
+}
+
+use access_counts::pin;
+use ratchet_module::__module_ast_self;
+
+mod access_counts {
+    use super::*;
+    use cutile_compiler::compile_api::CheckPlacementCounts;
+
+    pub struct Pinned {
+        pub name: &'static str,
+        pub generics: &'static [&'static str],
+        pub strides: &'static [(&'static str, &'static [i32])],
+        pub grid: Option<(u32, u32, u32)>,
+        /// (discharged, hoisted, in_place, launch_checks)
+        pub counts: (u32, u32, u32, usize),
+    }
+
+    pub fn pin(p: &Pinned) {
+        let generics: Vec<String> = p.generics.iter().map(|s| s.to_string()).collect();
+        let strides: Vec<(&str, &[i32])> = p.strides.to_vec();
+        let mut compiler = cutile_compiler::compile_api::KernelCompiler::new(
+            __module_ast_self,
+            "ratchet_module",
+            p.name,
+        )
+        .target("sm_120")
+        .generics(generics)
+        .strides(&strides)
+        .options(CompileOptions::default());
+        if let Some(grid) = p.grid {
+            compiler = compiler.grid(grid);
+        }
+        let artifacts = compiler
+            .compile()
+            .unwrap_or_else(|e| panic!("compile {}: {e}", p.name));
+        let CheckPlacementCounts {
+            discharged,
+            hoisted,
+            in_place,
+        } = artifacts.check_counts();
+        let got = (
+            discharged,
+            hoisted,
+            in_place,
+            artifacts.launch_checks().len(),
+        );
+        assert_eq!(
+            got, p.counts,
+            "{}: placement counts moved (discharged, hoisted, in_place, launch). \
+             If they moved AWAY from the device, re-pin consciously in the same \
+             commit; if they moved TOWARD it, this is a regression.",
+            p.name
+        );
+    }
+}
+
+#[test]
+fn ratchet_branded_static() {
+    common::with_test_stack(|| {
+        pin(&access_counts::Pinned {
+            name: "branded_static",
+            generics: &["256", "64"],
+            strides: &[("out", &[256, 1])],
+            grid: None,
+            counts: (2, 0, 0, 0),
+        });
+    });
+}
+
+#[test]
+fn ratchet_branded_dynamic() {
+    common::with_test_stack(|| {
+        pin(&access_counts::Pinned {
+            name: "branded_dynamic",
+            generics: &["64", "64"],
+            strides: &[("z", &[64, 1]), ("x", &[64, 1])],
+            grid: None,
+            counts: (2, 0, 0, 2),
+        });
+    });
+}
+
+#[test]
+fn ratchet_plain_static_loop() {
+    common::with_test_stack(|| {
+        pin(&access_counts::Pinned {
+            name: "plain_static_loop",
+            generics: &["64"],
+            strides: &[("z", &[1]), ("x", &[1])],
+            grid: None,
+            counts: (1, 0, 0, 0),
+        });
+    });
+}
+
+#[test]
+fn ratchet_plain_dynamic_loop() {
+    common::with_test_stack(|| {
+        pin(&access_counts::Pinned {
+            name: "plain_dynamic_loop",
+            generics: &["64"],
+            strides: &[("z", &[1]), ("x", &[1])],
+            grid: None,
+            counts: (0, 1, 0, 0),
+        });
+    });
+}
+
+#[test]
+fn ratchet_plain_runtime_scalar() {
+    common::with_test_stack(|| {
+        pin(&access_counts::Pinned {
+            name: "plain_runtime_scalar",
+            generics: &["64"],
+            strides: &[("z", &[1]), ("x", &[1])],
+            grid: None,
+            counts: (0, 0, 1, 0),
+        });
+    });
+}
+
+#[test]
+fn ratchet_mapped_gemm() {
+    common::with_test_stack(|| {
+        pin(&access_counts::Pinned {
+            name: "mapped_gemm",
+            generics: &["32", "32", "32", "4", "4"],
+            strides: &[("z", &[256, 1]), ("x", &[256, 1]), ("y", &[256, 1])],
+            grid: Some((16, 1, 1)),
+            counts: (2, 2, 0, 0),
+        });
+    });
+}

--- a/cutile/tests/checked_store_corpus.rs
+++ b/cutile/tests/checked_store_corpus.rs
@@ -1,0 +1,307 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Adversarial corpus for the checked store surface (`PartitionMut::store`).
+//!
+//! Making stores checked moved a whole family of accesses from "unverified"
+//! to "must be proven or checked", so each way of writing an index gets a
+//! case here: what must be rejected outright, what must keep a real check,
+//! what must leave for launch, and what must cost nothing. Together they say
+//! that the safe store is neither too weak (a bad index slipping through) nor
+//! too strong (a provable index paying for a check).
+//!
+//! Two members of the corpus live elsewhere because they are not specific to
+//! stores, and are not duplicated here: permuted-axis discharge against the
+//! remapped root axis, and lower-bound guards on dynamic indices, both in
+//! `partition_access_soundness.rs`; cross-tensor shared-dimension discharge
+//! in `inferred_axis_bounds.rs`. There is no `partition_permuted_mut`, so the
+//! permuted case is only reachable through loads.
+
+use cutile;
+use cutile_compiler::compiler::utils::CompileOptions;
+
+mod common;
+
+#[cutile::module]
+mod checked_store_module {
+    use cutile::core::*;
+
+    /// A constant tile index past the end of the axis. The slab has one tile
+    /// on axis 0; this writes the second.
+    #[cutile::entry]
+    fn constant_out_of_range<const N: i32, const BLOCK: i32>(out: &mut Tensor<f32, { [1, N] }>) {
+        let tile_shape = const_shape![1, BLOCK];
+        let mut p = out.partition_mut(tile_shape);
+        let t: Tile<f32, { [1, BLOCK] }> = constant(0.0, tile_shape);
+        p.store(t, [1i32, 0i32]);
+    }
+
+    /// A negative constant tile index. The upper comparison alone would admit
+    /// it, so this exercises the lower goal on the store path.
+    #[cutile::entry]
+    fn constant_negative<const N: i32, const BLOCK: i32>(out: &mut Tensor<f32, { [1, N] }>) {
+        let tile_shape = const_shape![1, BLOCK];
+        let mut p = out.partition_mut(tile_shape);
+        let t: Tile<f32, { [1, BLOCK] }> = constant(0.0, tile_shape);
+        p.store(t, [0i32, -1i32]);
+    }
+
+    /// A runtime scalar index: unknown in both directions, so the store keeps
+    /// a real in-kernel check.
+    #[cutile::entry]
+    fn runtime_scalar_index<const N: i32, const BLOCK: i32>(
+        out: &mut Tensor<f32, { [1, N] }>,
+        idx: i32,
+    ) {
+        let tile_shape = const_shape![1, BLOCK];
+        let mut p = out.partition_mut(tile_shape);
+        let t: Tile<f32, { [1, BLOCK] }> = constant(0.0, tile_shape);
+        p.store(t, [0i32, idx]);
+    }
+
+    /// A tile-block id as the index. The hardware bound on a block id counts
+    /// CTA slabs, which is NOT this partition's tile count, so it proves
+    /// nothing here and the store must keep its check. (The rung that once
+    /// conflated the two admitted out-of-bounds stores; see the note in
+    /// `checks/mod.rs`.)
+    #[cutile::entry]
+    fn block_id_index<const N: i32, const BLOCK: i32>(out: &mut Tensor<f32, { [1, N] }>) {
+        let pid: (i32, i32, i32) = get_tile_block_id();
+        let tile_shape = const_shape![1, BLOCK];
+        let mut p = out.partition_mut(tile_shape);
+        let t: Tile<f32, { [1, BLOCK] }> = constant(0.0, tile_shape);
+        p.store(t, [0i32, pid.0]);
+    }
+
+    /// Mixed coordinates: a constant on one axis, an inferred loop index on
+    /// the other. Each axis is decided on its own evidence.
+    #[cutile::entry]
+    fn mixed_constant_and_inferred<const N: i32, const BLOCK: i32>(
+        out: &mut Tensor<f32, { [1, N] }>,
+    ) {
+        let tile_shape = const_shape![1, BLOCK];
+        let mut p = out.partition_mut(tile_shape);
+        for j in 0i32..num_tiles(&p, 1) {
+            let t: Tile<f32, { [1, BLOCK] }> = constant(0.0, tile_shape);
+            p.store(t, [0i32, j]);
+        }
+    }
+
+    /// The same store loop against a genuinely dynamic row extent: nothing at
+    /// compile time can decide the constant row `0`, so it becomes a
+    /// non-empty-extent check at launch instead of an in-kernel one.
+    #[cutile::entry]
+    fn dynamic_row_extent<const N: i32, const BLOCK: i32>(out: &mut Tensor<f32, { [-1, N] }>) {
+        let tile_shape = const_shape![1, BLOCK];
+        let mut p = out.partition_mut(tile_shape);
+        for j in 0i32..num_tiles(&p, 1) {
+            let t: Tile<f32, { [1, BLOCK] }> = constant(0.0, tile_shape);
+            p.store(t, [0i32, j]);
+        }
+    }
+}
+
+use checked_store_module::__module_ast_self;
+use cutile_compiler::compile_api::CheckPlacementCounts;
+
+fn compile_mlir(
+    name: &str,
+    generics: &[&str],
+    strides: &[(&str, &[i32])],
+) -> Result<String, String> {
+    let generics: Vec<String> = generics.iter().map(|s| s.to_string()).collect();
+    common::compile_to_ir(
+        __module_ast_self,
+        "checked_store_module",
+        name,
+        &generics,
+        strides,
+        &[],
+        &[],
+        None,
+        &CompileOptions::default(),
+    )
+    .map_err(|err| err.to_string())
+}
+
+fn artifacts(
+    name: &str,
+    generics: &[&str],
+    strides: &[(&str, &[i32])],
+) -> cutile_compiler::compile_api::CompileArtifacts {
+    let generics: Vec<String> = generics.iter().map(|s| s.to_string()).collect();
+    cutile_compiler::compile_api::KernelCompiler::new(
+        __module_ast_self,
+        "checked_store_module",
+        name,
+    )
+    .target("sm_120")
+    .generics(generics)
+    .strides(strides)
+    .options(CompileOptions::default())
+    .compile()
+    .unwrap_or_else(|e| panic!("compile {name}: {e}"))
+}
+
+/// `(discharged, hoisted, in_place)` for one kernel.
+fn counts(name: &str, generics: &[&str], strides: &[(&str, &[i32])]) -> (u32, u32, u32) {
+    let CheckPlacementCounts {
+        discharged,
+        hoisted,
+        in_place,
+    } = artifacts(name, generics, strides).check_counts();
+    (discharged, hoisted, in_place)
+}
+
+const STRIDES: &[(&str, &[i32])] = &[("out", &[256, 1])];
+
+// An index the compiler can prove is out of range is a compile error, not a
+// runtime trap — the same treatment a constant out-of-range subscript gets.
+#[test]
+fn constant_past_the_end_is_rejected() {
+    common::with_test_stack(|| {
+        let err = compile_mlir("constant_out_of_range", &["256", "64"], STRIDES)
+            .expect_err("a constant past the end of the axis must not compile");
+        assert!(
+            err.contains("Bounds check failed") || err.contains("out of bounds"),
+            "expected an out-of-range diagnostic, got: {err}"
+        );
+    });
+}
+
+// The lower goal has to be enforced on the store path too: a negative index
+// passes any upper comparison.
+#[test]
+fn constant_negative_index_is_rejected() {
+    common::with_test_stack(|| {
+        let err = compile_mlir("constant_negative", &["256", "64"], STRIDES)
+            .expect_err("a negative constant index must not compile");
+        assert!(
+            err.contains("Bounds check failed")
+                || err.contains("0 <=")
+                || err.to_lowercase().contains("negative"),
+            "expected a lower-bound diagnostic, got: {err}"
+        );
+    });
+}
+
+// Nothing bounds a runtime scalar, so the store must keep a real check —
+// guarded in both directions.
+#[test]
+fn runtime_scalar_index_keeps_a_two_sided_check() {
+    common::with_test_stack(|| {
+        let mlir = compile_mlir("runtime_scalar_index", &["256", "64"], STRIDES)
+            .expect("compile runtime_scalar_index");
+        assert!(
+            mlir.contains("partition access out of bounds"),
+            "an unprovable store index must keep its check:\n{mlir}"
+        );
+        assert!(
+            mlir.contains("greater_than_or_equal"),
+            "a runtime store index needs a lower-bound guard, found none:\n{mlir}"
+        );
+        assert_eq!(
+            counts("runtime_scalar_index", &["256", "64"], STRIDES),
+            (1, 0, 1),
+            "expected the constant row to discharge and the runtime column to \
+             stay in the kernel"
+        );
+    });
+}
+
+// A block id bounds the launch grid, not this partition's tiles — the id
+// alone is still not a proof. The axiom rung may discharge the in-kernel
+// check ONLY by staking a launch check that the grid fits the view's tile
+// count, verified against the exact grid the kernel launches with; a grid
+// wider than the tiles is rejected before any GPU work. (This pin's earlier
+// form asserted the check stayed in the kernel, the sound-but-conservative
+// posture before the rung existed.)
+#[test]
+fn block_id_index_discharges_by_staking_a_grid_check() {
+    common::with_test_stack(|| {
+        use cutile::tile_kernel::validate_launch_checks;
+        let mlir = compile_mlir("block_id_index", &["256", "64"], STRIDES)
+            .expect("compile block_id_index");
+        assert!(
+            !mlir.contains("partition access out of bounds"),
+            "the block-id store check should leave the kernel:\n{mlir}"
+        );
+        let compiled = artifacts("block_id_index", &["256", "64"], STRIDES);
+        let checks = compiled.launch_checks();
+        assert!(
+            format!("{checks:?}").contains("num_tile_blocks(0)"),
+            "the discharge must stake a claim on the launch grid: {checks:?}"
+        );
+        // The view has ceil(256/64) = 4 column tiles; the indexed axis is the
+        // grid's x axis. Four blocks launch; five must not.
+        let roots = [vec![256i32, 256]];
+        let views = [vec![1i32, 256]];
+        assert!(
+            validate_launch_checks(checks, &roots, &views, (4, 1, 1)).is_ok(),
+            "a grid inside the view's tile count must launch: {checks:?}"
+        );
+        assert!(
+            validate_launch_checks(checks, &roots, &views, (5, 1, 1)).is_err(),
+            "a grid wider than the view's tile count must be rejected: {checks:?}"
+        );
+    });
+}
+
+// Constant and inferred coordinates are decided independently, and both are
+// provable here: a checked store costs nothing.
+#[test]
+fn mixed_constant_and_inferred_coordinates_fully_discharge() {
+    common::with_test_stack(|| {
+        assert_eq!(
+            counts("mixed_constant_and_inferred", &["256", "64"], STRIDES),
+            (2, 0, 0),
+            "expected the constant row and the inferred column to discharge"
+        );
+        let mlir = compile_mlir("mixed_constant_and_inferred", &["256", "64"], STRIDES)
+            .expect("compile mixed_constant_and_inferred");
+        assert!(
+            !mlir.contains("partition access out of bounds"),
+            "a fully provable checked store must emit no check:\n{mlir}"
+        );
+    });
+}
+
+// With a dynamic row extent the constant row cannot be decided at compile
+// time, but it reduces to "this axis is non-empty" — a launch-known fact. It
+// leaves the kernel entirely, and rejects an empty slab at launch.
+#[test]
+fn dynamic_row_extent_moves_the_check_to_launch() {
+    common::with_test_stack(|| {
+        use cutile::tile_kernel::validate_launch_checks;
+        let mlir = compile_mlir("dynamic_row_extent", &["256", "64"], STRIDES)
+            .expect("compile dynamic_row_extent");
+        assert!(
+            !mlir.contains("partition access out of bounds"),
+            "the non-empty-extent obligation should leave the kernel:\n{mlir}"
+        );
+        let compiled = artifacts("dynamic_row_extent", &["256", "64"], STRIDES);
+        let checks = compiled.launch_checks();
+        assert!(
+            !checks.is_empty(),
+            "expected a launch check for the dynamic row extent, got none"
+        );
+        // A `&mut` parameter is slabbed, so the check is over the per-CTA view,
+        // not the root — an empty slab must be rejected even though the root
+        // tensor is non-empty.
+        assert!(
+            format!("{checks:?}").contains("ViewExtent"),
+            "a &mut param's extent check must be in the view (slab) frame: {checks:?}"
+        );
+        let roots = [vec![256i32, 256]];
+        assert!(
+            validate_launch_checks(checks, &roots, &[vec![0i32, 256]], (1, 1, 1)).is_err(),
+            "an empty slab must be rejected at launch"
+        );
+        assert!(
+            validate_launch_checks(checks, &roots, &[vec![1i32, 256]], (1, 1, 1)).is_ok(),
+            "a non-empty slab must be accepted at launch"
+        );
+    });
+}

--- a/cutile/tests/common/mod.rs
+++ b/cutile/tests/common/mod.rs
@@ -6,7 +6,7 @@
 
 use std::sync::{Mutex, MutexGuard, OnceLock};
 
-use cutile::compile_api::KernelCompiler;
+use cutile::compile_api::{CheckPlacementCounts, KernelCompiler};
 use cutile_compiler::ast::Module;
 use cutile_compiler::compiler::utils::CompileOptions;
 use cutile_compiler::error::JITError;
@@ -84,6 +84,36 @@ pub fn compile_to_ir<F>(
 where
     F: Fn() -> Module,
 {
+    compile_to_ir_with_counts(
+        module_ast_fn,
+        module_name,
+        function_name,
+        generics,
+        strides,
+        spec_args,
+        scalar_hints,
+        const_grid,
+        options,
+    )
+    .map(|(ir, _)| ir)
+}
+
+/// `compile_to_ir` that also returns the bounds-check placement counters.
+#[allow(clippy::too_many_arguments, dead_code)]
+pub fn compile_to_ir_with_counts<F>(
+    module_ast_fn: F,
+    module_name: &str,
+    function_name: &str,
+    generics: &[String],
+    strides: &[(&str, &[i32])],
+    spec_args: &[(&str, &SpecializationBits)],
+    scalar_hints: &[(&str, &DivHint)],
+    const_grid: Option<(u32, u32, u32)>,
+    options: &CompileOptions,
+) -> Result<(String, CheckPlacementCounts), JITError>
+where
+    F: Fn() -> Module,
+{
     let spec_args = spec_args
         .iter()
         .map(|(name, spec)| (*name, (*spec).clone()))
@@ -105,5 +135,7 @@ where
         compiler = compiler.grid(grid);
     }
 
-    compiler.compile().map(|artifacts| artifacts.ir_text())
+    compiler
+        .compile()
+        .map(|artifacts| (artifacts.ir_text(), artifacts.check_counts()))
 }

--- a/cutile/tests/differential_placement.rs
+++ b/cutile/tests/differential_placement.rs
@@ -1,0 +1,686 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Differential placement testing: the checker's output, compiled two ways,
+//! must produce outcome-refining executions.
+//!
+//! Every case runs twice — normally, and under `CUTILE_FORCE_DEVICE_CHECKS=1`
+//! (full placement ablation: every plain-family check at its access site,
+//! two-sided, over the actual runtime values — no discharge by provenance,
+//! fold, entailment, or inferred bounds, so the reference build inherits
+//! none of the proofs it referees; 2026-08-12 review, S2). Placement is
+//! allowed to move a stop earlier and cleaner (an in-loop trap may become a
+//! preheader trap may become a launch rejection) and must change nothing
+//! else:
+//!
+//! - ablated `ok` ⟹ normal `ok` with an identical result (else placement
+//!   manufactured a failure — a precision violation);
+//! - ablated `stop` ⟹ normal `stop` of any kind (else placement erased a
+//!   failure — a soundness violation, never tolerable);
+//! - equal `ok` outcomes must hash equal (else a miscompile).
+//!
+//! Each case runs in a subprocess because a device-side assert poisons the
+//! CUDA context; the runner executes one case per process and reports one
+//! `OUTCOME:` line.
+//!
+//! Known precision violations are pinned in `KNOWN_P_VIOLATIONS` with the
+//! defect they trace to, so the harness both proves it can detect them and
+//! fails the moment one appears or disappears unannounced. Fixing a defect
+//! moves its rows out of the ledger in the same commit. Soundness violations
+//! have no ledger: one observed is a hard failure.
+
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+use std::process::Command;
+use std::sync::Arc;
+
+use cutile::api;
+use cutile::compile_api::KernelCompiler;
+use cutile::prelude::*;
+use cutile::tensor::{IntoPartition, ToHostVec};
+use cutile_compiler::compiler::utils::CompileOptions;
+
+mod common;
+
+#[cutile::module]
+mod diff_module {
+    use cutile::core::*;
+
+    /// A foreign access behind a runtime flag. The `k` walk is bounded by
+    /// `x`'s axis 1; using it on `y` derives `dim(x,1) <= dim(y,0)` plus a
+    /// non-empty-extent fact — both currently enforced at launch regardless
+    /// of `flag` (defect D1 in `CHECK_PLACEMENT_CONTROL_FLOW.md`).
+    #[cutile::entry]
+    fn guarded_foreign<const B: i32>(
+        z: &mut Tensor<f32, { [B, B] }>,
+        x: &Tensor<f32, { [-1, -1] }>,
+        y: &Tensor<f32, { [-1, -1] }>,
+        flag: i32,
+    ) {
+        let px = x.partition(const_shape![B, B]);
+        let py = y.partition(const_shape![B, B]);
+        let mut acc: Tile<f32, { [B, B] }> = constant(0.0, const_shape![B, B]);
+        for k in 0i32..num_tiles(&px, 1) {
+            if flag > 0i32 {
+                let t = py.load([k, 0i32]);
+                acc = acc + t;
+            }
+        }
+        z.store(acc);
+    }
+
+    /// An access skipped by `continue` for `k >= limit`. The attained index
+    /// set is `[0, limit)`, a strict subset of the loop's range; the hoisted
+    /// check tests the range's extreme anyway (defect D2).
+    #[cutile::entry]
+    fn continue_before<const B: i32>(
+        z: &mut Tensor<f32, { [B] }>,
+        x: &Tensor<f32, { [-1] }>,
+        limit: i32,
+    ) {
+        let p = x.partition(const_shape![B]);
+        let mut acc: Tile<f32, { [B] }> = constant(0.0, const_shape![B]);
+        for k in 0i32..64i32 {
+            if k >= limit {
+                continue;
+            }
+            acc = acc + p.load([k]);
+        }
+        z.store(acc);
+    }
+
+    // NOTE: the H5b row (`break` after the access) is unrepresentable today:
+    // Tile IR rejects `cuda_tile.break` inside `cuda_tile.for` at verification
+    // ("can only be nested within ... 'cuda_tile.loop', 'cuda_tile.if'"), and
+    // the DSL's `while`/`loop` forms push no frame, so nothing hoists across
+    // them. The hypothesis guards the future generalization, not current
+    // reachability — see CHECK_PLACEMENT_CONTROL_FLOW.md.
+
+    /// A runtime scalar index: in place under both modes, so outcomes must
+    /// match exactly — the control case that keeps the harness honest.
+    #[cutile::entry]
+    fn runtime_scalar<const B: i32>(
+        z: &mut Tensor<f32, { [B] }>,
+        x: &Tensor<f32, { [-1] }>,
+        idx: i32,
+    ) {
+        let p = x.partition(const_shape![B]);
+        let t = p.load([idx]);
+        z.store(t);
+    }
+
+    /// A tile-block id indexing a foreign partition directly (the wide-tile
+    /// idiom): normal placement discharges via the block-id axiom rung and
+    /// stakes a launch check on the grid; the reference build checks the
+    /// actual id at the access site. A grid wider than the target's tile
+    /// count must stop in both builds.
+    #[cutile::entry]
+    fn block_id_foreign<const B: i32>(z: &mut Tensor<f32, { [B] }>, x: &Tensor<f32, { [-1] }>) {
+        let p = x.partition(const_shape![B]);
+        let pid: (i32, i32, i32) = get_tile_block_id();
+        let t = p.load([pid.0]);
+        z.store(t);
+    }
+
+    /// A same-view walk: fully discharged by provenance normally, so the
+    /// ONLY thing standing between it and silence under ablation is the
+    /// reference build refusing to inherit that proof (S2's count pin).
+    #[cutile::entry]
+    fn same_view_walk<const B: i32>(z: &mut Tensor<f32, { [B] }>, x: &Tensor<f32, { [-1] }>) {
+        let p = x.partition(const_shape![B]);
+        let mut acc: Tile<f32, { [B] }> = constant(0.0, const_shape![B]);
+        for i in 0i32..num_tiles(&p, 0) {
+            acc = acc + p.load([i]);
+        }
+        z.store(acc);
+    }
+
+    /// A safe static walk, used to pin that full ablation bypasses the static
+    /// fold and emits an actual-value check at the access.
+    #[cutile::entry]
+    fn static_fold_walk<const B: i32>(z: &mut Tensor<f32, { [B] }>, x: &Tensor<f32, { [48] }>) {
+        let p = x.partition(const_shape![B]);
+        let mut acc: Tile<f32, { [B] }> = constant(0.0, const_shape![B]);
+        for i in 0i32..3i32 {
+            acc = acc + p.load([i]);
+        }
+        z.store(acc);
+    }
+
+    /// Mathematical range `[0, 2]`, machine value 294,967,296 at `i = 2`
+    /// (the product wraps; `max` keeps the wreck). Both builds must stop
+    /// (2026-08-12 review, S1 scenario 1).
+    #[cutile::entry]
+    fn wrapped_product_masked_by_max<const B: i32>(
+        z: &mut Tensor<f32, { [B] }>,
+        x: &Tensor<f32, { [-1] }>,
+    ) {
+        let p = x.partition(const_shape![B]);
+        let mut acc: Tile<f32, { [B] }> = constant(0.0, const_shape![B]);
+        for i in 0i32..3i32 {
+            let index = max(i * -2_000_000_000i32, i);
+            acc = acc + p.load([index]);
+        }
+        z.store(acc);
+    }
+
+    /// Mathematically nonnegative remainder, machine value `-296` at
+    /// `i = 2` (the dividend wraps). The lower guard must exist and fire in
+    /// both builds (2026-08-12 review, S1 scenario 2 — the row the old
+    /// reference silently passed).
+    #[cutile::entry]
+    fn wrapped_dividend_negative_remainder<const B: i32>(
+        z: &mut Tensor<f32, { [B] }>,
+        x: &Tensor<f32, { [-1] }>,
+    ) {
+        let p = x.partition(const_shape![B]);
+        let mut acc: Tile<f32, { [B] }> = constant(0.0, const_shape![B]);
+        for i in 0i32..3i32 {
+            let index = (i * 2_000_000_000i32) % 1_000i32;
+            acc = acc + p.load([index]);
+        }
+        z.store(acc);
+    }
+
+    /// Static-extent twin of the wrapped product: the row the old reference
+    /// passed by inheriting the static fold (2026-08-12 review, S1/S2).
+    #[cutile::entry]
+    fn wrapped_product_static_extent<const B: i32>(
+        z: &mut Tensor<f32, { [B] }>,
+        x: &Tensor<f32, { [48] }>,
+    ) {
+        let p = x.partition(const_shape![B]);
+        let mut acc: Tile<f32, { [B] }> = constant(0.0, const_shape![B]);
+        for i in 0i32..3i32 {
+            let index = max(i * -2_000_000_000i32, i);
+            acc = acc + p.load([index]);
+        }
+        z.store(acc);
+    }
+}
+
+use diff_module::__module_ast_self;
+
+const B: usize = 16;
+
+/// One corpus row: a kernel, its launch data, and what the differential is
+/// expected to show today.
+struct Case {
+    name: &'static str,
+    /// `Some(reason)`: this row currently VIOLATES precision (ablated ok,
+    /// normal stop) for the stated defect, and the harness asserts the
+    /// violation is still present. `None`: the row must refine.
+    known_p_violation: Option<&'static str>,
+    /// Some rows are deliberately out of bounds. Their ablated execution
+    /// must stop; allowing `Ok`/`Ok` would recreate the S2 oracle blind spot.
+    reference_must_stop: bool,
+}
+
+const CASES: &[Case] = &[
+    Case {
+        name: "guarded_foreign_flag_off_mismatched",
+        known_p_violation: Some(
+            "D1: launch checks ignore control dependence; enforced with flag = 0",
+        ),
+        reference_must_stop: false,
+    },
+    Case {
+        name: "guarded_foreign_flag_on_matching",
+        known_p_violation: None,
+        reference_must_stop: false,
+    },
+    Case {
+        name: "guarded_foreign_flag_on_larger_target",
+        known_p_violation: None,
+        reference_must_stop: false,
+    },
+    Case {
+        name: "guarded_foreign_flag_on_short_target",
+        known_p_violation: None,
+        reference_must_stop: true,
+    },
+    Case {
+        name: "continue_before_limit_in_bounds",
+        known_p_violation: Some("D2: hoisted check tests an index `continue` never attains"),
+        reference_must_stop: false,
+    },
+    Case {
+        name: "block_id_foreign_matching",
+        known_p_violation: None,
+        reference_must_stop: false,
+    },
+    Case {
+        name: "block_id_foreign_short_target",
+        known_p_violation: None,
+        reference_must_stop: true,
+    },
+    Case {
+        name: "runtime_scalar_in_bounds",
+        known_p_violation: None,
+        reference_must_stop: false,
+    },
+    Case {
+        name: "runtime_scalar_out_of_bounds",
+        known_p_violation: None,
+        reference_must_stop: true,
+    },
+    Case {
+        name: "same_view_walk",
+        known_p_violation: None,
+        reference_must_stop: false,
+    },
+    Case {
+        name: "static_fold_walk",
+        known_p_violation: None,
+        reference_must_stop: false,
+    },
+    Case {
+        name: "wrapped_product_masked_by_max",
+        known_p_violation: None,
+        reference_must_stop: true,
+    },
+    Case {
+        name: "wrapped_dividend_negative_remainder",
+        known_p_violation: None,
+        reference_must_stop: true,
+    },
+    Case {
+        name: "wrapped_product_static_extent",
+        known_p_violation: None,
+        reference_must_stop: true,
+    },
+];
+
+fn patterned(len: usize) -> Arc<Vec<f32>> {
+    Arc::new((0..len).map(|i| ((i % 23) as f32) * 0.25 - 2.0).collect())
+}
+
+fn hash_outputs(v: &[f32]) -> u64 {
+    let mut h = DefaultHasher::new();
+    for x in v {
+        x.to_bits().hash(&mut h);
+    }
+    h.finish()
+}
+
+/// Runs one corpus row to completion in THIS process and returns
+/// `Ok(output)` or `Err(stop message)`. Every launch error and device trap
+/// surfaces as an `Err` from a `sync()`.
+fn execute_case(name: &str) -> Result<Vec<f32>, String> {
+    fn e<E: std::fmt::Display>(err: E) -> String {
+        err.to_string()
+    }
+    match name {
+        // x is [B, 4B] (4 k-tiles); y's row count is the variable.
+        n if n.starts_with("guarded_foreign") => {
+            let (flag, y_rows): (i32, usize) = match n {
+                "guarded_foreign_flag_off_mismatched" => (0, 3 * B),
+                "guarded_foreign_flag_on_matching" => (1, 4 * B),
+                "guarded_foreign_flag_on_larger_target" => (1, 8 * B),
+                "guarded_foreign_flag_on_short_target" => (1, 3 * B),
+                other => return Err(format!("unknown case {other}")),
+            };
+            let x: Arc<Tensor<f32>> = api::copy_host_vec_to_device(&patterned(B * 4 * B))
+                .reshape(&[B, 4 * B])
+                .sync()
+                .map_err(e)?
+                .into();
+            // NOTE: a zero-extent row is untestable here — the host API
+            // refuses zero-length tensors — so the accepted non-empty-extent
+            // trade is covered at the validate level by
+            // `hoisted_check_rejects_zero_extent_at_launch` instead.
+            let y: Arc<Tensor<f32>> = api::copy_host_vec_to_device(&patterned(y_rows * B))
+                .reshape(&[y_rows, B])
+                .sync()
+                .map_err(e)?
+                .into();
+            let z = api::zeros::<f32>(&[B, B]).sync().map_err(e)?;
+            let (z, _x, _y, _flag) = diff_module::guarded_foreign(z.partition([B, B]), x, y, flag)
+                .generics(vec![B.to_string()])
+                .sync()
+                .map_err(e)?;
+            z.unpartition().to_host_vec().sync().map_err(e)
+        }
+        "continue_before_limit_in_bounds" => {
+            // 10 tiles; the loop range is 0..64; limit keeps every attained
+            // access inside the 10 tiles.
+            let x: Arc<Tensor<f32>> = api::copy_host_vec_to_device(&patterned(10 * B))
+                .sync()
+                .map_err(e)?
+                .into();
+            let z = api::zeros::<f32>(&[B]).sync().map_err(e)?;
+            let limit = 4i32;
+            let (z, _x, _limit) = diff_module::continue_before(z.partition([B]), x, limit)
+                .generics(vec![B.to_string()])
+                .sync()
+                .map_err(e)?;
+            z.unpartition().to_host_vec().sync().map_err(e)
+        }
+        n if n.starts_with("block_id_foreign") => {
+            // z is 4 tiles of B, so the inferred grid is 4; x's tile count is
+            // the variable: 4 (grid fits) or 3 (grid one tile too wide).
+            let x_tiles = if n.ends_with("matching") { 4 } else { 3 };
+            let x: Arc<Tensor<f32>> = api::copy_host_vec_to_device(&patterned(x_tiles * B))
+                .sync()
+                .map_err(e)?
+                .into();
+            let z = api::zeros::<f32>(&[4 * B]).sync().map_err(e)?;
+            let (z, _x) = diff_module::block_id_foreign(z.partition([B]), x)
+                .generics(vec![B.to_string()])
+                .sync()
+                .map_err(e)?;
+            z.unpartition().to_host_vec().sync().map_err(e)
+        }
+        n if n.starts_with("runtime_scalar") => {
+            let idx: i32 = if n.ends_with("in_bounds") { 3 } else { 12 };
+            let x: Arc<Tensor<f32>> = api::copy_host_vec_to_device(&patterned(10 * B))
+                .sync()
+                .map_err(e)?
+                .into();
+            let z = api::zeros::<f32>(&[B]).sync().map_err(e)?;
+            let (z, _x, _idx) = diff_module::runtime_scalar(z.partition([B]), x, idx)
+                .generics(vec![B.to_string()])
+                .sync()
+                .map_err(e)?;
+            z.unpartition().to_host_vec().sync().map_err(e)
+        }
+        "same_view_walk"
+        | "static_fold_walk"
+        | "wrapped_product_masked_by_max"
+        | "wrapped_dividend_negative_remainder"
+        | "wrapped_product_static_extent" => {
+            let x_len = if name == "wrapped_dividend_negative_remainder" {
+                1_000 * B
+            } else {
+                3 * B
+            };
+            let x: Arc<Tensor<f32>> = api::copy_host_vec_to_device(&patterned(x_len))
+                .sync()
+                .map_err(e)?
+                .into();
+            let z = api::zeros::<f32>(&[B]).sync().map_err(e)?;
+            let z = match name {
+                "same_view_walk" => {
+                    let (z, _x) = diff_module::same_view_walk(z.partition([B]), x)
+                        .generics(vec![B.to_string()])
+                        .sync()
+                        .map_err(e)?;
+                    z
+                }
+                "static_fold_walk" => {
+                    let (z, _x) = diff_module::static_fold_walk(z.partition([B]), x)
+                        .generics(vec![B.to_string()])
+                        .sync()
+                        .map_err(e)?;
+                    z
+                }
+                "wrapped_product_masked_by_max" => {
+                    let (z, _x) = diff_module::wrapped_product_masked_by_max(z.partition([B]), x)
+                        .generics(vec![B.to_string()])
+                        .sync()
+                        .map_err(e)?;
+                    z
+                }
+                "wrapped_dividend_negative_remainder" => {
+                    let (z, _x) =
+                        diff_module::wrapped_dividend_negative_remainder(z.partition([B]), x)
+                            .generics(vec![B.to_string()])
+                            .sync()
+                            .map_err(e)?;
+                    z
+                }
+                "wrapped_product_static_extent" => {
+                    let (z, _x) = diff_module::wrapped_product_static_extent(z.partition([B]), x)
+                        .generics(vec![B.to_string()])
+                        .sync()
+                        .map_err(e)?;
+                    z
+                }
+                _ => unreachable!(),
+            };
+            z.unpartition().to_host_vec().sync().map_err(e)
+        }
+        other => Err(format!("unknown case {other}")),
+    }
+}
+
+/// Subprocess entry point: runs the case named by `CUTILE_DIFF_CASE` and
+/// prints exactly one `OUTCOME:` line. Ignored so it only runs when the
+/// parent test invokes it by name.
+#[test]
+#[ignore]
+fn differential_case_runner() {
+    let case = std::env::var("CUTILE_DIFF_CASE").expect("CUTILE_DIFF_CASE not set");
+    common::with_test_stack(move || {
+        let result = std::panic::catch_unwind(|| execute_case(&case));
+        match result {
+            Ok(Ok(out)) => println!("OUTCOME:OK:{:016x}", hash_outputs(&out)),
+            Ok(Err(msg)) => println!("OUTCOME:STOP:{}", msg.replace('\n', " | ")),
+            Err(panic) => {
+                let msg = panic
+                    .downcast_ref::<String>()
+                    .cloned()
+                    .or_else(|| panic.downcast_ref::<&str>().map(|s| s.to_string()))
+                    .unwrap_or_else(|| "opaque panic".to_string());
+                println!("OUTCOME:PANIC:{}", msg.replace('\n', " | "));
+            }
+        }
+    });
+}
+
+/// Compile-only subprocess entry point for pinning proof ablation without
+/// mutating process-global environment variables in the parent test.
+#[test]
+#[ignore]
+fn differential_compile_runner() {
+    let case = std::env::var("CUTILE_DIFF_COMPILE_CASE").expect("CUTILE_DIFF_COMPILE_CASE not set");
+    common::with_test_stack(move || {
+        let artifacts = KernelCompiler::new(__module_ast_self, "diff_module", &case)
+            .target("sm_120")
+            .generics(vec![B.to_string()])
+            .strides(&[("z", &[1]), ("x", &[1])])
+            .options(CompileOptions::default())
+            .compile()
+            .unwrap_or_else(|err| panic!("compile {case}: {err}"));
+        let counts = artifacts.check_counts();
+        println!(
+            "COUNTS:{}:{}:{}:{}",
+            counts.discharged,
+            counts.hoisted,
+            counts.in_place,
+            artifacts.launch_checks().len()
+        );
+    });
+}
+
+#[derive(Debug, PartialEq)]
+enum Outcome {
+    Ok(String),
+    Stop(String),
+}
+
+fn run_subprocess(case: &str, ablate: bool) -> Outcome {
+    let exe = std::env::current_exe().expect("current_exe");
+    let mut cmd = Command::new(exe);
+    cmd.args([
+        "--exact",
+        "differential_case_runner",
+        "--ignored",
+        "--nocapture",
+    ])
+    .env("CUTILE_DIFF_CASE", case)
+    .env_remove("CUTILE_FORCE_DEVICE_CHECKS")
+    .env_remove("CUTILE_DISABLE_CHECK_HOISTING");
+    if ablate {
+        cmd.env("CUTILE_FORCE_DEVICE_CHECKS", "1");
+    }
+    let out = cmd.output().expect("spawn case subprocess");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    let Some(line) = stdout.lines().find(|l| l.starts_with("OUTCOME:")) else {
+        // A device trap poisons the CUDA context; the destructors that run
+        // while the error propagates then panic themselves, which aborts the
+        // process before the runner can print. That IS a stop — classify it
+        // as one when the wreckage says so, and fail loudly otherwise.
+        if out.status.code() != Some(0) && stderr.contains("panicked") {
+            let first = stderr
+                .lines()
+                .find(|l| l.contains("panicked"))
+                .unwrap_or("aborted");
+            return Outcome::Stop(format!("aborted during cleanup: {first}"));
+        }
+        panic!(
+            "case {case} (ablate={ablate}) produced no OUTCOME line.\nstdout:\n{stdout}\nstderr:\n{stderr}"
+        );
+    };
+    if let Some(hash) = line.strip_prefix("OUTCOME:OK:") {
+        Outcome::Ok(hash.to_string())
+    } else if let Some(msg) = line.strip_prefix("OUTCOME:STOP:") {
+        Outcome::Stop(msg.to_string())
+    } else {
+        panic!("case {case} (ablate={ablate}) infrastructure failure: {line}")
+    }
+}
+
+fn run_compile_subprocess(case: &str, ablate: bool) -> (u32, u32, u32, usize) {
+    let exe = std::env::current_exe().expect("current_exe");
+    let mut cmd = Command::new(exe);
+    cmd.args([
+        "--exact",
+        "differential_compile_runner",
+        "--ignored",
+        "--nocapture",
+    ])
+    .env("CUTILE_DIFF_COMPILE_CASE", case)
+    .env_remove("CUTILE_FORCE_DEVICE_CHECKS")
+    .env_remove("CUTILE_DISABLE_CHECK_HOISTING");
+    if ablate {
+        cmd.env("CUTILE_FORCE_DEVICE_CHECKS", "1");
+    }
+    let out = cmd.output().expect("spawn compile subprocess");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "compile case {case} (ablate={ablate}) failed:\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    let line = stdout
+        .lines()
+        .find(|line| line.starts_with("COUNTS:"))
+        .unwrap_or_else(|| panic!("compile case {case} produced no COUNTS line:\n{stdout}"));
+    let values = line["COUNTS:".len()..]
+        .split(':')
+        .map(|value| value.parse::<usize>().expect("numeric placement count"))
+        .collect::<Vec<_>>();
+    assert_eq!(values.len(), 4, "malformed placement counts: {line}");
+    (
+        values[0] as u32,
+        values[1] as u32,
+        values[2] as u32,
+        values[3],
+    )
+}
+
+// The differential proper. For each row: ablated is the reference semantics
+// (every check at its access site); normal placement must refine it.
+#[test]
+fn placement_is_outcome_refining() {
+    let mut failures: Vec<String> = vec![];
+    for case in CASES {
+        let ablated = run_subprocess(case.name, true);
+        let normal = run_subprocess(case.name, false);
+        if case.reference_must_stop && !matches!(ablated, Outcome::Stop(_)) {
+            failures.push(format!(
+                "{}: BROKEN REFERENCE — deliberately out-of-bounds case did not stop under full ablation ({ablated:?})",
+                case.name
+            ));
+        }
+        match (&ablated, &normal) {
+            // Soundness: a stop may never be erased. No ledger for these.
+            (Outcome::Stop(_), Outcome::Ok(_)) => failures.push(format!(
+                "{}: SOUNDNESS VIOLATION — ablated stopped ({ablated:?}) but placement ran to \
+                 completion",
+                case.name
+            )),
+            // Precision: placement may not manufacture a stop, unless the row
+            // is pinned to a known defect — in which case it MUST still fail,
+            // so the ledger cannot go stale.
+            (Outcome::Ok(_), Outcome::Stop(stop)) => match case.known_p_violation {
+                Some(reason) => println!(
+                    "{}: pinned precision violation present as expected ({reason}): {stop}",
+                    case.name
+                ),
+                None => failures.push(format!(
+                    "{}: PRECISION VIOLATION — ablated ok, placement stopped: {stop}",
+                    case.name
+                )),
+            },
+            (Outcome::Ok(a), Outcome::Ok(b)) => {
+                if case.known_p_violation.is_some() {
+                    failures.push(format!(
+                        "{}: pinned as a known precision violation but refines now — the \
+                         defect was fixed; move the row out of the ledger",
+                        case.name
+                    ));
+                } else if a != b {
+                    failures.push(format!(
+                        "{}: MISCOMPILE — both ran but outputs differ ({a} vs {b})",
+                        case.name
+                    ));
+                }
+            }
+            (Outcome::Stop(_), Outcome::Stop(_)) => {
+                if case.known_p_violation.is_some() {
+                    failures.push(format!(
+                        "{}: pinned as a precision violation but the ablated run also \
+                         stopped — the pin is mischaracterised",
+                        case.name
+                    ));
+                }
+            }
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "differential placement violations:\n{}",
+        failures.join("\n")
+    );
+}
+
+#[test]
+fn force_device_checks_ablate_provenance_and_static_folds() {
+    for case in ["same_view_walk", "static_fold_walk"] {
+        assert_eq!(
+            run_compile_subprocess(case, false),
+            (1, 0, 0, 0),
+            "{case}: normal compilation should discharge its proof"
+        );
+        assert_eq!(
+            run_compile_subprocess(case, true),
+            (0, 0, 1, 0),
+            "{case}: full ablation must emit one actual-value in-place check"
+        );
+    }
+}
+
+// The launch checks the compiler discharges against must actually run. The
+// validator snapshot used by the generated launcher was taken BEFORE
+// compilation — the accumulator fills during it — so every hoisted check was
+// silently dropped at launch and the discharged accesses ran unchecked. A
+// launch rejection happens before any kernel starts, so this is safe to
+// assert in-process.
+#[test]
+fn launch_checks_are_enforced_at_launch() {
+    common::with_test_stack(|| {
+        let result = execute_case("guarded_foreign_flag_on_short_target");
+        let err = result.expect_err(
+            "a launch violating dim(x, 1) <= dim(y, 0) must be rejected before the kernel runs",
+        );
+        assert!(
+            err.contains("<=") || err.to_lowercase().contains("launch"),
+            "expected a launch-check rejection, got: {err}"
+        );
+    });
+}

--- a/cutile/tests/flash_attention_compile.rs
+++ b/cutile/tests/flash_attention_compile.rs
@@ -15,7 +15,6 @@ mod flash_attention_compile_module {
     use cutile::core::*;
 
     #[cutile::entry(
-        unchecked_accesses = false,
         optimization_hints = (
             sm_120 = (num_cta_in_cga = 1, max_divisibility = 16,),
         )

--- a/cutile/tests/gpu.rs
+++ b/cutile/tests/gpu.rs
@@ -14,6 +14,12 @@ mod tensor;
 #[path = "gpu/num_tiles.rs"]
 mod num_tiles;
 
+#[path = "gpu/partial_coverage.rs"]
+mod partial_coverage;
+
+#[path = "gpu/launch_preconditions.rs"]
+mod launch_preconditions;
+
 // ---------------------------------------------------------------------------
 // Migrated from cutile-examples (smoke tests for kernel patterns that were
 // previously exposed as runnable examples but don't teach a pattern worth
@@ -49,3 +55,12 @@ mod book_snippets;
 
 #[path = "gpu/tensor_permute.rs"]
 mod tensor_permute;
+
+#[path = "gpu/mapped_partition_values.rs"]
+mod mapped_partition_values;
+
+#[path = "gpu/mapped_partition_schedule_matrix.rs"]
+mod mapped_partition_schedule_matrix;
+
+#[path = "gpu/atomic_red_view.rs"]
+mod atomic_red_view;

--- a/cutile/tests/gpu/atomic_red_view.rs
+++ b/cutile/tests/gpu/atomic_red_view.rs
@@ -1,0 +1,68 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Value test: `atomic_red_view_tko` accumulates concurrently into one tile.
+//!
+//! Every block atomically adds a ones-tile into tile [0, 0] of the output;
+//! that tile must equal the block count in every element (a non-atomic
+//! store would lose updates), and every other tile must stay zero.
+
+use cutile::prelude::*;
+
+use crate::common;
+
+#[cutile::module]
+mod atomic_red_kernels {
+    use cutile::core::*;
+    use cutile::tileir::*;
+
+    #[cutile::entry()]
+    unsafe fn atomic_red_accumulate(out: &Tensor<f32, { [-1, -1] }>) {
+        let mut out_part: PartitionMut<f32, { [16, 16] }> =
+            unsafe { out.partition_full_mut(const_shape![16, 16]) };
+        let tile: Tile<f32, { [16, 16] }> = constant(1.0f32, const_shape![16, 16]);
+        let _tok: Token = unsafe {
+            atomic_red_view_tko(
+                &mut out_part,
+                tile,
+                [0i32, 0i32],
+                atomic::AddF,
+                ordering::Relaxed,
+                scope::Device,
+            )
+        };
+    }
+}
+
+use atomic_red_kernels::atomic_red_accumulate;
+
+#[test]
+fn atomic_red_view_accumulates_across_blocks() {
+    common::with_test_stack(|| {
+        let device = cuda_core::Device::new(0).expect("device");
+        let stream = device.new_stream().expect("stream");
+
+        const BLOCKS: usize = 32;
+        let out = api::zeros::<f32>(&[512, 16])
+            .sync_on(&stream)
+            .expect("zeros");
+        unsafe { atomic_red_accumulate(&out) }
+            .grid((BLOCKS as u32, 1, 1))
+            .sync_on(&stream)
+            .expect("launch");
+        let host: Vec<f32> = out.dup().to_host_vec().sync_on(&stream).expect("to_host");
+        assert_eq!(host.len(), 512 * 16);
+        let (first_tile, rest) = host.split_at(16 * 16);
+        assert!(
+            first_tile.iter().all(|&v| v == BLOCKS as f32),
+            "expected tile [0, 0] to accumulate to {BLOCKS}, got {:?}",
+            &first_tile[..8]
+        );
+        assert!(
+            rest.iter().all(|&v| v == 0.0),
+            "expected all other tiles untouched"
+        );
+    });
+}

--- a/cutile/tests/gpu/launch_preconditions.rs
+++ b/cutile/tests/gpu/launch_preconditions.rs
@@ -1,0 +1,86 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! The launcher enforces declared preconditions end to end: a launch whose
+//! real shapes violate a declared fact is rejected before any GPU work,
+//! naming the fact. The compile-time half (declared facts entail the
+//! binding obligations, nothing emitted anywhere) lives in
+//! `optimization_hints.rs`; this file holds the launch half, which needs a
+//! real device. Moved here from `optimization_hints.rs`, which the CI CPU
+//! job runs on driverless runners.
+
+#![allow(deprecated)] // the kernel deliberately exercises the with_bounds path
+
+use cutile::prelude::*;
+
+use crate::common;
+
+#[cutile::module]
+mod launch_preconditions_module {
+    use cutile::core::*;
+
+    /// Declared divisibility: with `dim(x, k) % 64 == 0` declared (and so
+    /// verified by the launcher before the kernel runs), both binding
+    /// obligations are entailed at JIT.
+    #[cutile::entry(
+        preconditions = (
+            dim(x, 0) % 64 == 0,
+            dim(x, 1) % 64 == 0,
+        )
+    )]
+    fn declared_divisibility_binding<const BM: i32, const BN: i32>(
+        z: &mut Tensor<f32, { [BM, BN] }>,
+        x: &Tensor<f32, { [-1, -1] }>,
+    ) {
+        let m = Dim::new(x.shape()[0] / BM);
+        let n = Dim::new(x.shape()[1] / BN);
+        let part = x.partition(const_shape![BM, BN]).with_bounds((m, n));
+        for i in m {
+            for j in n {
+                let tile = part.load(coord((i, j)));
+                z.store(tile);
+            }
+        }
+    }
+}
+
+#[test]
+fn the_launcher_enforces_a_declared_divisibility() {
+    common::with_test_stack(|| {
+        use cutile::tensor::PartitionMut;
+        let generics = || vec!["64".to_string(), "64".to_string()];
+        let x = cutile::api::zeros::<f32>(&[128, 128])
+            .sync()
+            .expect("alloc x");
+        let mut z = cutile::api::zeros::<f32>(&[64, 64])
+            .sync()
+            .expect("alloc z");
+        launch_preconditions_module::declared_divisibility_binding(
+            (&mut z).partition([64, 64]),
+            &x,
+        )
+        .generics(generics())
+        .sync()
+        .expect("a divisible shape must launch");
+
+        let bad = cutile::api::zeros::<f32>(&[100, 128])
+            .sync()
+            .expect("alloc bad");
+        let result = launch_preconditions_module::declared_divisibility_binding(
+            (&mut z).partition([64, 64]),
+            &bad,
+        )
+        .generics(generics())
+        .sync();
+        let Err(err) = result else {
+            panic!("a non-divisible shape must be rejected at launch");
+        };
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("% 64 == 0 failed"),
+            "expected the precondition failure to name the declared fact, got: {msg}"
+        );
+    });
+}

--- a/cutile/tests/gpu/mapped_partition_schedule_matrix.rs
+++ b/cutile/tests/gpu/mapped_partition_schedule_matrix.rs
@@ -1,0 +1,617 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Exhaustive coverage-and-disjointness matrix for mapped partition
+//! schedules, plus sub-range and overhang edge cases.
+//!
+//! The matrix kernels write each tile's flat logical index as the tile
+//! value into a poison-filled output, so after the launch every element
+//! must equal its own tile's index: a swizzle off-by-one shows up as a
+//! wrong index somewhere, a dropped tile as surviving poison, and a
+//! misrouted duplicate as a wrong index in the tile it clobbered (with the
+//! tile it came from left poisoned — tile count equals index count, so
+//! duplication implies omission). Ranks 1-3 are crossed with grouped
+//! trailing-pair maps, persistent tile-block counts of 1 / a non-divisor /
+//! the full grid, and logical grids that do not divide evenly by the map
+//! shape (exercising the remainder-band `min` path).
+
+use crate::common;
+use cutile::prelude::*;
+use std::sync::Arc;
+
+const POISON_I32: i32 = -0x5EAD;
+const POISON_F32: f32 = -333.25;
+
+#[cutile::module]
+mod schedule_matrix_kernels {
+    use cutile::core::*;
+
+    #[cutile::entry]
+    fn write_flat_index_rank1<const BN: i32, const MAP_SHAPE: [i32; 1]>(
+        mut z: MappedPartitionMut<i32, { [BN] }, MAP_SHAPE>,
+    ) {
+        for index in z.iter_indices() {
+            let coords = index.coords();
+            let tile: Tile<i32, { [BN] }> = broadcast_scalar(coords[0], const_shape![BN]);
+            z.store(tile, index);
+        }
+    }
+
+    #[cutile::entry]
+    fn write_flat_index_rank2<const BM: i32, const BN: i32, const MAP_SHAPE: [i32; 2]>(
+        mut z: MappedPartitionMut<i32, { [BM, BN] }, MAP_SHAPE>,
+    ) {
+        let g1 = num_tiles(&z, 1);
+        for index in z.iter_indices() {
+            let (c0, c1) = index.components();
+            let flat: i32 = c0 * g1 + c1;
+            let tile: Tile<i32, { [BM, BN] }> = broadcast_scalar(flat, const_shape![BM, BN]);
+            z.store(tile, index);
+        }
+    }
+
+    #[cutile::entry]
+    fn write_flat_index_rank3<
+        const B0: i32,
+        const B1: i32,
+        const B2: i32,
+        const MAP_SHAPE: [i32; 3],
+    >(
+        mut z: MappedPartitionMut<i32, { [B0, B1, B2] }, MAP_SHAPE>,
+    ) {
+        let g1 = num_tiles(&z, 1);
+        let g2 = num_tiles(&z, 2);
+        for index in z.iter_indices() {
+            let (c0, c1, c2) = index.components();
+            let flat: i32 = (c0 * g1 + c1) * g2 + c2;
+            let tile: Tile<i32, { [B0, B1, B2] }> =
+                broadcast_scalar(flat, const_shape![B0, B1, B2]);
+            z.store(tile, index);
+        }
+    }
+
+    /// Sub-range flat-index writer: only tiles inside the axis-0 range may
+    /// be written, everything else must keep its poison fill.
+    #[cutile::entry]
+    fn write_flat_index_subrange<const BM: i32, const BN: i32, const MAP_SHAPE: [i32; 2]>(
+        mut z: MappedPartitionMut<i32, { [BM, BN] }, MAP_SHAPE>,
+        start_tile: i32,
+        n_tiles: i32,
+    ) {
+        let g1 = num_tiles(&z, 1);
+        for index in z.iter_indices_within([(start_tile, n_tiles), (0i32, -1i32)]) {
+            let (c0, c1) = index.components();
+            let flat: i32 = c0 * g1 + c1;
+            let tile: Tile<i32, { [BM, BN] }> = broadcast_scalar(flat, const_shape![BM, BN]);
+            z.store(tile, index);
+        }
+    }
+
+    /// Remainder spelling: runtime start with the literal `-1` length
+    /// ("rest of the axis"), which must resolve at compile time.
+    #[cutile::entry]
+    fn write_flat_index_subrange_rest<const BM: i32, const BN: i32, const MAP_SHAPE: [i32; 2]>(
+        mut z: MappedPartitionMut<i32, { [BM, BN] }, MAP_SHAPE>,
+        start_tile: i32,
+    ) {
+        let g1 = num_tiles(&z, 1);
+        for index in z.iter_indices_within([(start_tile, -1i32), (0i32, -1i32)]) {
+            let (c0, c1) = index.components();
+            let flat: i32 = c0 * g1 + c1;
+            let tile: Tile<i32, { [BM, BN] }> = broadcast_scalar(flat, const_shape![BM, BN]);
+            z.store(tile, index);
+        }
+    }
+
+    /// The grout KV shape: rank-3 shared maps with the seq-axis sub-range
+    /// start read from device memory (dynpos).
+    #[cutile::entry]
+    fn dynpos_shared_rank3<const BS: i32, const BD: i32, const MAP_SHAPE: [i32; 3]>(
+        mut k_cache: MappedPartitionMut<f32, { [1, BS, BD] }, MAP_SHAPE>,
+        mut v_cache: MappedPartitionMut<f32, { [1, BS, BD] }, MAP_SHAPE>,
+        new_k: &Tensor<f32, { [-1, -1, -1] }>,
+        pos: &Tensor<i32, { [1] }>,
+        n_tiles: i32,
+    ) {
+        let pos_tile: Tile<i32, { [1] }> = pos.partition(const_shape![1]).load([0i32]);
+        let pos_scalar: i32 = tile_to_scalar(pos_tile.reshape(const_shape![]));
+        let part_k = new_k.partition(const_shape![1, BS, BD]);
+        for index in k_cache.iter_indices_within_with(
+            [(0i32, -1i32), (pos_scalar, n_tiles), (0i32, -1i32)],
+            &v_cache,
+        ) {
+            let (h, s, d) = index.components();
+            // Source row for cache row s is s - pos.
+            let tile = part_k.load([h, s - pos_scalar, d]);
+            k_cache.store(tile, index);
+            v_cache.store(tile + tile, index);
+        }
+    }
+
+    /// The grout prefill shape: the cache's sequence axis is much larger than
+    /// the source, but the mapped stream visits only `[0, seq_len)`. The
+    /// projected `s` coordinate therefore proves a cache store, not a
+    /// full-cache-axis bound for the `new_k` load.
+    #[cutile::entry]
+    fn prefill_shared_rank3<const BS: i32, const BD: i32, const MAP_SHAPE: [i32; 3]>(
+        mut k_cache: MappedPartitionMut<f32, { [1, BS, BD] }, MAP_SHAPE>,
+        mut v_cache: MappedPartitionMut<f32, { [1, BS, BD] }, MAP_SHAPE>,
+        new_k: &Tensor<f32, { [-1, -1, -1] }>,
+        seq_len: i32,
+    ) {
+        let part_k = new_k.partition(const_shape![1, BS, BD]);
+        for index in k_cache
+            .iter_indices_within_with([(0i32, -1i32), (0i32, seq_len), (0i32, -1i32)], &v_cache)
+        {
+            let [head, s, d] = index.coords();
+            let tile = part_k.load([s, head, d]);
+            k_cache.store(tile, index);
+            v_cache.store(tile + tile, index);
+        }
+    }
+
+    /// Overhang: tile shape overhangs the tensor edge (BN > columns).
+    /// Checked loads must pad the out-of-bounds lanes and mapped stores
+    /// must drop the overhang instead of corrupting adjacent memory.
+    #[cutile::entry]
+    fn overhang_copy<const BM: i32, const BN: i32, const MAP_SHAPE: [i32; 2]>(
+        mut z: MappedPartitionMut<f32, { [BM, BN] }, MAP_SHAPE>,
+        x: &Tensor<f32, { [-1, -1] }>,
+    ) {
+        let part_x = x.partition(const_shape![BM, BN]);
+        for index in z.iter_indices() {
+            let (c0, c1) = index.components();
+            let tile = part_x.load([c0, c1]);
+            z.store(tile, index);
+        }
+    }
+
+    /// Overhang combined with pipelined loads (the risky combo: pipelining
+    /// hints on masked boundary tiles).
+    #[cutile::entry]
+    fn overhang_copy_pipelined<
+        const BM: i32,
+        const BN: i32,
+        const L: i32,
+        const MAP_SHAPE: [i32; 2],
+    >(
+        mut z: MappedPartitionMut<f32, { [BM, BN] }, MAP_SHAPE>,
+        x: &Tensor<f32, { [-1, -1] }>,
+    ) {
+        let part_x = x.partition(const_shape![BM, BN]);
+        for index in z.iter_indices() {
+            let (c0, c1) = index.components();
+            let tile = part_x.load_pipelined::<L>([c0, c1]);
+            z.store(tile, index);
+        }
+    }
+}
+
+fn to_host_i32(z: Partition<Tensor<i32>>) -> Vec<i32> {
+    z.unpartition().to_host_vec().sync().unwrap()
+}
+
+/// Every element must equal its tile's flat logical index.
+fn assert_flat_index_coverage(actual: &[i32], dims: &[usize], tiles: &[usize], label: &str) {
+    assert_eq!(actual.len(), dims.iter().product::<usize>(), "{label}: len");
+    let rank = dims.len();
+    let grid: Vec<usize> = (0..rank).map(|a| dims[a].div_ceil(tiles[a])).collect();
+    for (i, &value) in actual.iter().enumerate() {
+        // Element index → coordinates → owning tile → flat tile index.
+        let mut rem = i;
+        let mut flat = 0usize;
+        for axis in 0..rank {
+            let inner: usize = dims[axis + 1..].iter().product();
+            let coord = rem / inner;
+            rem %= inner;
+            flat = flat * grid[axis] + coord / tiles[axis];
+        }
+        assert_eq!(
+            value, flat as i32,
+            "{label}: element {i} belongs to tile {flat} but holds {value} \
+             (poison = {POISON_I32}; poison here means the tile was never written)"
+        );
+    }
+}
+
+#[test]
+fn rank1_schedule_matrix_covers_every_tile_exactly() {
+    common::with_test_stack(|| {
+        for ntb in [1u32, 3, 4] {
+            let z = api::full::<i32>(POISON_I32, &[64])
+                .sync()
+                .unwrap()
+                .partition([16])
+                .map([1], ntb);
+            let generics = vec!["16".to_string(), "1".to_string()];
+            let (z,) = schedule_matrix_kernels::write_flat_index_rank1(z)
+                .generics(generics)
+                .sync()
+                .unwrap_or_else(|e| panic!("rank1 ntb={ntb}: {e}"));
+            assert_flat_index_coverage(&to_host_i32(z), &[64], &[16], &format!("rank1 ntb={ntb}"));
+        }
+    });
+}
+
+#[test]
+fn rank2_schedule_matrix_covers_every_tile_exactly() {
+    common::with_test_stack(|| {
+        // Grids (4, 4) and (3, 5): the latter does not divide evenly by any
+        // grouped map below, exercising the remainder-band min path.
+        for (rows, cols) in [(4usize, 4usize), (3, 5)] {
+            let dims = [rows * 8, cols * 8];
+            let total = (rows * cols) as u32;
+            for map in [[1usize, 1], [2, 1], [2, 2], [3, 2]] {
+                for ntb in [1u32, 5.min(total), total] {
+                    let z = api::full::<i32>(POISON_I32, &dims)
+                        .sync()
+                        .unwrap()
+                        .partition([8, 8])
+                        .map(map, ntb);
+                    let generics = vec![
+                        "8".to_string(),
+                        "8".to_string(),
+                        map[0].to_string(),
+                        map[1].to_string(),
+                    ];
+                    let label = format!("rank2 grid=({rows},{cols}) map={map:?} ntb={ntb}");
+                    let (z,) = schedule_matrix_kernels::write_flat_index_rank2(z)
+                        .generics(generics)
+                        .sync()
+                        .unwrap_or_else(|e| panic!("{label}: {e}"));
+                    assert_flat_index_coverage(&to_host_i32(z), &dims, &[8, 8], &label);
+                }
+            }
+        }
+    });
+}
+
+#[test]
+fn rank3_schedule_matrix_covers_every_tile_exactly() {
+    common::with_test_stack(|| {
+        // Logical grid (2, 3, 2) = 12 tiles; (1, 2, 2) does not divide the
+        // (3, 2) trailing pair evenly.
+        let dims = [2usize, 3 * 4, 2 * 8];
+        for map in [[1usize, 1, 1], [1, 2, 1], [1, 2, 2], [1, 3, 2]] {
+            for ntb in [1u32, 5, 12] {
+                let z = api::full::<i32>(POISON_I32, &dims)
+                    .sync()
+                    .unwrap()
+                    .partition([1, 4, 8])
+                    .map(map, ntb);
+                let generics = vec![
+                    "1".to_string(),
+                    "4".to_string(),
+                    "8".to_string(),
+                    map[0].to_string(),
+                    map[1].to_string(),
+                    map[2].to_string(),
+                ];
+                let label = format!("rank3 map={map:?} ntb={ntb}");
+                let (z,) = schedule_matrix_kernels::write_flat_index_rank3(z)
+                    .generics(generics)
+                    .sync()
+                    .unwrap_or_else(|e| panic!("{label}: {e}"));
+                assert_flat_index_coverage(&to_host_i32(z), &dims, &[1, 4, 8], &label);
+            }
+        }
+    });
+}
+
+/// Expected sub-range output: flat tile index inside the axis-0 tile range,
+/// poison elsewhere.
+fn subrange_flat_expected(dims: [usize; 2], tiles: [usize; 2], lo: usize, hi: usize) -> Vec<i32> {
+    let grid1 = dims[1].div_ceil(tiles[1]);
+    (0..dims[0] * dims[1])
+        .map(|i| {
+            let (r, c) = (i / dims[1], i % dims[1]);
+            let (t0, t1) = (r / tiles[0], c / tiles[1]);
+            if t0 >= lo && t0 < hi {
+                (t0 * grid1 + t1) as i32
+            } else {
+                POISON_I32
+            }
+        })
+        .collect()
+}
+
+fn run_subrange_case(map: [usize; 2], start: i32, len: i32, expect_lo: usize, expect_hi: usize) {
+    let dims = [64usize, 64];
+    let z = api::full::<i32>(POISON_I32, &dims)
+        .sync()
+        .unwrap()
+        .partition([16, 16])
+        .map(map, 4);
+    let generics = vec![
+        "16".to_string(),
+        "16".to_string(),
+        map[0].to_string(),
+        map[1].to_string(),
+    ];
+    let label = format!("subrange map={map:?} start={start} len={len}");
+    // The `-1` rest-of-axis spelling must be a source literal, so the
+    // remainder cases go through a kernel that hardcodes it; passing -1
+    // through a runtime scalar is a negative length by contract.
+    let z = if len == -1 {
+        let (z, _s) = schedule_matrix_kernels::write_flat_index_subrange_rest(z, start)
+            .generics(generics)
+            .sync()
+            .unwrap_or_else(|e| panic!("{label}: {e}"));
+        z
+    } else {
+        let (z, _s, _n) = schedule_matrix_kernels::write_flat_index_subrange(z, start, len)
+            .generics(generics)
+            .sync()
+            .unwrap_or_else(|e| panic!("{label}: {e}"));
+        z
+    };
+    let expected = subrange_flat_expected(dims, [16, 16], expect_lo, expect_hi);
+    assert_eq!(to_host_i32(z), expected, "{label}");
+}
+
+#[test]
+fn subrange_edge_cases_write_exactly_the_range() {
+    common::with_test_stack(|| {
+        // Empty range: the loop body must not run at all.
+        run_subrange_case([1, 1], 1, 0, 0, 0);
+        // Start at the last tile.
+        run_subrange_case([1, 1], 3, 1, 3, 4);
+        // (start, -1): the rest of the axis from a nonzero start.
+        run_subrange_case([1, 1], 2, -1, 2, 4);
+        // (0, -1) covers the whole axis, equivalent to plain iter_indices.
+        run_subrange_case([1, 1], 0, -1, 0, 4);
+        // Sub-range on a grouped axis: the swizzle applies within the range.
+        run_subrange_case([2, 1], 1, 2, 1, 3);
+        run_subrange_case([2, 2], 0, 3, 0, 3);
+    });
+}
+
+#[test]
+fn dynpos_shared_rank3_updates_only_the_device_read_range() {
+    common::with_test_stack(|| {
+        // Cache [heads=2, max_seq=8, D=16], tiles [1, 1, 16] → grid (2, 8, 1).
+        // Position 3 (device-resident), seq_len 2 → rows 3..5 written.
+        const H: usize = 2;
+        const MAX_SEQ: usize = 8;
+        const D: usize = 16;
+        let src: Vec<f32> = (0..H * 2 * D).map(|i| i as f32 * 0.5 + 1.0).collect();
+        let new_k: Arc<Tensor<f32>> = api::copy_host_vec_to_device(&Arc::new(src.clone()))
+            .reshape(&[H, 2, D])
+            .sync()
+            .unwrap()
+            .into();
+        let pos: Arc<Tensor<i32>> = api::copy_host_vec_to_device(&Arc::new(vec![3i32]))
+            .reshape(&[1])
+            .sync()
+            .unwrap()
+            .into();
+        let k_cache = api::full::<f32>(POISON_F32, &[H, MAX_SEQ, D])
+            .sync()
+            .unwrap()
+            .partition([1, 1, D])
+            .map([1, 1, 1], 4);
+        let v_cache = api::full::<f32>(POISON_F32, &[H, MAX_SEQ, D])
+            .sync()
+            .unwrap()
+            .partition([1, 1, D])
+            .map([1, 1, 1], 4);
+        let generics = vec![
+            "1".to_string(),
+            D.to_string(),
+            "1".to_string(),
+            "1".to_string(),
+            "1".to_string(),
+        ];
+        let (k_cache, v_cache, _k, _p, _n) =
+            schedule_matrix_kernels::dynpos_shared_rank3(k_cache, v_cache, new_k, pos, 2i32)
+                .generics(generics)
+                .sync()
+                .expect("dynpos shared rank-3 kernel should run");
+        let k_host = k_cache.unpartition().to_host_vec().sync().unwrap();
+        let v_host = v_cache.unpartition().to_host_vec().sync().unwrap();
+        for h in 0..H {
+            for s in 0..MAX_SEQ {
+                for d in 0..D {
+                    let i = (h * MAX_SEQ + s) * D + d;
+                    let (k_expect, v_expect) = if (3..5).contains(&s) {
+                        let src_value = src[(h * 2 + (s - 3)) * D + d];
+                        (src_value, src_value * 2.0)
+                    } else {
+                        (POISON_F32, POISON_F32)
+                    };
+                    assert_eq!(k_host[i], k_expect, "k_cache[{h},{s},{d}]");
+                    assert_eq!(v_host[i], v_expect, "v_cache[{h},{s},{d}]");
+                }
+            }
+        }
+    });
+}
+
+#[test]
+fn prefill_shared_rank3_bounds_the_source_by_the_subrange_not_the_cache() {
+    common::with_test_stack(|| {
+        // Grout's layout: cache [heads, max_seq, D], source [seq, heads, D].
+        // MAX_SEQ deliberately exceeds SEQ; only cache rows 0..SEQ are visited.
+        const H: usize = 2;
+        const SEQ: usize = 2;
+        const MAX_SEQ: usize = 8;
+        const D: usize = 16;
+        let src: Vec<f32> = (0..SEQ * H * D).map(|i| i as f32 * 0.25 + 1.0).collect();
+        let new_k: Arc<Tensor<f32>> = api::copy_host_vec_to_device(&Arc::new(src.clone()))
+            .reshape(&[SEQ, H, D])
+            .sync()
+            .unwrap()
+            .into();
+        let k_cache = api::full::<f32>(POISON_F32, &[H, MAX_SEQ, D])
+            .sync()
+            .unwrap()
+            .partition([1, 1, D])
+            .map([1, 1, 1], (H * SEQ) as u32);
+        let v_cache = api::full::<f32>(POISON_F32, &[H, MAX_SEQ, D])
+            .sync()
+            .unwrap()
+            .partition([1, 1, D])
+            .map([1, 1, 1], (H * SEQ) as u32);
+        let generics = vec![
+            "1".to_string(),
+            D.to_string(),
+            "1".to_string(),
+            "1".to_string(),
+            "1".to_string(),
+        ];
+        let (k_cache, v_cache, _k, _n) =
+            schedule_matrix_kernels::prefill_shared_rank3(k_cache, v_cache, new_k, SEQ as i32)
+                .generics(generics)
+                .sync()
+                .expect("a source covering the mapped sub-range should run");
+        let k_host = k_cache.unpartition().to_host_vec().sync().unwrap();
+        let v_host = v_cache.unpartition().to_host_vec().sync().unwrap();
+        for h in 0..H {
+            for s in 0..MAX_SEQ {
+                for d in 0..D {
+                    let cache_i = (h * MAX_SEQ + s) * D + d;
+                    let (k_expect, v_expect) = if s < SEQ {
+                        let value = src[(s * H + h) * D + d];
+                        (value, value * 2.0)
+                    } else {
+                        (POISON_F32, POISON_F32)
+                    };
+                    assert_eq!(k_host[cache_i], k_expect, "k_cache[{h},{s},{d}]");
+                    assert_eq!(v_host[cache_i], v_expect, "v_cache[{h},{s},{d}]");
+                }
+            }
+        }
+    });
+}
+
+fn run_overhang_case(pipelined: bool) {
+    // Tensor [40, 48], tiles [16, 32]: grid (3, 2) with overhang on both
+    // axes (rows 40 → last row tile is 8 deep, cols 48 → last col tile is
+    // 16 wide). Checked loads pad, mapped stores drop the overhang.
+    let dims = [40usize, 48];
+    let x_host: Vec<f32> = (0..dims[0] * dims[1])
+        .map(|i| ((i % 11) as f32 - 5.0) * 0.75)
+        .collect();
+    let x: Arc<Tensor<f32>> = api::copy_host_vec_to_device(&Arc::new(x_host.clone()))
+        .reshape(&dims)
+        .sync()
+        .unwrap()
+        .into();
+    let z = api::full::<f32>(POISON_F32, &dims)
+        .sync()
+        .unwrap()
+        .partition([16, 32])
+        .map([1, 1], 3);
+    let generics: Vec<String> = if pipelined {
+        vec!["16".into(), "32".into(), "2".into(), "1".into(), "1".into()]
+    } else {
+        vec!["16".into(), "32".into(), "1".into(), "1".into()]
+    };
+    let label = format!("overhang pipelined={pipelined}");
+    let z_host = if pipelined {
+        let (z, _x) = schedule_matrix_kernels::overhang_copy_pipelined(z, x)
+            .generics(generics)
+            .sync()
+            .unwrap_or_else(|e| panic!("{label}: {e}"));
+        z.unpartition().to_host_vec().sync().unwrap()
+    } else {
+        let (z, _x) = schedule_matrix_kernels::overhang_copy(z, x)
+            .generics(generics)
+            .sync()
+            .unwrap_or_else(|e| panic!("{label}: {e}"));
+        z.unpartition().to_host_vec().sync().unwrap()
+    };
+    for (i, (actual, expected)) in z_host.iter().zip(x_host.iter()).enumerate() {
+        assert_eq!(actual, expected, "{label}: element {i}");
+    }
+}
+
+#[test]
+fn overhang_tiles_load_padded_and_store_clipped() {
+    common::with_test_stack(|| run_overhang_case(false));
+}
+
+#[test]
+fn overhang_tiles_with_pipelined_loads_match() {
+    common::with_test_stack(|| run_overhang_case(true));
+}
+
+#[test]
+fn pipelined_loads_are_value_identical_across_latencies() {
+    // Same copy at L ∈ {1, 2, 4, 8} inside a persistent iter_indices loop
+    // over masked boundary tiles: the pipelining hint must never change
+    // values, only scheduling.
+    common::with_test_stack(|| {
+        for latency in [1i32, 2, 4, 8] {
+            let dims = [40usize, 48];
+            let x_host: Vec<f32> = (0..dims[0] * dims[1])
+                .map(|i| ((i % 11) as f32 - 5.0) * 0.75)
+                .collect();
+            let x: Arc<Tensor<f32>> = api::copy_host_vec_to_device(&Arc::new(x_host.clone()))
+                .reshape(&dims)
+                .sync()
+                .unwrap()
+                .into();
+            let z = api::full::<f32>(POISON_F32, &dims)
+                .sync()
+                .unwrap()
+                .partition([16, 32])
+                .map([1, 1], 3);
+            let generics: Vec<String> = vec![
+                "16".into(),
+                "32".into(),
+                latency.to_string(),
+                "1".into(),
+                "1".into(),
+            ];
+            let (z, _x) = schedule_matrix_kernels::overhang_copy_pipelined(z, x)
+                .generics(generics)
+                .sync()
+                .unwrap_or_else(|e| panic!("pipelined L={latency}: {e}"));
+            let z_host = z.unpartition().to_host_vec().sync().unwrap();
+            assert_eq!(
+                z_host, x_host,
+                "pipelined L={latency} must match plain copy"
+            );
+        }
+    });
+}
+
+#[test]
+fn shared_maps_with_mismatched_tile_block_counts_error_at_launch() {
+    common::with_test_stack(|| {
+        // Two mapped outputs requesting different physical grids (4 vs 8)
+        // is an inconsistent launch: it must fail, not silently pick one.
+        let dims = [64usize, 64];
+        let x: Arc<Tensor<f32>> = api::full::<f32>(1.0, &dims).sync().unwrap().into();
+        let out = api::full::<f32>(POISON_F32, &dims)
+            .sync()
+            .unwrap()
+            .partition([16, 16])
+            .map([1, 1], 4);
+        let doubled_out = api::full::<f32>(POISON_F32, &dims)
+            .sync()
+            .unwrap()
+            .partition([16, 16])
+            .map([1, 1], 8);
+        let generics = vec![
+            "f32".to_string(),
+            "16".to_string(),
+            "16".to_string(),
+            "1".to_string(),
+            "1".to_string(),
+        ];
+        let result = crate::mapped_partition_values::shared_map_kernel_for_ntb_probe(
+            out,
+            doubled_out,
+            x,
+            generics,
+        );
+        assert!(
+            result.is_err(),
+            "mismatched num_tile_blocks on shared mapped outputs must fail at launch, got Ok"
+        );
+    });
+}

--- a/cutile/tests/gpu/mapped_partition_values.rs
+++ b/cutile/tests/gpu/mapped_partition_values.rs
@@ -1,0 +1,418 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Device value-correctness tests for mapped partition schedules beyond
+//! rank 2: rank-3 and rank-1 `iter_indices()` and shared index streams via
+//! `iter_indices_with()`. Each kernel routes patterned input tiles through
+//! the schedule under test, so a misrouted or duplicated `PartitionIndex`
+//! scrambles the output and fails the elementwise comparison. Rank-2 grouped
+//! schedules are covered by the `persistent_gemm` example.
+
+use crate::common;
+use cutile::prelude::*;
+use std::sync::Arc;
+
+#[cutile::module]
+mod mapped_value_kernels {
+    use cutile::core::*;
+
+    #[cutile::entry]
+    fn rank3_copy<T: ElementType, const BS: i32, const BD: i32, const MAP_SHAPE: [i32; 3]>(
+        mut z: MappedPartitionMut<T, { [1, BS, BD] }, MAP_SHAPE>,
+        x: &Tensor<T, { [-1, -1, -1] }>,
+    ) {
+        let part_x = x.partition(const_shape![1, BS, BD]);
+        for index in z.iter_indices() {
+            let (bid_b, bid_s, bid_d) = index.components();
+            let tile = part_x.load([bid_b, bid_s, bid_d]);
+            z.store(tile, index);
+        }
+    }
+
+    #[cutile::entry]
+    fn rank1_copy<T: ElementType, const BN: i32, const MAP_SHAPE: [i32; 1]>(
+        mut z: MappedPartitionMut<T, { [BN] }, MAP_SHAPE>,
+        x: &Tensor<T, { [-1] }>,
+    ) {
+        let part_x = x.partition(const_shape![BN]);
+        for index in z.iter_indices() {
+            let coords = index.coords();
+            let tile = part_x.load([coords[0]]);
+            z.store(tile, index);
+        }
+    }
+
+    #[cutile::entry]
+    fn shared_map_copy_and_double<
+        T: ElementType,
+        const BM: i32,
+        const BN: i32,
+        const MAP_SHAPE: [i32; 2],
+    >(
+        mut out: MappedPartitionMut<T, { [BM, BN] }, MAP_SHAPE>,
+        mut doubled_out: MappedPartitionMut<T, { [BM, BN] }, MAP_SHAPE>,
+        x: &Tensor<T, { [-1, -1] }>,
+    ) {
+        let part_x = x.partition(const_shape![BM, BN]);
+        for index in out.iter_indices_with(&doubled_out) {
+            let (bid_m, bid_n) = index.components();
+            let tile = part_x.load([bid_m, bid_n]);
+            out.store(tile, index);
+            doubled_out.store(tile + tile, index);
+        }
+    }
+
+    /// KV-cache-shaped: copy input tiles into a sub-range of rows only,
+    /// with runtime start/len (the dynpos codepath).
+    #[cutile::entry]
+    fn subrange_copy<T: ElementType, const BM: i32, const BN: i32, const MAP_SHAPE: [i32; 2]>(
+        mut z: MappedPartitionMut<T, { [BM, BN] }, MAP_SHAPE>,
+        x: &Tensor<T, { [-1, -1] }>,
+        start_tile: i32,
+        n_tiles: i32,
+    ) {
+        let part_x = x.partition(const_shape![BM, BN]);
+        for index in z.iter_indices_within([(start_tile, n_tiles), (0i32, -1i32)]) {
+            let (bid_m, bid_n) = index.components();
+            let tile = part_x.load([bid_m, bid_n]);
+            z.store(tile, index);
+        }
+    }
+
+    /// Sub-range composed with a shared index stream: dual outputs written
+    /// only inside the row range.
+    #[cutile::entry]
+    fn subrange_shared_copy_and_double<
+        T: ElementType,
+        const BM: i32,
+        const BN: i32,
+        const MAP_SHAPE: [i32; 2],
+    >(
+        mut out: MappedPartitionMut<T, { [BM, BN] }, MAP_SHAPE>,
+        mut doubled_out: MappedPartitionMut<T, { [BM, BN] }, MAP_SHAPE>,
+        x: &Tensor<T, { [-1, -1] }>,
+        start_tile: i32,
+        n_tiles: i32,
+    ) {
+        let part_x = x.partition(const_shape![BM, BN]);
+        for index in
+            out.iter_indices_within_with([(start_tile, n_tiles), (0i32, -1i32)], &doubled_out)
+        {
+            let (bid_m, bid_n) = index.components();
+            let tile = part_x.load([bid_m, bid_n]);
+            out.store(tile, index);
+            doubled_out.store(tile + tile, index);
+        }
+    }
+
+    /// Pipelined safe load: the latency hint must not change values.
+    #[cutile::entry]
+    fn pipelined_copy<T: ElementType, const BM: i32, const BN: i32, const MAP_SHAPE: [i32; 2]>(
+        mut z: MappedPartitionMut<T, { [BM, BN] }, MAP_SHAPE>,
+        x: &Tensor<T, { [-1, -1] }>,
+    ) {
+        let part_x = x.partition(const_shape![BM, BN]);
+        for index in z.iter_indices() {
+            let (bid_m, bid_n) = index.components();
+            let tile = part_x.load_pipelined::<4>([bid_m, bid_n]);
+            z.store(tile, index);
+        }
+    }
+}
+
+/// Launch helper for the mismatched-ntb probe in the schedule-matrix tests:
+/// returns the launch result instead of unwrapping.
+pub fn shared_map_kernel_for_ntb_probe(
+    out: cutile::tensor::MappedLaunchPartition<Partition<Tensor<f32>>>,
+    doubled_out: cutile::tensor::MappedLaunchPartition<Partition<Tensor<f32>>>,
+    x: Arc<Tensor<f32>>,
+    generics: Vec<String>,
+) -> Result<(), cuda_async::error::DeviceError> {
+    let _ = mapped_value_kernels::shared_map_copy_and_double(out, doubled_out, x)
+        .generics(generics)
+        .sync()?;
+    Ok(())
+}
+
+fn patterned(len: usize) -> Vec<f32> {
+    (0..len)
+        .map(|i| ((i % 13) as f32 - 6.0) * 0.5 + ((i % 7) as f32) * 0.25)
+        .collect()
+}
+
+/// Outputs are poison-initialized, never zero-initialized: a spurious write
+/// of zero into a zero-filled buffer is invisible, so untouched-region and
+/// full-coverage assertions only mean something when the sentinel is a value
+/// no kernel under test can produce. Outside `patterned`'s range.
+const POISON: f32 = -333.25;
+
+fn assert_elementwise(actual: &[f32], expected: &[f32], label: &str) {
+    assert_eq!(actual.len(), expected.len(), "{label}: length mismatch");
+    for (i, (a, e)) in actual.iter().zip(expected.iter()).enumerate() {
+        assert!(
+            (a - e).abs() < 1e-6,
+            "{label}: element {i} is {a}, expected {e}"
+        );
+    }
+}
+
+fn run_rank3_copy(map_shape: [usize; 3]) {
+    const B: usize = 4;
+    const S: usize = 8;
+    const D: usize = 16;
+    let x_host = patterned(B * S * D);
+    let x: Arc<Tensor<f32>> = api::copy_host_vec_to_device(&Arc::new(x_host.clone()))
+        .reshape(&[B, S, D])
+        .sync()
+        .unwrap()
+        .into();
+    // Tile [1, 4, 8] over [4, 8, 16] → a (4, 2, 2) logical grid walked by 4
+    // persistent tile blocks (4 indices each).
+    let z = api::full::<f32>(POISON, &[B, S, D])
+        .sync()
+        .unwrap()
+        .partition([1, 4, 8])
+        .map(map_shape, 4);
+    let generics = vec![
+        "f32".to_string(),
+        "4".to_string(),
+        "8".to_string(),
+        map_shape[0].to_string(),
+        map_shape[1].to_string(),
+        map_shape[2].to_string(),
+    ];
+    let (z, _x) = mapped_value_kernels::rank3_copy(z, x)
+        .generics(generics)
+        .sync()
+        .expect("rank-3 mapped kernel should run");
+    let z_host = z.unpartition().to_host_vec().sync().unwrap();
+    assert_elementwise(&z_host, &x_host, &format!("rank3 map {map_shape:?}"));
+}
+
+#[test]
+fn rank3_mapped_store_routes_tiles_correctly() {
+    common::with_test_stack(|| run_rank3_copy([1, 1, 1]));
+}
+
+#[test]
+fn rank3_mapped_store_routes_tiles_correctly_grouped() {
+    common::with_test_stack(|| run_rank3_copy([1, 2, 1]));
+}
+
+#[test]
+fn rank1_mapped_store_routes_tiles_correctly() {
+    common::with_test_stack(|| {
+        const N: usize = 64;
+        let x_host = patterned(N);
+        let x: Arc<Tensor<f32>> = api::copy_host_vec_to_device(&Arc::new(x_host.clone()))
+            .reshape(&[N])
+            .sync()
+            .unwrap()
+            .into();
+        // Tile [16] over [64] → 4 logical tiles walked by 2 persistent blocks.
+        let z = api::full::<f32>(POISON, &[N])
+            .sync()
+            .unwrap()
+            .partition([16])
+            .map([1], 2);
+        let generics = vec!["f32".to_string(), "16".to_string(), "1".to_string()];
+        let (z, _x) = mapped_value_kernels::rank1_copy(z, x)
+            .generics(generics)
+            .sync()
+            .expect("rank-1 mapped kernel should run");
+        let z_host = z.unpartition().to_host_vec().sync().unwrap();
+        assert_elementwise(&z_host, &x_host, "rank1");
+    });
+}
+
+fn run_shared_map(map_shape: [usize; 2]) {
+    const M: usize = 64;
+    const N: usize = 64;
+    let x_host = patterned(M * N);
+    let x: Arc<Tensor<f32>> = api::copy_host_vec_to_device(&Arc::new(x_host.clone()))
+        .reshape(&[M, N])
+        .sync()
+        .unwrap()
+        .into();
+    // Tile [16, 16] over [64, 64] → a (4, 4) logical grid walked by 4
+    // persistent tile blocks through one shared index stream.
+    let out = api::full::<f32>(POISON, &[M, N])
+        .sync()
+        .unwrap()
+        .partition([16, 16])
+        .map(map_shape, 4);
+    let doubled_out = api::full::<f32>(POISON, &[M, N])
+        .sync()
+        .unwrap()
+        .partition([16, 16])
+        .map(map_shape, 4);
+    let generics = vec![
+        "f32".to_string(),
+        "16".to_string(),
+        "16".to_string(),
+        map_shape[0].to_string(),
+        map_shape[1].to_string(),
+    ];
+    let (out, doubled_out, _x) =
+        mapped_value_kernels::shared_map_copy_and_double(out, doubled_out, x)
+            .generics(generics)
+            .sync()
+            .expect("shared-map kernel should run");
+    let out_host = out.unpartition().to_host_vec().sync().unwrap();
+    let doubled_host = doubled_out.unpartition().to_host_vec().sync().unwrap();
+    let doubled_expected: Vec<f32> = x_host.iter().map(|v| v * 2.0).collect();
+    assert_elementwise(&out_host, &x_host, &format!("shared out map {map_shape:?}"));
+    assert_elementwise(
+        &doubled_host,
+        &doubled_expected,
+        &format!("shared doubled map {map_shape:?}"),
+    );
+}
+
+#[test]
+fn shared_map_stores_route_to_both_partitions() {
+    common::with_test_stack(|| run_shared_map([1, 1]));
+}
+
+#[test]
+fn shared_map_stores_route_to_both_partitions_grouped() {
+    common::with_test_stack(|| run_shared_map([2, 1]));
+}
+
+const SUB_M: usize = 64;
+const SUB_N: usize = 64;
+const SUB_TILE: usize = 16;
+const SUB_START_TILE: i32 = 1;
+const SUB_N_TILES: i32 = 2;
+
+/// Expected output when rows `[16, 48)` (tiles 1..3 of 4) are written from
+/// `x` (optionally scaled) and everything else keeps its poison fill.
+fn subrange_expected(x_host: &[f32], scale: f32) -> Vec<f32> {
+    let row_lo = SUB_START_TILE as usize * SUB_TILE;
+    let row_hi = row_lo + SUB_N_TILES as usize * SUB_TILE;
+    (0..SUB_M * SUB_N)
+        .map(|i| {
+            let row = i / SUB_N;
+            if row >= row_lo && row < row_hi {
+                x_host[i] * scale
+            } else {
+                POISON
+            }
+        })
+        .collect()
+}
+
+#[test]
+fn subrange_mapped_store_writes_only_the_range() {
+    common::with_test_stack(|| {
+        let x_host = patterned(SUB_M * SUB_N);
+        let x: Arc<Tensor<f32>> = api::copy_host_vec_to_device(&Arc::new(x_host.clone()))
+            .reshape(&[SUB_M, SUB_N])
+            .sync()
+            .unwrap()
+            .into();
+        let z = api::full::<f32>(POISON, &[SUB_M, SUB_N])
+            .sync()
+            .unwrap()
+            .partition([SUB_TILE, SUB_TILE])
+            .map([1, 1], 4);
+        let generics = vec![
+            "f32".to_string(),
+            SUB_TILE.to_string(),
+            SUB_TILE.to_string(),
+            "1".to_string(),
+            "1".to_string(),
+        ];
+        let (z, _x, _start, _n) =
+            mapped_value_kernels::subrange_copy(z, x, SUB_START_TILE, SUB_N_TILES)
+                .generics(generics)
+                .sync()
+                .expect("sub-range mapped kernel should run");
+        let z_host = z.unpartition().to_host_vec().sync().unwrap();
+        assert_elementwise(&z_host, &subrange_expected(&x_host, 1.0), "subrange");
+    });
+}
+
+#[test]
+fn subrange_shared_map_writes_both_outputs_in_range_only() {
+    common::with_test_stack(|| {
+        let x_host = patterned(SUB_M * SUB_N);
+        let x: Arc<Tensor<f32>> = api::copy_host_vec_to_device(&Arc::new(x_host.clone()))
+            .reshape(&[SUB_M, SUB_N])
+            .sync()
+            .unwrap()
+            .into();
+        let out = api::full::<f32>(POISON, &[SUB_M, SUB_N])
+            .sync()
+            .unwrap()
+            .partition([SUB_TILE, SUB_TILE])
+            .map([1, 1], 4);
+        let doubled_out = api::full::<f32>(POISON, &[SUB_M, SUB_N])
+            .sync()
+            .unwrap()
+            .partition([SUB_TILE, SUB_TILE])
+            .map([1, 1], 4);
+        let generics = vec![
+            "f32".to_string(),
+            SUB_TILE.to_string(),
+            SUB_TILE.to_string(),
+            "1".to_string(),
+            "1".to_string(),
+        ];
+        let (out, doubled_out, _x, _start, _n) =
+            mapped_value_kernels::subrange_shared_copy_and_double(
+                out,
+                doubled_out,
+                x,
+                SUB_START_TILE,
+                SUB_N_TILES,
+            )
+            .generics(generics)
+            .sync()
+            .expect("shared sub-range kernel should run");
+        let out_host = out.unpartition().to_host_vec().sync().unwrap();
+        let doubled_host = doubled_out.unpartition().to_host_vec().sync().unwrap();
+        assert_elementwise(
+            &out_host,
+            &subrange_expected(&x_host, 1.0),
+            "subrange shared out",
+        );
+        assert_elementwise(
+            &doubled_host,
+            &subrange_expected(&x_host, 2.0),
+            "subrange shared doubled",
+        );
+    });
+}
+
+#[test]
+fn pipelined_safe_load_preserves_values() {
+    common::with_test_stack(|| {
+        let x_host = patterned(SUB_M * SUB_N);
+        let x: Arc<Tensor<f32>> = api::copy_host_vec_to_device(&Arc::new(x_host.clone()))
+            .reshape(&[SUB_M, SUB_N])
+            .sync()
+            .unwrap()
+            .into();
+        let z = api::full::<f32>(POISON, &[SUB_M, SUB_N])
+            .sync()
+            .unwrap()
+            .partition([SUB_TILE, SUB_TILE])
+            .map([1, 1], 4);
+        let generics = vec![
+            "f32".to_string(),
+            SUB_TILE.to_string(),
+            SUB_TILE.to_string(),
+            "1".to_string(),
+            "1".to_string(),
+        ];
+        let (z, _x) = mapped_value_kernels::pipelined_copy(z, x)
+            .generics(generics)
+            .sync()
+            .expect("pipelined copy kernel should run");
+        let z_host = z.unpartition().to_host_vec().sync().unwrap();
+        assert_elementwise(&z_host, &x_host, "pipelined copy");
+    });
+}

--- a/cutile/tests/gpu/partial_coverage.rs
+++ b/cutile/tests/gpu/partial_coverage.rs
@@ -1,0 +1,115 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Partial-coverage launches: a `partition_prefix` output binding lets the
+//! launch grid cover a per-axis PREFIX of the block grid — launched blocks
+//! embed identically, uncovered blocks keep their contents — while both
+//! guarded directions stay errors: exceeding the block grid on any axis
+//! (genuine out-of-bounds), and the default `partition()` binding's strict
+//! equality (the intent diagnostic partial coverage opts out of).
+//!
+//! The motivating shape: a wide-tile kernel covering only the BM-aligned
+//! row prefix of a `seq_len % BM != 0` tensor, with a per-row kernel taking
+//! the remainder.
+
+use cutile::prelude::*;
+use partial_coverage_module::fill_rows;
+
+use crate::common;
+
+#[cutile::module]
+mod partial_coverage_module {
+    use cutile::core::*;
+
+    /// Writes a constant to this CTA's slab; safe, and provably so.
+    #[cutile::entry(deny_in_kernel_checks = true)]
+    fn fill_rows<const BM: i32, const D: i32>(out: &mut Tensor<f32, { [BM, D] }>) {
+        let t: Tile<f32, { [BM, D] }> = constant(7.0, const_shape![BM, D]);
+        out.store(t);
+    }
+}
+
+const BM: usize = 16;
+const D: usize = 8;
+const ROWS: usize = 40; // ceil(40/16) = 3 blocks; the aligned prefix is 2.
+
+fn generics() -> Vec<String> {
+    vec![BM.to_string(), D.to_string()]
+}
+
+#[test]
+fn prefix_binding_writes_the_covered_prefix_and_nothing_else() {
+    common::with_test_stack(|| {
+        let z = api::zeros::<f32>(&[ROWS, D])
+            .sync()
+            .expect("alloc")
+            .partition_prefix([BM, D]);
+        let (out,) = fill_rows(z)
+            .generics(generics())
+            .grid((2, 1, 1))
+            .sync()
+            .expect("a per-axis prefix launch must be accepted");
+        let out = out.unpartition().to_host_vec().sync().expect("copy back");
+        let covered = 2 * BM * D;
+        assert!(
+            out[..covered].iter().all(|&v| v == 7.0),
+            "covered blocks must be written"
+        );
+        assert!(
+            out[covered..].iter().all(|&v| v == 0.0),
+            "uncovered blocks must keep their prior contents"
+        );
+    });
+}
+
+#[test]
+fn prefix_binding_still_rejects_the_oob_direction_and_cannot_infer() {
+    common::with_test_stack(|| {
+        // Exceeding the block grid on an axis is genuine out-of-bounds.
+        let z = api::zeros::<f32>(&[ROWS, D])
+            .sync()
+            .expect("alloc")
+            .partition_prefix([BM, D]);
+        let err = match fill_rows(z).generics(generics()).grid((4, 1, 1)).sync() {
+            Ok(_) => panic!("a grid beyond the block grid must be rejected"),
+            Err(err) => err,
+        };
+        assert!(
+            err.to_string().contains("exceeds"),
+            "expected the per-axis excess diagnostic: {err}"
+        );
+        // A prefix binding is a bound, not a grid: inference must refuse.
+        let z = api::zeros::<f32>(&[ROWS, D])
+            .sync()
+            .expect("alloc")
+            .partition_prefix([BM, D]);
+        let err = match fill_rows(z).generics(generics()).sync() {
+            Ok(_) => panic!("a partial-coverage binding must not define the grid"),
+            Err(err) => err,
+        };
+        assert!(
+            err.to_string().contains("partial-coverage"),
+            "expected the inference-refusal diagnostic: {err}"
+        );
+    });
+}
+
+#[test]
+fn default_binding_keeps_strict_equality() {
+    common::with_test_stack(|| {
+        let z = api::zeros::<f32>(&[ROWS, D])
+            .sync()
+            .expect("alloc")
+            .partition([BM, D]);
+        let err = match fill_rows(z).generics(generics()).grid((2, 1, 1)).sync() {
+            Ok(_) => panic!("without the opt-in, a partial grid must still be rejected"),
+            Err(err) => err,
+        };
+        assert!(
+            err.to_string().contains("does not match"),
+            "the strict-equality diagnostic must be unchanged: {err}"
+        );
+    });
+}

--- a/cutile/tests/inferred_axis_bounds.rs
+++ b/cutile/tests/inferred_axis_bounds.rs
@@ -1,0 +1,510 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Half of each twin pair is deliberately the deprecated spelling: the tests
+// exist to show the two place identically.
+#![allow(deprecated)]
+
+//! Ordinary `for i in 0..num_tiles(&p, a)` loops must prove their accesses
+//! safe without any annotation.
+//!
+//! `num_tiles(&p, a)` already tells the compiler which partition axis its
+//! result counts. These tests pin that an ordinary integer loop over that
+//! bound carries the same information as the annotated forms — iterating a
+//! `Dim`, or binding the axis with `with_bounds` — so the unannotated
+//! kernel places its checks exactly where its annotated twin does. That
+//! equality is the precondition for removing the annotations entirely.
+
+use cutile;
+use cutile_compiler::compiler::utils::CompileOptions;
+
+mod common;
+
+#[cutile::module]
+mod inferred_module {
+    use cutile::core::*;
+
+    /// Unannotated: an ordinary range loop over `num_tiles`, dynamic extent.
+    #[cutile::entry]
+    fn plain_loop<const B: i32>(z: &mut Tensor<f32, { [B] }>, x: &Tensor<f32, { [-1] }>) {
+        let p = x.partition(const_shape![B]);
+        for i in 0i32..num_tiles(&p, 0) {
+            let t = p.load([i]);
+            z.store(t);
+        }
+    }
+
+    /// Annotated twin: the same loop over an explicit `Dim`.
+    #[cutile::entry]
+    fn dim_loop<const B: i32>(z: &mut Tensor<f32, { [B] }>, x: &Tensor<f32, { [-1] }>) {
+        let p = x.partition(const_shape![B]);
+        let d = num_tiles(&p, 0).into_dim();
+        for i in d {
+            let t = p.load([i]);
+            z.store(t);
+        }
+    }
+
+    /// Unannotated, rank 2: both axes iterate their own `num_tiles`.
+    #[cutile::entry]
+    fn plain_loop_2d<const BM: i32, const BN: i32>(
+        z: &mut Tensor<f32, { [BM, BN] }>,
+        x: &Tensor<f32, { [-1, -1] }>,
+    ) {
+        let p = x.partition(const_shape![BM, BN]);
+        for i in 0i32..num_tiles(&p, 0) {
+            for j in 0i32..num_tiles(&p, 1) {
+                let t = p.load([i, j]);
+                z.store(t);
+            }
+        }
+    }
+
+    /// Annotated twin of `plain_loop_2d`, using `with_bounds` branding.
+    #[cutile::entry]
+    fn bounded_loop_2d<const BM: i32, const BN: i32>(
+        z: &mut Tensor<f32, { [BM, BN] }>,
+        x: &Tensor<f32, { [-1, -1] }>,
+    ) {
+        let p = x.partition(const_shape![BM, BN]);
+        let rows = num_tiles(&p, 0).into_dim();
+        let cols = num_tiles(&p, 1).into_dim();
+        let bp = p.with_bounds((rows, cols));
+        for i in rows {
+            for j in cols {
+                let t: Tile<f32, { [BM, BN] }> = bp.load(coord((i, j)));
+                z.store(t);
+            }
+        }
+    }
+
+    /// Unannotated shared-dimension GEMM: the `k` loop iterates `px`'s axis 1,
+    /// and `py.load([k, _])` indexes a DIFFERENT tensor's axis 0. A declared
+    /// equality relates the two extents.
+    #[cutile::entry(
+        preconditions = (dim(x, 1) == dim(y, 0),)
+    )]
+    fn plain_shared_dim_gemm<const BM: i32, const BN: i32, const BK: i32>(
+        z: &mut Tensor<f32, { [BM, BN] }>,
+        x: &Tensor<f32, { [-1, -1] }>,
+        y: &Tensor<f32, { [-1, -1] }>,
+    ) {
+        let px = x.partition(const_shape![BM, BK]);
+        let py = y.partition(const_shape![BK, BN]);
+        let mut acc: Tile<f32, { [BM, BN] }> = constant(0.0, const_shape![BM, BN]);
+        for k in 0i32..num_tiles(&px, 1) {
+            let tx = px.load([0i32, k]);
+            let ty = py.load([k, 0i32]);
+            acc = mma(tx, ty, acc);
+        }
+        z.store(acc);
+    }
+
+    /// Identical to `plain_shared_dim_gemm` but with NO declared equality.
+    /// Iterating `x`'s axis says nothing about `y`'s extent, so the foreign
+    /// access must keep a real check.
+    #[cutile::entry]
+    fn plain_shared_dim_gemm_undeclared<const BM: i32, const BN: i32, const BK: i32>(
+        z: &mut Tensor<f32, { [BM, BN] }>,
+        x: &Tensor<f32, { [-1, -1] }>,
+        y: &Tensor<f32, { [-1, -1] }>,
+    ) {
+        let px = x.partition(const_shape![BM, BK]);
+        let py = y.partition(const_shape![BK, BN]);
+        let mut acc: Tile<f32, { [BM, BN] }> = constant(0.0, const_shape![BM, BN]);
+        for k in 0i32..num_tiles(&px, 1) {
+            let tx = px.load([0i32, k]);
+            let ty = py.load([k, 0i32]);
+            acc = mma(tx, ty, acc);
+        }
+        z.store(acc);
+    }
+
+    /// The dominant shape in grout's safe kernels: components minted by a
+    /// mapped partition's schedule index a plain partition of ANOTHER tensor,
+    /// with `with_bounds` tying that tensor's axes to the mapped grid.
+    #[cutile::entry]
+    fn mapped_components_bounded<const BM: i32, const BN: i32, const MAP_SHAPE: [i32; 2]>(
+        mut z: MappedPartitionMut<f32, { [BM, BN] }, MAP_SHAPE>,
+        x: &Tensor<f32, { [-1, -1] }>,
+    ) {
+        let xp = x
+            .partition(const_shape![BM, BN])
+            .with_bounds((num_tiles(&z, 0), num_tiles(&z, 1)));
+        for index in z.iter_indices() {
+            let (m, n) = index.components();
+            let t = xp.load(coord((m, n)));
+            z.store(t, index);
+        }
+    }
+
+    /// The same kernel with the binding stated as a signature contract instead
+    /// of a body annotation, and plain indexing.
+    #[cutile::entry(
+        preconditions = (
+            dim(z, 0) == dim(x, 0),
+            dim(z, 1) == dim(x, 1),
+        )
+    )]
+    fn mapped_components_declared<const BM: i32, const BN: i32, const MAP_SHAPE: [i32; 2]>(
+        mut z: MappedPartitionMut<f32, { [BM, BN] }, MAP_SHAPE>,
+        x: &Tensor<f32, { [-1, -1] }>,
+    ) {
+        let xp = x.partition(const_shape![BM, BN]);
+        for index in z.iter_indices() {
+            let (m, n) = index.components();
+            let t = xp.load([m, n]);
+            z.store(t, index);
+        }
+    }
+    /// KNOWN LIMITATION, pinned deliberately: the foreign access sits behind a
+    /// runtime condition, but the fact it needs is still hoisted, so the check
+    /// applies to every launch — including those where `flag <= 0` and the load
+    /// never runs. See LIMITATIONS in `HOISTING_COVERAGE.md`.
+    #[cutile::entry]
+    fn conditional_foreign_access<const BM: i32, const BN: i32, const BK: i32>(
+        z: &mut Tensor<f32, { [BK, BN] }>,
+        x: &Tensor<f32, { [-1, -1] }>,
+        y: &Tensor<f32, { [-1, -1] }>,
+        flag: i32,
+    ) {
+        let px = x.partition(const_shape![BM, BK]);
+        let py = y.partition(const_shape![BK, BN]);
+        for k in 0i32..num_tiles(&px, 1) {
+            if flag > 0i32 {
+                let ty = py.load([k, 0i32]);
+                z.store(ty);
+            }
+        }
+    }
+
+    /// The wide-tile idiom: a tile-block id indexes a partition directly —
+    /// no loop, no annotation. The block-id axiom rung must discharge the
+    /// access and stake a launch check on the grid instead. Root frame.
+    #[cutile::entry(deny_in_kernel_checks = true)]
+    fn block_id_indexed_load<const B: i32>(
+        z: &mut Tensor<f32, { [B] }>,
+        x: &Tensor<f32, { [-1] }>,
+    ) {
+        let p = x.partition(const_shape![B]);
+        let pid: (i32, i32, i32) = get_tile_block_id();
+        let t = p.load([pid.0]);
+        z.store(t);
+    }
+
+    /// The store side of the same idiom, through a mutable (view-framed)
+    /// partition: the staked launch check must be stated over the
+    /// kernel-visible view.
+    #[cutile::entry(deny_in_kernel_checks = true)]
+    fn block_id_indexed_store<const B: i32>(out: &mut Tensor<f32, { [-1] }>) {
+        let mut p = out.partition_mut(const_shape![B]);
+        let pid: (i32, i32, i32) = get_tile_block_id();
+        let t: Tile<f32, { [B] }> = constant(1.0, const_shape![B]);
+        p.store(t, [pid.0]);
+    }
+}
+
+use cutile_compiler::compile_api::CheckPlacementCounts;
+use inferred_module::__module_ast_self;
+
+fn artifacts(
+    name: &str,
+    generics: &[&str],
+    strides: &[(&str, &[i32])],
+) -> cutile_compiler::compile_api::CompileArtifacts {
+    let generics: Vec<String> = generics.iter().map(|s| s.to_string()).collect();
+    cutile_compiler::compile_api::KernelCompiler::new(__module_ast_self, "inferred_module", name)
+        .target("sm_120")
+        .generics(generics)
+        .strides(strides)
+        .options(CompileOptions::default())
+        .compile()
+        .unwrap_or_else(|e| panic!("compile {name}: {e}"))
+}
+
+/// `(discharged, hoisted, in_place, launch_checks)` for one kernel.
+fn counts(name: &str, generics: &[&str], strides: &[(&str, &[i32])]) -> (u32, u32, u32, usize) {
+    let generics: Vec<String> = generics.iter().map(|s| s.to_string()).collect();
+    let strides: Vec<(&str, &[i32])> = strides.to_vec();
+    let artifacts = cutile_compiler::compile_api::KernelCompiler::new(
+        __module_ast_self,
+        "inferred_module",
+        name,
+    )
+    .target("sm_120")
+    .generics(generics)
+    .strides(&strides)
+    .options(CompileOptions::default())
+    .compile()
+    .unwrap_or_else(|e| panic!("compile {name}: {e}"));
+    let CheckPlacementCounts {
+        discharged,
+        hoisted,
+        in_place,
+    } = artifacts.check_counts();
+    (
+        discharged,
+        hoisted,
+        in_place,
+        artifacts.launch_checks().len(),
+    )
+}
+
+// An ordinary `0..num_tiles(&p, 0)` loop must place its check exactly where
+// the `Dim`-iterating twin does: fully discharged, nothing left for the
+// device.
+#[test]
+fn plain_loop_matches_its_dim_loop_twin() {
+    common::with_test_stack(|| {
+        let strides: &[(&str, &[i32])] = &[("z", &[1]), ("x", &[1])];
+        let plain = counts("plain_loop", &["64"], strides);
+        let annotated = counts("dim_loop", &["64"], strides);
+        assert_eq!(
+            plain, annotated,
+            "unannotated loop placed its checks differently from the `Dim` twin \
+             (discharged, hoisted, in_place, launch)"
+        );
+        assert_eq!(
+            plain,
+            (1, 0, 0, 0),
+            "expected the access to discharge at compile time with no residual check"
+        );
+    });
+}
+
+// The same equality on a rank-2 partition, against the `with_bounds` twin.
+#[test]
+fn plain_loop_2d_matches_its_bounded_twin() {
+    common::with_test_stack(|| {
+        let strides: &[(&str, &[i32])] = &[("z", &[64, 1]), ("x", &[64, 1])];
+        let plain = counts("plain_loop_2d", &["64", "64"], strides);
+        let annotated = counts("bounded_loop_2d", &["64", "64"], strides);
+        assert_eq!(
+            plain, annotated,
+            "unannotated rank-2 loops placed their checks differently from the \
+             `with_bounds` twin (discharged, hoisted, in_place, launch)"
+        );
+        assert_eq!(
+            plain,
+            (2, 0, 0, 0),
+            "expected both axes to discharge at compile time"
+        );
+    });
+}
+
+// A shared-dimension GEMM: the loop axis belongs to `x`, but one access
+// indexes `y`. A declared `dim(x, 1) == dim(y, 0)` must carry the inferred
+// provenance across tensors, exactly as it does for `with_bounds` today.
+#[test]
+fn shared_dimension_gemm_discharges_across_tensors() {
+    common::with_test_stack(|| {
+        let got = counts(
+            "plain_shared_dim_gemm",
+            &["32", "32", "32"],
+            &[("z", &[32, 1]), ("x", &[32, 1]), ("y", &[32, 1])],
+        );
+        assert_eq!(
+            got,
+            (4, 0, 0, 2),
+            "expected all four coordinates to leave the kernel: `k` on `x`'s own \
+             axis and `k` on `y`'s axis via the declared equality, plus the two \
+             constant-0 coordinates as non-empty-extent checks at launch"
+        );
+    });
+}
+
+// Without a declared equality, iterating `x`'s axis still says nothing about
+// `y`'s extent — but the compiler can now DERIVE the fact it needs and have
+// the host check it, rather than demanding the author declare it. The access
+// leaves the kernel; the obligation does not disappear, it relocates. Both
+// halves matter, so both are asserted: the placement, and that the emitted
+// check actually rejects the shapes it exists to reject.
+#[test]
+fn undeclared_cross_tensor_access_relocates_to_launch() {
+    common::with_test_stack(|| {
+        use cutile::tile_kernel::validate_launch_checks;
+        let strides: &[(&str, &[i32])] = &[("z", &[32, 1]), ("x", &[32, 1]), ("y", &[32, 1])];
+        let (discharged, hoisted, in_place, _) = counts(
+            "plain_shared_dim_gemm_undeclared",
+            &["32", "32", "32"],
+            strides,
+        );
+        assert_eq!(
+            (discharged, hoisted + in_place),
+            (4, 0),
+            "with the fact derived rather than declared, nothing should remain \
+             in the kernel"
+        );
+
+        let artifacts = artifacts(
+            "plain_shared_dim_gemm_undeclared",
+            &["32", "32", "32"],
+            strides,
+        );
+        let checks = artifacts.launch_checks();
+        // Params in signature order: z, x, y. The derived fact is
+        // `dim(x, 1) <= dim(y, 0)`: the kernel walks x's k tiles into y's
+        // axis 0, so y short there is unsafe, and y LARGER is safe — the
+        // check must be an inequality, not an equality. Stating equality
+        // rejected the larger case (2026-08-05 review of `2ca6e3d`).
+        let matching = [vec![32i32, 32], vec![64, 128], vec![128, 64]];
+        assert!(
+            validate_launch_checks(checks, &matching, &matching, (1, 1, 1)).is_ok(),
+            "a launch whose shared dimension agrees must be accepted: {checks:?}"
+        );
+        let larger_y = [vec![32i32, 32], vec![64, 128], vec![256, 64]];
+        assert!(
+            validate_launch_checks(checks, &larger_y, &larger_y, (1, 1, 1)).is_ok(),
+            "a `y` larger than the walk needs is safe and must be accepted; \
+             rejecting it means the derived fact is an equality again: {checks:?}"
+        );
+        let short_y = [vec![32i32, 32], vec![64, 128], vec![96, 64]];
+        assert!(
+            validate_launch_checks(checks, &short_y, &short_y, (1, 1, 1)).is_err(),
+            "a launch whose `y` is short on the shared dimension must be \
+             rejected at launch: {checks:?}"
+        );
+        // Shorter in ELEMENTS but equal in TILES: ceil(100/32) == ceil(128/32)
+        // == 4, so every walked index is in range. The extent-form check
+        // rejected this band (issue #216); the tile-count form must accept.
+        let band_y = [vec![32i32, 32], vec![64, 128], vec![100, 64]];
+        assert!(
+            validate_launch_checks(checks, &band_y, &band_y, (1, 1, 1)).is_ok(),
+            "equal tile counts must be accepted even when the target is \
+             shorter in elements: {checks:?}"
+        );
+    });
+}
+
+// The grout shape, both spellings. `with_bounds` states the tie between the
+// mapped grid and `x`'s axes in the body and has the compiler verify it;
+// declared preconditions state the same tie in the signature and have the
+// launcher verify it. If the two place identically, the annotation is a
+// second way to say something the signature already says — which is what
+// deciding the annotation's future turns on.
+#[test]
+fn mapped_component_access_places_the_same_either_way() {
+    common::with_test_stack(|| {
+        let strides: &[(&str, &[i32])] = &[("z", &[256, 1]), ("x", &[256, 1])];
+        let bounded = counts(
+            "mapped_components_bounded",
+            &["32", "32", "4", "4"],
+            strides,
+        );
+        let declared = counts(
+            "mapped_components_declared",
+            &["32", "32", "4", "4"],
+            strides,
+        );
+        assert_eq!(
+            bounded, declared,
+            "the `with_bounds` and declared-precondition spellings placed their \
+             checks differently (discharged, hoisted, in_place, launch)"
+        );
+        assert_eq!(
+            declared.1 + declared.2,
+            0,
+            "neither spelling should leave a check in the kernel: {declared:?}"
+        );
+    });
+}
+
+// KNOWN LIMITATION — pinned so it cannot change silently, not because it is
+// desirable. A launch check is unconditional: it constrains every launch, even
+// ones where the access it guards never executes. Here the foreign load sits
+// behind `flag > 0`, yet the derived tile-count fact is still enforced at launch,
+// so a caller passing mismatched extents and `flag = 0` is rejected despite
+// running no offending access. Before cross-tensor facts relocated, that
+// caller got a device check inside the branch, which simply never fired.
+//
+// Fixing it means not lowering an obligation whose access is control-dependent
+// — trading hoisting coverage for not rejecting valid launches. That is a
+// design decision, not an oversight.
+// Name reviewed and approved by hme (2026-08-05): the length is fantastic.
+// It states the limitation being pinned, so whoever trips this failure knows
+// what changed before opening anything.
+#[test]
+fn control_dependent_access_still_imposes_an_unconditional_launch_check() {
+    common::with_test_stack(|| {
+        let artifacts = artifacts(
+            "conditional_foreign_access",
+            &["32", "32", "32"],
+            &[("z", &[32, 1]), ("x", &[32, 1]), ("y", &[32, 1])],
+        );
+        let causes: Vec<&str> = artifacts
+            .launch_checks()
+            .iter()
+            .map(|c| c.cause.as_str())
+            .collect();
+        assert!(
+            causes
+                .iter()
+                .any(|c| c.contains("ceil(dim(x, 1)/32) <= ceil(dim(y, 0)/32)")),
+            "the guarded access's extent fact is hoisted regardless of the \
+             condition guarding it; if this ever stops being true, the \
+             limitation documented here has been addressed: {causes:?}"
+        );
+    });
+}
+
+// A tile-block id is grid-bounded by the execution model — the one hardware
+// axiom the checker admits. It is NOT partition-bounded: the rung discharges
+// the in-kernel check only by staking a launch check that the grid fits the
+// axis's tile count, verified against the exact grid the kernel launches
+// with. Pinned per frame — a root-framed load and a view-framed store, both
+// compiled under deny_in_kernel_checks (the wide-tile kernel class from the
+// 2026-08 B200 evaluation carried 8-16 in-kernel checks for exactly this).
+#[test]
+fn block_id_index_discharges_against_the_launch_grid() {
+    common::with_test_stack(|| {
+        use cutile::tile_kernel::validate_launch_checks;
+
+        // Load, root frame. Compiling under deny already proves nothing
+        // stayed in the kernel; the counts and the staked check are pinned
+        // on top of that.
+        let strides: &[(&str, &[i32])] = &[("z", &[1]), ("x", &[1])];
+        let (_, hoisted, in_place, _) = counts("block_id_indexed_load", &["16"], strides);
+        assert_eq!(
+            (hoisted, in_place),
+            (0, 0),
+            "the block-id access must leave the kernel entirely"
+        );
+        let art = artifacts("block_id_indexed_load", &["16"], strides);
+        let checks = art.launch_checks();
+        assert!(
+            format!("{checks:?}").contains("num_tile_blocks(0)"),
+            "the discharge must stake a claim on the launch grid: {checks:?}"
+        );
+        // x has ceil(48/16) = 3 tiles: a grid of 3 launches, 4 must not.
+        let shapes = [vec![16i32], vec![48]];
+        assert!(
+            validate_launch_checks(checks, &shapes, &shapes, (3, 1, 1)).is_ok(),
+            "a grid inside the tile count must launch: {checks:?}"
+        );
+        assert!(
+            validate_launch_checks(checks, &shapes, &shapes, (4, 1, 1)).is_err(),
+            "a grid wider than the tile count must be rejected at launch: {checks:?}"
+        );
+        // A ragged final tile still counts: ceil(40/16) = 3.
+        let ragged = [vec![16i32], vec![40]];
+        assert!(
+            validate_launch_checks(checks, &ragged, &ragged, (3, 1, 1)).is_ok(),
+            "a partial final tile is still a tile: {checks:?}"
+        );
+
+        // Store, view frame.
+        let strides: &[(&str, &[i32])] = &[("out", &[1])];
+        let (_, hoisted, in_place, _) = counts("block_id_indexed_store", &["16"], strides);
+        assert_eq!((hoisted, in_place), (0, 0));
+        let art = artifacts("block_id_indexed_store", &["16"], strides);
+        let checks = art.launch_checks();
+        let shapes = [vec![48i32]];
+        assert!(validate_launch_checks(checks, &shapes, &shapes, (3, 1, 1)).is_ok());
+        assert!(
+            validate_launch_checks(checks, &shapes, &shapes, (4, 1, 1)).is_err(),
+            "the view-framed store must also be grid-gated: {checks:?}"
+        );
+    });
+}

--- a/cutile/tests/memory_and_atomic_ops.rs
+++ b/cutile/tests/memory_and_atomic_ops.rs
@@ -491,6 +491,32 @@ mod memory_and_atomic_ops_module {
 
 use memory_and_atomic_ops_module::__module_ast_self;
 
+#[cutile::module]
+mod atomic_red_view_module {
+    use cutile::core::*;
+    use cutile::tileir::*;
+
+    /// Split-K style accumulation: atomically reduce a tile into the
+    /// output view, no old values returned.
+    #[cutile::entry()]
+    unsafe fn atomic_red_view_kernel(output: &mut Tensor<f32, { [-1, -1] }>) {
+        let mut out_part: PartitionMut<f32, { [16, 16] }> =
+            output.partition_mut(const_shape![16, 16]);
+        let pid: (i32, i32, i32) = get_tile_block_id();
+        let tile: Tile<f32, { [16, 16] }> = constant(1.0f32, const_shape![16, 16]);
+        let _tok: Token = unsafe {
+            atomic_red_view_tko(
+                &mut out_part,
+                tile,
+                [pid.0, 0i32],
+                atomic::AddF,
+                ordering::Relaxed,
+                scope::Device,
+            )
+        };
+    }
+}
+
 fn compile_ir(function_name: &str, generics: &[String], strides: &[(&str, &[i32])]) -> String {
     common::compile_to_ir(
         __module_ast_self,
@@ -1066,5 +1092,181 @@ fn compile_padded_partition_view() -> () {
         );
 
         println!("\n✓ make_partition_view with neg_inf padding verified");
+    });
+}
+
+#[test]
+fn compile_atomic_red_view_tko() -> () {
+    common::with_test_stack(|| {
+        let module_op_str = common::compile_to_ir(
+            atomic_red_view_module::__module_ast_self,
+            "atomic_red_view_module",
+            "atomic_red_view_kernel",
+            &[],
+            &[("output", &[16, 1])],
+            &[],
+            &[],
+            None,
+            &CompileOptions::default(),
+        )
+        .expect("Failed.");
+        assert!(
+            module_op_str.contains("atomic_red_view_tko"),
+            "Expected atomic_red_view_tko operation in MLIR output.\n{module_op_str}"
+        );
+    });
+}
+
+// ── GatherScatterView / StridedView tests ─────────────────────────────────────
+
+#[cutile::module]
+mod gather_scatter_view_module {
+    use cutile::core::*;
+    use cutile::tileir::*;
+
+    #[cutile::entry()]
+    unsafe fn gsv_kernel(data: &Tensor<f32, { [-1, -1] }>) {
+        let tok: Token = new_token_unordered();
+        let gsv: GatherScatterView<f32, { [8, 64] }, 0> =
+            unsafe { make_gather_scatter_view(data, const_shape![8, 64], padding::None) };
+        let sparse_idx: Tile<i32, { [8] }> = constant(0i32, const_shape![8]);
+        let pid: (i32, i32, i32) = get_tile_block_id();
+        let (_tile, _tok): (Tile<f32, { [8, 64] }>, Token) = unsafe {
+            load_gather_scatter_view_tko(
+                &gsv,
+                sparse_idx,
+                pid.1,
+                tok,
+                ordering::Relaxed,
+                scope::TileBlock,
+            )
+        };
+    }
+}
+
+#[test]
+fn compile_make_gather_scatter_view() -> () {
+    common::with_test_stack(|| {
+        let module_op_str = common::compile_to_ir(
+            gather_scatter_view_module::__module_ast_self,
+            "gather_scatter_view_module",
+            "gsv_kernel",
+            &[],
+            &[("data", &[64, 64])],
+            &[],
+            &[],
+            None,
+            &CompileOptions::default(),
+        )
+        .expect("Failed.");
+        assert!(
+            module_op_str.contains("make_gather_scatter_view"),
+            "Expected make_gather_scatter_view in MLIR output.\n{module_op_str}"
+        );
+        assert!(
+            module_op_str.contains("load_view_tko"),
+            "Expected load_view_tko in MLIR output.\n{module_op_str}"
+        );
+    });
+}
+
+#[cutile::module]
+mod strided_view_module {
+    use cutile::core::*;
+    use cutile::tileir::*;
+
+    #[cutile::entry()]
+    unsafe fn sv_kernel(data: &Tensor<f32, { [-1, -1] }>) {
+        let tok: Token = new_token_unordered();
+        let sv: StridedView<f32, { [16, 16] }, { [2, 1] }, { [0, 1] }> =
+            unsafe { make_strided_view(data, const_shape![16, 16], padding::None) };
+        let pid: (i32, i32, i32) = get_tile_block_id();
+        let (_tile, _tok): (Tile<f32, { [16, 16] }>, Token) = unsafe {
+            load_strided_view_tko(
+                &sv,
+                [pid.0, pid.1],
+                tok,
+                ordering::Relaxed,
+                scope::TileBlock,
+            )
+        };
+    }
+}
+
+#[test]
+fn compile_make_strided_view() -> () {
+    common::with_test_stack(|| {
+        let module_op_str = common::compile_to_ir(
+            strided_view_module::__module_ast_self,
+            "strided_view_module",
+            "sv_kernel",
+            &[],
+            &[("data", &[64, 64])],
+            &[],
+            &[],
+            None,
+            &CompileOptions::default(),
+        )
+        .expect("Failed.");
+        assert!(
+            module_op_str.contains("make_strided_view"),
+            "Expected make_strided_view in MLIR output.\n{module_op_str}"
+        );
+        assert!(
+            module_op_str.contains("load_view_tko"),
+            "Expected load_view_tko in MLIR output.\n{module_op_str}"
+        );
+    });
+}
+
+// A non-identity `DIM_MAP` so the emitted type actually carries it: the fmt
+// omits `dim_map` when it is the identity permutation, so an identity map
+// cannot distinguish "DIM_MAP threaded" from "DIM_MAP dropped".
+#[cutile::module]
+mod strided_view_permuted_module {
+    use cutile::core::*;
+    use cutile::tileir::*;
+
+    #[cutile::entry()]
+    unsafe fn sv_permuted_kernel(data: &Tensor<f32, { [-1, -1] }>) {
+        let tok: Token = new_token_unordered();
+        let sv: StridedView<f32, { [16, 16] }, { [2, 1] }, { [1, 0] }> =
+            unsafe { make_strided_view(data, const_shape![16, 16], padding::None) };
+        let pid: (i32, i32, i32) = get_tile_block_id();
+        let (_tile, _tok): (Tile<f32, { [16, 16] }>, Token) = unsafe {
+            load_strided_view_tko(
+                &sv,
+                [pid.0, pid.1],
+                tok,
+                ordering::Relaxed,
+                scope::TileBlock,
+            )
+        };
+    }
+}
+
+#[test]
+fn compile_strided_view_threads_dim_map() -> () {
+    common::with_test_stack(|| {
+        let module_op_str = common::compile_to_ir(
+            strided_view_permuted_module::__module_ast_self,
+            "strided_view_permuted_module",
+            "sv_permuted_kernel",
+            &[],
+            &[("data", &[64, 64])],
+            &[],
+            &[],
+            None,
+            &CompileOptions::default(),
+        )
+        .expect("Failed.");
+        assert!(
+            module_op_str.contains("traversal_strides=[2,1]"),
+            "Expected traversal_strides=[2,1] in MLIR output.\n{module_op_str}"
+        );
+        assert!(
+            module_op_str.contains("dim_map=[1,0]"),
+            "Expected dim_map=[1,0] in MLIR output.\n{module_op_str}"
+        );
     });
 }

--- a/cutile/tests/nested_partition_mut.rs
+++ b/cutile/tests/nested_partition_mut.rs
@@ -48,11 +48,11 @@ mod nested_partition_mut_module {
 
         let input_part: Partition<f32, { [1, BLOCK] }> = input.partition(const_shape![1, BLOCK]);
         let mut out_part: PartitionMut<f32, { [1, BLOCK] }> =
-            unsafe { out.partition_mut(const_shape![1, BLOCK]) };
+            out.partition_mut(const_shape![1, BLOCK]);
 
         for j in 0i32..((N + BLOCK - 1) / BLOCK) {
             let tile: Tile<f32, { [1, BLOCK] }> = input_part.load([row, j]);
-            unsafe { out_part.store(tile, [0i32, j]) };
+            out_part.store(tile, [0i32, j]);
         }
     }
 
@@ -68,11 +68,11 @@ mod nested_partition_mut_module {
         let input_part: Partition<f32, { [1, 1, BLOCK] }> =
             input.partition(const_shape![1, 1, BLOCK]);
         let mut out_part: PartitionMut<f32, { [1, 1, BLOCK] }> =
-            unsafe { out.partition_mut(const_shape![1, 1, BLOCK]) };
+            out.partition_mut(const_shape![1, 1, BLOCK]);
 
         for j in 0i32..((N + BLOCK - 1) / BLOCK) {
             let tile: Tile<f32, { [1, 1, BLOCK] }> = input_part.load([row, head, j]);
-            unsafe { out_part.store(tile, [0i32, 0i32, j]) };
+            out_part.store(tile, [0i32, 0i32, j]);
         }
     }
 }

--- a/cutile/tests/optimization_hints.rs
+++ b/cutile/tests/optimization_hints.rs
@@ -2,6 +2,11 @@
  * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
+
+// These kernels pin the behaviour of the deprecated annotation path, which
+// must keep working unchanged until it is removed.
+#![allow(deprecated)]
+
 use cutile;
 use cutile_compiler::compiler::utils::CompileOptions;
 
@@ -11,7 +16,7 @@ mod common;
 mod opt_hints_module {
     use cutile::core::*;
 
-    #[cutile::entry()]
+    #[cutile::entry]
     fn load_ptr_latency_kernel<const S: [i32; 1]>(output: &mut Tensor<f32, S>) {
         let ptr_seed: Tile<i64, S> = constant(0i64, output.shape());
         let ptrs_i64: PointerTile<*mut i64, S> = int_to_ptr(ptr_seed);
@@ -28,7 +33,7 @@ mod opt_hints_module {
         output.store(loaded);
     }
 
-    #[cutile::entry()]
+    #[cutile::entry]
     fn store_ptr_latency_kernel<const S: [i32; 1]>(output: &mut Tensor<f32, S>) {
         let ptr_seed: Tile<i64, S> = constant(0i64, output.shape());
         let ptrs_i64: PointerTile<*mut i64, S> = int_to_ptr(ptr_seed);
@@ -46,7 +51,7 @@ mod opt_hints_module {
         output.store(vals);
     }
 
-    #[cutile::entry()]
+    #[cutile::entry]
     fn option_bindings_for_optional_operands_kernel<const S: [i32; 1]>(
         output: &mut Tensor<f32, S>,
     ) {
@@ -84,7 +89,7 @@ mod opt_hints_module {
         output.store(loaded);
     }
 
-    #[cutile::entry()]
+    #[cutile::entry]
     fn load_view_latency_kernel<const S: [i32; 1]>(input: &Tensor<f32, S>) {
         let token: Token = new_token_unordered();
         let shape = input.shape();
@@ -101,7 +106,7 @@ mod opt_hints_module {
         );
     }
 
-    #[cutile::entry()]
+    #[cutile::entry]
     fn store_view_disallow_tma_kernel<const S: [i32; 1]>(y: &mut Tensor<f32, S>) {
         let shape = y.shape();
         let token: Token = get_tensor_token(y);
@@ -143,7 +148,7 @@ mod opt_hints_module {
     }
 
     /// Latency as a const generic — specialized at launch time.
-    #[cutile::entry()]
+    #[cutile::entry]
     fn load_view_const_latency_kernel<const S: [i32; 1], const L: i32>(input: &Tensor<f32, S>) {
         let token: Token = new_token_unordered();
         let shape = input.shape();
@@ -158,6 +163,455 @@ mod opt_hints_module {
             Some(L),
             tma::Enabled,
         );
+    }
+
+    /// Safe checked load with a literal latency hint.
+    #[cutile::entry]
+    fn safe_load_pipelined_kernel<const S: [i32; 1]>(
+        z: &mut Tensor<f32, S>,
+        x: &Tensor<f32, { [-1] }>,
+    ) {
+        let part = x.partition(const_shape!(S));
+        let tile = part.load_pipelined::<6>([0]);
+        z.store(tile);
+    }
+
+    /// Safe checked load with the latency hint from a kernel const generic.
+    #[cutile::entry]
+    fn safe_load_pipelined_const_kernel<const S: [i32; 1], const L: i32>(
+        z: &mut Tensor<f32, S>,
+        x: &Tensor<f32, { [-1] }>,
+    ) {
+        let part = x.partition(const_shape!(S));
+        let tile = part.load_pipelined::<L>([0]);
+        z.store(tile);
+    }
+
+    /// Two loads with different latency hints in one kernel: each must keep
+    /// its own hint (not last-wins).
+    #[cutile::entry]
+    fn safe_load_two_latencies_kernel<const S: [i32; 1]>(
+        z: &mut Tensor<f32, S>,
+        x: &Tensor<f32, { [-1] }>,
+        y: &Tensor<f32, { [-1] }>,
+    ) {
+        let part_x = x.partition(const_shape!(S));
+        let part_y = y.partition(const_shape!(S));
+        let tile_x = part_x.load_pipelined::<3>([0]);
+        let tile_y = part_y.load_pipelined::<9>([0]);
+        z.store(tile_x + tile_y);
+    }
+
+    /// Safe bounded load with a latency hint: the proof path (`with_bounds`
+    /// + `coord`) and the pipelining knob compose.
+    #[cutile::entry]
+    fn safe_bounded_load_pipelined_kernel<const BM: i32, const BN: i32>(
+        z: &mut Tensor<f32, { [BM, BN] }>,
+        x: &Tensor<f32, { [-1, -1] }>,
+    ) {
+        let m = Dim::new(x.shape()[0] / BM);
+        let n = Dim::new(x.shape()[1] / BN);
+        let part = x.partition(const_shape![BM, BN]).with_bounds((m, n));
+        for i in m {
+            for j in n {
+                let tile = part.load_pipelined::<7>(coord((i, j)));
+                z.store(tile);
+            }
+        }
+    }
+
+    /// The two-statement spelling: `partition_mut` bound to a name, then
+    /// `with_bounds` on the binding. Semantically identical to the chained
+    /// form, and it once failed typeck at the subsequent `.store(..)` — this
+    /// kernel keeps that path compiling, with both bindings folding against
+    /// the declared `[1, N]` shape.
+    #[cutile::entry]
+    fn two_stmt_with_bounds<const N: i32, const B: i32>(out: &mut Tensor<f32, { [1, N] }>) {
+        let cols = Dim::new(N / B);
+        let out_part = out.partition_mut(const_shape![1, B]);
+        let mut out_part = out_part.with_bounds((Dim::new(1), cols));
+        for j in cols {
+            let t: Tile<f32, { [1, B] }> = constant(0.0, const_shape![1, B]);
+            out_part.store(t, coord((0i32, j)));
+        }
+    }
+
+    /// The shared-extent pattern (Theorem 2): one `Dim`, derived from `x`'s
+    /// contraction extent, bound to an axis of *both* partitions — the GEMM
+    /// spelling. The declared precondition states the extents are equal, so
+    /// the cross-tensor binding discharges from that fact plus the numerator's
+    /// own divisibility check: zero in-kernel asserts.
+    #[cutile::entry(
+        preconditions = (
+            dim(x, 1) == dim(y, 0),
+        )
+    )]
+    fn shared_dim_binding<const BM: i32, const BK: i32>(
+        z: &mut Tensor<f32, { [BM, BK] }>,
+        x: &Tensor<f32, { [-1, -1] }>,
+        y: &Tensor<f32, { [-1, -1] }>,
+    ) {
+        let m = Dim::new(x.shape()[0] / BM);
+        let k = Dim::new(x.shape()[1] / BK);
+        let n = Dim::new(y.shape()[1] / BM);
+        let xp = x.partition(const_shape![BM, BK]).with_bounds((m, k));
+        let yp = y.partition(const_shape![BK, BM]).with_bounds((k, n));
+        for i in m {
+            for j in k {
+                let tx = xp.load(coord((i, j)));
+                z.store(tx);
+            }
+        }
+        for j in k {
+            for l in n {
+                let ty = yp.load(coord((j, l)));
+                z.store(ty.transpose());
+            }
+        }
+    }
+
+    /// Fail-closed twin of `shared_dim_binding`: same kernel, no declared
+    /// equality. The cross-tensor binding must NOT hoist — an unproven extent
+    /// equality is strictly stronger than the tile-count equality the binding
+    /// obliges, so hoisting it unasked would reject launches the device assert
+    /// accepts. It stays a device assert until the kernel opts in.
+    #[cutile::entry]
+    fn shared_dim_binding_undeclared<const BM: i32, const BK: i32>(
+        z: &mut Tensor<f32, { [BM, BK] }>,
+        x: &Tensor<f32, { [-1, -1] }>,
+        y: &Tensor<f32, { [-1, -1] }>,
+    ) {
+        let m = Dim::new(x.shape()[0] / BM);
+        let k = Dim::new(x.shape()[1] / BK);
+        let n = Dim::new(y.shape()[1] / BM);
+        let xp = x.partition(const_shape![BM, BK]).with_bounds((m, k));
+        let yp = y.partition(const_shape![BK, BM]).with_bounds((k, n));
+        for i in m {
+            for j in k {
+                let tx = xp.load(coord((i, j)));
+                z.store(tx);
+            }
+        }
+        for j in k {
+            for l in n {
+                let ty = yp.load(coord((j, l)));
+                z.store(ty.transpose());
+            }
+        }
+    }
+
+    /// Declared divisibility, the payoff of stating binding obligations over
+    /// the extent atom: with `dim(x, k) % 64 == 0` declared (and so verified by
+    /// the launcher before the kernel runs), both binding obligations are
+    /// entailed at JIT. No in-kernel assert, and no launch check either -- the
+    /// declared facts already carry the verification.
+    #[cutile::entry(
+        preconditions = (
+            dim(x, 0) % 64 == 0,
+            dim(x, 1) % 64 == 0,
+        )
+    )]
+    fn declared_divisibility_binding<const BM: i32, const BN: i32>(
+        z: &mut Tensor<f32, { [BM, BN] }>,
+        x: &Tensor<f32, { [-1, -1] }>,
+    ) {
+        let m = Dim::new(x.shape()[0] / BM);
+        let n = Dim::new(x.shape()[1] / BN);
+        let part = x.partition(const_shape![BM, BN]).with_bounds((m, n));
+        for i in m {
+            for j in n {
+                let tile = part.load(coord((i, j)));
+                z.store(tile);
+            }
+        }
+    }
+
+    /// SOUNDNESS PROBE (immutable / read side): the same unvalidated contract on
+    /// `Tensor::partition`, which has been safe on `main` all along. The declared
+    /// row bound is absurd (999); nothing checks it against the view's tile count.
+    #[cutile::entry]
+    fn with_bounds_bogus_dim_load<const BM: i32, const BN: i32>(
+        z: &mut Tensor<f32, { [BM, BN] }>,
+        x: &Tensor<f32, { [-1, -1] }>,
+    ) {
+        let bogus_rows = Dim::new(999);
+        let n = Dim::new(x.shape()[1] / BN);
+        let part = x
+            .partition(const_shape![BM, BN])
+            .with_bounds((bogus_rows, n));
+        for i in bogus_rows {
+            for j in n {
+                let tile = part.load(coord((i, j)));
+                z.store(tile);
+            }
+        }
+    }
+
+    /// SOUNDNESS PROBE: `with_bounds` is an *unvalidated* contract — the `Dim`
+    /// value is never checked against the view's real tile count. The declared
+    /// row bound here is absurd (999) for a single-row view, yet the branded
+    /// store discharges and no check is emitted. This is safe Rust: it must be
+    /// rejected, or the bound must become a verified `Launch` obligation.
+    #[cutile::entry]
+    fn with_bounds_bogus_dim<const N: i32, const BLOCK_SIZE: i32>(
+        out: &mut Tensor<f32, { [1, N] }>,
+    ) {
+        let cols = Dim::new(N / BLOCK_SIZE);
+        let bogus_rows = Dim::new(999);
+        let tile_shape = const_shape![1, BLOCK_SIZE];
+        let mut out_part = out
+            .partition_mut(tile_shape)
+            .with_bounds((bogus_rows, cols));
+        for i in bogus_rows {
+            for j in cols {
+                let tile: Tile<f32, { [1, BLOCK_SIZE] }> = constant(0.0, tile_shape);
+                out_part.store(tile, coord((i, j)));
+            }
+        }
+    }
+
+    /// Mutable mirror of `with_bounds`: `partition_mut` → `with_bounds` →
+    /// branded-coord `store`. The row is re-based (constant `0`) so only the
+    /// branded column index `j` varies — the raw kernel's tight store shape.
+    #[cutile::entry]
+    fn bounded_mut_store_smoke<const N: i32, const BLOCK_SIZE: i32>(
+        out: &mut Tensor<f32, { [1, N] }>,
+    ) {
+        let num_tiles = N / BLOCK_SIZE;
+        let cols = Dim::new(num_tiles);
+        let tile_shape = const_shape![1, BLOCK_SIZE];
+        let mut out_part = out
+            .partition_mut(tile_shape)
+            .with_bounds((Dim::new(1), cols));
+        for j in cols {
+            let tile: Tile<f32, { [1, BLOCK_SIZE] }> = constant(0.0, tile_shape);
+            out_part.store(tile, coord((0i32, j)));
+        }
+    }
+
+    /// The launch-hoist rungs with a *genuinely* dynamic extent: the row count
+    /// is declared `-1`, so no compile-time source can decide either the
+    /// binding `tiles(out, 0) == 1` or the constant row-`0` access. Both leave
+    /// the kernel for the host, in the *view* frame — a `&mut Tensor` is
+    /// slabbed, so the checks are over the per-CTA slab extent, not the root.
+    ///
+    /// Contrast `bounded_mut_store_smoke`, whose `[1, N]` signature pins the row
+    /// extent: there everything discharges at compile time and no launch check
+    /// is produced at all.
+    #[cutile::entry]
+    fn hoisted_dynamic_row_store<const N: i32, const BLOCK_SIZE: i32>(
+        out: &mut Tensor<f32, { [-1, N] }>,
+    ) {
+        let num_tiles = N / BLOCK_SIZE;
+        let cols = Dim::new(num_tiles);
+        let tile_shape = const_shape![1, BLOCK_SIZE];
+        let mut out_part = out
+            .partition_mut(tile_shape)
+            .with_bounds((Dim::new(1), cols));
+        for j in cols {
+            let tile: Tile<f32, { [1, BLOCK_SIZE] }> = constant(0.0, tile_shape);
+            out_part.store(tile, coord((0i32, j)));
+        }
+    }
+
+    /// Raw (unchecked) twin of `bounded_mut_store_smoke`: the identical store
+    /// loop via `partition_mut` + an unchecked `store`, with no bounds check at
+    /// all. This is the register baseline the hoisted safe store must match —
+    /// the two kernels differ only in the store's safety, so any register delta
+    /// is exactly the cost of the store's bounds check.
+    #[cutile::entry(unchecked_accesses = true)]
+    unsafe fn unchecked_mut_store_smoke<const N: i32, const BLOCK_SIZE: i32>(
+        out: &mut Tensor<f32, { [1, N] }>,
+    ) {
+        let num_tiles = N / BLOCK_SIZE;
+        let tile_shape = const_shape![1, BLOCK_SIZE];
+        let mut out_part = out.partition_mut(tile_shape);
+        for j in 0i32..num_tiles {
+            let tile: Tile<f32, { [1, BLOCK_SIZE] }> = constant(0.0, tile_shape);
+            out_part.store(tile, [0i32, j]);
+        }
+    }
+
+    /// A safe bounded store whose row is a tile-block id (`get_tile_block_id().0`)
+    /// into a dynamic-row `&mut Tensor` — the owned-axis (per-CTA row) pattern.
+    /// The row-axis access `TileBlockId(0) < num_partitions(out, 0)` discharges
+    /// at JIT via the universal hardware axiom `TileBlockId(0) < NumTileBlocks(0)`
+    /// (the direct partition's launch grid is verified equal to its partition
+    /// grid), so NO in-kernel bounds check is emitted for the row axis.
+    #[cutile::entry]
+    fn blockid_row_store<const N: i32, const BLOCK_SIZE: i32>(out: &mut Tensor<f32, { [-1, N] }>) {
+        let cols = Dim::new(N / BLOCK_SIZE);
+        let rows = Dim::new(get_num_tile_blocks().0);
+        let tile_shape = const_shape![1, BLOCK_SIZE];
+        let pid: (i32, i32, i32) = get_tile_block_id();
+        let row = pid.0;
+        let mut out_part = out.partition_mut(tile_shape).with_bounds((rows, cols));
+        for j in cols {
+            let tile: Tile<f32, { [1, BLOCK_SIZE] }> = constant(0.0, tile_shape);
+            out_part.store(tile, coord((row, j)));
+        }
+    }
+
+    /// Negative: a block-id whose *component* does not match the axis it indexes
+    /// must be rejected. Here grid component 1 (`pid.1`) is used as the row (axis
+    /// 0): `TileBlockId(1) < NumTileBlocks(1)` does not bound `num_partitions(out,
+    /// 0)`, so the discharge must not fire — the correspondence gate is `k == axis`.
+    #[cutile::entry]
+    fn blockid_wrong_axis_store<const N: i32, const BLOCK_SIZE: i32>(
+        out: &mut Tensor<f32, { [-1, N] }>,
+    ) {
+        let cols = Dim::new(N / BLOCK_SIZE);
+        let rows = Dim::new(get_num_tile_blocks().0);
+        let tile_shape = const_shape![1, BLOCK_SIZE];
+        let pid: (i32, i32, i32) = get_tile_block_id();
+        let wrong = pid.1; // component 1 used as the axis-0 row
+        let mut out_part = out.partition_mut(tile_shape).with_bounds((rows, cols));
+        for j in cols {
+            let tile: Tile<f32, { [1, BLOCK_SIZE] }> = constant(0.0, tile_shape);
+            out_part.store(tile, coord((wrong, j)));
+        }
+    }
+
+    /// Raw (unchecked) twin of `blockid_row_store` — same loop, unchecked store.
+    #[cutile::entry(unchecked_accesses = true)]
+    unsafe fn unchecked_blockid_row_store<const N: i32, const BLOCK_SIZE: i32>(
+        out: &mut Tensor<f32, { [-1, N] }>,
+    ) {
+        let num_tiles = N / BLOCK_SIZE;
+        let tile_shape = const_shape![1, BLOCK_SIZE];
+        let pid: (i32, i32, i32) = get_tile_block_id();
+        let row = pid.0;
+        let mut out_part = out.partition_mut(tile_shape);
+        for j in 0i32..num_tiles {
+            let tile: Tile<f32, { [1, BLOCK_SIZE] }> = constant(0.0, tile_shape);
+            out_part.store(tile, [row, j]);
+        }
+    }
+
+    /// A checked load whose index (`2 * tile-block id`) is not provably in
+    /// bounds — the block-id axiom gives `pid.0 < gridDim.0` but says nothing
+    /// about `2 * pid.0`, so a bounds check must remain in the kernel. Compiles
+    /// normally: the residual check is emitted in-kernel.
+    #[cutile::entry]
+    fn residual_in_kernel_check<const BM: i32, const BN: i32>(
+        z: &mut Tensor<f32, { [BM, BN] }>,
+        x: &Tensor<f32, { [-1, -1] }>,
+    ) {
+        let part = x.partition(const_shape![BM, BN]);
+        let pid = get_tile_block_id();
+        let tile: Tile<f32, { [BM, BN] }> = part.load([pid.0 * 2i32, pid.1]);
+        z.store(tile);
+    }
+
+    /// Identical body under `deny_in_kernel_checks`: the residual bounds check
+    /// makes this a hard JIT error naming the axis that could not leave the
+    /// kernel. (Contrast `unchecked_accesses`, which would drop the check.)
+    #[cutile::entry(deny_in_kernel_checks = true)]
+    fn residual_in_kernel_check_denied<const BM: i32, const BN: i32>(
+        z: &mut Tensor<f32, { [BM, BN] }>,
+        x: &Tensor<f32, { [-1, -1] }>,
+    ) {
+        let part = x.partition(const_shape![BM, BN]);
+        let pid = get_tile_block_id();
+        let tile: Tile<f32, { [BM, BN] }> = part.load([pid.0 * 2i32, pid.1]);
+        z.store(tile);
+    }
+
+    /// DENY-COVERAGE PROBE: `deny_in_kernel_checks` must cover *every*
+    /// compiler-emitted safety check, not just the partition-access one. Here
+    /// the view extent is dynamic, so the `with_bounds` binding obligation
+    /// cannot fold at JIT and lands as an in-kernel assert — a residual check
+    /// that costs device registers, which is exactly what the attribute
+    /// forbids.
+    #[cutile::entry(deny_in_kernel_checks = true)]
+    fn with_bounds_binding_check_denied<const BM: i32, const BN: i32>(
+        out: &mut Tensor<f32, { [-1, -1] }>,
+    ) {
+        // A special-register-derived bound has no symbolic form at any stage
+        // below Device: it cannot fold and cannot hoist, so it must be
+        // rejected under the flag.
+        let rows = Dim::new(get_num_tile_blocks().0);
+        let cols = Dim::new(get_num_tile_blocks().1);
+        let tile_shape = const_shape![BM, BN];
+        let mut out_part = out.partition_mut(tile_shape).with_bounds((rows, cols));
+        for i in rows {
+            for j in cols {
+                let tile: Tile<f32, { [BM, BN] }> = constant(0.0, tile_shape);
+                out_part.store(tile, coord((i, j)));
+            }
+        }
+    }
+
+    /// DENY-COVERAGE: the mapped sub-range family. Runtime range bounds cannot
+    /// fold at compile time and are not launch-known, so the range assert is a
+    /// residual in-kernel check — which the flag must reject, exactly as it
+    /// rejects the access and binding families.
+    #[cutile::entry(deny_in_kernel_checks = true)]
+    unsafe fn subrange_check_denied<const BM: i32, const BN: i32, const MAP_SHAPE: [i32; 2]>(
+        mut z: MappedPartitionMut<f32, { [BM, BN] }, MAP_SHAPE>,
+        start_tile: i32,
+        n_tiles: i32,
+    ) {
+        for index in z.iter_indices_within([(start_tile, n_tiles), (0i32, -1i32)]) {
+            let tile: Tile<f32, { [BM, BN] }> = constant(0.0, const_shape![BM, BN]);
+            z.store(tile, index);
+        }
+    }
+
+    /// POSITIVE CONTROL: every check discharges at compile time, so the flag
+    /// must ACCEPT this. Without a case like it, a bug that made the flag
+    /// always reject would pass the whole suite.
+    #[cutile::entry(deny_in_kernel_checks = true)]
+    fn deny_accepts_fully_discharged<const N: i32, const BLOCK: i32>(
+        out: &mut Tensor<f32, { [1, N] }>,
+    ) {
+        let tile_shape = const_shape![1, BLOCK];
+        let mut p = out.partition_mut(tile_shape);
+        for j in 0i32..num_tiles(&p, 1) {
+            let tile: Tile<f32, { [1, BLOCK] }> = constant(0.0, tile_shape);
+            p.store(tile, [0i32, j]);
+        }
+    }
+
+    /// POSITIVE CONTROL: nothing here discharges at compile time — the foreign
+    /// access into `y` needs a fact no precondition declares. It compiles under
+    /// the flag only because that fact is derived and checked on the host
+    /// (measured: 3 launch checks), so this pins the flag and launch-hoisting
+    /// working together. If the hoist regressed, this kernel stops building.
+    #[cutile::entry(deny_in_kernel_checks = true)]
+    fn deny_accepts_relocated_cross_tensor<const BM: i32, const BN: i32, const BK: i32>(
+        z: &mut Tensor<f32, { [BM, BN] }>,
+        x: &Tensor<f32, { [-1, -1] }>,
+        y: &Tensor<f32, { [-1, -1] }>,
+    ) {
+        let px = x.partition(const_shape![BM, BK]);
+        let py = y.partition(const_shape![BK, BN]);
+        let mut acc: Tile<f32, { [BM, BN] }> = constant(0.0, const_shape![BM, BN]);
+        for k in 0i32..num_tiles(&px, 1) {
+            let tx = px.load([0i32, k]);
+            let ty = py.load([k, 0i32]);
+            acc = mma(tx, ty, acc);
+        }
+        z.store(acc);
+    }
+
+    /// Non-denied twin of `with_bounds_binding_check_denied`: two bindings that
+    /// can fold nowhere and hoist nowhere (special-register-derived), so both
+    /// need the runtime tile count -- and must share one index-space query.
+    #[cutile::entry]
+    fn with_bounds_binding_check_unchecked<const BM: i32, const BN: i32>(
+        out: &mut Tensor<f32, { [-1, -1] }>,
+    ) {
+        let rows = Dim::new(get_num_tile_blocks().0);
+        let cols = Dim::new(get_num_tile_blocks().1);
+        let tile_shape = const_shape![BM, BN];
+        let mut out_part = out.partition_mut(tile_shape).with_bounds((rows, cols));
+        for i in rows {
+            for j in cols {
+                let tile: Tile<f32, { [BM, BN] }> = constant(0.0, tile_shape);
+                out_part.store(tile, coord((i, j)));
+            }
+        }
     }
 }
 
@@ -176,6 +630,455 @@ fn compile_kernel(name: &str, strides: &[(&str, &[i32])], options: &CompileOptio
         options,
     )
     .expect("Failed to compile")
+}
+
+// The re-based row axis of a mutable partition is dynamic (extent set per-block
+// at launch), so the constant `0` row coordinate cannot be discharged by the
+// constant rung, which needs a static axis extent. Launch-time check hoisting
+// resolves it: the safety condition reduces to `extent(out, 0) > 0`, a
+// launch-known predicate, so the check is evacuated to a host `validate_launch`
+// and NO in-kernel bounds assert is emitted — the store lowers with zero
+// bounds-check registers.
+#[test]
+fn bounded_mut_store_lowers() {
+    common::with_test_stack(|| {
+        let mlir = common::compile_to_ir(
+            __module_ast_self,
+            "opt_hints_module",
+            "bounded_mut_store_smoke",
+            &["256".to_string(), "64".to_string()],
+            &[("out", &[256, 1])],
+            &[],
+            &[],
+            None,
+            &CompileOptions::default(),
+        )
+        .expect("Failed to compile bounded_mut_store_smoke");
+        println!("{mlir}");
+        assert!(
+            mlir.contains("store_view_tko"),
+            "expected store_view_tko in MLIR:\n{mlir}"
+        );
+        // The row bounds check was hoisted to launch, not emitted in-kernel.
+        assert!(
+            !mlir.contains("out of bounds"),
+            "row bounds check must be hoisted to launch, not emitted in-kernel:\n{mlir}"
+        );
+    });
+}
+
+/// Compiles a kernel from `opt_hints_module` all the way to a cubin and returns
+/// its device register count via `cuobjdump --dump-resource-usage`. This is pure
+/// compilation — `tileiras` + `cuobjdump`, no kernel execution — so it runs
+/// anywhere those tools are present, no GPU launch required.
+fn kernel_register_count(
+    function_name: &str,
+    generics: &[&str],
+    strides: &[(&str, &[i32])],
+) -> u32 {
+    use cutile::compile_api::KernelCompiler;
+    let generics: Vec<String> = generics.iter().map(|s| s.to_string()).collect();
+    let artifacts = KernelCompiler::new(__module_ast_self, "opt_hints_module", function_name)
+        .target("sm_120")
+        .generics(generics)
+        .strides(strides)
+        .compile()
+        .expect("compile to Tile IR");
+    // compile_tile_ir_module returns the cubin BYTES since the on-disk cache
+    // landed (#193); cuobjdump wants a file, so write them to a temp path.
+    let cubin = cutile_compiler::cuda_tile_runtime_utils::compile_tile_ir_module(
+        artifacts.module(),
+        "sm_120",
+    )
+    .expect("compile Tile IR to cubin");
+    let cubin_path = std::env::temp_dir().join(format!(
+        "cutile_regcount_{}_{}.cubin",
+        function_name,
+        std::process::id()
+    ));
+    std::fs::write(&cubin_path, &cubin).expect("write cubin for cuobjdump");
+    let output = std::process::Command::new("cuobjdump")
+        .arg("--dump-resource-usage")
+        .arg(&cubin_path)
+        .output()
+        .expect("run cuobjdump");
+    let _ = std::fs::remove_file(&cubin_path);
+    let text = String::from_utf8_lossy(&output.stdout);
+    // cuobjdump prints e.g. `REG:40 STACK:0 SHARED:0 ...` per function; take the
+    // max across functions (the entry is the register-heaviest).
+    text.split_whitespace()
+        .filter_map(|tok| tok.strip_prefix("REG:").and_then(|n| n.parse::<u32>().ok()))
+        .max()
+        .unwrap_or_else(|| {
+            panic!("no register count in cuobjdump output for {function_name}:\n{text}")
+        })
+}
+
+// The safe bounded store hoists its bounds check to launch, so the safe kernel
+// must reach the raw unchecked store's register count — the whole point of
+// launch-time check hoisting. Asserts the invariant (safe <= raw), not a brittle
+// golden number, so it survives future codegen changes.
+#[test]
+fn bounded_store_matches_raw_register_count() {
+    // Requires the CUDA offline toolchain (tileiras + cuobjdump). Skip cleanly
+    // where it is absent rather than fail (cf. LLVM lit `REQUIRES:`).
+    if std::process::Command::new("cuobjdump")
+        .arg("--version")
+        .output()
+        .is_err()
+    {
+        eprintln!("skipping bounded_store_matches_raw_register_count: cuobjdump not available");
+        return;
+    }
+    common::with_test_stack(|| {
+        let generics = ["256", "64"];
+        let strides: &[(&str, &[i32])] = &[("out", &[256, 1])];
+        let safe = kernel_register_count("bounded_mut_store_smoke", &generics, strides);
+        let raw = kernel_register_count("unchecked_mut_store_smoke", &generics, strides);
+        eprintln!("register counts: safe={safe}, raw={raw}");
+        assert!(
+            safe <= raw,
+            "hoisted safe store must not exceed the raw store's registers: safe={safe}, raw={raw}"
+        );
+    });
+}
+
+// A per-CTA row store indexed by a tile-block id must NOT be discharged: the
+// launch grid counts CTA *slabs* (`div_ceil(root_shape, slab_shape)`, what
+// `validate_grids` checks) while the access needs the tile count *within* the
+// kernel-visible view. Those are unrelated, so `TileBlockId(0) < NumTileBlocks(0)`
+// does not bound this access. A rung that discharged it (by proving the axiom
+// against itself) admitted out-of-bounds stores and was reverted; until the real
+// fix lands — form the actual proposition and verify `NumTileBlocks(axis) ==
+// num_partitions(view, axis)` as a `Launch` obligation — this must be rejected.
+#[test]
+fn blockid_row_store_is_rejected() {
+    common::with_test_stack(|| {
+        let err = common::compile_to_ir(
+            __module_ast_self,
+            "opt_hints_module",
+            "blockid_row_store",
+            &["256".to_string(), "64".to_string()],
+            &[("out", &[256, 1])],
+            &[],
+            &[],
+            None,
+            &CompileOptions::default(),
+        )
+        .expect_err("a tile-block-id row index must not be discharged (unsound)");
+        assert!(
+            err.to_string()
+                .contains("must come from iterating the matching dimension"),
+            "unexpected block-id row error: {err}"
+        );
+    });
+}
+
+// Soundness: a block-id whose component does not match the indexed axis must
+// NOT discharge — the gate is `k == axis`, so this fails to compile (rejected).
+#[test]
+fn blockid_wrong_axis_store_is_rejected() {
+    common::with_test_stack(|| {
+        let err = common::compile_to_ir(
+            __module_ast_self,
+            "opt_hints_module",
+            "blockid_wrong_axis_store",
+            &["256".to_string(), "64".to_string()],
+            &[("out", &[256, 1])],
+            &[],
+            &[],
+            None,
+            &CompileOptions::default(),
+        )
+        .expect_err("a block-id with a mismatched component must be rejected");
+        assert!(
+            err.to_string()
+                .contains("must come from iterating the matching dimension"),
+            "unexpected wrong-axis block-id error: {err}"
+        );
+    });
+}
+
+// The block-id owned-axis store must not cost registers vs the raw unchecked
+// twin: the row check discharges at JIT (zero code), the column check hoists.
+
+// The row bounds check the compiler hoisted to launch must actually reject a
+// degenerate (zero-extent) tensor when evaluated at launch — soundness of the
+// evacuated check. Uses the *real* emitted check (not a synthesized one) and is
+// pure compilation (no launch).
+//
+// The row extent is declared `-1`, so this is a check with something to decide:
+// no compile-time source knows the extent, and an empty tensor really would put
+// the constant row-`0` store out of bounds.
+#[test]
+fn hoisted_check_rejects_zero_extent_at_launch() {
+    common::with_test_stack(|| {
+        use cutile::compile_api::KernelCompiler;
+        use cutile::tile_kernel::validate_launch_checks;
+        let artifacts = KernelCompiler::new(
+            __module_ast_self,
+            "opt_hints_module",
+            "hoisted_dynamic_row_store",
+        )
+        .target("sm_120")
+        .generics(vec!["256".to_string(), "64".to_string()])
+        .strides(&[("out", &[256, 1])])
+        .compile()
+        .expect("compile hoisted_dynamic_row_store");
+        let mlir = common::compile_to_ir(
+            __module_ast_self,
+            "opt_hints_module",
+            "hoisted_dynamic_row_store",
+            &["256".to_string(), "64".to_string()],
+            &[("out", &[256, 1])],
+            &[],
+            &[],
+            None,
+            &CompileOptions::default(),
+        )
+        .expect("compile hoisted_dynamic_row_store");
+        let asserts = mlir
+            .lines()
+            .filter(|l| l.trim_start().starts_with("assert "))
+            .count();
+        assert_eq!(asserts, 0, "everything should leave the kernel:\n{mlir}");
+        let checks = artifacts.launch_checks();
+        // Everything left the kernel: the row binding (`tiles == 1`, a range
+        // pair) and the row-`0` access (non-empty), all in the view frame.
+        assert!(
+            !checks.is_empty(),
+            "expected hoisted launch checks, got none"
+        );
+        assert!(
+            format!("{checks:?}").contains("ViewExtent"),
+            "a &mut param's extent checks must be in the view (slab) frame: {checks:?}"
+        );
+        // The frame matters: the root shape says 256 rows, but the checks are
+        // against the kernel-visible slab. An empty slab must be rejected even
+        // though the root is non-empty...
+        let roots = [vec![256i32, 256]];
+        assert!(
+            validate_launch_checks(checks, &roots, &[vec![0i32, 256]], (1, 1, 1)).is_err(),
+            "hoisted checks must reject a zero-extent view at launch"
+        );
+        // ...a one-row slab (what the kernel's `with_bounds` claims) accepted...
+        assert!(
+            validate_launch_checks(checks, &roots, &[vec![1i32, 256]], (1, 1, 1)).is_ok(),
+            "hoisted checks must accept the declared one-row view"
+        );
+        // ...and a two-row slab rejected: the binding claimed exactly one tile.
+        assert!(
+            validate_launch_checks(checks, &roots, &[vec![2i32, 256]], (1, 1, 1)).is_err(),
+            "hoisted checks must reject a view with more tiles than the binding declares"
+        );
+    });
+}
+
+// A signature that pins the extent must be believed. `bounded_mut_store_smoke`
+// declares `out: &mut Tensor<f32, {[1, N]}>`, so `tiles(out, 0) == 1` and the
+// constant row-`0` store is safe outright — there is nothing for the host to
+// decide, and emitting a launch check would be checking a compile-time constant.
+//
+// The two checks reach that extent by different routes: the `with_bounds`
+// binding reads the declared parameter shape, the access reads the partition
+// view type — which erases a `&mut Tensor` param's shape to `?`. When only the
+// binding consulted the signature, the access fell a rung and manufactured a
+// launch check for an extent the signature had already fixed. Both now read the
+// same source, so this asserts the disagreement stays fixed.
+#[test]
+fn a_pinned_extent_produces_no_launch_check() {
+    common::with_test_stack(|| {
+        use cutile::compile_api::KernelCompiler;
+        let artifacts = KernelCompiler::new(
+            __module_ast_self,
+            "opt_hints_module",
+            "bounded_mut_store_smoke",
+        )
+        .target("sm_120")
+        .generics(vec!["256".to_string(), "64".to_string()])
+        .strides(&[("out", &[256, 1])])
+        .compile()
+        .expect("compile bounded_mut_store_smoke");
+        let checks = artifacts.launch_checks();
+        assert!(
+            checks.is_empty(),
+            "a signature-pinned extent should discharge at compile time, but a launch \
+             check was emitted: {checks:?}"
+        );
+    });
+}
+
+// `deny_in_kernel_checks`: a kernel whose safety check cannot be discharged at
+// compile time or hoisted to launch (so it would remain in the kernel) is a hard
+// JIT error under the flag, while the same kernel compiles without it. This is
+// the safe-strict counterpart to `unchecked_accesses` (the unsafe waiver).
+#[test]
+fn deny_in_kernel_checks_rejects_a_residual_check() {
+    common::with_test_stack(|| {
+        // Without the flag: the residual check is emitted in-kernel; compiles.
+        common::compile_to_ir(
+            __module_ast_self,
+            "opt_hints_module",
+            "residual_in_kernel_check",
+            &["64".to_string(), "64".to_string()],
+            &[("z", &[64, 1]), ("x", &[64, 1])],
+            &[],
+            &[],
+            None,
+            &CompileOptions::default(),
+        )
+        .expect("residual_in_kernel_check should compile (check stays in kernel)");
+        // With deny_in_kernel_checks: the same residual check is a hard error
+        // that names the offending axis.
+        let err = common::compile_to_ir(
+            __module_ast_self,
+            "opt_hints_module",
+            "residual_in_kernel_check_denied",
+            &["64".to_string(), "64".to_string()],
+            &[("z", &[64, 1]), ("x", &[64, 1])],
+            &[],
+            &[],
+            None,
+            &CompileOptions::default(),
+        )
+        .expect_err("deny_in_kernel_checks must reject a residual in-kernel check");
+        assert!(
+            err.to_string().contains("deny_in_kernel_checks"),
+            "expected a deny_in_kernel_checks diagnostic, got: {err}"
+        );
+    });
+}
+
+// Coverage of the sub-range family. Every compiler-synthesized assert routes
+// through `deny_residual_check`, and the flag is only worth trusting if it
+// covers all of them — a partial guarantee would let an author ship exactly
+// the register cost it claims to forbid.
+#[test]
+fn deny_in_kernel_checks_covers_the_subrange_check() {
+    common::with_test_stack(|| {
+        let err = common::compile_to_ir(
+            __module_ast_self,
+            "opt_hints_module",
+            "subrange_check_denied",
+            &[
+                "32".to_string(),
+                "32".to_string(),
+                "4".to_string(),
+                "4".to_string(),
+            ],
+            &[("z", &[256, 1])],
+            &[],
+            &[],
+            Some((16, 1, 1)),
+            &CompileOptions::default(),
+        )
+        .expect_err("a runtime sub-range bound leaves a residual check the flag must reject");
+        assert!(
+            err.to_string().contains("deny_in_kernel_checks")
+                && err.to_string().contains("sub-range"),
+            "expected a sub-range deny diagnostic, got: {err}"
+        );
+    });
+}
+
+// The flag must ACCEPT a kernel whose checks all leave. Without this, a bug
+// making it always reject would satisfy every other deny test here, since they
+// all assert failure.
+#[test]
+fn deny_in_kernel_checks_accepts_a_fully_discharged_kernel() {
+    common::with_test_stack(|| {
+        common::compile_to_ir(
+            __module_ast_self,
+            "opt_hints_module",
+            "deny_accepts_fully_discharged",
+            &["256".to_string(), "64".to_string()],
+            &[("out", &[256, 1])],
+            &[],
+            &[],
+            None,
+            &CompileOptions::default(),
+        )
+        .expect("a kernel whose checks all discharge must compile under the flag");
+    });
+}
+
+// The same acceptance, earned at launch rather than at compile time: the
+// foreign access into `y` has no declaring precondition, so this compiles only
+// because the fact it needs is derived and checked on the host.
+#[test]
+fn deny_in_kernel_checks_accepts_a_check_relocated_to_launch() {
+    common::with_test_stack(|| {
+        common::compile_to_ir(
+            __module_ast_self,
+            "opt_hints_module",
+            "deny_accepts_relocated_cross_tensor",
+            &["32".to_string(), "32".to_string(), "32".to_string()],
+            &[("z", &[32, 1]), ("x", &[32, 1]), ("y", &[32, 1])],
+            &[],
+            &[],
+            None,
+            &CompileOptions::default(),
+        )
+        .expect("a cross-tensor check that relocates to launch must satisfy the flag");
+    });
+}
+
+// `deny_in_kernel_checks` promises that NO safety check remains in the kernel.
+// That promise has to hold for every compiler-emitted check, not just the
+// partition-access one: a residual `with_bounds` binding assert costs the same
+// device registers and pins the same operands live. Accepting this kernel would
+// make the attribute a partial guarantee, which is worse than none — a kernel
+// author who trusts it would ship the very register cost it claims to forbid.
+#[test]
+fn deny_in_kernel_checks_covers_the_with_bounds_binding_check() {
+    common::with_test_stack(|| {
+        let err = common::compile_to_ir(
+            __module_ast_self,
+            "opt_hints_module",
+            "with_bounds_binding_check_denied",
+            &["64".to_string(), "64".to_string()],
+            &[("out", &[64, 1])],
+            &[],
+            &[],
+            None,
+            &CompileOptions::default(),
+        )
+        .expect_err(
+            "deny_in_kernel_checks must reject a residual with_bounds binding check, \
+             just as it rejects a residual partition-access check",
+        );
+        assert!(
+            err.to_string().contains("deny_in_kernel_checks"),
+            "expected a deny_in_kernel_checks diagnostic, got: {err}"
+        );
+    });
+}
+
+// A partition's index-space shape is one query answering every axis at once.
+// Emitting it per axis is pure waste: a rank-n `with_bounds` whose bindings all
+// need the runtime path would materialize n identical ops, each keeping its
+// results live. One op, n results.
+#[test]
+fn with_bounds_queries_the_index_space_once_per_partition() {
+    common::with_test_stack(|| {
+        let mlir = common::compile_to_ir(
+            __module_ast_self,
+            "opt_hints_module",
+            "with_bounds_binding_check_unchecked",
+            &["64".to_string(), "64".to_string()],
+            &[("out", &[64, 1])],
+            &[],
+            &[],
+            None,
+            &CompileOptions::default(),
+        )
+        .expect("Failed to compile");
+        let queries = mlir.matches("get_index_space_shape").count();
+        assert_eq!(
+            queries, 1,
+            "a rank-2 `with_bounds` should query the index space once, got {queries}:\n{mlir}"
+        );
+    });
 }
 
 #[test]
@@ -377,6 +1280,432 @@ fn load_view_const_latency_in_mlir() {
         assert!(
             mlir.contains("latency = 5"),
             "Expected latency=5 from const generic L=5.\nMLIR:\n{mlir}"
+        );
+    });
+}
+
+#[test]
+fn safe_load_pipelined_latency_in_mlir() {
+    common::with_test_stack(|| {
+        let mlir = compile_kernel(
+            "safe_load_pipelined_kernel",
+            &[("z", &[1]), ("x", &[1])],
+            &CompileOptions::default(),
+        );
+        assert!(
+            mlir.contains("latency = 6"),
+            "Expected latency=6 from Partition::load_pipelined.\nMLIR:\n{mlir}"
+        );
+    });
+}
+
+#[test]
+fn safe_load_pipelined_const_latency_in_mlir() {
+    common::with_test_stack(|| {
+        let mlir = common::compile_to_ir(
+            __module_ast_self,
+            "opt_hints_module",
+            "safe_load_pipelined_const_kernel",
+            &[128.to_string(), 5.to_string()], // S=128, L=5
+            &[("z", &[1]), ("x", &[1])],
+            &[],
+            &[],
+            None,
+            &CompileOptions::default(),
+        )
+        .expect("Failed to compile");
+        assert!(
+            mlir.contains("latency = 5"),
+            "Expected latency=5 from load_pipelined::<L> with L=5.\nMLIR:\n{mlir}"
+        );
+    });
+}
+
+#[test]
+fn safe_bounded_load_pipelined_latency_in_mlir() {
+    common::with_test_stack(|| {
+        let mlir = common::compile_to_ir(
+            __module_ast_self,
+            "opt_hints_module",
+            "safe_bounded_load_pipelined_kernel",
+            &[16.to_string(), 16.to_string()], // BM=16, BN=16
+            &[("z", &[16, 1]), ("x", &[128, 1])],
+            &[],
+            &[],
+            None,
+            &CompileOptions::default(),
+        )
+        .expect("Failed to compile");
+        assert!(
+            mlir.contains("latency = 7"),
+            "Expected latency=7 from BoundedPartition::load_pipelined.\nMLIR:\n{mlir}"
+        );
+        assert!(
+            !mlir.contains("partition access out of bounds"),
+            "Bounded pipelined loads must keep the discharge proof.\nMLIR:\n{mlir}"
+        );
+    });
+}
+
+#[test]
+fn two_pipelined_loads_keep_distinct_latencies_in_mlir() {
+    common::with_test_stack(|| {
+        let mlir = compile_kernel(
+            "safe_load_two_latencies_kernel",
+            &[("z", &[1]), ("x", &[1]), ("y", &[1])],
+            &CompileOptions::default(),
+        );
+        assert!(
+            mlir.contains("latency = 3") && mlir.contains("latency = 9"),
+            "each load must keep its own latency hint (not last-wins).\nMLIR:\n{mlir}"
+        );
+    });
+}
+
+// SOUNDNESS SPEC (currently failing — documents a live hole in the safe surface).
+//
+// `with_bounds` records which `Dim` brands which axis but never verifies the
+// `Dim`'s *value* against the view's real tile count, so a bogus bound is
+// silently trusted and the branded store discharges. This is reachable from
+// safe Rust (both `Tensor::partition` and `partition_mut` are safe), so safe
+// code can produce out-of-bounds accesses. `LAUNCH_PRECONDITION_HOISTING.md`
+// names this ("an unvalidated host-contract") and proposes synthesizing a
+// precondition from `with_bounds`; that synthesis is not implemented.
+//
+// The fix: emit `declared_dim <= num_partitions(view, axis)` as a verified
+// `Launch` obligation. Then this kernel either fails at JIT or is caught at
+// launch. Un-ignore when it lands.
+#[test]
+fn with_bounds_bogus_dim_must_not_silently_discharge() {
+    common::with_test_stack(|| {
+        let result = common::compile_to_ir(
+            __module_ast_self,
+            "opt_hints_module",
+            "with_bounds_bogus_dim",
+            &["256".to_string(), "64".to_string()],
+            &[("out", &[256, 1])],
+            &[],
+            &[],
+            None,
+            &CompileOptions::default(),
+        );
+        match result {
+            Err(_) => {} // rejected at JIT: acceptable.
+            Ok(mlir) => assert!(
+                mlir.contains("does not equal this partition's tile count")
+                    || mlir.contains("out of bounds"),
+                "a bogus with_bounds Dim discharged with no check and no launch \
+                 obligation — safe code can write out of bounds:\n{mlir}"
+            ),
+        }
+    });
+}
+
+// SOUNDNESS SPEC (read side): a bogus declared bound must be *caught*, at the
+// earliest stage able to decide it. On `main` this kernel silently discharged —
+// a safe-code out-of-bounds READ. The first fix trapped it with a device
+// assert. The constant launch rung now decides it before the kernel exists:
+// `Dim::new(999)` on a dynamic immutable axis becomes the host range check
+// `998·BM < dim(x, 0) ≤ 999·BM`, which every real launch of this kernel fails —
+// strictly earlier detection than the device trap, zero registers.
+#[test]
+fn with_bounds_bogus_dim_load_must_not_silently_discharge() {
+    common::with_test_stack(|| {
+        use cutile::compile_api::KernelCompiler;
+        use cutile::tile_kernel::validate_launch_checks;
+        let mlir = common::compile_to_ir(
+            __module_ast_self,
+            "opt_hints_module",
+            "with_bounds_bogus_dim_load",
+            &["16".to_string(), "64".to_string()],
+            &[("z", &[64, 1]), ("x", &[64, 1])],
+            &[],
+            &[],
+            None,
+            &CompileOptions::default(),
+        )
+        .expect("compiles; the bogus bound is deferred to a launch check");
+        let asserts = mlir
+            .lines()
+            .filter(|l| l.trim_start().starts_with("assert "))
+            .count();
+        assert_eq!(
+            asserts, 0,
+            "the bogus bound should hoist, not trap in-kernel:\n{mlir}"
+        );
+
+        let artifacts = KernelCompiler::new(
+            __module_ast_self,
+            "opt_hints_module",
+            "with_bounds_bogus_dim_load",
+        )
+        .target("sm_120")
+        .generics(vec!["16".to_string(), "64".to_string()])
+        .strides(&[("z", &[64, 1]), ("x", &[64, 1])])
+        .compile()
+        .expect("compile with_bounds_bogus_dim_load");
+        let checks = artifacts.launch_checks();
+        assert!(
+            !checks.is_empty(),
+            "the bogus bound must leave a launch obligation behind: {checks:?}"
+        );
+        // Any plausible tensor fails the 999-tile range check at launch.
+        assert!(
+            validate_launch_checks(
+                checks,
+                &[vec![16, 64], vec![128, 128]],
+                &[vec![16, 64], vec![128, 128]],
+                (1, 1, 1)
+            )
+            .is_err(),
+            "a 128-row tensor must be rejected against a declared 999-tile bound: {checks:?}"
+        );
+        // The declared bound is satisfiable by exactly one extent range: with
+        // BM = 16, rows in (15968, 15984] — and 64 must divide the columns.
+        assert!(
+            validate_launch_checks(
+                checks,
+                &[vec![16, 64], vec![15984, 128]],
+                &[vec![16, 64], vec![15984, 128]],
+                (1, 1, 1)
+            )
+            .is_ok(),
+            "the one extent range that satisfies the declared bound must be accepted: {checks:?}"
+        );
+    });
+}
+
+// The binding's Launch rung. `safe_bounded_load_pipelined_kernel` binds
+// `Dim::new(x.shape()[k] / B)` to a partition of `x` tiled by `B`. That bound is
+// `floor(e/B)` while the partition has `ceil(e/B)` tiles, so the binding holds
+// exactly when `B` divides `e` -- a predicate over the extent atom itself. Both
+// operands are launch-known, so it must leave the kernel entirely and be decided
+// once by the host, including rejecting an extent that violates it.
+//
+// Stating it as divisibility rather than naming the division as an opaque atom
+// is what keeps it discharge-able: the goal mentions only `Dim`, the same
+// vocabulary preconditions are written in.
+#[test]
+fn a_divisible_binding_leaves_the_kernel_for_the_host() {
+    common::with_test_stack(|| {
+        use cutile::compile_api::KernelCompiler;
+        use cutile::tile_kernel::validate_launch_checks;
+        let mlir = common::compile_to_ir(
+            __module_ast_self,
+            "opt_hints_module",
+            "safe_bounded_load_pipelined_kernel",
+            &["64".to_string(), "64".to_string()],
+            &[("z", &[64, 1]), ("x", &[64, 1])],
+            &[],
+            &[],
+            None,
+            &CompileOptions::default(),
+        )
+        .expect("Failed to compile");
+        let asserts = mlir
+            .lines()
+            .filter(|l| l.trim_start().starts_with("assert "))
+            .count();
+        assert_eq!(asserts, 0, "both bindings should leave the kernel:\n{mlir}");
+
+        let artifacts = KernelCompiler::new(
+            __module_ast_self,
+            "opt_hints_module",
+            "safe_bounded_load_pipelined_kernel",
+        )
+        .target("sm_120")
+        .generics(vec!["64".to_string(), "64".to_string()])
+        .strides(&[("z", &[64, 1]), ("x", &[64, 1])])
+        .compile()
+        .expect("compile safe_bounded_load_pipelined_kernel");
+        let checks = artifacts.launch_checks();
+        assert_eq!(
+            checks.len(),
+            2,
+            "expected one host check per axis: {checks:?}"
+        );
+        // x is 128x128: 64 divides both extents.
+        assert!(
+            validate_launch_checks(
+                checks,
+                &[vec![64i32, 64], vec![128i32, 128]],
+                &[vec![64i32, 64], vec![128i32, 128]],
+                (1, 1, 1)
+            )
+            .is_ok(),
+            "a divisible shape must be accepted: {checks:?}"
+        );
+        // x is 100x128: 64 does not divide 100, so `floor` undercounts the tiles
+        // and an index from the loop could reach past the last full tile.
+        assert!(
+            validate_launch_checks(
+                checks,
+                &[vec![64i32, 64], vec![100i32, 128]],
+                &[vec![64i32, 64], vec![100i32, 128]],
+                (1, 1, 1)
+            )
+            .is_err(),
+            "a non-divisible extent must be rejected at launch: {checks:?}"
+        );
+    });
+}
+
+// The two-statement `with_bounds` spelling (bind the partition, then bound it)
+// is the natural way to write the pattern and once died in typeck at the
+// subsequent store. It must compile, and with a declared [1, N] shape both
+// bindings must fold: zero in-kernel asserts.
+#[test]
+fn two_statement_with_bounds_compiles_and_folds() {
+    common::with_test_stack(|| {
+        let mlir = common::compile_to_ir(
+            __module_ast_self,
+            "opt_hints_module",
+            "two_stmt_with_bounds",
+            &["256".to_string(), "64".to_string()],
+            &[("out", &[256, 1])],
+            &[],
+            &[],
+            None,
+            &CompileOptions::default(),
+        )
+        .expect("the two-statement with_bounds form must compile");
+        let asserts = mlir
+            .lines()
+            .filter(|l| l.trim_start().starts_with("assert "))
+            .count();
+        assert_eq!(asserts, 0, "both bindings should fold at JIT:\n{mlir}");
+    });
+}
+
+// Theorem 2, end to end: a shared `Dim` bound across two tensors. With the
+// extent equality declared (and so verified by the launcher), the cross-tensor
+// binding discharges from the declared fact plus the numerator's divisibility
+// check -- the same host compare the sibling binding emits, deduplicated. The
+// undeclared twin must keep its device assert: hoisting an unproven extent
+// equality would be stricter than the binding's real obligation.
+#[test]
+fn a_shared_dim_binding_discharges_from_the_declared_equality() {
+    common::with_test_stack(|| {
+        use cutile::compile_api::KernelCompiler;
+        use cutile::tile_kernel::validate_launch_checks;
+        let count_asserts = |name: &str| {
+            common::compile_to_ir(
+                __module_ast_self,
+                "opt_hints_module",
+                name,
+                &["32".to_string(), "64".to_string()],
+                &[("z", &[64, 1]), ("x", &[128, 1]), ("y", &[128, 1])],
+                &[],
+                &[],
+                None,
+                &CompileOptions::default(),
+            )
+            .map(|m| {
+                m.lines()
+                    .filter(|l| l.trim_start().starts_with("assert "))
+                    .count()
+            })
+            .expect("compile")
+        };
+        assert_eq!(
+            count_asserts("shared_dim_binding"),
+            0,
+            "with the equality declared, every binding should leave the kernel"
+        );
+        assert_eq!(
+            count_asserts("shared_dim_binding_undeclared"),
+            1,
+            "without the declared equality the cross-tensor binding must stay a device assert"
+        );
+
+        let artifacts =
+            KernelCompiler::new(__module_ast_self, "opt_hints_module", "shared_dim_binding")
+                .target("sm_120")
+                .generics(vec!["32".to_string(), "64".to_string()])
+                .strides(&[("z", &[64, 1]), ("x", &[128, 1]), ("y", &[128, 1])])
+                .compile()
+                .expect("compile shared_dim_binding");
+        let checks = artifacts.launch_checks();
+        // m|BM on x0, k|BK on x1 (shared by both bindings, deduplicated),
+        // n|BM on y1: exactly three host compares.
+        assert_eq!(
+            checks.len(),
+            3,
+            "expected three deduplicated checks: {checks:?}"
+        );
+        // x = [128, 128], y = [128, 128]: 32 | 128 and 64 | 128.
+        assert!(
+            validate_launch_checks(
+                checks,
+                &[vec![32, 64], vec![128, 128], vec![128, 128]],
+                &[vec![32, 64], vec![128, 128], vec![128, 128]],
+                (1, 1, 1)
+            )
+            .is_ok(),
+            "divisible extents must be accepted: {checks:?}"
+        );
+        // x = [128, 100]: 64 does not divide the shared contraction extent.
+        assert!(
+            validate_launch_checks(
+                checks,
+                &[vec![32, 64], vec![128, 100], vec![128, 128]],
+                &[vec![32, 64], vec![128, 100], vec![128, 128]],
+                (1, 1, 1)
+            )
+            .is_err(),
+            "a non-divisible shared extent must be rejected at launch: {checks:?}"
+        );
+    });
+}
+
+// The full trust chain for a declared divisibility fact, in one place:
+//
+//   declared  ->  entailed at JIT (no assert, no launch check)
+//             ->  verified by the generated launcher (bad shape rejected)
+//
+// The first half is what the reduction bought: the binding obligation
+// `divisible_by(dim(x, k), 64)` is exact set membership against the declared
+// fact, so it resolves at `Jit` and nothing is emitted anywhere. The second
+// half is why believing the declaration is sound: the launcher rejects any
+// launch whose shapes violate it, before the kernel exists.
+#[test]
+fn a_declared_divisibility_discharges_at_jit() {
+    common::with_test_stack(|| {
+        use cutile::compile_api::KernelCompiler;
+        let mlir = common::compile_to_ir(
+            __module_ast_self,
+            "opt_hints_module",
+            "declared_divisibility_binding",
+            &["64".to_string(), "64".to_string()],
+            &[("z", &[64, 1]), ("x", &[128, 1])],
+            &[],
+            &[],
+            None,
+            &CompileOptions::default(),
+        )
+        .expect("compile declared_divisibility_binding");
+        let asserts = mlir
+            .lines()
+            .filter(|l| l.trim_start().starts_with("assert "))
+            .count();
+        assert_eq!(
+            asserts, 0,
+            "declared facts should entail both bindings:\n{mlir}"
+        );
+        let artifacts = KernelCompiler::new(
+            __module_ast_self,
+            "opt_hints_module",
+            "declared_divisibility_binding",
+        )
+        .target("sm_120")
+        .generics(vec!["64".to_string(), "64".to_string()])
+        .strides(&[("z", &[64, 1]), ("x", &[128, 1])])
+        .compile()
+        .expect("compile declared_divisibility_binding");
+        assert!(
+            artifacts.launch_checks().is_empty(),
+            "an entailed obligation must not also emit a launch check: {:?}",
+            artifacts.launch_checks()
         );
     });
 }

--- a/cutile/tests/partition_access_soundness.rs
+++ b/cutile/tests/partition_access_soundness.rs
@@ -1,0 +1,506 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Adversarial soundness probes for the plain (`Partition`) access checker,
+//! from the 2026-08-04 external review
+//! (`.internal/tasks/in_progress/check_hoisting/REVIEW_FINDINGS_2026-08-04.md`):
+//! the dynamic path must bound indices from BELOW as well as above, and a
+//! foreign mapped index against a permuted target must discharge against the
+//! REMAPPED root axis, not the logical coordinate.
+
+use cutile;
+use cutile_compiler::compiler::utils::CompileOptions;
+
+mod common;
+
+#[cutile::module]
+mod access_soundness_module {
+    use cutile::core::*;
+
+    /// A raw runtime scalar indexing a dynamic-extent partition: nothing
+    /// bounds `idx` at compile time in either direction.
+    #[cutile::entry]
+    fn runtime_scalar_index<const B: i32>(
+        z: &mut Tensor<f32, { [B] }>,
+        x: &Tensor<f32, { [-1] }>,
+        idx: i32,
+    ) {
+        let p = x.partition(const_shape![B]);
+        let t = p.load([idx]);
+        z.store(t);
+    }
+
+    /// A loop whose lower endpoint is provably negative: iteration `-2`
+    /// produces a negative block index.
+    #[cutile::entry]
+    fn negative_loop_start<const B: i32>(z: &mut Tensor<f32, { [B] }>, x: &Tensor<f32, { [-1] }>) {
+        let p = x.partition(const_shape![B]);
+        for j in -2i32..4i32 {
+            let t = p.load([j]);
+            z.store(t);
+        }
+    }
+
+    /// A mapped component (root axis 0 of `z`) indexing logical axis 0 of a
+    /// PERMUTED partition of `x` (`dim_map = [1, 0]`), so the real bound is
+    /// `x`'s root axis 1. Only the WRONG equality — `dim(z,0) == dim(x,0)` —
+    /// is declared: the check must NOT discharge.
+    #[cutile::entry(
+        preconditions = (
+            dim(z, 0) == dim(x, 0),
+        )
+    )]
+    fn permuted_wrong_axis<const BM: i32, const BN: i32, const MAP_SHAPE: [i32; 2]>(
+        mut z: MappedPartitionMut<f32, { [BM, BN] }, MAP_SHAPE>,
+        x: &Tensor<f32, { [-1, -1] }>,
+    ) {
+        let xp = x.partition_permuted(const_shape![BM, BN], const_array![1, 0]);
+        for index in z.iter_indices() {
+            let (bid_m, _bid_n) = index.components();
+            let t = xp.load([bid_m, 0i32]);
+            z.store(t, index);
+        }
+    }
+
+    /// Positive control: the CORRECT equality — `dim(z,0) == dim(x,1)`, the
+    /// remapped axis — is declared, so the axis-0 check discharges.
+    #[cutile::entry(
+        preconditions = (
+            dim(z, 0) == dim(x, 1),
+        )
+    )]
+    fn permuted_right_axis<const BM: i32, const BN: i32, const MAP_SHAPE: [i32; 2]>(
+        mut z: MappedPartitionMut<f32, { [BM, BN] }, MAP_SHAPE>,
+        x: &Tensor<f32, { [-1, -1] }>,
+    ) {
+        let xp = x.partition_permuted(const_shape![BM, BN], const_array![1, 0]);
+        for index in z.iter_indices() {
+            let (bid_m, _bid_n) = index.components();
+            let t = xp.load([bid_m, 0i32]);
+            z.store(t, index);
+        }
+    }
+    /// An index that carries axis provenance, conditionally reassigned to a
+    /// constant that is out of range. The join must not keep the old value's
+    /// proof (issue #212): before the fix this compiled fully discharged and
+    /// executed the out-of-range read.
+    #[cutile::entry]
+    fn reassigned_index_keeps_no_proof<const B: i32>(
+        z: &mut Tensor<f32, { [B] }>,
+        x: &Tensor<f32, { [-1] }>,
+        flag: i32,
+    ) {
+        let p = x.partition(const_shape![B]);
+        let mut acc: Tile<f32, { [B] }> = constant(0.0, const_shape![B]);
+        for i in 0i32..num_tiles(&p, 0) {
+            let mut j = i;
+            if flag > 0i32 {
+                j = 100i32;
+            }
+            acc = acc + p.load([j]);
+        }
+        z.store(acc);
+    }
+    /// A partition conditionally reassigned to a DIFFERENT tensor, accessed
+    /// by an index walked from a third tensor tied to the first by a
+    /// precondition. If the join keeps the pre-branch tensor origin, the
+    /// cross-tensor rung bounds a `b`-run access against `a`'s extent
+    /// (issue #212, structural residual).
+    #[cutile::entry(
+        preconditions = (dim(w, 0) == dim(a, 0),)
+    )]
+    fn reassigned_partition_keeps_no_origin<const B: i32>(
+        z: &mut Tensor<f32, { [B] }>,
+        w: &Tensor<f32, { [-1] }>,
+        a: &Tensor<f32, { [-1] }>,
+        b: &Tensor<f32, { [-1] }>,
+        flag: i32,
+    ) {
+        let pw = w.partition(const_shape![B]);
+        let mut p = a.partition(const_shape![B]);
+        if flag > 0i32 {
+            p = b.partition(const_shape![B]);
+        }
+        let mut acc: Tile<f32, { [B] }> = constant(0.0, const_shape![B]);
+        for i in 0i32..num_tiles(&pw, 0) {
+            acc = acc + p.load([i]);
+        }
+        z.store(acc);
+    }
+
+    /// Mathematical range analysis says `index` is in `[0, 2]`, but the
+    /// machine multiplies in wrapping `i32`: at `i = 2` the product wraps
+    /// to 294,967,296 and `max` keeps it. No interval may survive the
+    /// wrapping op, so this access must pay a real check
+    /// (2026-08-12 review, S1).
+    #[cutile::entry]
+    fn wrapped_product_masked_by_max<const B: i32>(
+        z: &mut Tensor<f32, { [B] }>,
+        x: &Tensor<f32, { [-1] }>,
+    ) {
+        let p = x.partition(const_shape![B]);
+        let mut acc: Tile<f32, { [B] }> = constant(0.0, const_shape![B]);
+        for i in 0i32..3i32 {
+            let index = max(i * -2_000_000_000i32, i);
+            acc = acc + p.load([index]);
+        }
+        z.store(acc);
+    }
+
+    /// The mathematical remainder is nonnegative, but the wrapped dividend
+    /// makes the machine remainder negative (`i = 2` gives `-296`): the
+    /// lower guard must stay (2026-08-12 review, S1).
+    #[cutile::entry]
+    fn wrapped_dividend_negative_remainder<const B: i32>(
+        z: &mut Tensor<f32, { [B] }>,
+        x: &Tensor<f32, { [-1] }>,
+    ) {
+        let p = x.partition(const_shape![B]);
+        let mut acc: Tile<f32, { [B] }> = constant(0.0, const_shape![B]);
+        for i in 0i32..3i32 {
+            let index = (i * 2_000_000_000i32) % 1_000i32;
+            acc = acc + p.load([index]);
+        }
+        z.store(acc);
+    }
+
+    /// Static-extent twin of the wrapped product: the static fold must not
+    /// discharge from a wrap-tainted interval either
+    /// (2026-08-12 review, S1).
+    #[cutile::entry]
+    fn wrapped_product_static_extent<const B: i32>(
+        z: &mut Tensor<f32, { [B] }>,
+        x: &Tensor<f32, { [48] }>,
+    ) {
+        let p = x.partition(const_shape![B]);
+        let mut acc: Tile<f32, { [B] }> = constant(0.0, const_shape![B]);
+        for i in 0i32..3i32 {
+            let index = max(i * -2_000_000_000i32, i);
+            acc = acc + p.load([index]);
+        }
+        z.store(acc);
+    }
+
+    /// An exact condition is inlined, not joined. Reassigning the mapped
+    /// index to the same proven value on the sole feasible path must preserve
+    /// its store provenance (2026-08-12 review, P1).
+    #[allow(unused_assignments)] // the deliberate overwrite is the regression shape
+    #[cutile::entry]
+    fn constant_if_preserves_mapped_index<const B: i32, const MAP_SHAPE: [i32; 1]>(
+        mut z: MappedPartitionMut<f32, { [B] }, MAP_SHAPE>,
+    ) {
+        for index in z.iter_indices() {
+            let mut same = index;
+            if true {
+                same = index;
+            }
+            if false {
+                same = index;
+            } else {
+                same = index;
+            }
+            let tile: Tile<f32, { [B] }> = constant(0.0, const_shape![B]);
+            z.store(tile, same);
+        }
+    }
+
+    /// Publishing the sole taken path must preserve its RHS facts, not the
+    /// pre-branch template's provenance. This exact branch replaces a proven
+    /// iterand with an unproven out-of-range constant, so a check must remain.
+    #[allow(unused_assignments)] // the deliberate overwrite is the regression shape
+    #[cutile::entry]
+    fn constant_if_reassignment_uses_rhs_facts<const B: i32>(
+        z: &mut Tensor<f32, { [B] }>,
+        x: &Tensor<f32, { [-1] }>,
+    ) {
+        let p = x.partition(const_shape![B]);
+        let mut acc: Tile<f32, { [B] }> = constant(0.0, const_shape![B]);
+        for i in 0i32..num_tiles(&p, 0) {
+            let mut index = i;
+            if true {
+                index = 100i32;
+            }
+            acc = acc + p.load([index]);
+        }
+        z.store(acc);
+    }
+}
+
+use access_soundness_module::__module_ast_self;
+
+fn compile(name: &str, generics: &[&str], strides: &[(&str, &[i32])]) -> Result<String, String> {
+    let generics: Vec<String> = generics.iter().map(|s| s.to_string()).collect();
+    common::compile_to_ir(
+        __module_ast_self,
+        "access_soundness_module",
+        name,
+        &generics,
+        strides,
+        &[],
+        &[],
+        Some((16, 1, 1)),
+        &CompileOptions::default(),
+    )
+    .map_err(|err| err.to_string())
+}
+
+// A signed `-1` passes `index < ceil(extent/tile)`, so the upper comparison
+// alone is not a bounds check. The dynamic path must also prove or emit
+// `0 <= index`.
+#[test]
+fn runtime_scalar_index_is_bounded_below() {
+    common::with_test_stack(|| {
+        let mlir = compile("runtime_scalar_index", &["64"], &[("z", &[1]), ("x", &[1])])
+            .expect("compile runtime_scalar_index");
+        assert!(
+            mlir.contains("greater_than_or_equal"),
+            "a runtime index needs a lower-bound guard, found none:\n{mlir}"
+        );
+    });
+}
+
+// Iteration -2 is a provably negative block index: reject at compile time,
+// exactly as the static path rejects a provably out-of-range constant.
+#[test]
+fn provably_negative_loop_start_is_rejected() {
+    common::with_test_stack(|| {
+        let err = compile("negative_loop_start", &["64"], &[("z", &[1]), ("x", &[1])])
+            .expect_err("a provably negative block index must not compile");
+        assert!(
+            err.contains("0 <=") || err.to_lowercase().contains("negative"),
+            "expected a lower-bound diagnostic, got: {err}"
+        );
+    });
+}
+
+// The declared `dim(z,0) == dim(x,0)` talks about the WRONG root axis for a
+// permuted target: the access is bounded by x's root axis 1 = dim_map[0]. The
+// wrong-axis fact must not discharge it.
+//
+// Since cross-tensor obligations now relocate to launch, "not discharged" no
+// longer means "a device assert appears" — it means the enforcement is on the
+// axis the access actually needs. That is the stronger property, so it is what
+// this asserts: a launch satisfying the DECLARED fact but violating the real
+// one must still be rejected. If the wrong-axis equality were being believed,
+// such a launch would sail through.
+#[test]
+fn wrong_axis_equality_must_not_discharge_a_permuted_access() {
+    common::with_test_stack(|| {
+        use cutile::tile_kernel::validate_launch_checks;
+        let artifacts = cutile_compiler::compile_api::KernelCompiler::new(
+            __module_ast_self,
+            "access_soundness_module",
+            "permuted_wrong_axis",
+        )
+        .target("sm_120")
+        .generics(vec![
+            "32".to_string(),
+            "32".to_string(),
+            "4".to_string(),
+            "4".to_string(),
+        ])
+        .strides(&[("z", &[256, 1]), ("x", &[256, 1])])
+        .grid((16, 1, 1))
+        .options(CompileOptions::default())
+        .compile()
+        .expect("compile permuted_wrong_axis");
+        let checks = artifacts.launch_checks();
+        assert!(
+            !checks.is_empty(),
+            "the axis-0 obligation must be enforced somewhere, and nothing \
+             discharged it at compile time"
+        );
+        // Params in signature order: z, x. The access needs
+        // `dim(z,0) == dim(x,1)`; the declared fact is `dim(z,0) == dim(x,0)`.
+        // These shapes satisfy the declared fact and violate the real one.
+        let declared_holds_real_fails = [vec![64i32, 64], vec![64, 32]];
+        assert!(
+            validate_launch_checks(
+                checks,
+                &declared_holds_real_fails,
+                &declared_holds_real_fails,
+                (1, 1, 1)
+            )
+            .is_err(),
+            "a launch matching only the WRONG axis must be rejected: {checks:?}"
+        );
+        // The remapped axis agreeing is what actually makes the access safe.
+        let real_holds = [vec![64i32, 64], vec![32, 64]];
+        assert!(
+            validate_launch_checks(checks, &real_holds, &real_holds, (1, 1, 1)).is_ok(),
+            "a launch matching the remapped axis must be accepted: {checks:?}"
+        );
+    });
+}
+
+// Control: the remapped-axis equality is the right evidence and must
+// discharge, proving the fix redirects the query rather than killing the rung.
+#[test]
+fn right_axis_equality_discharges_a_permuted_access() {
+    common::with_test_stack(|| {
+        let mlir = compile(
+            "permuted_right_axis",
+            &["32", "32", "4", "4"],
+            &[("z", &[256, 1]), ("x", &[256, 1])],
+        )
+        .expect("compile permuted_right_axis");
+        assert!(
+            !(mlir.contains("out of bounds: dim 0") || mlir.contains("out of range: dim 0")),
+            "the remapped-axis equality should discharge the axis-0 check:\n{mlir}"
+        );
+    });
+}
+
+// A conditionally reassigned index must not inherit the proof of the value
+// it replaced. The join clears value-dependent facts, so the access keeps a
+// real check somewhere; full discharge here means stale provenance leaked
+// through the join again (issue #212).
+#[test]
+fn reassigned_index_keeps_its_check() {
+    common::with_test_stack(|| {
+        let artifacts = cutile_compiler::compile_api::KernelCompiler::new(
+            __module_ast_self,
+            "access_soundness_module",
+            "reassigned_index_keeps_no_proof",
+        )
+        .target("sm_120")
+        .generics(vec!["16".to_string()])
+        .strides(&[("z", &[1]), ("x", &[1])])
+        .options(CompileOptions::default())
+        .compile()
+        .expect("compile reassigned_index_keeps_no_proof");
+        let counts = artifacts.check_counts();
+        let placed = counts.hoisted + counts.in_place + artifacts.launch_checks().len() as u32;
+        assert!(
+            placed >= 1,
+            "the reassigned index must keep a real check; fully discharged \
+             means the join leaked stale provenance: discharged={} hoisted={} \
+             in_place={} launch={}",
+            counts.discharged,
+            counts.hoisted,
+            counts.in_place,
+            artifacts.launch_checks().len()
+        );
+    });
+}
+
+// A partition reassigned across a conditional must not keep the origin of the
+// value it replaced; the cross-tensor rung would otherwise prove a b-access
+// against a's extent (issue #212, structural residual).
+#[test]
+fn reassigned_partition_keeps_its_check() {
+    common::with_test_stack(|| {
+        let art = cutile_compiler::compile_api::KernelCompiler::new(
+            __module_ast_self,
+            "access_soundness_module",
+            "reassigned_partition_keeps_no_origin",
+        )
+        .target("sm_120")
+        .generics(vec!["16".to_string()])
+        .strides(&[("z", &[1]), ("w", &[1]), ("a", &[1]), ("b", &[1])])
+        .options(CompileOptions::default())
+        .compile()
+        .expect("compile reassigned_partition_keeps_no_origin");
+        let c = art.check_counts();
+        let placed = c.hoisted + c.in_place + art.launch_checks().len() as u32;
+        assert!(
+            placed >= 1,
+            "reassigned partition kept a stale origin and discharged: \
+             discharged={} hoisted={} in_place={} launch={}",
+            c.discharged,
+            c.hoisted,
+            c.in_place,
+            art.launch_checks().len()
+        );
+    });
+}
+
+// An interval fact is a claim about the machine value, and the machine wraps
+// at i32 while interval composition is mathematical. An op whose mathematical
+// range escapes the type's domain must yield NO interval — otherwise a later
+// max/% narrows the mathematical range back into the domain while the wrapped
+// machine value stays outside it, and the stale interval discharges or hoists
+// away the only check standing between the access and memory it doesn't own
+// (2026-08-12 review, S1: both scenarios, plus the static-fold twin).
+#[test]
+fn wrapping_intermediate_arithmetic_keeps_its_check() {
+    common::with_test_stack(|| {
+        for (name, is_static) in [
+            ("wrapped_product_masked_by_max", false),
+            ("wrapped_dividend_negative_remainder", false),
+            ("wrapped_product_static_extent", true),
+        ] {
+            let artifacts = cutile_compiler::compile_api::KernelCompiler::new(
+                __module_ast_self,
+                "access_soundness_module",
+                name,
+            )
+            .target("sm_120")
+            .generics(vec!["16".to_string()])
+            .strides(&[("z", &[1]), ("x", &[1])])
+            .options(CompileOptions::default())
+            .compile()
+            .unwrap_or_else(|err| panic!("compile {name}: {err}"));
+            let c = artifacts.check_counts();
+            assert_eq!(
+                (c.discharged, c.hoisted, c.in_place),
+                (0, 0, 1),
+                "{name}: a wrap-tainted interval must not discharge or hoist \
+                 the check (static extent: {is_static})"
+            );
+        }
+        // Scenario 2's essence is the LOWER guard: the wrapped remainder is
+        // negative, so the in-place check must be two-sided.
+        let mlir = compile(
+            "wrapped_dividend_negative_remainder",
+            &["16"],
+            &[("z", &[1]), ("x", &[1])],
+        )
+        .expect("compile wrapped_dividend_negative_remainder");
+        assert!(
+            mlir.contains("greater_than_or_equal"),
+            "the wrapped remainder can be negative; the check must bound below:\n{mlir}"
+        );
+    });
+}
+
+#[test]
+fn constant_if_preserves_facts_from_the_only_feasible_path() {
+    common::with_test_stack(|| {
+        let artifacts = cutile_compiler::compile_api::KernelCompiler::new(
+            __module_ast_self,
+            "access_soundness_module",
+            "constant_if_preserves_mapped_index",
+        )
+        .target("sm_120")
+        .generics(vec!["16".to_string(), "1".to_string()])
+        .strides(&[("z", &[1])])
+        .grid((4, 1, 1))
+        .options(CompileOptions::default())
+        .compile()
+        .expect("a constant if must preserve the taken path's mapped-index provenance");
+        assert!(
+            artifacts.ir_text().contains("store_view_tko"),
+            "the proven mapped store should lower after an inlined exact condition"
+        );
+
+        let artifacts = cutile_compiler::compile_api::KernelCompiler::new(
+            __module_ast_self,
+            "access_soundness_module",
+            "constant_if_reassignment_uses_rhs_facts",
+        )
+        .target("sm_120")
+        .generics(vec!["16".to_string()])
+        .strides(&[("z", &[1]), ("x", &[1])])
+        .options(CompileOptions::default())
+        .compile()
+        .expect("compile exact-branch reassignment");
+        let counts = artifacts.check_counts();
+        assert!(
+            counts.hoisted + counts.in_place > 0,
+            "the exact branch must publish the constant RHS without retaining the old iterand proof: {counts:?}"
+        );
+    });
+}

--- a/cutile/tests/partition_index_schedules.rs
+++ b/cutile/tests/partition_index_schedules.rs
@@ -3,6 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// Schedule coverage predates the deprecation; the kernels still exercise the
+// annotation path deliberately.
+#![allow(deprecated)]
+
 use cutile;
 use cutile_compiler::compiler::utils::CompileOptions;
 
@@ -12,7 +16,7 @@ mod common;
 mod partition_index_schedules_module {
     use cutile::core::*;
 
-    #[cutile::entry(unchecked_accesses = false)]
+    #[cutile::entry]
     unsafe fn static_persistent_gemm_scheduled<
         T: ElementType,
         const BM: i32,
@@ -45,7 +49,6 @@ mod partition_index_schedules_module {
     }
 
     #[cutile::entry(
-        unchecked_accesses = false,
         preconditions = (
             dim(z, 0) == dim(x, 0),
             dim(z, 1) == dim(y, 1),
@@ -82,7 +85,7 @@ mod partition_index_schedules_module {
         }
     }
 
-    #[cutile::entry(unchecked_accesses = false)]
+    #[cutile::entry]
     unsafe fn dynamic_persistent_gemm_bounded<
         T: ElementType,
         const BM: i32,
@@ -113,7 +116,166 @@ mod partition_index_schedules_module {
         }
     }
 
-    #[cutile::entry(unchecked_accesses = false)]
+    /// Owned-axis composite stores: the RMSNorm-family target shape. The
+    /// stream proves the axis-0 component; the owned axis-1 coordinate is a
+    /// `Dim` index, so both two-pass loops are plain counted loops and the
+    /// stores use `coord((row, j))`.
+    #[cutile::entry]
+    unsafe fn owned_axis_composite_store<
+        T: ElementType,
+        const BS: i32,
+        const MAP_SHAPE: [i32; 2],
+    >(
+        mut out: MappedPartitionMut<T, { [1, BS] }, MAP_SHAPE>,
+        x: &Tensor<T, { [-1, -1] }>,
+    ) {
+        let rows = num_tiles(&out, 0);
+        let cols = num_tiles(&out, 1);
+        let part_x = x.partition(const_shape![1, BS]).with_bounds((rows, cols));
+        let cols = cols.into_dim();
+        for index in out.iter_indices() {
+            let (row, _col) = index.components();
+            let mut acc: Tile<T, { [1, BS] }> = constant(T::ZERO, const_shape![1, BS]);
+            for j in cols {
+                let t = part_x.load(coord((row, j)));
+                acc = acc + t;
+            }
+            for j in cols {
+                out.store(acc, coord((row, j)));
+            }
+        }
+    }
+
+    /// Negative: a tile-block id used as a store index into a `MappedPartitionMut`
+    /// must be REJECTED. The block-id discharge (`TileBlockId(k) < NumTileBlocks(k)`)
+    /// is only sound for a *direct* partition, whose launch grid is verified equal
+    /// to its partition grid. A mapped/persistent partition has a work-item grid
+    /// (`gridDim != num_partitions`), so it routes through `validate_partition_store`
+    /// — which never accepts a block-id — never the direct bounded-access handler.
+    #[cutile::entry]
+    unsafe fn mapped_blockid_store_rejected<
+        T: ElementType,
+        const BS: i32,
+        const MAP_SHAPE: [i32; 2],
+    >(
+        mut out: MappedPartitionMut<T, { [1, BS] }, MAP_SHAPE>,
+    ) {
+        let cols = num_tiles(&out, 1).into_dim();
+        let pid: (i32, i32, i32) = get_tile_block_id();
+        let row = pid.0;
+        for j in cols {
+            let tile: Tile<T, { [1, BS] }> = constant(T::ZERO, const_shape![1, BS]);
+            out.store(tile, coord((row, j)));
+        }
+    }
+
+    /// Fused two-output owned-axis kernel: one shared index stream, composite
+    /// stores into both partitions (the AddRmsNorm shape).
+    #[cutile::entry]
+    unsafe fn owned_axis_fused_composite_store<
+        T: ElementType,
+        const BS: i32,
+        const MAP_SHAPE: [i32; 2],
+    >(
+        mut out: MappedPartitionMut<T, { [1, BS] }, MAP_SHAPE>,
+        mut res: MappedPartitionMut<T, { [1, BS] }, MAP_SHAPE>,
+        x: &Tensor<T, { [-1, -1] }>,
+    ) {
+        let rows = num_tiles(&out, 0);
+        let cols = num_tiles(&out, 1);
+        let part_x = x.partition(const_shape![1, BS]).with_bounds((rows, cols));
+        let cols = cols.into_dim();
+        for index in out.iter_indices_with(&res) {
+            let (row, _col) = index.components();
+            let mut acc: Tile<T, { [1, BS] }> = constant(T::ZERO, const_shape![1, BS]);
+            for j in cols {
+                let t = part_x.load(coord((row, j)));
+                acc = acc + t;
+            }
+            for j in cols {
+                out.store(acc, coord((row, j)));
+                res.store(acc, coord((row, j)));
+            }
+        }
+    }
+
+    /// The fused kernel with declared grid equalities: the per-axis
+    /// shared-grid runtime asserts discharge at JIT time, leaving the kernel
+    /// with zero runtime checks.
+    #[cutile::entry(
+        preconditions = (
+            dim(out, 0) == dim(res, 0),
+            dim(out, 1) == dim(res, 1),
+        )
+    )]
+    unsafe fn owned_axis_fused_composite_store_with_preconditions<
+        T: ElementType,
+        const BS: i32,
+        const MAP_SHAPE: [i32; 2],
+    >(
+        mut out: MappedPartitionMut<T, { [1, BS] }, MAP_SHAPE>,
+        mut res: MappedPartitionMut<T, { [1, BS] }, MAP_SHAPE>,
+        x: &Tensor<T, { [-1, -1] }>,
+    ) {
+        let rows = num_tiles(&out, 0);
+        let cols = num_tiles(&out, 1);
+        let part_x = x.partition(const_shape![1, BS]).with_bounds((rows, cols));
+        let cols = cols.into_dim();
+        for index in out.iter_indices_with(&res) {
+            let (row, _col) = index.components();
+            let mut acc: Tile<T, { [1, BS] }> = constant(T::ZERO, const_shape![1, BS]);
+            for j in cols {
+                let t = part_x.load(coord((row, j)));
+                acc = acc + t;
+            }
+            for j in cols {
+                out.store(acc, coord((row, j)));
+                res.store(acc, coord((row, j)));
+            }
+        }
+    }
+
+    /// Negative: the owned-axis coordinate must come from the axis's own Dim;
+    /// reusing the streamed axis-0 component on owned axis 1 must fail.
+    #[cutile::entry]
+    unsafe fn owned_axis_rejects_wrong_owned_component<
+        T: ElementType,
+        const BS: i32,
+        const MAP_SHAPE: [i32; 2],
+    >(
+        mut out: MappedPartitionMut<T, { [1, BS] }, MAP_SHAPE>,
+    ) {
+        for index in out.iter_indices() {
+            let (row, _col) = index.components();
+            let tile: Tile<T, { [1, BS] }> = constant(T::ZERO, const_shape![1, BS]);
+            out.store(tile, coord((row, row)));
+        }
+    }
+
+    /// Owned-axis schedule: axis 1 is OWNED (map dim 0), so the stream yields
+    /// one item per axis-0 tile and the in-kernel `Dim` loop traverses the
+    /// owned axis with proof-carrying coordinates.
+    #[cutile::entry]
+    unsafe fn owned_axis_two_pass<T: ElementType, const BS: i32, const MAP_SHAPE: [i32; 2]>(
+        mut out: MappedPartitionMut<T, { [1, BS] }, MAP_SHAPE>,
+        x: &Tensor<T, { [-1, -1] }>,
+    ) {
+        let rows = num_tiles(&out, 0);
+        let cols = num_tiles(&out, 1);
+        let part_x = x.partition(const_shape![1, BS]).with_bounds((rows, cols));
+        let cols = cols.into_dim();
+        for index in out.iter_indices() {
+            let (row, _col) = index.components();
+            let mut acc: Tile<T, { [1, BS] }> = constant(T::ZERO, const_shape![1, BS]);
+            for j in cols {
+                let t = part_x.load(coord((row, j)));
+                acc = acc + t;
+            }
+            out.store(acc, index);
+        }
+    }
+
+    #[cutile::entry]
     unsafe fn dynamic_bounded_rejects_swapped_axes<
         T: ElementType,
         const BM: i32,
@@ -133,7 +295,77 @@ mod partition_index_schedules_module {
         }
     }
 
-    #[cutile::entry(unchecked_accesses = false)]
+    /// Rank-3 bounded loads in the splitk-merge shape: axes 0/2 brand-match
+    /// `num_tiles` bounds of the mapped output, axis 1 is a constant checked
+    /// against the axis's static tile grid.
+    #[cutile::entry]
+    unsafe fn rank3_bounded_load<
+        T: ElementType,
+        const BS: i32,
+        const BD: i32,
+        const S1: i32,
+        const MAP_SHAPE: [i32; 3],
+    >(
+        mut z: MappedPartitionMut<T, { [1, BS, BD] }, MAP_SHAPE>,
+        x: &Tensor<T, { [-1, S1, -1] }>,
+    ) {
+        let d0 = num_tiles(&z, 0);
+        let d2 = num_tiles(&z, 2);
+        let part_x = x
+            .partition(const_shape![1, BS, BD])
+            .with_bounds((d0, Dim::new(1), d2));
+        for index in z.iter_indices() {
+            let [i0, _i1, i2] = index.coords();
+            let tile_x = part_x.load_pipelined::<4>(coord((i0, 0i32, i2)));
+            z.store(tile_x, index);
+        }
+    }
+
+    #[cutile::entry]
+    unsafe fn rank3_bounded_rejects_swapped_axes<
+        T: ElementType,
+        const BS: i32,
+        const BD: i32,
+        const S1: i32,
+        const MAP_SHAPE: [i32; 3],
+    >(
+        z: MappedPartitionMut<T, { [1, BS, BD] }, MAP_SHAPE>,
+        x: &Tensor<T, { [-1, S1, -1] }>,
+    ) {
+        let d0 = num_tiles(&z, 0);
+        let d2 = num_tiles(&z, 2);
+        let part_x = x
+            .partition(const_shape![1, BS, BD])
+            .with_bounds((d0, Dim::new(1), d2));
+        for index in z.iter_indices() {
+            let [i0, _i1, i2] = index.coords();
+            let _tile_x = part_x.load(coord((i2, 0i32, i0)));
+        }
+    }
+
+    #[cutile::entry]
+    unsafe fn rank3_bounded_rejects_out_of_grid_constant<
+        T: ElementType,
+        const BS: i32,
+        const BD: i32,
+        const S1: i32,
+        const MAP_SHAPE: [i32; 3],
+    >(
+        z: MappedPartitionMut<T, { [1, BS, BD] }, MAP_SHAPE>,
+        x: &Tensor<T, { [-1, S1, -1] }>,
+    ) {
+        let d0 = num_tiles(&z, 0);
+        let d2 = num_tiles(&z, 2);
+        let part_x = x
+            .partition(const_shape![1, BS, BD])
+            .with_bounds((d0, Dim::new(1), d2));
+        for index in z.iter_indices() {
+            let [i0, _i1, i2] = index.coords();
+            let _tile_x = part_x.load(coord((i0, 9i32, i2)));
+        }
+    }
+
+    #[cutile::entry]
     unsafe fn rejects_unbranded_partition_index<
         T: ElementType,
         const BM: i32,
@@ -148,7 +380,7 @@ mod partition_index_schedules_module {
         z.store(tile, index);
     }
 
-    #[cutile::entry(unchecked_accesses = false)]
+    #[cutile::entry]
     unsafe fn rejects_foreign_partition_index<
         T: ElementType,
         const BM: i32,
@@ -161,6 +393,187 @@ mod partition_index_schedules_module {
         for index in a.iter_indices() {
             let tile: Tile<T, { [BM, BN] }> = constant(T::ZERO, const_shape![BM, BN]);
             b.store(tile, index);
+        }
+    }
+
+    #[cutile::entry]
+    unsafe fn rank3_scheduled_store<
+        T: ElementType,
+        const BS: i32,
+        const BD: i32,
+        const MAP_SHAPE: [i32; 3],
+    >(
+        mut z: MappedPartitionMut<T, { [1, BS, BD] }, MAP_SHAPE>,
+    ) {
+        for index in z.iter_indices() {
+            let (_bid_b, _bid_s, _bid_d) = index.components();
+            let tile: Tile<T, { [1, BS, BD] }> = constant(T::ZERO, const_shape![1, BS, BD]);
+            z.store(tile, index);
+        }
+    }
+
+    #[cutile::entry]
+    unsafe fn rank1_scheduled_store<T: ElementType, const BN: i32, const MAP_SHAPE: [i32; 1]>(
+        mut z: MappedPartitionMut<T, { [BN] }, MAP_SHAPE>,
+    ) {
+        for index in z.iter_indices() {
+            let tile: Tile<T, { [BN] }> = constant(T::ZERO, const_shape![BN]);
+            z.store(tile, index);
+        }
+    }
+
+    #[cutile::entry]
+    unsafe fn shared_map_dual_store<
+        T: ElementType,
+        const BM: i32,
+        const BN: i32,
+        const MAP_SHAPE: [i32; 2],
+    >(
+        mut out: MappedPartitionMut<T, { [BM, BN] }, MAP_SHAPE>,
+        mut residual_out: MappedPartitionMut<T, { [BM, BN] }, MAP_SHAPE>,
+    ) {
+        for index in out.iter_indices_with(&residual_out) {
+            let tile: Tile<T, { [BM, BN] }> = constant(T::ZERO, const_shape![BM, BN]);
+            out.store(tile, index);
+            residual_out.store(tile, index);
+        }
+    }
+
+    #[cutile::entry]
+    unsafe fn shared_map_rejects_third_partition<
+        T: ElementType,
+        const BM: i32,
+        const BN: i32,
+        const MAP_SHAPE: [i32; 2],
+    >(
+        a: MappedPartitionMut<T, { [BM, BN] }, MAP_SHAPE>,
+        b: MappedPartitionMut<T, { [BM, BN] }, MAP_SHAPE>,
+        mut c: MappedPartitionMut<T, { [BM, BN] }, MAP_SHAPE>,
+    ) {
+        for index in a.iter_indices_with(&b) {
+            let tile: Tile<T, { [BM, BN] }> = constant(T::ZERO, const_shape![BM, BN]);
+            c.store(tile, index);
+        }
+    }
+
+    /// Attention-shaped check-hoisting: a KV-style inner loop whose loads
+    /// index [loop-invariant scalar, induction var, literal]. The bounds
+    /// checks must move to the loop preheader, keeping the hot body free of
+    /// asserts (grout fmha regression, 2026-07-03).
+    #[cutile::entry]
+    unsafe fn hoisted_checks_kv_loop<
+        T: ElementType,
+        const BM: i32,
+        const BN: i32,
+        const D: i32,
+        const MAP_SHAPE: [i32; 3],
+    >(
+        mut out: MappedPartitionMut<T, { [BM, 1, D] }, MAP_SHAPE>,
+        k: &Tensor<T, { [-1, -1, D] }>,
+        kv_tiles: i32,
+    ) {
+        let part_k = k.partition(const_shape![1, BN, D]);
+        for index in out.iter_indices() {
+            let (_q_idx, head_idx, _d0) = index.components();
+            let mut acc: Tile<T, { [BM, 1, D] }> = constant(T::ZERO, const_shape![BM, 1, D]);
+            for j in 0i32..kv_tiles {
+                let k_tile = part_k.load_pipelined::<2>([head_idx, j, 0i32]);
+                let k_tile: Tile<T, { [BM, 1, D] }> = k_tile.reshape(const_shape![BM, 1, D]);
+                acc = acc + k_tile;
+            }
+            out.store(acc, index);
+        }
+    }
+
+    /// Multi-level hoisting: the load's checks are invariant across both
+    /// loops; the inner loop is statically non-empty (0..2), so the checks
+    /// cross it and land in the function body, before the outer `for`.
+    #[cutile::entry]
+    unsafe fn nested_invariant_checks<T: ElementType, const BN: i32, const D: i32>(
+        z: &mut Tensor<T, { [BN, D] }>,
+        x: &Tensor<T, { [-1, -1] }>,
+        head: i32,
+        n: i32,
+    ) {
+        let part = x.partition(const_shape![BN, D]);
+        let mut acc: Tile<T, { [BN, D] }> = constant(T::ZERO, const_shape![BN, D]);
+        for _a in 0i32..n {
+            for b in 0i32..2i32 {
+                let t = part.load([head, b]);
+                acc = acc + t;
+            }
+        }
+        z.store(acc);
+    }
+
+    /// Affine hoisting: the row index is `2*j + 1`, monotone in the
+    /// unit-step induction variable, so the check substitutes the strongest
+    /// instance `2*(n-1) + 1` in the preheader.
+    #[cutile::entry]
+    unsafe fn affine_index_checks<T: ElementType, const BN: i32, const D: i32>(
+        z: &mut Tensor<T, { [BN, D] }>,
+        x: &Tensor<T, { [-1, -1] }>,
+        n: i32,
+    ) {
+        let part = x.partition(const_shape![BN, D]);
+        let mut acc: Tile<T, { [BN, D] }> = constant(T::ZERO, const_shape![BN, D]);
+        for j in 0i32..n {
+            let t = part.load([2i32 * j + 1i32, 0i32]);
+            acc = acc + t;
+        }
+        z.store(acc);
+    }
+
+    #[cutile::entry]
+    unsafe fn subrange_store<
+        T: ElementType,
+        const BM: i32,
+        const BN: i32,
+        const MAP_SHAPE: [i32; 2],
+    >(
+        mut z: MappedPartitionMut<T, { [BM, BN] }, MAP_SHAPE>,
+        start_tile: i32,
+        n_tiles: i32,
+    ) {
+        for index in z.iter_indices_within([(start_tile, n_tiles), (0i32, -1i32)]) {
+            let tile: Tile<T, { [BM, BN] }> = constant(T::ZERO, const_shape![BM, BN]);
+            z.store(tile, index);
+        }
+    }
+
+    #[cutile::entry]
+    unsafe fn subrange_rejects_negative_start<
+        T: ElementType,
+        const BM: i32,
+        const BN: i32,
+        const MAP_SHAPE: [i32; 2],
+    >(
+        mut z: MappedPartitionMut<T, { [BM, BN] }, MAP_SHAPE>,
+    ) {
+        for index in z.iter_indices_within([(-1i32, 2i32), (0i32, -1i32)]) {
+            let tile: Tile<T, { [BM, BN] }> = constant(T::ZERO, const_shape![BM, BN]);
+            z.store(tile, index);
+        }
+    }
+
+    #[cutile::entry]
+    unsafe fn subrange_shared_dual_store<
+        T: ElementType,
+        const BM: i32,
+        const BN: i32,
+        const MAP_SHAPE: [i32; 2],
+    >(
+        mut out: MappedPartitionMut<T, { [BM, BN] }, MAP_SHAPE>,
+        mut residual_out: MappedPartitionMut<T, { [BM, BN] }, MAP_SHAPE>,
+        start_tile: i32,
+        n_tiles: i32,
+    ) {
+        for index in
+            out.iter_indices_within_with([(start_tile, n_tiles), (0i32, -1i32)], &residual_out)
+        {
+            let tile: Tile<T, { [BM, BN] }> = constant(T::ZERO, const_shape![BM, BN]);
+            out.store(tile, index);
+            residual_out.store(tile, index);
         }
     }
 }
@@ -178,6 +591,28 @@ async fn mapped_partition_launcher_accepts_host_map() {
             z.partition([64, 64]).map([4, 1], 4),
             x,
             y,
+        )
+    };
+}
+
+#[allow(dead_code)]
+async fn mapped_partition_launcher_accepts_rank3_and_shared_host_maps() {
+    use cutile::api;
+    use cutile::prelude::*;
+
+    let z = api::zeros::<f32>(&[8, 256, 256]).await.unwrap();
+    let _op = unsafe {
+        partition_index_schedules_module::rank3_scheduled_store(
+            z.partition([1, 64, 64]).map([1, 1, 1], 4),
+        )
+    };
+
+    let out = api::zeros::<f32>(&[256, 256]).await.unwrap();
+    let residual_out = api::zeros::<f32>(&[256, 256]).await.unwrap();
+    let _op = unsafe {
+        partition_index_schedules_module::shared_map_dual_store(
+            out.partition([64, 64]).map([1, 1], 4),
+            residual_out.partition([64, 64]).map([1, 1], 4),
         )
     };
 }
@@ -300,6 +735,189 @@ fn mapped_partition_indices_lower_to_persistent_loop() {
     });
 }
 
+fn compile_owned_axis_named(function_name: &str, map_shape: [i32; 2]) -> Result<String, String> {
+    let generics = vec![
+        "f32".to_string(),
+        "64".to_string(),
+        map_shape[0].to_string(),
+        map_shape[1].to_string(),
+    ];
+    let stride_args: Vec<(&str, &[i32])> = match function_name {
+        "owned_axis_fused_composite_store"
+        | "owned_axis_fused_composite_store_with_preconditions" => {
+            vec![("out", &[256, 1]), ("res", &[256, 1]), ("x", &[256, 1])]
+        }
+        "owned_axis_rejects_wrong_owned_component" | "mapped_blockid_store_rejected" => {
+            vec![("out", &[256, 1])]
+        }
+        _ => vec![("out", &[256, 1]), ("x", &[256, 1])],
+    };
+    common::compile_to_ir(
+        __module_ast_self,
+        "partition_index_schedules_module",
+        function_name,
+        &generics,
+        &stride_args,
+        &[],
+        &[],
+        Some((4, 1, 1)),
+        &CompileOptions::default(),
+    )
+    .map_err(|err| err.to_string())
+}
+
+fn compile_owned_axis_kernel(map_shape: [i32; 2]) -> Result<String, String> {
+    compile_owned_axis_named("owned_axis_two_pass", map_shape)
+}
+
+#[test]
+fn owned_axis_schedule_streams_only_streamed_axes() {
+    common::with_test_stack(|| {
+        let mlir = compile_owned_axis_kernel([1, 0]).expect("Failed to compile");
+        assert!(
+            mlir.contains("get_tile_block_id"),
+            "expected persistent loop over the streamed axis:\n{mlir}"
+        );
+        assert!(
+            mlir.contains("store_view_tko"),
+            "expected the all-minted store to remain valid with an owned axis:\n{mlir}"
+        );
+        // A single streamed axis needs no flat-id decomposition: the rank-2
+        // linear schedule's div/rem pair must be absent.
+        let baseline = compile_owned_axis_kernel([1, 1]).expect("Failed to compile baseline");
+        let count = |text: &str, needle: &str| text.matches(needle).count();
+        assert!(
+            count(&mlir, "remi") < count(&baseline, "remi"),
+            "owned-axis schedule should drop the flat-id rem of the fully-streamed baseline:\nowned:\n{mlir}\nbaseline:\n{baseline}"
+        );
+    });
+}
+
+#[test]
+fn owned_axis_composite_store_discharges_all_checks() {
+    common::with_test_stack(|| {
+        let mlir = compile_owned_axis_named("owned_axis_composite_store", [1, 0])
+            .expect("Failed to compile composite-store kernel");
+        assert!(
+            mlir.contains("store_view_tko"),
+            "expected composite stores to lower to store_view_tko:\n{mlir}"
+        );
+        // Single-owner stream + Dim-proven loads and stores: every *access*
+        // check discharges at JIT time.
+        assert!(
+            !mlir.contains("out of bounds"),
+            "expected zero runtime access checks in the single-output owned-axis kernel:\n{mlir}"
+        );
+        // One `with_bounds` binding check remains, and correctly so: this kernel
+        // binds `num_tiles(&out, k)` as the bound for a partition of `x`, i.e.
+        // it claims `tiles(x, k) == tiles(out, k)` across two tensors. `x` is
+        // `{[-1, -1]}`, so that cannot be decided at JIT, and the kernel
+        // declares no `preconditions` — nothing else verifies the claim.
+        // Declaring the dim equalities (see the `_with_preconditions` variant)
+        // is what should discharge it, once the binding obligation is routed
+        // through the obligation solver.
+    });
+}
+
+#[test]
+fn owned_axis_fused_composite_store_accepts_partner_dim() {
+    common::with_test_stack(|| {
+        let mlir = compile_owned_axis_named("owned_axis_fused_composite_store", [1, 0])
+            .expect("Failed to compile fused composite-store kernel");
+        // Both outputs store through composite coords: the axis-1 Dim was
+        // minted from `out`, and the shared stream makes it valid for `res`.
+        let store_count = mlir.matches("store_view_tko").count();
+        assert!(
+            store_count >= 2,
+            "expected stores into both shared partitions, found {store_count}:\n{mlir}"
+        );
+        // Dynamic shapes: the shared-grid obligation is now derived and checked
+        // on the host, so no assert remains in the kernel.
+        assert!(
+            !mlir.contains("equal logical partition grids"),
+            "shared-grid validation should relocate to launch:\n{mlir}"
+        );
+    });
+}
+
+#[test]
+fn owned_axis_fused_preconditions_discharge_grid_asserts() {
+    common::with_test_stack(|| {
+        let mlir = compile_owned_axis_named(
+            "owned_axis_fused_composite_store_with_preconditions",
+            [1, 0],
+        )
+        .expect("Failed to compile preconditioned fused kernel");
+        assert!(
+            !mlir.contains("equal logical partition grids"),
+            "declared dim equalities should discharge the shared-grid asserts:\n{mlir}"
+        );
+        // With the grid asserts discharged, the fused kernel carries zero
+        // runtime *access* checks — the probe-measured STACK 32 / 4 spills channel.
+        assert!(
+            !mlir.contains("out of bounds"),
+            "expected zero runtime access checks in the preconditioned fused kernel:\n{mlir}"
+        );
+        // TODO (hme): the `with_bounds` binding check still lowers to a runtime
+        // assert here. This kernel declares the dim equalities, so the binding
+        // obligation `tiles(x, k) == tiles(out, k)` follows from them and should
+        // discharge at JIT — route the binding through the obligation solver
+        // (`resolve_dim_eq` already decides exactly this against declared
+        // `preconditions`) and this kernel returns to zero runtime asserts.
+    });
+}
+
+#[test]
+fn owned_axis_rejects_wrong_owned_component() {
+    common::with_test_stack(|| {
+        let err = compile_owned_axis_named("owned_axis_rejects_wrong_owned_component", [1, 0])
+            .expect_err("streamed component reused on the owned axis must fail");
+        assert!(
+            err.contains("owned axis 1") && err.contains("different dimension"),
+            "unexpected wrong-owned-component error: {err}"
+        );
+    });
+}
+
+// Soundness knife-edge: the block-id discharge must NOT green-light a mapped
+// store. A `MappedPartitionMut` block-id store routes through the mapped handler
+// (`validate_partition_store`), never the direct bounded-access handler where the
+// grid≡partition equality holds, so it stays rejected.
+#[test]
+fn mapped_blockid_store_is_rejected() {
+    common::with_test_stack(|| {
+        let err = compile_owned_axis_named("mapped_blockid_store_rejected", [1, 1])
+            .expect_err("a tile-block id store into a mapped partition must be rejected");
+        assert!(
+            err.contains("requires an index produced by this partition's iter_indices()"),
+            "unexpected mapped block-id rejection error: {err}"
+        );
+    });
+}
+
+#[test]
+fn composite_store_rejected_on_fully_streamed_map() {
+    common::with_test_stack(|| {
+        let err = compile_owned_axis_named("owned_axis_composite_store", [1, 1])
+            .expect_err("composite store must be rejected without OWNED axes");
+        assert!(
+            err.contains("requires an index produced by this partition's iter_indices()"),
+            "unexpected fully-streamed composite error: {err}"
+        );
+    });
+}
+
+#[test]
+fn owned_axis_rejects_all_owned_map() {
+    common::with_test_stack(|| {
+        let err = compile_owned_axis_kernel([0, 0]).expect_err("all-OWNED map must be rejected");
+        assert!(
+            err.contains("at least one streamed"),
+            "unexpected all-OWNED error: {err}"
+        );
+    });
+}
+
 fn compile_dynamic_persistent_gemm_bounded_with_map(map_shape: [i32; 2]) -> Result<String, String> {
     let generics = vec![
         "f32".to_string(),
@@ -360,18 +978,19 @@ fn mapped_persistent_mlir_is_stable_across_repeated_compiles() {
     });
 }
 
+// A foreign partition load with no declared preconditions used to keep its
+// check in the kernel. The compiler now derives the extent fact it needs and
+// has the host verify it, so the check leaves — enforced, not dropped. The
+// sibling test below covers the declared spelling, which discharges one stage
+// earlier still, at compile time.
 #[test]
-fn mapped_partition_indices_keep_foreign_partition_load_checks_without_preconditions() {
+fn mapped_partition_indices_relocate_foreign_load_checks_without_preconditions() {
     common::with_test_stack(|| {
         let mlir = compile_static_persistent_gemm_kernel("static_persistent_gemm_scheduled")
             .expect("Failed to compile");
         assert!(
-            mlir.contains("partition access out of bounds: dim 0, block index >= ceil(256/64)"),
-            "expected x-load bid_m check without dim preconditions:\n{mlir}"
-        );
-        assert!(
-            mlir.contains("partition access out of bounds: dim 1, block index >= ceil(256/64)"),
-            "expected y-load bid_n check without dim preconditions:\n{mlir}"
+            !mlir.contains("partition access out of bounds"),
+            "foreign-load checks should relocate to launch, not stay in the kernel:\n{mlir}"
         );
     });
 }
@@ -424,6 +1043,93 @@ fn bounded_partition_rejects_swapped_coordinate_axes() {
     });
 }
 
+fn compile_rank3_bounded_kernel(
+    function_name: &str,
+) -> Result<(String, cutile::compile_api::CheckPlacementCounts), String> {
+    let generics = vec![
+        "f32".to_string(),
+        "64".to_string(),
+        "64".to_string(),
+        "64".to_string(),
+        "1".to_string(),
+        "1".to_string(),
+        "1".to_string(),
+    ];
+    let stride_args = vec![("z", &[4096, 64, 1][..]), ("x", &[4096, 64, 1][..])];
+    common::compile_to_ir_with_counts(
+        __module_ast_self,
+        "partition_index_schedules_module",
+        function_name,
+        &generics,
+        &stride_args,
+        &[],
+        &[],
+        Some((4, 1, 1)),
+        &CompileOptions::default(),
+    )
+    .map_err(|err| err.to_string())
+}
+
+#[test]
+fn rank3_bounded_load_discharges_all_checks() {
+    common::with_test_stack(|| {
+        let (mlir, counts) =
+            compile_rank3_bounded_kernel("rank3_bounded_load").expect("Failed to compile");
+        assert!(
+            !mlir.contains("partition access out of bounds"),
+            "rank-3 bounded coordinates should discharge every load check:\n{mlir}"
+        );
+        assert_eq!(
+            counts.in_place, 0,
+            "rank-3 bounded loads must not leave in-place checks:\n{mlir}"
+        );
+        assert_eq!(
+            counts.hoisted, 0,
+            "rank-3 bounded loads must not need hoisted checks:\n{mlir}"
+        );
+        assert_eq!(
+            counts.discharged, 3,
+            "each coordinate axis should discharge at compile time:\n{mlir}"
+        );
+        assert!(
+            mlir.contains("latency = 4"),
+            "bounded pipelined load should keep its latency hint:\n{mlir}"
+        );
+        assert!(
+            mlir.contains("store_view_tko"),
+            "rank-3 bounded kernel should still store through the mapped partition:\n{mlir}"
+        );
+    });
+}
+
+#[test]
+fn rank3_bounded_rejects_swapped_coordinate_axes() {
+    common::with_test_stack(|| {
+        let err = compile_rank3_bounded_kernel("rank3_bounded_rejects_swapped_axes")
+            .map(|(mlir, _)| mlir)
+            .expect_err("swapped rank-3 bounded coordinate axes should fail");
+        assert!(
+            err.contains(
+                "bounded partition coordinate axis 0 was produced by a different dimension"
+            ),
+            "unexpected error for swapped rank-3 bounded coordinate axes:\n{err}"
+        );
+    });
+}
+
+#[test]
+fn rank3_bounded_rejects_out_of_grid_constant() {
+    common::with_test_stack(|| {
+        let err = compile_rank3_bounded_kernel("rank3_bounded_rejects_out_of_grid_constant")
+            .map(|(mlir, _)| mlir)
+            .expect_err("out-of-grid constant coordinate should fail at compile time");
+        assert!(
+            err.contains("is not within the 1-tile grid"),
+            "unexpected error for out-of-grid constant coordinate:\n{err}"
+        );
+    });
+}
+
 #[test]
 fn mapped_partition_store_rejects_unbranded_index() {
     common::with_test_stack(|| {
@@ -444,6 +1150,386 @@ fn mapped_partition_store_rejects_foreign_index() {
         assert!(
             err.contains("index was produced by a different mapped partition"),
             "unexpected error for foreign partition index:\n{err}"
+        );
+    });
+}
+
+fn compile_rank3_scheduled_store(map_shape: [i32; 3]) -> Result<String, String> {
+    let generics = vec![
+        "f32".to_string(),
+        "64".to_string(),
+        "64".to_string(),
+        map_shape[0].to_string(),
+        map_shape[1].to_string(),
+        map_shape[2].to_string(),
+    ];
+    let stride_args = vec![("z", &[4096, 64, 1][..])];
+    common::compile_to_ir(
+        __module_ast_self,
+        "partition_index_schedules_module",
+        "rank3_scheduled_store",
+        &generics,
+        &stride_args,
+        &[],
+        &[],
+        Some((4, 1, 1)),
+        &CompileOptions::default(),
+    )
+    .map_err(|err| err.to_string())
+}
+
+#[test]
+fn rank3_mapped_partition_lowers_to_persistent_loop() {
+    common::with_test_stack(|| {
+        let mlir =
+            compile_rank3_scheduled_store([1, 1, 1]).expect("Failed to compile rank-3 kernel");
+        assert!(
+            mlir.contains("get_index_space_shape"),
+            "expected rank-3 index-space query in MLIR:\n{mlir}"
+        );
+        assert!(
+            mlir.contains("get_tile_block_id"),
+            "expected rank-3 persistent loop to use tile-block id:\n{mlir}"
+        );
+        assert!(
+            mlir.contains("store_view_tko"),
+            "expected rank-3 mapped store in MLIR:\n{mlir}"
+        );
+        assert!(
+            !mlir.contains("mini "),
+            "linear rank-3 map should not use the grouped/swizzled min path:\n{mlir}"
+        );
+    });
+}
+
+#[test]
+fn rank3_mapped_partition_supports_grouped_inner_axes() {
+    common::with_test_stack(|| {
+        let mlir = compile_rank3_scheduled_store([1, 4, 1])
+            .expect("Failed to compile grouped rank-3 kernel");
+        assert!(
+            mlir.contains("mini "),
+            "grouped rank-3 map should lower through the grouped swizzle path:\n{mlir}"
+        );
+        assert!(
+            mlir.contains("store_view_tko"),
+            "expected grouped rank-3 mapped store in MLIR:\n{mlir}"
+        );
+    });
+}
+
+#[test]
+fn rank3_mapped_partition_rejects_grouped_leading_axis() {
+    common::with_test_stack(|| {
+        let err = compile_rank3_scheduled_store([2, 1, 1])
+            .expect_err("grouped leading map axis should fail");
+        assert!(
+            err.contains("leading map axis 0 must be 1"),
+            "unexpected error for grouped leading map axis:\n{err}"
+        );
+    });
+}
+
+#[test]
+fn rank1_mapped_partition_lowers_to_persistent_loop() {
+    common::with_test_stack(|| {
+        let generics = vec!["f32".to_string(), "128".to_string(), "1".to_string()];
+        let stride_args = vec![("z", &[1][..])];
+        let mlir = common::compile_to_ir(
+            __module_ast_self,
+            "partition_index_schedules_module",
+            "rank1_scheduled_store",
+            &generics,
+            &stride_args,
+            &[],
+            &[],
+            Some((4, 1, 1)),
+            &CompileOptions::default(),
+        )
+        .map_err(|err| err.to_string())
+        .expect("Failed to compile rank-1 kernel");
+        assert!(
+            mlir.contains("get_index_space_shape"),
+            "expected rank-1 index-space query in MLIR:\n{mlir}"
+        );
+        assert!(
+            mlir.contains("store_view_tko"),
+            "expected rank-1 mapped store in MLIR:\n{mlir}"
+        );
+    });
+}
+
+fn compile_shared_map_kernel(function_name: &str) -> Result<String, String> {
+    let generics = vec![
+        "f32".to_string(),
+        "64".to_string(),
+        "64".to_string(),
+        "1".to_string(),
+        "1".to_string(),
+    ];
+    let stride_args: Vec<(&str, &[i32])> = match function_name {
+        "shared_map_dual_store" => vec![("out", &[256, 1]), ("residual_out", &[256, 1])],
+        "shared_map_rejects_third_partition" => {
+            vec![("a", &[256, 1]), ("b", &[256, 1]), ("c", &[256, 1])]
+        }
+        other => panic!("unexpected shared-map test kernel `{other}`"),
+    };
+    common::compile_to_ir(
+        __module_ast_self,
+        "partition_index_schedules_module",
+        function_name,
+        &generics,
+        &stride_args,
+        &[],
+        &[],
+        Some((4, 1, 1)),
+        &CompileOptions::default(),
+    )
+    .map_err(|err| err.to_string())
+}
+
+#[test]
+fn shared_map_indices_store_into_both_partitions() {
+    common::with_test_stack(|| {
+        let mlir =
+            compile_shared_map_kernel("shared_map_dual_store").expect("Failed to compile zip");
+        let store_count = mlir.matches("store_view_tko").count();
+        assert!(
+            store_count >= 2,
+            "expected two mapped stores through one shared index stream, found {store_count}:\n{mlir}"
+        );
+        assert!(
+            !mlir.contains("shared mapped partitions require equal logical partition grids"),
+            "per-axis grid equality is now derived and checked on the host, so no \
+             assert should remain in the kernel:\n{mlir}"
+        );
+    });
+}
+
+#[test]
+fn shared_map_still_rejects_unrelated_partition_store() {
+    common::with_test_stack(|| {
+        let err = compile_shared_map_kernel("shared_map_rejects_third_partition")
+            .expect_err("store into a partition outside the shared map should fail");
+        assert!(
+            err.contains("index was produced by a different mapped partition"),
+            "unexpected error for unrelated partition store:\n{err}"
+        );
+    });
+}
+
+fn compile_subrange_kernel(function_name: &str) -> Result<String, String> {
+    let generics = vec![
+        "f32".to_string(),
+        "64".to_string(),
+        "64".to_string(),
+        "1".to_string(),
+        "1".to_string(),
+    ];
+    let stride_args: Vec<(&str, &[i32])> = match function_name {
+        "subrange_store" | "subrange_rejects_negative_start" => vec![("z", &[256, 1])],
+        "subrange_shared_dual_store" => vec![("out", &[256, 1]), ("residual_out", &[256, 1])],
+        other => panic!("unexpected sub-range test kernel `{other}`"),
+    };
+    common::compile_to_ir(
+        __module_ast_self,
+        "partition_index_schedules_module",
+        function_name,
+        &generics,
+        &stride_args,
+        &[],
+        &[],
+        Some((4, 1, 1)),
+        &CompileOptions::default(),
+    )
+    .map_err(|err| err.to_string())
+}
+
+#[test]
+fn subrange_iteration_checks_dynamic_ranges_at_runtime() {
+    common::with_test_stack(|| {
+        let mlir =
+            compile_subrange_kernel("subrange_store").expect("Failed to compile sub-range kernel");
+        assert!(
+            mlir.contains("mapped partition sub-range out of bounds"),
+            "dynamic sub-ranges should carry runtime bounds asserts:\n{mlir}"
+        );
+        assert!(
+            mlir.contains("store_view_tko"),
+            "expected mapped store in sub-range kernel:\n{mlir}"
+        );
+        assert!(
+            mlir.contains("get_index_space_shape"),
+            "sub-range iteration still queries the logical grid:\n{mlir}"
+        );
+    });
+}
+
+#[test]
+fn subrange_rejects_provably_negative_start() {
+    common::with_test_stack(|| {
+        let err = compile_subrange_kernel("subrange_rejects_negative_start")
+            .expect_err("negative sub-range start should fail at compile time");
+        assert!(
+            err.contains("start -1 is negative"),
+            "unexpected error for negative sub-range start:\n{err}"
+        );
+    });
+}
+
+#[test]
+fn subrange_composes_with_shared_maps() {
+    common::with_test_stack(|| {
+        let mlir = compile_subrange_kernel("subrange_shared_dual_store")
+            .expect("Failed to compile shared sub-range kernel");
+        assert!(
+            mlir.contains("mapped partition sub-range out of bounds"),
+            "shared sub-range should keep range asserts:\n{mlir}"
+        );
+        assert!(
+            !mlir.contains("shared mapped partitions require equal logical partition grids"),
+            "grid equality relocates to launch; only the sub-range assert above \
+             (whose bounds are not launch-known) stays:\n{mlir}"
+        );
+        let store_count = mlir.matches("store_view_tko").count();
+        assert!(
+            store_count >= 2,
+            "expected two mapped stores through the shared sub-range stream, found {store_count}:\n{mlir}"
+        );
+    });
+}
+
+#[test]
+fn kv_loop_bounds_checks_hoist_to_the_preheader() {
+    common::with_test_stack(|| {
+        let generics = vec![
+            "f32".to_string(),
+            "16".to_string(),
+            "16".to_string(),
+            "64".to_string(),
+            "1".to_string(),
+            "1".to_string(),
+            "1".to_string(),
+        ];
+        let stride_args: Vec<(&str, &[i32])> = vec![("out", &[64, 64, 1]), ("k", &[1024, 64, 1])];
+        let mlir = common::compile_to_ir(
+            __module_ast_self,
+            "partition_index_schedules_module",
+            "hoisted_checks_kv_loop",
+            &generics,
+            &stride_args,
+            &[],
+            &[],
+            Some((4, 1, 1)),
+            &CompileOptions::default(),
+        )
+        .map_err(|err| err.to_string())
+        .expect("Failed to compile hoisted-checks kernel");
+        assert!(
+            mlir.contains("partition access out of bounds"),
+            "checked loads must keep their bounds asserts somewhere:\n{mlir}"
+        );
+        // The inner KV loop is the `for` op carrying loop values
+        // (`iter_values`, the accumulator). Nothing between its header and
+        // its closing brace may assert: the checks live in the preheader.
+        let kv_loop_start = mlir
+            .find("iter_values")
+            .expect("expected the KV loop with a loop-carried accumulator");
+        let mut depth = 0usize;
+        let mut kv_loop_end = mlir.len();
+        let bytes = mlir.as_bytes();
+        let mut began = false;
+        for (offset, &byte) in bytes.iter().enumerate().skip(kv_loop_start) {
+            match byte {
+                b'{' => {
+                    depth += 1;
+                    began = true;
+                }
+                b'}' => {
+                    depth = depth.saturating_sub(1);
+                    if began && depth == 0 {
+                        kv_loop_end = offset;
+                        break;
+                    }
+                }
+                _ => {}
+            }
+        }
+        let kv_loop_body = &mlir[kv_loop_start..kv_loop_end];
+        assert!(
+            !kv_loop_body.contains("assert"),
+            "bounds checks must hoist out of the KV loop body:\n{kv_loop_body}"
+        );
+    });
+}
+
+fn compile_hoist_kernel(function_name: &str, generics: &[&str]) -> String {
+    let generics: Vec<String> = generics.iter().map(|g| g.to_string()).collect();
+    let stride_args: Vec<(&str, &[i32])> = vec![("z", &[64, 1]), ("x", &[512, 1])];
+    common::compile_to_ir(
+        __module_ast_self,
+        "partition_index_schedules_module",
+        function_name,
+        &generics,
+        &stride_args,
+        &[],
+        &[],
+        None,
+        &CompileOptions::default(),
+    )
+    .map_err(|err| err.to_string())
+    .expect("Failed to compile hoist kernel")
+}
+
+/// Every bounds assert must appear before the first loop op.
+fn assert_all_checks_precede_loops(mlir: &str, label: &str) {
+    let first_loop = mlir
+        .find("for %")
+        .unwrap_or_else(|| panic!("{label}: expected a for loop in MLIR:\n{mlir}"));
+    assert!(
+        mlir.contains("partition access out of bounds"),
+        "{label}: checked loads must keep their asserts:\n{mlir}"
+    );
+    let last_assert = mlir
+        .rfind("partition access out of bounds")
+        .expect("asserted above");
+    assert!(
+        last_assert < first_loop,
+        "{label}: all bounds checks must hoist above every loop:\n{mlir}"
+    );
+}
+
+#[test]
+fn invariant_checks_hoist_across_nested_loops() {
+    common::with_test_stack(|| {
+        let mlir = compile_hoist_kernel("nested_invariant_checks", &["f32", "16", "64"]);
+        assert_all_checks_precede_loops(&mlir, "nested invariant");
+    });
+}
+
+#[test]
+fn affine_induction_checks_stay_in_place_without_an_overflow_proof() {
+    common::with_test_stack(|| {
+        // `2*j + 1` over a runtime range used to hoist by substituting the
+        // scaled loop bound — but the substituted instance is wrapping i32
+        // arithmetic, and without a static range proving the image fits, a
+        // wrapped extreme can pass the hoisted check while the real indices
+        // run wild (issue #213). Non-identity affine forms now refuse to
+        // hoist unless range analysis proves the i64 image representable;
+        // this kernel's `n` is unbounded, so the check stays at the access,
+        // testing the actual runtime value, which wraps exactly as the
+        // access does.
+        let mlir = compile_hoist_kernel("affine_index_checks", &["f32", "16", "64"]);
+        let first_loop = mlir.find("for %").unwrap();
+        let body = &mlir[first_loop..];
+        assert!(
+            body.contains("out of bounds"),
+            "the non-identity affine check must remain in the loop body:\n{mlir}"
+        );
+        let preheader = &mlir[..first_loop];
+        assert!(
+            !preheader.contains("out of bounds"),
+            "no hoisted instance may be emitted for an unproven affine image:\n{preheader}"
         );
     });
 }

--- a/cutile/tests/review_probe_block_id_2026_08_18.rs
+++ b/cutile/tests/review_probe_block_id_2026_08_18.rs
@@ -1,0 +1,460 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Audit probes for the 2026-08-18 block-id bounds-check review.
+//!
+//! These kernels deliberately combine the block-id proof with symbolic
+//! arithmetic, control-flow joins, loop iterands, crossed grid/tensor axes,
+//! and a permuted partition. The compile-only test runs everywhere; the
+//! ignored execution test additionally exercises the generated launcher and
+//! JIT cache on a GPU.
+
+use std::process::Command;
+use std::sync::Arc;
+
+use cutile::api;
+use cutile::compile_api::{CheckPlacementCounts, KernelCompiler};
+use cutile::prelude::*;
+use cutile::tensor::{IntoPartition, ToHostVec};
+
+mod common;
+
+#[cutile::module]
+mod block_id_review_module {
+    use cutile::core::*;
+
+    /// The two additions cancel modulo 2^32, so the value remains exactly
+    /// `pid.1` even on the wrapping path. Tuple repacking must preserve that
+    /// fact, while `dim_map = [1, 0]` must send logical axis 0 to root axis 1.
+    #[cutile::entry(deny_in_kernel_checks = true)]
+    fn permuted_wrapping_identity<const B: i32>(
+        z: &mut Tensor<f32, { [B, B] }>,
+        x: &Tensor<f32, { [-1, -1] }>,
+    ) {
+        let p = x.partition_permuted(const_shape![B, B], const_array![1, 0]);
+        let pid: (i32, i32, i32) = get_tile_block_id();
+        let repacked = (pid.1, pid.0);
+        let (y, _x) = repacked;
+        let index = (y + 2_147_483_647i32) - 2_147_483_647i32;
+        let t = p.load([index, 0i32]);
+        z.store(t);
+    }
+
+    /// A runtime join can replace the block id with an arbitrary scalar. The
+    /// joined value must lose the block-id term and retain an in-kernel check.
+    #[cutile::entry]
+    fn joined_reassignment<const B: i32>(
+        z: &mut Tensor<f32, { [B] }>,
+        x: &Tensor<f32, { [-1] }>,
+        replacement: i32,
+    ) {
+        let p = x.partition(const_shape![B]);
+        let pid: (i32, i32, i32) = get_tile_block_id();
+        let mut index = pid.0;
+        if replacement >= 0i32 {
+            index = replacement;
+        }
+        let t = p.load([index]);
+        z.store(t);
+    }
+
+    /// Compile-time branch adoption must publish the value from the sole
+    /// feasible branch, not retain the pre-branch block-id term.
+    #[cutile::entry]
+    fn exact_if_replacement<const B: i32>(
+        z: &mut Tensor<f32, { [B] }>,
+        x: &Tensor<f32, { [-1] }>,
+        replacement: i32,
+    ) {
+        let p = x.partition(const_shape![B]);
+        let pid: (i32, i32, i32) = get_tile_block_id();
+        let mut index = pid.0;
+        if true {
+            index = replacement;
+        }
+        let t = p.load([index]);
+        z.store(t);
+    }
+
+    /// Conversely, an assignment in the unreachable compile-time branch must
+    /// not erase the exact block-id value that reaches the access.
+    #[cutile::entry(deny_in_kernel_checks = true)]
+    fn exact_if_unreachable_replacement<const B: i32>(
+        z: &mut Tensor<f32, { [B] }>,
+        x: &Tensor<f32, { [-1] }>,
+        replacement: i32,
+    ) {
+        let p = x.partition(const_shape![B]);
+        let pid: (i32, i32, i32) = get_tile_block_id();
+        let mut index = pid.0;
+        if false {
+            index = replacement;
+        }
+        let t = p.load([index]);
+        z.store(t);
+    }
+
+    /// A variable carried out of a loop must not keep the block-id term it had
+    /// before the loop once the body can replace its runtime value.
+    #[cutile::entry]
+    fn loop_carried_replacement<const B: i32>(
+        z: &mut Tensor<f32, { [B] }>,
+        x: &Tensor<f32, { [-1] }>,
+        replacement: i32,
+    ) {
+        let p = x.partition(const_shape![B]);
+        let pid: (i32, i32, i32) = get_tile_block_id();
+        let mut index = pid.0;
+        for _i in 0i32..1i32 {
+            index = replacement;
+        }
+        let t = p.load([index]);
+        z.store(t);
+    }
+
+    /// The access uses the loop iterand, not the bare special register. Its
+    /// proof is the loop bound / same-view provenance; the block-id rung must
+    /// not stake a launch check for it.
+    #[cutile::entry]
+    fn persistent_walk<const B: i32>(z: &mut Tensor<f32, { [B] }>, x: &Tensor<f32, { [-1] }>) {
+        let p = x.partition(const_shape![B]);
+        let pid: (i32, i32, i32) = get_tile_block_id();
+        let ntb: (i32, i32, i32) = get_num_tile_blocks();
+        let mut acc: Tile<f32, { [B] }> = constant(0.0, const_shape![B]);
+        for i in (pid.0..num_tiles(&p, 0)).step_by(ntb.0 as usize) {
+            acc = acc + p.load([i]);
+        }
+        z.store(acc);
+    }
+
+    /// No mutable argument contributes an inferred grid. This lets the same
+    /// JIT specialization be launched repeatedly with different explicit
+    /// grids; every invocation must validate its own grid before launch.
+    #[cutile::entry(deny_in_kernel_checks = true)]
+    fn explicit_grid_revalidation<const B: i32>(x: &Tensor<f32, { [-1] }>) {
+        let p = x.partition(const_shape![B]);
+        let pid: (i32, i32, i32) = get_tile_block_id();
+        let _t = p.load([pid.0]);
+    }
+
+    /// Same access without the deny policy, used to inspect forced-device
+    /// placement in a subprocess with isolated environment variables.
+    #[cutile::entry]
+    fn block_id_ablation<const B: i32>(x: &Tensor<f32, { [-1] }>) {
+        let p = x.partition(const_shape![B]);
+        let pid: (i32, i32, i32) = get_tile_block_id();
+        let _t = p.load([pid.0]);
+    }
+
+    /// The symbolic cancellation is valid only if the runtime integer ops
+    /// obey the same modulo-2^32 ring identity on their wrapping path.
+    #[cutile::entry(deny_in_kernel_checks = true)]
+    fn wrapping_identity_execution<const B: i32>(
+        z: &mut Tensor<f32, { [B] }>,
+        x: &Tensor<f32, { [-1] }>,
+    ) {
+        let p = x.partition(const_shape![B]);
+        let pid: (i32, i32, i32) = get_tile_block_id();
+        let index = (pid.0 + 2_147_483_647i32) - 2_147_483_647i32;
+        z.store(p.load([index]));
+    }
+
+    /// Frame attack: `partition_mut` adds `pid * ceil(OUTER/INNER)` after the
+    /// safe check. Using pid again as the local coordinate can therefore make
+    /// the effective coordinate much larger than the one the rung proves.
+    #[cutile::entry(deny_in_kernel_checks = true)]
+    fn nested_nondivisible_block_id<const OUTER: i32, const INNER: i32>(
+        out: &mut Tensor<f32, { [1, OUTER] }>,
+    ) {
+        let mut p: PartitionMut<f32, { [1, INNER] }> = out.partition_mut(const_shape![1, INNER]);
+        let pid: (i32, i32, i32) = get_tile_block_id();
+        let tile: Tile<f32, { [1, INNER] }> = constant(7.0, const_shape![1, INNER]);
+        p.store(tile, [0i32, pid.1]);
+    }
+}
+
+use block_id_review_module::__module_ast_self;
+
+const B: usize = 16;
+
+fn compile(name: &str, strides: &[(&str, &[i32])]) -> cutile::compile_api::CompileArtifacts {
+    KernelCompiler::new(__module_ast_self, "block_id_review_module", name)
+        .target("sm_120")
+        .generics(vec![B.to_string()])
+        .strides(strides)
+        .compile()
+        .unwrap_or_else(|err| panic!("compile {name}: {err}"))
+}
+
+#[test]
+#[ignore = "subprocess entry point for isolated force-device compilation"]
+fn block_id_ablation_compile_runner() {
+    let art = compile("block_id_ablation", &[("x", &[1])]);
+    let counts = art.check_counts();
+    println!(
+        "COUNTS:{}:{}:{}:{}",
+        counts.discharged,
+        counts.hoisted,
+        counts.in_place,
+        art.launch_checks().len()
+    );
+}
+
+fn ablation_counts(force_device: bool) -> (u32, u32, u32, usize) {
+    let exe = std::env::current_exe().expect("current test executable");
+    let mut cmd = Command::new(exe);
+    cmd.args([
+        "--exact",
+        "block_id_ablation_compile_runner",
+        "--ignored",
+        "--nocapture",
+    ])
+    .env_remove("CUTILE_FORCE_DEVICE_CHECKS")
+    .env_remove("CUTILE_DISABLE_CHECK_HOISTING");
+    if force_device {
+        cmd.env("CUTILE_FORCE_DEVICE_CHECKS", "1");
+    }
+    let output = cmd.output().expect("ablation compile subprocess");
+    assert!(
+        output.status.success(),
+        "ablation compile failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let line = stdout
+        .lines()
+        .find(|line| line.starts_with("COUNTS:"))
+        .unwrap_or_else(|| panic!("missing placement counts in:\n{stdout}"));
+    let values = line["COUNTS:".len()..]
+        .split(':')
+        .map(|value| value.parse::<usize>().expect("numeric placement count"))
+        .collect::<Vec<_>>();
+    assert_eq!(values.len(), 4);
+    (
+        values[0] as u32,
+        values[1] as u32,
+        values[2] as u32,
+        values[3],
+    )
+}
+
+#[test]
+fn adversarial_block_id_placements_are_framed_by_the_staked_predicate() {
+    common::with_test_stack(|| {
+        use cutile::tile_kernel::validate_launch_checks;
+
+        let art = compile(
+            "permuted_wrapping_identity",
+            &[("z", &[B as i32, 1]), ("x", &[B as i32, 1])],
+        );
+        let counts = art.check_counts();
+        assert_eq!(
+            counts,
+            CheckPlacementCounts {
+                discharged: 2,
+                hoisted: 0,
+                in_place: 0,
+            },
+            "the block-id axis and constant-zero axis should both discharge"
+        );
+        let checks = art.launch_checks();
+        let debug = format!("{checks:?}");
+        assert!(
+            debug.contains("num_tile_blocks(1)") && debug.contains("extent(x, 1)"),
+            "pid.1 must be checked against x's remapped root axis 1: {debug}"
+        );
+
+        // The grid's y extent is four. Four target tiles pass; three reject.
+        let roots_matching = [vec![B as i32, 4 * B as i32], vec![B as i32, 4 * B as i32]];
+        let views_matching = [vec![B as i32, B as i32], roots_matching[1].clone()];
+        assert!(
+            validate_launch_checks(checks, &roots_matching, &views_matching, (1, 4, 1)).is_ok()
+        );
+        let roots_short = [vec![B as i32, 4 * B as i32], vec![B as i32, 3 * B as i32]];
+        let views_short = [vec![B as i32, B as i32], roots_short[1].clone()];
+        assert!(
+            validate_launch_checks(checks, &roots_short, &views_short, (1, 4, 1)).is_err(),
+            "the remapped target has only three tiles for four y-blocks"
+        );
+
+        let joined = compile("joined_reassignment", &[("z", &[1]), ("x", &[1])]);
+        assert_eq!(
+            joined.check_counts(),
+            CheckPlacementCounts {
+                discharged: 0,
+                hoisted: 0,
+                in_place: 1,
+            },
+            "a runtime join must invalidate the stale TileBlockId term"
+        );
+        assert!(
+            joined
+                .launch_checks()
+                .iter()
+                .all(|check| !check.cause.contains("num_tile_blocks")),
+            "the joined value must not reach the block-id rung"
+        );
+
+        let exact_taken = compile("exact_if_replacement", &[("z", &[1]), ("x", &[1])]);
+        assert_eq!(
+            exact_taken.check_counts(),
+            CheckPlacementCounts {
+                discharged: 0,
+                hoisted: 0,
+                in_place: 1,
+            },
+            "the taken compile-time branch must publish its unproven replacement"
+        );
+        assert!(
+            exact_taken.launch_checks().is_empty(),
+            "the replaced value must not retain a stale block-id launch proof"
+        );
+
+        let exact_untaken = compile(
+            "exact_if_unreachable_replacement",
+            &[("z", &[1]), ("x", &[1])],
+        );
+        assert_eq!(
+            exact_untaken.check_counts(),
+            CheckPlacementCounts {
+                discharged: 1,
+                hoisted: 0,
+                in_place: 0,
+            },
+            "the unreachable branch must leave the actual block-id value intact"
+        );
+        assert_eq!(exact_untaken.launch_checks().len(), 1);
+
+        let loop_carried = compile("loop_carried_replacement", &[("z", &[1]), ("x", &[1])]);
+        assert_eq!(loop_carried.check_counts().in_place, 1);
+        assert!(
+            loop_carried.launch_checks().is_empty(),
+            "a loop-carried replacement must not retain a stale block-id term"
+        );
+
+        let persistent = compile("persistent_walk", &[("z", &[1]), ("x", &[1])]);
+        assert_eq!(
+            persistent.check_counts().in_place,
+            1,
+            "the current non-unit-step loop proof remains a residual device check"
+        );
+        assert!(
+            persistent
+                .launch_checks()
+                .iter()
+                .all(|check| !check.cause.contains("num_tile_blocks")),
+            "the loop iterand must discharge from its loop proof, not the block-id rung"
+        );
+
+        assert_eq!(
+            ablation_counts(false),
+            (1, 0, 0, 1),
+            "normal mode should discharge and stake one grid check"
+        );
+        assert_eq!(
+            ablation_counts(true),
+            (0, 0, 1, 0),
+            "full ablation must skip the rung and check the actual id in place"
+        );
+    });
+}
+
+#[test]
+#[ignore = "audit probe requires a CUDA GPU"]
+fn generated_launcher_revalidates_explicit_grid_on_every_cached_launch() {
+    common::with_test_stack(|| {
+        // Blocks 1 through 3 overflow the first add. Their loaded tiles still
+        // have to match pid.0 exactly after the cancelling subtraction.
+        let host = Arc::new((0..4 * B).map(|i| i as f32).collect::<Vec<_>>());
+        let input: Arc<Tensor<f32>> = api::copy_host_vec_to_device(&host)
+            .sync()
+            .expect("identity input")
+            .into();
+        let output = api::zeros::<f32>(&[4 * B]).sync().expect("identity output");
+        let (output, _input) =
+            block_id_review_module::wrapping_identity_execution(output.partition([B]), input)
+                .generics(vec![B.to_string()])
+                .sync()
+                .expect("wrapping identity launch");
+        let got = output
+            .unpartition()
+            .to_host_vec()
+            .sync()
+            .expect("identity output copy");
+        assert_eq!(
+            got, *host,
+            "the canonical term must equal the runtime value"
+        );
+
+        let x: Arc<Tensor<f32>> = api::zeros::<f32>(&[3 * B])
+            .sync()
+            .expect("x allocation")
+            .into();
+
+        // First launch compiles/populates the cache and fits the three-tile x.
+        let (_x,) = block_id_review_module::explicit_grid_revalidation(x.clone())
+            .generics(vec![B.to_string()])
+            .grid((3, 1, 1))
+            .sync()
+            .expect("three-block launch");
+
+        // Same specialization and input, different runtime grid. A cache hit
+        // must not bypass the per-invocation launch validator.
+        let err = block_id_review_module::explicit_grid_revalidation(x)
+            .generics(vec![B.to_string()])
+            .grid((4, 1, 1))
+            .sync()
+            .expect_err("four blocks must not index a three-tile tensor");
+        assert!(
+            err.to_string().contains("num_tile_blocks(0)"),
+            "expected the block-id launch check, got: {err}"
+        );
+    });
+}
+
+#[test]
+#[ignore = "audit soundness probe requires a CUDA GPU"]
+fn nested_nondivisible_frame_does_not_spill_into_the_next_row() {
+    common::with_test_stack(|| {
+        const ROWS: usize = 2;
+        const EXTENT: usize = 200;
+        const OUTER: usize = 50;
+        const INNER: usize = 16;
+
+        let output = api::zeros::<f32>(&[ROWS, EXTENT])
+            .sync()
+            .expect("nested frame output");
+        let (output,) =
+            block_id_review_module::nested_nondivisible_block_id(output.partition([1, OUTER]))
+                .generics(vec![OUTER.to_string(), INNER.to_string()])
+                .sync()
+                .expect("the staked grid check accepts grid (2, 4)");
+        let got = output
+            .unpartition()
+            .to_host_vec()
+            .sync()
+            .expect("nested frame output copy");
+
+        for row in 0..ROWS {
+            for col in [0usize, 80, 160] {
+                assert_eq!(
+                    got[row * EXTENT + col],
+                    7.0,
+                    "the in-range CTAs must execute their stores"
+                );
+            }
+        }
+        // For y=3 the adjusted nested index is 3*ceil(50/16)+3 = 15,
+        // whose element offset is 240. If the unchecked store linearizes that
+        // out-of-axis coordinate, row 0 spills into row 1 columns 40..55.
+        assert!(
+            got[EXTENT + 40..EXTENT + 56]
+                .iter()
+                .all(|&value| value == 0.0),
+            "out-of-axis nested store spilled into the next row: {:?}",
+            &got[EXTENT + 40..EXTENT + 56]
+        );
+    });
+}

--- a/cutile/tests/review_probe_gpt_2026_08_12.rs
+++ b/cutile/tests/review_probe_gpt_2026_08_12.rs
@@ -1,0 +1,262 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Audit-only regression probe for the 2026-08-12 bounds-check placement review.
+//!
+//! This test is deliberately ignored because every case intentionally trips a
+//! device assert. It began as the review's executable repro and now verifies
+//! that normal and fully ablated builds both stop on the original bad inputs.
+
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+use std::process::Command;
+use std::sync::Arc;
+
+use cutile::api;
+use cutile::compile_api::{CheckPlacementCounts, KernelCompiler};
+use cutile::prelude::*;
+use cutile::tensor::{IntoPartition, ToHostVec};
+
+mod common;
+
+#[cutile::module]
+mod review_probe_module {
+    use cutile::core::*;
+
+    /// Range analysis concludes that `index` is in `[0, 2]`, but the `i = 2`
+    /// multiplication wraps in `i32` and produces index 294,967,296.
+    #[cutile::entry]
+    fn final_interval_fits_dynamic<const B: i32>(
+        z: &mut Tensor<f32, { [B] }>,
+        x: &Tensor<f32, { [-1] }>,
+    ) {
+        let p = x.partition(const_shape![B]);
+        let mut acc: Tile<f32, { [B] }> = constant(0.0, const_shape![B]);
+        for i in 0i32..3i32 {
+            let index = max(i * -2_000_000_000i32, i);
+            acc = acc + p.load([index]);
+        }
+        z.store(acc);
+    }
+
+    /// The inferred remainder is nonnegative, but wrapping in the dividend
+    /// makes the runtime remainder negative. Force mode uses the actual value
+    /// for the upper goal while still suppressing the lower guard from the
+    /// inferred interval.
+    #[cutile::entry]
+    fn final_nonnegative_after_wrap_dynamic<const B: i32>(
+        z: &mut Tensor<f32, { [B] }>,
+        x: &Tensor<f32, { [-1] }>,
+    ) {
+        let p = x.partition(const_shape![B]);
+        let mut acc: Tile<f32, { [B] }> = constant(0.0, const_shape![B]);
+        for i in 0i32..3i32 {
+            let index = (i * 2_000_000_000i32) % 1_000i32;
+            acc = acc + p.load([index]);
+        }
+        z.store(acc);
+    }
+
+    /// Static-extent twin: a wrap-tainted interval must not reach the static
+    /// fold, and full ablation must independently test the actual value.
+    #[cutile::entry]
+    fn final_interval_fits_static<const B: i32>(
+        z: &mut Tensor<f32, { [B] }>,
+        x: &Tensor<f32, { [48] }>,
+    ) {
+        let p = x.partition(const_shape![B]);
+        let mut acc: Tile<f32, { [B] }> = constant(0.0, const_shape![B]);
+        for i in 0i32..3i32 {
+            let index = max(i * -2_000_000_000i32, i);
+            acc = acc + p.load([index]);
+        }
+        z.store(acc);
+    }
+}
+
+use review_probe_module::__module_ast_self;
+
+const B: usize = 16;
+
+fn hash_outputs(v: &[f32]) -> u64 {
+    let mut h = DefaultHasher::new();
+    for x in v {
+        x.to_bits().hash(&mut h);
+    }
+    h.finish()
+}
+
+fn execute_case(case: &str) -> Result<Vec<f32>, String> {
+    fn e<E: std::fmt::Display>(err: E) -> String {
+        err.to_string()
+    }
+
+    let x_len = if case == "dynamic_lower" {
+        1_000 * B
+    } else {
+        3 * B
+    };
+    let x: Arc<Tensor<f32>> = api::copy_host_vec_to_device(&Arc::new(vec![1.0f32; x_len]))
+        .sync()
+        .map_err(e)?
+        .into();
+    let z = api::zeros::<f32>(&[B]).sync().map_err(e)?;
+    let z = match case {
+        "dynamic" => {
+            let (z, _x) = review_probe_module::final_interval_fits_dynamic(z.partition([B]), x)
+                .generics(vec![B.to_string()])
+                .sync()
+                .map_err(e)?;
+            z
+        }
+        "dynamic_lower" => {
+            let (z, _x) =
+                review_probe_module::final_nonnegative_after_wrap_dynamic(z.partition([B]), x)
+                    .generics(vec![B.to_string()])
+                    .sync()
+                    .map_err(e)?;
+            z
+        }
+        "static" => {
+            let (z, _x) = review_probe_module::final_interval_fits_static(z.partition([B]), x)
+                .generics(vec![B.to_string()])
+                .sync()
+                .map_err(e)?;
+            z
+        }
+        other => return Err(format!("unknown case {other}")),
+    };
+    z.unpartition().to_host_vec().sync().map_err(e)
+}
+
+#[test]
+#[ignore = "subprocess entry point for the audit-only probe"]
+fn review_probe_case_runner() {
+    let Ok(case) = std::env::var("CUTILE_REVIEW_PROBE_CASE") else {
+        return;
+    };
+    common::with_test_stack(move || {
+        let result = std::panic::catch_unwind(|| execute_case(&case));
+        match result {
+            Ok(Ok(out)) => println!("OUTCOME:OK:{:016x}", hash_outputs(&out)),
+            Ok(Err(msg)) => println!("OUTCOME:STOP:{}", msg.replace('\n', " | ")),
+            Err(panic) => {
+                let msg = panic
+                    .downcast_ref::<String>()
+                    .cloned()
+                    .or_else(|| panic.downcast_ref::<&str>().map(|s| s.to_string()))
+                    .unwrap_or_else(|| "opaque panic".to_string());
+                println!("OUTCOME:PANIC:{}", msg.replace('\n', " | "));
+            }
+        }
+    });
+}
+
+#[derive(Debug, PartialEq)]
+enum Outcome {
+    Ok(String),
+    Stop(String),
+}
+
+fn run_subprocess(case: &str, force_device_checks: bool) -> Outcome {
+    let exe = std::env::current_exe().expect("current_exe");
+    let mut cmd = Command::new(exe);
+    cmd.args([
+        "--exact",
+        "review_probe_case_runner",
+        "--ignored",
+        "--nocapture",
+    ])
+    .env("CUTILE_REVIEW_PROBE_CASE", case)
+    .env_remove("CUTILE_FORCE_DEVICE_CHECKS")
+    .env_remove("CUTILE_DISABLE_CHECK_HOISTING");
+    if force_device_checks {
+        cmd.env("CUTILE_FORCE_DEVICE_CHECKS", "1");
+    }
+
+    let out = cmd.output().expect("spawn probe subprocess");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    let Some(line) = stdout.lines().find(|line| line.starts_with("OUTCOME:")) else {
+        if out.status.code() != Some(0) && stderr.contains("panicked") {
+            let first = stderr
+                .lines()
+                .find(|line| line.contains("panicked"))
+                .unwrap_or("aborted");
+            return Outcome::Stop(format!("aborted during cleanup: {first}"));
+        }
+        panic!(
+            "case {case} (force={force_device_checks}) produced no OUTCOME line.\n\
+             stdout:\n{stdout}\nstderr:\n{stderr}"
+        );
+    };
+
+    if let Some(hash) = line.strip_prefix("OUTCOME:OK:") {
+        Outcome::Ok(hash.to_string())
+    } else if let Some(msg) = line.strip_prefix("OUTCOME:STOP:") {
+        Outcome::Stop(msg.to_string())
+    } else {
+        panic!("probe infrastructure failure: {line}")
+    }
+}
+
+fn compile_counts(function_name: &str) -> CheckPlacementCounts {
+    KernelCompiler::new(__module_ast_self, "review_probe_module", function_name)
+        .target("sm_120")
+        .generics(vec![B.to_string()])
+        .strides(&[("z", &[1]), ("x", &[1])])
+        .compile()
+        .unwrap_or_else(|err| panic!("compile {function_name}: {err}"))
+        .check_counts()
+}
+
+#[test]
+#[ignore = "audit regression probe intentionally trips device asserts"]
+fn fixes_final_interval_overflow_and_ablation_blind_spot() {
+    let (dynamic_counts, dynamic_lower_counts, static_counts) = common::with_test_stack(|| {
+        (
+            compile_counts("final_interval_fits_dynamic"),
+            compile_counts("final_nonnegative_after_wrap_dynamic"),
+            compile_counts("final_interval_fits_static"),
+        )
+    });
+    assert_eq!(
+        dynamic_counts,
+        CheckPlacementCounts {
+            discharged: 0,
+            hoisted: 0,
+            in_place: 1,
+        }
+    );
+    assert_eq!(
+        dynamic_lower_counts,
+        CheckPlacementCounts {
+            discharged: 0,
+            hoisted: 0,
+            in_place: 1,
+        }
+    );
+    assert_eq!(
+        static_counts,
+        CheckPlacementCounts {
+            discharged: 0,
+            hoisted: 0,
+            in_place: 1,
+        }
+    );
+
+    for case in ["dynamic", "dynamic_lower", "static"] {
+        let normal = run_subprocess(case, false);
+        let forced = run_subprocess(case, true);
+        assert!(
+            matches!(normal, Outcome::Stop(_)),
+            "normal compilation must stop on the original {case} repro: {normal:?}"
+        );
+        assert!(
+            matches!(forced, Outcome::Stop(_)),
+            "full ablation must independently stop on {case}: {forced:?}"
+        );
+    }
+}

--- a/cutile/tests/token_ordering.rs
+++ b/cutile/tests/token_ordering.rs
@@ -1,0 +1,516 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Token/ordering coverage is independent of the bounds annotations, but the
+// kernels are written in the older spelling.
+#![allow(deprecated)]
+
+//! Happens-before (token) ordering for mutable partition stores.
+//!
+//! The Tile IR memory model
+//! (<https://docs.nvidia.com/cuda/tile-ir/latest/sections/memory_model.html>)
+//! orders memory ops *only* through tokens: two ops that consume the same input
+//! token are unordered (a data race — UB — if they conflict); ordering requires
+//! threading one op's output token into the next op's input.
+//!
+//! The rule is brand-directed: two writes are **ordered** when they hit the same
+//! region (same brand / aliasing) and **forked** (share an input token) when
+//! their brands are distinct (disjoint). Resource token threading implements it:
+//! a view roots at its tensor, and the tensor's token propagates up the borrow
+//! link and across every scope boundary — the method-call boundary (a view's
+//! token advances its tensor's) and the loop boundary (the tensor's token is
+//! carried, each store's output joined into it, the result published at exit).
+//!
+//! - **straight-line** same-region writes chain (ordered); a later view of the
+//!   same tensor is ordered after the prior view's writes;
+//! - **loop** distinct-index writes fork off the loop-invariant view token and
+//!   join into an accumulator published to the tensor; a constant/repeated index
+//!   serializes (the views read the carried accumulator);
+//! - **cross-epoch** — a second `partition_mut` seeds from the tensor's published
+//!   token, so it is ordered after the first view's writes.
+//!
+//! One spec remains `#[ignore]`d: `straightline_disjoint_should_fork` is a
+//! deferred perf optimization (forking *straight-line* disjoint stores), not a
+//! soundness gap — serializing them is correct, just slower.
+
+use cutile_compiler::compiler::utils::CompileOptions;
+
+mod common;
+
+#[cutile::module]
+mod token_ordering_module {
+    use cutile::core::*;
+
+    /// Two straight-line stores to the **same** column (region). Aliasing →
+    /// must be ordered.
+    #[cutile::entry()]
+    fn straightline_same_index<const N: i32, const BLOCK_SIZE: i32>(
+        out: &mut Tensor<f32, { [1, N] }>,
+    ) {
+        let cols = Dim::new(N / BLOCK_SIZE);
+        let tile_shape = const_shape![1, BLOCK_SIZE];
+        let mut v = out
+            .partition_mut(tile_shape)
+            .with_bounds((Dim::new(1), cols));
+        let tile: Tile<f32, { [1, BLOCK_SIZE] }> = constant(0.0, tile_shape);
+        v.store(tile, coord((0i32, 0i32)));
+        v.store(tile, coord((0i32, 0i32)));
+    }
+
+    /// Two straight-line stores to **distinct** columns. Disjoint → should fork.
+    #[cutile::entry()]
+    fn straightline_disjoint<const N: i32, const BLOCK_SIZE: i32>(
+        out: &mut Tensor<f32, { [1, N] }>,
+    ) {
+        let cols = Dim::new(N / BLOCK_SIZE);
+        let tile_shape = const_shape![1, BLOCK_SIZE];
+        let mut v = out
+            .partition_mut(tile_shape)
+            .with_bounds((Dim::new(1), cols));
+        let tile: Tile<f32, { [1, BLOCK_SIZE] }> = constant(0.0, tile_shape);
+        v.store(tile, coord((0i32, 0i32)));
+        v.store(tile, coord((0i32, 1i32)));
+    }
+
+    /// A single view iterating a branded column index: distinct region per
+    /// iteration → the stores should fork off the loop-entry token.
+    #[cutile::entry()]
+    fn single_view_loop<const N: i32, const BLOCK_SIZE: i32>(out: &mut Tensor<f32, { [1, N] }>) {
+        let cols = Dim::new(N / BLOCK_SIZE);
+        let tile_shape = const_shape![1, BLOCK_SIZE];
+        let mut v = out
+            .partition_mut(tile_shape)
+            .with_bounds((Dim::new(1), cols));
+        for j in cols {
+            let tile: Tile<f32, { [1, BLOCK_SIZE] }> = constant(0.0, tile_shape);
+            v.store(tile, coord((0i32, j)));
+        }
+    }
+
+    /// Two sequential `partition_mut` epochs of the SAME tensor, each writing
+    /// the same column. Aliasing across the epochs → view B must be ordered
+    /// after view A.
+    #[cutile::entry()]
+    fn two_epoch_aliasing<const N: i32, const BLOCK_SIZE: i32>(out: &mut Tensor<f32, { [1, N] }>) {
+        let cols = Dim::new(N / BLOCK_SIZE);
+        let tile_shape = const_shape![1, BLOCK_SIZE];
+        {
+            let mut a = out
+                .partition_mut(tile_shape)
+                .with_bounds((Dim::new(1), cols));
+            let tile: Tile<f32, { [1, BLOCK_SIZE] }> = constant(1.0, tile_shape);
+            a.store(tile, coord((0i32, 0i32)));
+        }
+        {
+            let mut b = out
+                .partition_mut(tile_shape)
+                .with_bounds((Dim::new(1), cols));
+            let tile: Tile<f32, { [1, BLOCK_SIZE] }> = constant(2.0, tile_shape);
+            b.store(tile, coord((0i32, 0i32)));
+        }
+    }
+
+    /// Two sequential epochs, each a store *loop* over the whole column range.
+    /// Every column is written by both epochs → view B's loop must be ordered
+    /// after view A's.
+    #[cutile::entry()]
+    fn two_epoch_aliasing_in_loop<const N: i32, const BLOCK_SIZE: i32>(
+        out: &mut Tensor<f32, { [1, N] }>,
+    ) {
+        let cols = Dim::new(N / BLOCK_SIZE);
+        let tile_shape = const_shape![1, BLOCK_SIZE];
+        {
+            let mut a = out
+                .partition_mut(tile_shape)
+                .with_bounds((Dim::new(1), cols));
+            for j in cols {
+                let tile: Tile<f32, { [1, BLOCK_SIZE] }> = constant(1.0, tile_shape);
+                a.store(tile, coord((0i32, j)));
+            }
+        }
+        {
+            let mut b = out
+                .partition_mut(tile_shape)
+                .with_bounds((Dim::new(1), cols));
+            for j in cols {
+                let tile: Tile<f32, { [1, BLOCK_SIZE] }> = constant(2.0, tile_shape);
+                b.store(tile, coord((0i32, j)));
+            }
+        }
+    }
+
+    // ── Inductive composition (depth-2 nesting) ────────────────────────────
+
+    /// Nested loops over branded `(row, col)`: every `(i, j)` is a distinct
+    /// (disjoint) region, so every leaf store should fork off the *outermost*
+    /// loop-invariant token — the fork rule composing across two loop levels.
+    #[cutile::entry()]
+    fn nested_loop<const M: i32, const N: i32, const BM: i32, const BN: i32>(
+        out: &mut Tensor<f32, { [M, N] }>,
+    ) {
+        let rows = Dim::new(M / BM);
+        let cols = Dim::new(N / BN);
+        let ts = const_shape![BM, BN];
+        let mut v = out.partition_mut(ts).with_bounds((rows, cols));
+        for i in rows {
+            for j in cols {
+                let tile: Tile<f32, { [BM, BN] }> = constant(0.0, ts);
+                v.store(tile, coord((i, j)));
+            }
+        }
+    }
+
+    /// Two epochs, each a *nested* loop over the same region → epoch B must be
+    /// ordered after epoch A: the epoch-boundary join composing with nesting
+    /// (the inner loop's join feeds the outer, which feeds the epoch boundary).
+    #[cutile::entry()]
+    fn two_epoch_nested_loop<const M: i32, const N: i32, const BM: i32, const BN: i32>(
+        out: &mut Tensor<f32, { [M, N] }>,
+    ) {
+        let rows = Dim::new(M / BM);
+        let cols = Dim::new(N / BN);
+        let ts = const_shape![BM, BN];
+        {
+            let mut a = out.partition_mut(ts).with_bounds((rows, cols));
+            for i in rows {
+                for j in cols {
+                    let tile: Tile<f32, { [BM, BN] }> = constant(1.0, ts);
+                    a.store(tile, coord((i, j)));
+                }
+            }
+        }
+        {
+            let mut b = out.partition_mut(ts).with_bounds((rows, cols));
+            for i in rows {
+                for j in cols {
+                    let tile: Tile<f32, { [BM, BN] }> = constant(2.0, ts);
+                    b.store(tile, coord((i, j)));
+                }
+            }
+        }
+    }
+
+    /// Within one epoch: a store loop, then a straight-line store to a column
+    /// the loop already wrote → the trailing store must be ordered after the
+    /// loop (ordering composing across the loop boundary inside an epoch).
+    #[cutile::entry()]
+    fn store_after_loop<const N: i32, const BLOCK_SIZE: i32>(out: &mut Tensor<f32, { [1, N] }>) {
+        let cols = Dim::new(N / BLOCK_SIZE);
+        let ts = const_shape![1, BLOCK_SIZE];
+        let mut v = out.partition_mut(ts).with_bounds((Dim::new(1), cols));
+        for j in cols {
+            let tile: Tile<f32, { [1, BLOCK_SIZE] }> = constant(0.0, ts);
+            v.store(tile, coord((0i32, j)));
+        }
+        // Trailing straight-line store aliasing the `j == 0` write.
+        let tile: Tile<f32, { [1, BLOCK_SIZE] }> = constant(1.0, ts);
+        v.store(tile, coord((0i32, 0i32)));
+    }
+
+    /// Two stores to the SAME branded index within one loop iteration → same
+    /// region → must be ordered (the second depends on the first) inside the
+    /// body. The base of the induction for same-region ordering under a loop.
+    #[cutile::entry()]
+    fn within_iteration_aliasing<const N: i32, const BLOCK_SIZE: i32>(
+        out: &mut Tensor<f32, { [1, N] }>,
+    ) {
+        let cols = Dim::new(N / BLOCK_SIZE);
+        let ts = const_shape![1, BLOCK_SIZE];
+        let mut v = out.partition_mut(ts).with_bounds((Dim::new(1), cols));
+        for j in cols {
+            let t0: Tile<f32, { [1, BLOCK_SIZE] }> = constant(0.0, ts);
+            v.store(t0, coord((0i32, j)));
+            let t1: Tile<f32, { [1, BLOCK_SIZE] }> = constant(1.0, ts);
+            v.store(t1, coord((0i32, j))); // same `j` → same address
+        }
+    }
+
+    /// A loop whose index does NOT vary the written address (constant column 0
+    /// every iteration) → every iteration writes the SAME region. The fork
+    /// guard (L1): these must serialize, not fork off the loop-entry token.
+    #[cutile::entry()]
+    fn const_index_loop<const N: i32, const BLOCK_SIZE: i32>(out: &mut Tensor<f32, { [1, N] }>) {
+        let cols = Dim::new(N / BLOCK_SIZE);
+        let ts = const_shape![1, BLOCK_SIZE];
+        let mut v = out.partition_mut(ts).with_bounds((Dim::new(1), cols));
+        for _j in cols {
+            let tile: Tile<f32, { [1, BLOCK_SIZE] }> = constant(0.0, ts);
+            v.store(tile, coord((0i32, 0i32))); // same address every iteration
+        }
+    }
+}
+
+use token_ordering_module::__module_ast_self;
+
+fn compile_g(function_name: &str, generics: &[&str], strides: &[(&str, &[i32])]) -> String {
+    let function_name = function_name.to_string();
+    let generics: Vec<String> = generics.iter().map(|s| s.to_string()).collect();
+    let strides: Vec<(String, Vec<i32>)> = strides
+        .iter()
+        .map(|(n, s)| (n.to_string(), s.to_vec()))
+        .collect();
+    common::with_test_stack(move || {
+        let strides: Vec<(&str, &[i32])> = strides
+            .iter()
+            .map(|(n, s)| (n.as_str(), s.as_slice()))
+            .collect();
+        common::compile_to_ir(
+            __module_ast_self,
+            "token_ordering_module",
+            &function_name,
+            &generics,
+            &strides,
+            &[],
+            &[],
+            None,
+            &CompileOptions::default(),
+        )
+        .unwrap_or_else(|e| panic!("failed to compile {function_name}: {e}"))
+    })
+}
+
+fn compile(function_name: &str) -> String {
+    compile_g(function_name, &["256", "64"], &[("out", &[256, 1])])
+}
+
+use std::collections::{HashMap, HashSet};
+
+/// The input token operand (`token = %NN`) of each `store_view_tko`. Two stores
+/// sharing an input token are *unordered* (forked) — the strong assertion for
+/// disjoint writes (per the memory model, same input token = concurrent).
+fn store_input_tokens(mlir: &str) -> Vec<String> {
+    mlir.lines()
+        .filter(|l| l.contains("store_view_tko"))
+        .filter_map(store_input_token)
+        .collect()
+}
+
+fn store_input_token(line: &str) -> Option<String> {
+    line.split("token = ")
+        .nth(1)
+        .and_then(|rest| rest.split_whitespace().next())
+        .map(str::to_string)
+}
+
+/// Per `store_view_tko`, `(output token, input token)` — the LHS result and the
+/// `token = %NN` operand, in program order.
+fn store_io_tokens(mlir: &str) -> Vec<(String, String)> {
+    mlir.lines()
+        .filter(|l| l.contains("store_view_tko"))
+        .filter_map(|l| {
+            let output = l.split_once('=')?.0.trim().to_string();
+            let input = store_input_token(l)?;
+            output.starts_with('%').then_some((output, input))
+        })
+        .collect()
+}
+
+/// Every `%<ident>` SSA reference in a text fragment.
+fn ssa_refs(s: &str) -> Vec<String> {
+    let bytes = s.as_bytes();
+    let mut refs = vec![];
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' {
+            let start = i;
+            i += 1;
+            while i < bytes.len() && (bytes[i].is_ascii_alphanumeric() || bytes[i] == b'_') {
+                i += 1;
+            }
+            refs.push(s[start..i].to_string());
+        } else {
+            i += 1;
+        }
+    }
+    refs
+}
+
+/// Map each SSA result `%id` to the SSA operands its defining op reads
+/// (`%a = op ... %b, %c` → `%a ↦ [%b, %c]`). Region-aware: a `for` op's result
+/// also depends on the operands its body `continue`/`yield`s, so the def-use
+/// walk can trace a loop result back into its region (a loop that accumulates a
+/// token yields it via `continue`, and the result carries that dependency).
+fn ssa_def_operands(mlir: &str) -> HashMap<String, Vec<String>> {
+    let mut defs: HashMap<String, Vec<String>> = HashMap::new();
+    // Stack of (for-op result, brace depth when it opened) for open regions.
+    let mut regions: Vec<(String, i32)> = Vec::new();
+    let mut depth = 0i32;
+    for line in mlir.lines() {
+        if let Some((lhs, rhs)) = line.split_once('=') {
+            let results: Vec<String> = lhs
+                .split(',')
+                .map(str::trim)
+                .filter(|s| s.starts_with('%'))
+                .map(str::to_string)
+                .collect();
+            if !results.is_empty() {
+                let operands = ssa_refs(rhs);
+                for r in &results {
+                    defs.entry(r.clone()).or_default().extend(operands.clone());
+                }
+                if rhs.trim_start().starts_with("for ") && line.contains('{') {
+                    regions.push((results[0].clone(), depth));
+                }
+            }
+        }
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("continue ") || trimmed.starts_with("yield ") {
+            if let Some((for_result, _)) = regions.last() {
+                let ops = ssa_refs(trimmed);
+                defs.entry(for_result.clone()).or_default().extend(ops);
+            }
+        }
+        depth += line.matches('{').count() as i32 - line.matches('}').count() as i32;
+        while regions.last().is_some_and(|(_, open)| depth <= *open) {
+            regions.pop();
+        }
+    }
+    defs
+}
+
+/// Does `source` transitively depend on `target` in the def-use graph? This is
+/// the *actual* happens-before edge — token inequality alone is too weak (a
+/// fresh, unrelated token also differs yet is still a race).
+fn depends_on(defs: &HashMap<String, Vec<String>>, source: &str, target: &str) -> bool {
+    let mut stack = vec![source.to_string()];
+    let mut seen = HashSet::new();
+    while let Some(v) = stack.pop() {
+        if v == target {
+            return true;
+        }
+        if !seen.insert(v.clone()) {
+            continue;
+        }
+        if let Some(ops) = defs.get(&v) {
+            stack.extend(ops.iter().cloned());
+        }
+    }
+    false
+}
+
+/// Assert store `later` happens-after store `earlier`: `later`'s input token
+/// transitively derives from `earlier`'s output token.
+fn assert_ordered(mlir: &str, earlier: usize, later: usize) {
+    let stores = store_io_tokens(mlir);
+    assert!(
+        stores.len() > earlier.max(later),
+        "expected at least {} stores, found {}:\n{mlir}",
+        earlier.max(later) + 1,
+        stores.len()
+    );
+    let defs = ssa_def_operands(mlir);
+    let earlier_out = &stores[earlier].0;
+    let later_in = &stores[later].1;
+    assert!(
+        depends_on(&defs, later_in, earlier_out),
+        "store {later} (input {later_in}) must depend on store {earlier} (output {earlier_out}); \
+         the happens-before edge is missing:\n{mlir}"
+    );
+}
+
+/// Assert the loop's store forks off a loop-invariant token (a `make_token`
+/// defined outside the loop) — the correct, unordered fork for disjoint writes.
+fn assert_forks_off_invariant(mlir: &str) {
+    let toks = store_input_tokens(mlir);
+    assert_eq!(
+        toks.len(),
+        1,
+        "expected one store in the loop body:\n{mlir}"
+    );
+    assert!(
+        mlir.contains(&format!("{} = make_token", toks[0])),
+        "loop store should fork off a loop-invariant token, got {}:\n{mlir}",
+        toks[0]
+    );
+}
+
+// ── Already correct: assertions that pass on today's lowering ──────────────
+
+#[test]
+fn straightline_same_index_is_ordered() {
+    // Store 2's input token derives from store 1's output (chained).
+    assert_ordered(&compile("straightline_same_index"), 0, 1);
+}
+
+#[test]
+fn within_iteration_aliasing_is_ordered() {
+    // Two stores to the same index in one iteration must be ordered inside the
+    // body — the base case for same-region ordering under a loop.
+    assert_ordered(&compile("within_iteration_aliasing"), 0, 1);
+}
+
+#[test]
+fn loop_stores_fork_off_the_entry_token() {
+    assert_forks_off_invariant(&compile("single_view_loop"));
+}
+
+// ── Inductive composition: the base rules must compose at depth-2 nesting ───
+
+const NESTED_G: [&str; 4] = ["256", "256", "64", "64"];
+
+#[test]
+fn nested_loop_stores_fork_at_all_levels() {
+    // Fork composes across two loop levels: distinct (i, j) are disjoint, so the
+    // leaf store reads a token defined outside *both* loops.
+    assert_forks_off_invariant(&compile_g("nested_loop", &NESTED_G, &[("out", &[256, 1])]));
+}
+
+// ── Executable specs of the pending token-dataflow fix (currently fail) ─────
+//
+// "ordered" now asserts a real def-use dependency (assert_ordered), not token
+// inequality — a fix that merely gives a fresh unrelated token would still race
+// and must NOT satisfy these.
+
+#[ignore = "target: disjoint straight-line stores should fork; today update_token over-serializes them"]
+#[test]
+fn straightline_disjoint_should_fork() {
+    let toks = store_input_tokens(&compile("straightline_disjoint"));
+    assert_eq!(toks.len(), 2, "expected two stores");
+    assert_eq!(
+        toks[0], toks[1],
+        "disjoint straight-line stores should share an input token (forked)"
+    );
+}
+
+#[test]
+fn cross_epoch_aliasing_should_serialize() {
+    assert_ordered(&compile("two_epoch_aliasing"), 0, 1);
+}
+
+#[test]
+fn cross_epoch_aliasing_in_loop_should_serialize() {
+    assert_ordered(&compile("two_epoch_aliasing_in_loop"), 0, 1);
+}
+
+#[test]
+fn cross_epoch_nested_loops_should_serialize() {
+    assert_ordered(
+        &compile_g("two_epoch_nested_loop", &NESTED_G, &[("out", &[256, 1])]),
+        0,
+        1,
+    );
+}
+
+#[test]
+fn store_after_loop_in_epoch_should_serialize() {
+    // The trailing store (index 1) must depend on the loop store (index 0).
+    assert_ordered(&compile("store_after_loop"), 0, 1);
+}
+
+#[test]
+fn const_index_loop_should_serialize() {
+    // The store must read a loop-carried token (an iter-arg), NOT a loop-
+    // invariant `make_token` — otherwise every iteration writes the same address
+    // unordered.
+    let mlir = compile("const_index_loop");
+    let toks = store_input_tokens(&mlir);
+    assert_eq!(toks.len(), 1, "expected one store in the loop body");
+    assert!(
+        !mlir.contains(&format!("{} = make_token", toks[0])),
+        "const-index loop store must be serialized (carried token), not forked off \
+         a loop-invariant make_token, got {}:\n{mlir}",
+        toks[0]
+    );
+}

--- a/cutile/tests/type_inference_sanity.rs
+++ b/cutile/tests/type_inference_sanity.rs
@@ -85,7 +85,7 @@ mod type_inference_sanity_module {
     ) {
         let pid: (i32, i32, i32) = get_tile_block_id();
         let source_part = source.partition(const_shape![1, 1, 8]);
-        let mut out_part = unsafe { out.partition_mut(const_shape![1, 1, 8]) };
+        let mut out_part = out.partition_mut(const_shape![1, 1, 8]);
         let s_start: i32 = pid.1 * 4i32;
         if s_start < seq_len {
             for s_local in 0i32..4i32 {
@@ -94,7 +94,7 @@ mod type_inference_sanity_module {
                     let tile = source_part
                         .load([s_global, pid.0, pid.2])
                         .reshape(const_shape![1, 1, 8]);
-                    unsafe { out_part.store(tile, [0i32, s_local, 0i32]) };
+                    out_part.store(tile, [0i32, s_local, 0i32]);
                 }
             }
         }
@@ -144,29 +144,34 @@ mod type_inference_sanity_module {
 
     #[cutile::entry()]
     fn index_result_method_arg_kernel(out: &mut Tensor<f32, { [4] }>) {
-        let values = [0i32, 1i32, 2i32];
+        // Values are all 0 because the partition below has exactly one tile;
+        // what this kernel tests is that an array-index expression's TYPE
+        // reaches the method argument, not which element it selects.
+        let values = [0i32, 0i32, 0i32];
         let idx = values[1];
         let tile = constant(1.0f32, const_shape![4]);
-        let mut out_part = unsafe { out.partition_mut(const_shape![4]) };
-        unsafe { out_part.store(tile, [idx]) };
+        let mut out_part = out.partition_mut(const_shape![4]);
+        out_part.store(tile, [idx]);
     }
 
     #[cutile::entry()]
     fn step_by_loop_local_kernel(out: &mut Tensor<f32, { [4] }>) {
-        let mut out_part = unsafe { out.partition_mut(const_shape![4]) };
-        for i in (0i32..4i32).step_by(1) {
+        let mut out_part = out.partition_mut(const_shape![4]);
+        // One tile, so one iteration: `step_by` lowering is the subject here.
+        for i in (0i32..1i32).step_by(1) {
             let tile = constant(1.0f32, const_shape![4]);
-            unsafe { out_part.store(tile, [i]) };
+            out_part.store(tile, [i]);
         }
     }
 
     #[cutile::entry()]
     fn step_by_cast_usize_kernel(out: &mut Tensor<f32, { [4] }>) {
-        let mut out_part = unsafe { out.partition_mut(const_shape![4]) };
+        let mut out_part = out.partition_mut(const_shape![4]);
         let step = 1i32;
-        for i in (0i32..4i32).step_by(step as usize) {
+        // One tile, so one iteration; the cast in `step_by` is the subject.
+        for i in (0i32..1i32).step_by(step as usize) {
             let tile = constant(1.0f32, const_shape![4]);
-            unsafe { out_part.store(tile, [i]) };
+            out_part.store(tile, [i]);
         }
     }
 
@@ -187,12 +192,13 @@ mod type_inference_sanity_module {
         flag: i32,
     ) {
         let part = source.partition(const_shape![4]);
-        let mut out_part = unsafe { out.partition_mut(const_shape![4]) };
+        let mut out_part = out.partition_mut(const_shape![4]);
         let default_int = 7;
         let default_float = 3.0;
         let _default_int_tile: Tile<i32, { [] }> = scalar_to_tile(default_int);
         let _default_float_tile: Tile<f64, { [] }> = scalar_to_tile(default_float);
-        for i in 0..4 {
+        // One tile, so one iteration; the if/else join is the subject.
+        for i in 0..1 {
             let indices = [0, i, 2];
             let idx = indices[1];
             let tile: Tile<f32, { [4] }> = if 0 < flag {
@@ -200,7 +206,7 @@ mod type_inference_sanity_module {
             } else {
                 part.load([idx])
             };
-            unsafe { out_part.store(tile, [idx]) };
+            out_part.store(tile, [idx]);
         }
     }
 
@@ -384,11 +390,11 @@ mod type_inference_sanity_module {
         out: &mut Tensor<f32, { [4] }>,
     ) {
         let part = source.partition(const_shape![4]);
-        let mut out_part = unsafe { out.partition_mut(const_shape![4]) };
+        let mut out_part = out.partition_mut(const_shape![4]);
         let mut i = 0;
         while i < 1i32 {
             let tile = part.load([i]);
-            unsafe { out_part.store(tile, [i]) };
+            out_part.store(tile, [i]);
             i = i + 1i32;
         }
     }
@@ -399,11 +405,11 @@ mod type_inference_sanity_module {
         out: &mut Tensor<f32, { [4] }>,
     ) {
         let part = source.partition(const_shape![4]);
-        let mut out_part = unsafe { out.partition_mut(const_shape![4]) };
+        let mut out_part = out.partition_mut(const_shape![4]);
         let mut i = 0;
         loop {
             let tile = part.load([i]);
-            unsafe { out_part.store(tile, [i]) };
+            out_part.store(tile, [i]);
             i = i + 1i32;
             if i >= 1i32 {
                 break;
@@ -449,8 +455,8 @@ mod type_inference_sanity_module {
         let _other_tile: Tile<i32, { [] }> = scalar_to_tile(other);
 
         let tile = constant(1.0f32, const_shape![4]);
-        let mut out_part = unsafe { out.partition_mut(const_shape![4]) };
-        unsafe { out_part.store(tile, [idx]) };
+        let mut out_part = out.partition_mut(const_shape![4]);
+        out_part.store(tile, [idx]);
     }
 
     #[cutile::entry()]
@@ -1339,22 +1345,20 @@ fn typeck_dump_golden_for_step_by_loop_local() {
     common::with_test_stack(|| {
         let dump = typeck_dump("step_by_loop_local_kernel", &[("out", &[4])]);
         let expected = r#"expr#0: PartitionMut < 'a , f32 , { [4] } >
-expr#1: PartitionMut < 'a , f32 , { [4] } >
-method#1: core::partition_mut -> _
-expr#2: & mut Tensor < f32 , { [4] } >
-expr#3: Shape < { [4] } >
+method#0: core::partition_mut -> _
+expr#1: & mut Tensor < f32 , { [4] } >
+expr#2: Shape < { [4] } >
+expr#5: i32
 expr#6: i32
 expr#7: i32
-expr#8: i32
-expr#9: Tile < f32 , { [4] } >
-expr#10: f32
-expr#11: Shape < { [4] } >
-expr#12: Token
-expr#13: Token
-method#13: core::store -> Token
-expr#15: Tile < f32 , { [4] } >
-expr#16: [i32 ; 1usize]
-expr#17: i32"#;
+expr#8: Tile < f32 , { [4] } >
+expr#9: f32
+expr#10: Shape < { [4] } >
+expr#11: Token
+method#11: core::store -> Token
+expr#13: Tile < f32 , { [4] } >
+expr#14: [i32 ; 1usize]
+expr#15: i32"#;
         assert_eq!(dump, expected);
     });
 }


### PR DESCRIPTION
Every safe partition load/store now proves its bounds through one ladder — axis provenance, static folding, declared preconditions, derived launch checks — and pays an in-kernel assert only as a last resort; `deny_in_kernel_checks = true` turns that last resort into a compile error. Checked `PartitionMut::store` becomes the default surface (raw is `store_unchecked`), tile-block-id indices discharge against a launch-verified grid claim, `partition_prefix` allows per-axis partial-coverage launches, and the `with_bounds`/`Dim` annotation family is deprecated as redundant. Register parity holds at safe == raw on the store corpus, and a 25-kernel engine consuming this branch runs with zero unchecked kernels at safe-vs-unsafe parity on sm_120 and sm_100. See `cutile-book/guide/bounds-check-placement.md` for the authoring model.