### PR TITLE
Add cuda-oxide host surface to host-side crates

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -84,6 +84,39 @@ jobs:
           source "${HOME}/.cargo/env"
           ./scripts/run_cpu_tests.sh
 
+  # The shared host-side crates (cuda-bindings, cuda-core, cuda-async)
+  # support CUDA 13.0+, while the Tile stack requires 13.2+. This lane keeps
+  # the 13.0 floor honest: compile-only, no GPU, no TileIR toolchain (13.0
+  # images have no tileiras, which is exactly the point).
+  shared-crates-cuda13:
+    runs-on: linux-amd64-cpu16
+    container:
+      image: nvidia/cuda:13.0.0-devel-ubuntu24.04
+      env:
+        DEBIAN_FRONTEND: noninteractive
+    env:
+      CUDA_TOOLKIT_PATH: /usr/local/cuda
+    timeout-minutes: 30
+    steps:
+      - name: Install basic dependencies
+        run: |
+          apt update
+          apt install -y --no-install-recommends build-essential curl \
+            ca-certificates git cmake pkg-config libclang-dev zlib1g-dev \
+            libzstd-dev
+
+      - name: Clone repository
+        uses: actions/checkout@v7
+
+      - name: Install Rust
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+
+      - name: Check shared crates against CUDA 13.0
+        run: |
+          source "${HOME}/.cargo/env"
+          cargo check -p cuda-bindings -p cuda-core -p cuda-async --all-targets
+
   # Model-checks / sanitizers for the cuda-async completion reactor's lock-free
   # slot protocol. CPU-only, no GPU: loom explores the interleavings and weak-
   # memory outcomes, miri checks the UnsafeCell/pointer UB, ThreadSanitizer

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,7 +41,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7eb93bbb63b9c227414f6eb3a0adfddca591a8ce1e9b60661bb08969b87e340b"
 dependencies = [
- "object",
+ "object 0.37.3",
 ]
 
 [[package]]
@@ -424,6 +424,7 @@ dependencies = [
  "half",
  "loom",
  "once_cell",
+ "rustc-hash 2.1.2",
  "thiserror 1.0.69",
 ]
 
@@ -445,7 +446,19 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "cuda-bindings",
+ "cuda-core-derive",
  "half",
+ "oxide-artifacts",
+ "trybuild",
+]
+
+[[package]]
+name = "cuda-core-derive"
+version = "0.3.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1250,6 +1263,18 @@ dependencies = [
 
 [[package]]
 name = "object"
+version = "0.36.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+dependencies = [
+ "crc32fast",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "memchr",
+]
+
+[[package]]
+name = "object"
 version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
@@ -1268,6 +1293,15 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "oxide-artifacts"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74d9a941c0c43d2dceaf25f5c9ca4c9f9cceb28dfa5e4e3cfd14e476f003e7c9"
+dependencies = [
+ "object 0.36.7",
+]
 
 [[package]]
 name = "parking_lot"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
 
     # Safe CUDA API. Uses cuda-bindings.
     "cuda-core",
+    "cuda-core-derive",
 
     # Async CUDA API. Uses cuda-core.
     "cuda-async",
@@ -83,6 +84,7 @@ phf = { version = "0.11", features = ["macros"] }
 convert_case = "0.8"
 linkme = "0.3"
 dashmap = "6"
+rustc-hash = "2.0"
 sha2 = "0.10"
 once_cell = "1.19"
 

--- a/cuda-async/Cargo.toml
+++ b/cuda-async/Cargo.toml
@@ -11,6 +11,7 @@ description = "Safe Async CUDA support via Async Rust."
 
 [dependencies]
 cuda-core = { workspace = true }
+rustc-hash = { workspace = true }
 cuda-bindings = { workspace = true }
 half = { workspace = true }
 futures = { workspace = true }

--- a/cuda-async/src/device_future.rs
+++ b/cuda-async/src/device_future.rs
@@ -124,12 +124,8 @@ impl<T: Send, DO: DeviceOp<Output = T>> DeviceFuture<T, DO> {
             // CUDA driver flag bindings have platform-dependent integer types, so FFI calls cast them as `_`.
             *MODE.get_or_init(
                 || match std::env::var("CUDA_ASYNC_HOST_SYNC").ok()?.as_str() {
-                    "spin" | "spinwait" => {
-                        Some(cuda_bindings::CUhostTaskSyncMode_enum_CU_HOST_TASK_SPINWAIT as _)
-                    }
-                    "block" | "blocking" => {
-                        Some(cuda_bindings::CUhostTaskSyncMode_enum_CU_HOST_TASK_BLOCKING as _)
-                    }
+                    "spin" | "spinwait" => Some(cuda_bindings::CU_HOST_TASK_SPINWAIT),
+                    "block" | "blocking" => Some(cuda_bindings::CU_HOST_TASK_BLOCKING),
                     _ => None,
                 },
             )

--- a/cuda-async/src/lib.rs
+++ b/cuda-async/src/lib.rs
@@ -22,6 +22,9 @@ pub mod prelude;
 #[cfg(not(loom))]
 mod reactor;
 pub mod scheduling_policies;
+/// SIMT-model async surface, copied from cuda-oxide for the shared
+/// host-crate migration. Not re-exported at the root; see the module docs.
+pub mod simt;
 mod slot_table;
 
 pub use futures;

--- a/cuda-async/src/simt/device_box.rs
+++ b/cuda-async/src/simt/device_box.rs
@@ -1,0 +1,164 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Owned and borrowed wrappers around CUDA device pointers.
+//!
+//! [`DevicePointer`] is a thin, `Copy` handle to device memory suitable for
+//! passing as a kernel argument. [`DeviceBox`] owns device memory and frees it
+//! asynchronously through a dedicated deallocator stream on drop.
+//!
+//! # Async deallocation
+//!
+//! [`DeviceBox`] enqueues `cuMemFreeAsync` on a per-device deallocator stream
+//! rather than blocking with `cuMemFree`. Callers **must** synchronize all
+//! streams that reference the allocation before dropping the box.
+
+use crate::simt::device_context::with_deallocator_stream;
+use crate::simt::error::DeviceError;
+use crate::simt::launch::{AsyncKernelLaunchBuilder, KernelArgument};
+use cuda_bindings::CUdeviceptr;
+use cuda_core::simt::memory::free_async;
+use std::io::{self, Write};
+use std::marker::PhantomData;
+
+/// Non-owning, `Copy` handle to a typed device allocation.
+///
+/// Does not manage lifetime -- the underlying memory must outlive all uses.
+#[derive(Debug, Copy, Clone)]
+pub struct DevicePointer<T> {
+    /// Ties the pointer to element type `T` without owning one.
+    _marker: PhantomData<T>,
+    /// Raw CUDA device pointer.
+    pub dptr: CUdeviceptr,
+}
+
+/// # Safety
+///
+/// `DevicePointer` is a plain integer handle with no thread-affine state.
+/// Sending it across threads does not violate CUDA's driver API contract.
+unsafe impl<T> Send for DevicePointer<T> {}
+
+impl<T> DevicePointer<T> {
+    /// Returns the raw [`CUdeviceptr`].
+    pub fn cu_deviceptr(&self) -> CUdeviceptr {
+        self.dptr
+    }
+}
+
+/// Pushes the underlying device address as a kernel argument.
+impl<T: Send + Sized> KernelArgument for DevicePointer<T> {
+    fn push_arg(self, launcher: &mut AsyncKernelLaunchBuilder<'_>) {
+        launcher.push_arg(self.cu_deviceptr());
+    }
+}
+
+/// Owning wrapper around a device allocation that frees memory asynchronously
+/// on drop.
+///
+/// `DeviceBox<[DType]>` represents a contiguous device buffer of `len`
+/// elements. The allocation is freed via `cuMemFreeAsync` on the device's
+/// deallocator stream when the box is dropped.
+///
+/// # Safety contract
+///
+/// All streams that reference this allocation **must** be synchronized before
+/// the box is dropped. Violating this causes use-after-free on the device.
+#[derive(Debug)]
+pub struct DeviceBox<T: Send + ?Sized> {
+    /// Ordinal of the device that owns this allocation.
+    device_id: usize,
+    /// Raw CUDA device pointer to the start of the allocation.
+    cudptr: CUdeviceptr,
+    /// Number of elements (not bytes) in the allocation.
+    len: usize,
+    /// Ties the box to the element type.
+    _marker: PhantomData<T>,
+}
+
+/// # Safety
+///
+/// Device pointers are plain integers. The CUDA driver API is thread-safe for
+/// distinct streams, and `DeviceBox` holds no thread-affine state.
+unsafe impl<T: Send + ?Sized> Send for DeviceBox<T> {}
+
+/// # Safety
+///
+/// See the [`Send`] impl. Shared references only expose the device pointer
+/// value, which is safe to read from any thread.
+unsafe impl<T: Send + ?Sized> Sync for DeviceBox<T> {}
+
+/// Best-effort enqueue of an asynchronous free on the device's deallocator
+/// stream.
+///
+/// Drop cannot return errors, so failures to access the deallocator stream or
+/// enqueue the free are reported to stderr instead of panicking.
+impl<T: Send + ?Sized> Drop for DeviceBox<T> {
+    fn drop(&mut self) {
+        let result = unsafe {
+            with_deallocator_stream(self.device_id, |stream| {
+                free_async(self.cudptr, stream.cu_stream()).map_err(DeviceError::Driver)
+            })
+        };
+
+        match result {
+            Ok(Ok(())) => {}
+            Ok(Err(err)) | Err(err) => {
+                let mut stderr = io::stderr().lock();
+                let _ = writeln!(
+                    stderr,
+                    "cuda-async: failed to enqueue async free for device pointer on device_id={}: {}",
+                    self.device_id, err
+                );
+            }
+        }
+    }
+}
+
+impl<DType: Send + Sized> DeviceBox<[DType]> {
+    /// Constructs a `DeviceBox<[DType]>` from a raw device pointer, element
+    /// count, and device ordinal.
+    ///
+    /// # Safety
+    ///
+    /// * `dptr` must point to a valid device allocation of at least
+    ///   `len * size_of::<DType>()` bytes on device `device_id`.
+    /// * Ownership of the allocation transfers to the returned `DeviceBox`.
+    pub unsafe fn from_raw_parts(dptr: CUdeviceptr, len: usize, device_id: usize) -> Self {
+        Self {
+            _marker: PhantomData,
+            cudptr: dptr,
+            len,
+            device_id,
+        }
+    }
+
+    /// Returns `true` if the buffer contains zero elements.
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Returns the number of elements in the buffer.
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Returns the raw [`CUdeviceptr`].
+    pub fn cu_deviceptr(&self) -> CUdeviceptr {
+        self.cudptr
+    }
+
+    /// Returns the ordinal of the device that owns this allocation.
+    pub fn device_id(&self) -> usize {
+        self.device_id
+    }
+
+    /// Creates a non-owning [`DevicePointer`] into this allocation.
+    pub fn device_pointer(&self) -> DevicePointer<DType> {
+        DevicePointer {
+            _marker: PhantomData,
+            dptr: self.cudptr,
+        }
+    }
+}

--- a/cuda-async/src/simt/device_context.rs
+++ b/cuda-async/src/simt/device_context.rs
@@ -1,0 +1,361 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Thread-local GPU device state, kernel cache, and scheduling policy management.
+//!
+//! Each thread maintains a set of [`AsyncDeviceContext`]s (one per device) via
+//! the `DEVICE_CONTEXTS` thread-local. A context bundles:
+//!
+//! * A [`CudaContext`] for driver API calls.
+//! * A [`GlobalSchedulingPolicy`] for stream selection.
+//! * A dedicated deallocator stream for async `cuMemFreeAsync`.
+//! * A kernel function cache keyed by [`FunctionKey`] hashes.
+//!
+//! Most users interact through the convenience functions
+//! ([`with_default_device_policy`], [`with_cuda_context`], etc.) rather than
+//! touching the thread-local directly.
+//!
+//! [`CudaContext`]: cuda_core::CudaContext
+
+use crate::simt::error::{device_assert, device_error, DeviceError};
+use crate::simt::scheduling_policies::{
+    GlobalSchedulingPolicy, SchedulingPolicy, StreamPoolRoundRobin,
+};
+use cuda_core::{CudaContext, CudaFunction, CudaModule, CudaStream};
+use rustc_hash::FxHashMap;
+use std::cell::Cell;
+use std::hash::{DefaultHasher, Hash, Hasher};
+use std::sync::Arc;
+
+/// Default CUDA device ordinal used when no explicit device is specified.
+pub const DEFAULT_DEVICE_ID: usize = 0;
+
+/// Default number of devices initialized by `init_device_contexts_default`.
+pub const DEFAULT_NUM_DEVICES: usize = 1;
+
+/// Default number of streams in the [`StreamPoolRoundRobin`] policy.
+pub const DEFAULT_ROUND_ROBIN_STREAM_POOL_SIZE: usize = 4;
+
+/// Trait for types that uniquely identify a compiled kernel function.
+///
+/// The hash is used as the lookup key in the per-device function cache.
+pub trait FunctionKey: Hash {
+    /// Returns a hex-encoded hash string suitable for use as a cache key.
+    fn get_hash_string(&self) -> String {
+        let mut hasher = DefaultHasher::new();
+        self.hash(&mut hasher);
+        format!("{:x}", hasher.finish())
+    }
+}
+
+/// Cached mapping from function hash keys to loaded `(module, function)` pairs.
+type DeviceFunctions = FxHashMap<String, (Arc<CudaModule>, Arc<CudaFunction>)>;
+
+/// Per-device state: CUDA context, scheduling policy, deallocator stream, and
+/// compiled-kernel cache.
+pub struct AsyncDeviceContext {
+    /// Device ordinal.
+    #[allow(dead_code)]
+    device_id: usize,
+    /// Primary CUDA context for this device.
+    context: Arc<CudaContext>,
+    /// Dedicated stream for async memory deallocation (see [`DeviceBox`]).
+    ///
+    /// [`DeviceBox`]: crate::simt::device_box::DeviceBox
+    deallocator_stream: Arc<CudaStream>,
+    /// Scheduling policy shared (via `Arc`) with all operations on this device.
+    policy: Arc<GlobalSchedulingPolicy>,
+    /// Cache of loaded kernel functions, keyed by [`FunctionKey`] hashes.
+    functions: DeviceFunctions,
+}
+
+/// Container for all per-device contexts on a single thread.
+///
+/// Uses interior mutability ([`Cell`]) because it lives inside a
+/// `thread_local!` and must be borrowed without `&mut`.
+pub struct AsyncDeviceContexts {
+    /// Currently selected default device ordinal.
+    default_device: Cell<usize>,
+    /// Lazily initialized map of device ordinal to context.
+    devices: Cell<Option<FxHashMap<usize, AsyncDeviceContext>>>,
+}
+
+// Thread-local storage for per-device CUDA state.
+// Lazily initialized on first access. Each thread gets its own independent
+// set of device contexts, streams, and kernel caches.
+thread_local!(static DEVICE_CONTEXTS: AsyncDeviceContexts = const {
+    AsyncDeviceContexts {
+        default_device: Cell::new(DEFAULT_DEVICE_ID),
+        devices: Cell::new(None),
+    }
+});
+
+/// Returns the default device ordinal for the current thread.
+pub fn get_default_device() -> usize {
+    DEVICE_CONTEXTS.with(|ctx| ctx.default_device.get())
+}
+
+/// Initializes the thread-local device context map with capacity for
+/// `num_devices` devices and sets `default_device_id` as the default.
+///
+/// Must be called at most once per thread. Returns an error if already
+/// initialized.
+pub fn init_device_contexts(
+    default_device_id: usize,
+    num_devices: usize,
+) -> Result<(), DeviceError> {
+    DEVICE_CONTEXTS.with(|ctx| {
+        let devices = ctx.devices.take();
+        let is_uninitialized = devices.is_none();
+        ctx.devices.set(devices);
+        device_assert(
+            default_device_id,
+            is_uninitialized,
+            "Context already initialized.",
+        )
+    })?;
+    let devices = FxHashMap::with_capacity_and_hasher(num_devices, Default::default());
+    DEVICE_CONTEXTS.with(|ctx| {
+        ctx.default_device.set(default_device_id);
+        ctx.devices.set(Some(devices));
+    });
+    Ok(())
+}
+
+/// Initializes the thread-local device contexts with default parameters.
+fn init_device_contexts_default() -> Result<(), DeviceError> {
+    let default_device = get_default_device();
+    init_device_contexts(default_device, DEFAULT_NUM_DEVICES)
+}
+
+/// Creates a new [`AsyncDeviceContext`] for `device_id` with the given policy.
+///
+/// Initializes the CUDA context, the scheduling policy's stream pool, and a
+/// dedicated deallocator stream.
+pub fn new_device_context(
+    device_id: usize,
+    mut policy: GlobalSchedulingPolicy,
+) -> Result<AsyncDeviceContext, DeviceError> {
+    let context = CudaContext::new(device_id)?;
+    policy.init(&context)?;
+    let deallocator_stream = context.new_stream()?;
+    Ok(AsyncDeviceContext {
+        device_id,
+        context,
+        deallocator_stream,
+        policy: Arc::new(policy),
+        functions: FxHashMap::default(),
+    })
+}
+
+/// Inserts a new device context into `hashmap`. Errors if the device is
+/// already present.
+fn init_device(
+    hashmap: &mut FxHashMap<usize, AsyncDeviceContext>,
+    device_id: usize,
+    policy: GlobalSchedulingPolicy,
+) -> Result<(), DeviceError> {
+    let device_context = new_device_context(device_id, policy)?;
+    let pred = hashmap.insert(device_id, device_context).is_none();
+    device_assert(device_id, pred, "Device is already initialized.")
+}
+
+/// Initializes a device with the default round-robin policy.
+fn init_with_default_policy(
+    hashmap: &mut FxHashMap<usize, AsyncDeviceContext>,
+    device_id: usize,
+) -> Result<(), DeviceError> {
+    let policy =
+        unsafe { StreamPoolRoundRobin::new(device_id, DEFAULT_ROUND_ROBIN_STREAM_POOL_SIZE) };
+    init_device(
+        hashmap,
+        device_id,
+        GlobalSchedulingPolicy::RoundRobin(policy),
+    )
+}
+
+/// Borrows the thread-local [`AsyncDeviceContext`] for `device_id` immutably.
+///
+/// Lazily initializes the context map and the specific device if needed.
+fn with_global_device_context<F, R>(device_id: usize, f: F) -> Result<R, DeviceError>
+where
+    F: FnOnce(&AsyncDeviceContext) -> R,
+{
+    DEVICE_CONTEXTS.with(|ctx| {
+        let mut hashmap = match ctx.devices.take() {
+            Some(hashmap) => hashmap,
+            None => {
+                init_device_contexts_default()?;
+                ctx.devices
+                    .take()
+                    .ok_or_else(|| device_error(device_id, "Failed to initialize context"))?
+            }
+        };
+        if !hashmap.contains_key(&device_id) {
+            init_with_default_policy(&mut hashmap, device_id)?;
+        }
+        let device_context = hashmap
+            .get(&device_id)
+            .ok_or_else(|| device_error(device_id, "Failed to get context"))?;
+        let r = f(device_context);
+        ctx.devices.replace(Some(hashmap));
+        Ok(r)
+    })
+}
+
+/// Borrows the thread-local [`AsyncDeviceContext`] for `device_id` mutably.
+///
+/// Lazily initializes the context map and the specific device if needed.
+fn with_global_device_context_mut<F, R>(device_id: usize, f: F) -> Result<R, DeviceError>
+where
+    F: FnOnce(&mut AsyncDeviceContext) -> R,
+{
+    DEVICE_CONTEXTS.with(|ctx| {
+        let mut hashmap = match ctx.devices.take() {
+            Some(hashmap) => hashmap,
+            None => {
+                init_device_contexts_default()?;
+                ctx.devices
+                    .take()
+                    .ok_or_else(|| device_error(device_id, "Failed to initialize context"))?
+            }
+        };
+        if !hashmap.contains_key(&device_id) {
+            init_with_default_policy(&mut hashmap, device_id)?;
+        }
+        let device_context = hashmap
+            .get_mut(&device_id)
+            .ok_or_else(|| device_error(device_id, "Failed to get context"))?;
+        let r = f(device_context);
+        ctx.devices.replace(Some(hashmap));
+        Ok(r)
+    })
+}
+
+/// Provides the default device's scheduling policy to `f`.
+///
+/// This is the primary entry point used by [`IntoFuture`] impls on
+/// `DeviceOperation` combinators.
+///
+/// [`IntoFuture`]: std::future::IntoFuture
+pub fn with_default_device_policy<F, R>(f: F) -> Result<R, DeviceError>
+where
+    F: FnOnce(&Arc<GlobalSchedulingPolicy>) -> R,
+{
+    let default_device = get_default_device();
+    with_global_device_context(default_device, |dc| f(&dc.policy))
+}
+
+/// Provides the deallocator stream for `device_id` to `f`.
+///
+/// # Safety
+///
+/// The stream must only be used for `cuMemFreeAsync` calls. Enqueuing other
+/// work on this stream may interfere with async deallocation ordering.
+pub unsafe fn with_deallocator_stream<F, R>(device_id: usize, f: F) -> Result<R, DeviceError>
+where
+    F: FnOnce(&Arc<CudaStream>) -> R,
+{
+    with_global_device_context(device_id, |dc| f(&dc.deallocator_stream))
+}
+
+/// Provides the CUDA context for `device_id` to `f`.
+pub fn with_cuda_context<F, R>(device_id: usize, f: F) -> Result<R, DeviceError>
+where
+    F: FnOnce(&Arc<CudaContext>) -> R,
+{
+    with_global_device_context(device_id, |dc| f(&dc.context))
+}
+
+/// Sets the default device ordinal for the current thread.
+pub fn set_default_device(default_device_id: usize) {
+    DEVICE_CONTEXTS.with(|ctx| {
+        ctx.default_device.set(default_device_id);
+    })
+}
+
+/// Loads a CUDA module from a file (`.cubin`, `.fatbin`, or `.ptx`) on
+/// `device_id`.
+pub fn load_module_from_file(
+    filename: &str,
+    device_id: usize,
+) -> Result<Arc<CudaModule>, DeviceError> {
+    with_cuda_context(device_id, |cuda_ctx| {
+        let module = cuda_ctx.load_module_from_file(filename)?;
+        Ok(module)
+    })?
+}
+
+/// Loads a CUDA module from PTX source text on `device_id`.
+pub fn load_module_from_ptx(
+    ptx_src: &str,
+    device_id: usize,
+) -> Result<Arc<CudaModule>, DeviceError> {
+    with_cuda_context(device_id, |cuda_ctx| {
+        let module = cuda_ctx.load_module_from_ptx_src(ptx_src)?;
+        Ok(module)
+    })?
+}
+
+/// Inserts a compiled function into the per-device kernel cache.
+///
+/// The function is keyed by the hash of `func_key`. Returns an error if a
+/// different function was already registered under the same key (hash
+/// collision).
+pub fn insert_cuda_function(
+    device_id: usize,
+    func_key: &impl FunctionKey,
+    value: (Arc<CudaModule>, Arc<CudaFunction>),
+) -> Result<(), DeviceError> {
+    with_global_device_context_mut(device_id, |dc| {
+        let key = func_key.get_hash_string();
+        let res = dc.functions.insert(key, value);
+        device_assert(device_id, res.is_none(), "Unexpected cache key collision.")
+    })?
+}
+
+/// Retrieves a compiled [`CudaFunction`] from the per-device kernel cache.
+///
+/// Returns an error if no function has been registered under `func_key`.
+pub fn get_cuda_function(
+    device_id: usize,
+    func_key: &impl FunctionKey,
+) -> Result<Arc<CudaFunction>, DeviceError> {
+    with_global_device_context(device_id, |dc| {
+        let key = func_key.get_hash_string();
+        let (_module, function) = dc
+            .functions
+            .get(&key)
+            .ok_or_else(|| device_error(device_id, "Failed to get cuda function."))?;
+        Ok(Arc::clone(function))
+    })?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_duplicate_init_error(result: Result<(), DeviceError>) {
+        assert!(matches!(
+            result,
+            Err(DeviceError::Context {
+                device_id: 0,
+                message,
+            }) if message == "Context already initialized."
+        ));
+    }
+
+    #[test]
+    fn duplicate_init_preserves_existing_device_contexts() {
+        std::thread::spawn(|| {
+            init_device_contexts(0, 1).expect("initial context initialization should succeed");
+
+            assert_duplicate_init_error(init_device_contexts(0, 1));
+            assert_duplicate_init_error(init_device_contexts(0, 1));
+        })
+        .join()
+        .expect("test thread should not panic");
+    }
+}

--- a/cuda-async/src/simt/device_future.rs
+++ b/cuda-async/src/simt/device_future.rs
@@ -1,0 +1,509 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Future type that bridges CUDA stream callbacks with Rust's async executor.
+//!
+//! [`DeviceFuture`] wraps a [`DeviceOperation`] and drives it through a
+//! three-state machine:
+//!
+//! ```text
+//!   Idle ──poll()──> Executing ──callback fires──> Complete
+//!                       │                              │
+//!                  (enqueue work                  (return result)
+//!                   + host callback)
+//! ```
+//!
+//! On the first poll the operation is executed on its assigned stream and a
+//! host callback is registered via `cuLaunchHostFunc`. When the GPU reaches
+//! the callback, it wakes the future through an [`AtomicWaker`], avoiding
+//! busy-waits.
+//!
+//! [`DeviceOperation`]: crate::simt::device_operation::DeviceOperation
+//! [`AtomicWaker`]: futures::task::AtomicWaker
+
+use crate::simt::device_operation::{DeviceOperation, ExecutionContext};
+use crate::simt::error::DeviceError;
+use crate::simt::reclaim;
+use futures::task::AtomicWaker;
+use std::future::Future;
+use std::io::{self, Write};
+use std::mem;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+/// Lifecycle state of a [`DeviceFuture`].
+#[derive(Debug, Default, Eq, PartialEq, Copy, Clone)]
+pub enum DeviceFutureState {
+    /// The future was constructed in a failed state (e.g. scheduling error).
+    Failed,
+    /// Initial state: the operation has not yet been submitted to the GPU.
+    #[default]
+    Idle,
+    /// The operation has been submitted; waiting for the stream callback.
+    Executing,
+    /// The result has been produced. Polling again will panic.
+    Complete,
+}
+
+/// Shared state between a [`DeviceFuture`] and its `cuLaunchHostFunc` callback.
+///
+/// The callback sets `complete` and wakes the stored waker, allowing the
+/// executor to re-poll the future without busy-waiting.
+#[derive(Debug, Default)]
+pub struct StreamCallbackState {
+    /// Waker registered by the executor during [`Future::poll`].
+    pub(crate) waker: AtomicWaker,
+    /// Set to `true` by the host callback when the GPU reaches the callback
+    /// point in the stream.
+    pub(crate) complete: AtomicBool,
+}
+
+impl StreamCallbackState {
+    /// Creates a new callback state with no registered waker and
+    /// `complete = false`.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Marks the stream callback as complete and wakes the associated future.
+    ///
+    /// Called from the `cuLaunchHostFunc` host-side callback.
+    pub fn signal(&self) {
+        self.complete.store(true, Ordering::Relaxed);
+        self.waker.wake();
+    }
+}
+
+/// A [`Future`] that executes a [`DeviceOperation`] on a CUDA stream and
+/// resolves when the GPU signals completion via a host callback.
+///
+/// Constructed by [`SchedulingPolicy::schedule`] or by the [`IntoFuture`] impl
+/// on any `DeviceOperation`.
+///
+/// # Cancellation
+///
+/// Dropping the future never cancels submitted GPU work; kernels always run
+/// to completion. Dropping an in-flight future records a CUDA event on the
+/// assigned stream and parks the stored result in the [`reclaim`] limbo,
+/// deferring host-side reclamation until the device timeline passes that
+/// event. The drop itself never blocks on GPU progress.
+///
+/// [`reclaim`]: crate::simt::reclaim
+///
+/// [`SchedulingPolicy::schedule`]: crate::simt::scheduling_policies::SchedulingPolicy::schedule
+/// [`IntoFuture`]: std::future::IntoFuture
+#[derive(Debug)]
+pub struct DeviceFuture<T: Send + 'static, DO: DeviceOperation<Output = T>> {
+    /// The operation to execute. Consumed on first poll.
+    pub(crate) device_operation: Option<DO>,
+    /// Stream and context for execution. Set by the scheduling policy.
+    pub(crate) execution_context: Option<ExecutionContext>,
+    /// Holds the result between execution and final poll resolution.
+    pub(crate) result: Option<T>,
+    /// Holds an error when the future is in the `Failed` state.
+    pub(crate) error: Option<DeviceError>,
+    /// Current lifecycle state.
+    pub(crate) state: DeviceFutureState,
+    /// Shared state with the `cuLaunchHostFunc` callback.
+    pub(crate) callback_state: Option<Arc<StreamCallbackState>>,
+}
+
+impl<T: Send + 'static, DO: DeviceOperation<Output = T>> DeviceFuture<T, DO> {
+    /// Creates an idle future with no operation or context attached.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Creates a future that will immediately yield `Err(error)` on first poll.
+    pub fn failed(error: DeviceError) -> Self {
+        Self {
+            execution_context: None,
+            device_operation: None,
+            state: DeviceFutureState::Failed,
+            callback_state: None,
+            result: None,
+            error: Some(error),
+        }
+    }
+
+    /// Registers a `cuLaunchHostFunc` callback that will signal `waker_state`
+    /// when the GPU reaches this point in the stream.
+    ///
+    /// # Safety
+    ///
+    /// The execution context must hold a valid, non-destroyed CUDA stream.
+    unsafe fn register_callback(
+        &self,
+        waker_state: Arc<StreamCallbackState>,
+    ) -> Result<(), DeviceError> {
+        let ctx = self.execution_context.as_ref().ok_or_else(|| {
+            DeviceError::Internal("Cannot execute future without an execution context.".to_string())
+        })?;
+        ctx.get_cuda_stream().launch_host_function(move || {
+            waker_state.signal();
+        })?;
+        Ok(())
+    }
+
+    /// Takes the stored operation, executes it on the bound stream, and stashes
+    /// the result. Called exactly once during the `Idle -> Executing` transition.
+    fn execute(&mut self) -> Result<(), DeviceError> {
+        let ctx = self.execution_context.as_ref().ok_or_else(|| {
+            DeviceError::Internal("Cannot execute future without an execution context.".to_string())
+        })?;
+        let operation = self
+            .device_operation
+            .take()
+            .ok_or_else(|| DeviceError::Internal("No operation has been set.".to_string()))?;
+        let out = unsafe { operation.execute(ctx) }?;
+        self.result = Some(out);
+        Ok(())
+    }
+
+    /// Returns `true` when GPU work was submitted but the stored result has
+    /// not been handed to the caller.
+    ///
+    /// `result` is only populated by a successful [`execute`], so a stored
+    /// result implies submitted GPU work. The state check excludes futures
+    /// that never submitted anything (`Idle`, `Failed`); a `Complete` future
+    /// can still hold a result when callback registration failed after a
+    /// successful launch.
+    ///
+    /// [`execute`]: Self::execute
+    fn has_undelivered_submission(&self) -> bool {
+        matches!(
+            self.state,
+            DeviceFutureState::Executing | DeviceFutureState::Complete
+        ) && self.result.is_some()
+    }
+
+    /// Hands a submitted-but-undelivered result to deferred reclamation.
+    ///
+    /// Records a completion event on the assigned stream and parks the
+    /// result in the [`reclaim`] limbo; the result is dropped by a later
+    /// sweep once the device timeline passes the event. Never blocks in
+    /// this path. Only when the event cannot be recorded does it fall back
+    /// to [`cleanup_executing_result_with`], which synchronizes the stream
+    /// and, if even that fails, leaks the result loudly.
+    ///
+    /// [`cleanup_executing_result_with`]: Self::cleanup_executing_result_with
+    fn reclaim_in_flight_result(&mut self) {
+        if !self.has_undelivered_submission() {
+            return;
+        }
+        let stream = self
+            .execution_context
+            .as_ref()
+            .map(|ctx| Arc::clone(ctx.get_cuda_stream()));
+        if let Some(stream) = &stream {
+            if let Ok(event) = stream.record_event(None) {
+                let result = self.result.take().expect("Checked above.");
+                reclaim::park(event, Box::new(result));
+                return;
+            }
+        }
+        // No execution context, or the driver rejected the event record.
+        // Fall back to the blocking path before resorting to a loud leak.
+        self.cleanup_executing_result_with(move || {
+            let stream = stream.ok_or_else(|| {
+                DeviceError::Internal(
+                    "Cannot clean up an in-flight future without an execution context.".to_string(),
+                )
+            })?;
+            stream.synchronize().map_err(DeviceError::Driver)
+        });
+    }
+
+    /// Blocking cleanup fallback: runs `synchronize` and drops the stored
+    /// result on success; on failure the result is leaked loudly, because
+    /// dropping resources the device may still use is worse than leaking.
+    ///
+    /// Deferred (non-blocking) reclamation in
+    /// [`reclaim_in_flight_result`](Self::reclaim_in_flight_result) is
+    /// always preferred; this path only runs when no completion event could
+    /// be recorded.
+    fn cleanup_executing_result_with<F>(&mut self, synchronize: F)
+    where
+        F: FnOnce() -> Result<(), DeviceError>,
+    {
+        if !self.has_undelivered_submission() {
+            return;
+        }
+
+        let Some(result) = self.result.take() else {
+            return;
+        };
+
+        if let Err(error) = synchronize() {
+            let mut stderr = io::stderr().lock();
+            let _ = writeln!(
+                stderr,
+                "cuda-async: leaking in-flight future result after cleanup failure: {}",
+                error
+            );
+            // If cleanup cannot prove the stream is idle, leaking the owned
+            // result is safer than dropping buffers that device work may still
+            // be using.
+            mem::forget(result);
+            return;
+        }
+
+        drop(result);
+    }
+}
+
+impl<T: Send + 'static, DO: DeviceOperation<Output = T>> Default for DeviceFuture<T, DO> {
+    fn default() -> Self {
+        Self {
+            device_operation: Default::default(),
+            execution_context: Default::default(),
+            result: Default::default(),
+            error: Default::default(),
+            state: Default::default(),
+            callback_state: Default::default(),
+        }
+    }
+}
+
+/// `DeviceFuture` does not contain self-referential pointers, so it is safe
+/// to move.
+impl<T: Send + 'static, DO: DeviceOperation<Output = T>> Unpin for DeviceFuture<T, DO> {}
+
+impl<T: Send + 'static, DO: DeviceOperation<Output = T>> Drop for DeviceFuture<T, DO> {
+    fn drop(&mut self) {
+        // Reclaim earlier cancellations whose GPU work has since finished,
+        // then defer this future's own in-flight result (if any).
+        reclaim::sweep();
+        self.reclaim_in_flight_result();
+    }
+}
+
+/// State-machine implementation of [`Future`] for CUDA device work.
+///
+/// | State       | Action on poll                                          |
+/// |-------------|---------------------------------------------------------|
+/// | `Failed`    | Immediately returns `Err`.                              |
+/// | `Idle`      | Executes the operation, registers callback, -> Pending. |
+/// | `Executing` | Checks callback flag; returns result if done.           |
+/// | `Complete`  | Panics -- must not poll after completion.               |
+impl<T: Send + 'static, DO: DeviceOperation<Output = T>> Future for DeviceFuture<T, DO> {
+    type Output = Result<T, DeviceError>;
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        // Opportunistically reclaim cancelled results whose GPU work has
+        // completed. Cheap when nothing is parked (one atomic load).
+        reclaim::sweep();
+
+        if self.state == DeviceFutureState::Failed {
+            self.state = DeviceFutureState::Complete;
+            let error = self
+                .error
+                .take()
+                .expect("Failed state must carry an error.");
+            return Poll::Ready(Err(error));
+        }
+
+        if self.callback_state.is_none() {
+            self.callback_state = Some(Arc::new(StreamCallbackState::new()));
+        }
+        let waker_state = self
+            .callback_state
+            .as_ref()
+            .map(Arc::clone)
+            .expect("Impossible.");
+
+        match self.state {
+            DeviceFutureState::Idle => {
+                waker_state.waker.register(cx.waker());
+                if let Err(e) = self.execute() {
+                    self.state = DeviceFutureState::Complete;
+                    return Poll::Ready(Err(e));
+                }
+                if let Err(e) = unsafe { self.register_callback(Arc::clone(&waker_state)) } {
+                    self.state = DeviceFutureState::Complete;
+                    // The launch already succeeded, so GPU work is in flight
+                    // and `result` holds the owned resources. Route them
+                    // through deferred reclamation instead of leaving them
+                    // for an immediate drop while the kernel may still run
+                    // (issue #99, callback-registration-failure path).
+                    self.reclaim_in_flight_result();
+                    return Poll::Ready(Err(e));
+                }
+                self.state = DeviceFutureState::Executing;
+                Poll::Pending
+            }
+            DeviceFutureState::Executing => {
+                if waker_state.complete.load(Ordering::Relaxed) {
+                    self.state = DeviceFutureState::Complete;
+                    return Poll::Ready(Ok(self.result.take().expect("Expected result.")));
+                }
+                waker_state.waker.register(cx.waker());
+                if waker_state.complete.load(Ordering::Relaxed) {
+                    self.state = DeviceFutureState::Complete;
+                    Poll::Ready(Ok(self.result.take().expect("Expected result.")))
+                } else {
+                    Poll::Pending
+                }
+            }
+            DeviceFutureState::Complete => panic!("Poll called after completion."),
+            DeviceFutureState::Failed => unreachable!(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::simt::device_operation::Value;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+    use std::sync::Mutex;
+
+    #[derive(Clone)]
+    struct DropTracker {
+        events: Arc<Mutex<Vec<&'static str>>>,
+    }
+
+    impl Drop for DropTracker {
+        fn drop(&mut self) {
+            self.events.lock().unwrap().push("drop");
+        }
+    }
+
+    #[test]
+    fn cleanup_executing_result_synchronizes_before_drop() {
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let tracker = DropTracker {
+            events: Arc::clone(&events),
+        };
+        let mut future: DeviceFuture<DropTracker, Value<DropTracker>> = DeviceFuture {
+            device_operation: None,
+            execution_context: None,
+            result: Some(tracker),
+            error: None,
+            state: DeviceFutureState::Executing,
+            callback_state: None,
+        };
+
+        future.cleanup_executing_result_with(|| {
+            events.lock().unwrap().push("sync");
+            Ok(())
+        });
+
+        assert_eq!(events.lock().unwrap().as_slice(), ["sync", "drop"]);
+        assert!(future.result.is_none());
+    }
+
+    #[test]
+    fn cleanup_executing_result_leaks_when_synchronize_fails() {
+        let drops = Arc::new(AtomicUsize::new(0));
+
+        struct CountDrop(Arc<AtomicUsize>);
+
+        impl Drop for CountDrop {
+            fn drop(&mut self) {
+                self.0.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+
+        let mut future: DeviceFuture<CountDrop, Value<CountDrop>> = DeviceFuture {
+            device_operation: None,
+            execution_context: None,
+            result: Some(CountDrop(Arc::clone(&drops))),
+            error: None,
+            state: DeviceFutureState::Executing,
+            callback_state: None,
+        };
+
+        future.cleanup_executing_result_with(|| Err(DeviceError::Internal("boom".to_string())));
+
+        assert_eq!(drops.load(Ordering::Relaxed), 0);
+        assert!(future.result.is_none());
+    }
+
+    /// The shape left behind by issue #99's second path: `execute()`
+    /// succeeded (GPU work submitted, `result` populated) but
+    /// `register_callback()` failed, so poll flipped the state to
+    /// `Complete` with the result still stored. Cleanup must treat that
+    /// exactly like a cancelled `Executing` future.
+    #[test]
+    fn cleanup_covers_complete_future_left_by_callback_registration_failure() {
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let tracker = DropTracker {
+            events: Arc::clone(&events),
+        };
+        let mut future: DeviceFuture<DropTracker, Value<DropTracker>> = DeviceFuture {
+            device_operation: None,
+            execution_context: None,
+            result: Some(tracker),
+            error: None,
+            state: DeviceFutureState::Complete,
+            callback_state: None,
+        };
+
+        assert!(future.has_undelivered_submission());
+        future.cleanup_executing_result_with(|| {
+            events.lock().unwrap().push("sync");
+            Ok(())
+        });
+
+        assert_eq!(events.lock().unwrap().as_slice(), ["sync", "drop"]);
+        assert!(future.result.is_none());
+        assert!(!future.has_undelivered_submission());
+    }
+
+    /// A `Complete` future whose result was already delivered to the caller
+    /// has nothing to reclaim.
+    #[test]
+    fn cleanup_is_noop_after_result_delivery() {
+        let mut future: DeviceFuture<u32, Value<u32>> = DeviceFuture {
+            device_operation: None,
+            execution_context: None,
+            result: None,
+            error: None,
+            state: DeviceFutureState::Complete,
+            callback_state: None,
+        };
+
+        assert!(!future.has_undelivered_submission());
+        future.cleanup_executing_result_with(|| {
+            panic!("delivered futures must not synchronize during cleanup")
+        });
+        future.reclaim_in_flight_result();
+    }
+
+    #[test]
+    fn cleanup_is_noop_for_idle_future() {
+        let drops = Arc::new(AtomicUsize::new(0));
+
+        struct CountDrop(Arc<AtomicUsize>);
+
+        impl Drop for CountDrop {
+            fn drop(&mut self) {
+                self.0.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+
+        let mut future: DeviceFuture<CountDrop, Value<CountDrop>> = DeviceFuture {
+            device_operation: None,
+            execution_context: None,
+            result: Some(CountDrop(Arc::clone(&drops))),
+            error: None,
+            state: DeviceFutureState::Idle,
+            callback_state: None,
+        };
+
+        future.cleanup_executing_result_with(|| {
+            panic!("idle futures should not synchronize during cleanup")
+        });
+
+        assert_eq!(drops.load(Ordering::Relaxed), 0);
+        assert!(future.result.is_some());
+
+        drop(future);
+        assert_eq!(drops.load(Ordering::Relaxed), 1);
+    }
+}

--- a/cuda-async/src/simt/device_operation.rs
+++ b/cuda-async/src/simt/device_operation.rs
@@ -1,0 +1,981 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Lazy, composable GPU operations and combinator types.
+//!
+//! The [`DeviceOperation`] trait is the core abstraction. Each operation
+//! describes GPU work without binding to a stream. Combinators (`and_then`,
+//! `zip`, `apply`, `with_context`) compose operations into dataflow graphs
+//! that remain stream-agnostic until scheduling time.
+//!
+//! # Scheduling model
+//!
+//! | Method       | What it does                                                      |
+//! |--------------|-------------------------------------------------------------------|
+//! | [`schedule`] | Pairs the operation with a stream, returns a [`DeviceFuture`].    |
+//! | [`sync`]     | Shorthand: schedule + execute + synchronize on the default device.|
+//! | [`sync_on`]  | Execute and synchronize on a specific stream.                     |
+//! | [`async_on`] | `unsafe`: execute on a specific stream **without** synchronizing.  |
+//!
+//! [`schedule`]: DeviceOperation::schedule
+//! [`sync`]: DeviceOperation::sync
+//! [`sync_on`]: DeviceOperation::sync_on
+//! [`async_on`]: DeviceOperation::async_on
+//! [`DeviceFuture`]: crate::simt::device_future::DeviceFuture
+
+use crate::simt::device_context::with_default_device_policy;
+use crate::simt::device_future::DeviceFuture;
+use crate::simt::error::DeviceError;
+use crate::simt::scheduling_policies::SchedulingPolicy;
+use cuda_core::{CudaContext, CudaStream};
+use std::cell::UnsafeCell;
+use std::future::IntoFuture;
+use std::marker::PhantomData;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+/// CUDA device ordinal. Type alias for readability.
+pub type Device = usize;
+
+/// Binds a [`DeviceOperation`] to a concrete CUDA stream and context for
+/// execution.
+///
+/// Created by the scheduling policy when an operation is scheduled. Passed to
+/// [`DeviceOperation::execute`] to provide the stream and context.
+#[derive(Debug, Clone)]
+pub struct ExecutionContext {
+    /// Device ordinal derived from the CUDA context.
+    device: Device,
+    /// Stream on which GPU work will be enqueued.
+    cuda_stream: Arc<CudaStream>,
+    /// CUDA context that owns the stream.
+    cuda_context: Arc<CudaContext>,
+}
+
+impl ExecutionContext {
+    /// Constructs a context from a stream, deriving the device and CUDA context
+    /// from the stream's owning context.
+    pub fn new(cuda_stream: Arc<CudaStream>) -> Self {
+        let cuda_context = Arc::clone(cuda_stream.context());
+        let device = cuda_context.ordinal();
+        Self {
+            cuda_stream,
+            cuda_context,
+            device,
+        }
+    }
+
+    /// Returns the CUDA stream.
+    pub fn get_cuda_stream(&self) -> &Arc<CudaStream> {
+        &self.cuda_stream
+    }
+
+    /// Returns the CUDA context.
+    pub fn get_cuda_context(&self) -> &Arc<CudaContext> {
+        &self.cuda_context
+    }
+
+    /// Returns the device ordinal.
+    pub fn get_device_id(&self) -> Device {
+        self.device
+    }
+}
+
+/// A lazy, composable GPU operation that may be executed synchronously or
+/// asynchronously.
+///
+/// `DeviceOperation` is the core trait of the `cuda-async` crate. It
+/// represents a unit of GPU work that is **stream-agnostic**: the concrete
+/// CUDA stream is chosen only at scheduling time, not at construction time.
+///
+/// # Composing operations
+///
+/// Combinators build complex dataflow graphs without touching streams:
+///
+/// | Combinator                | Effect                                          |
+/// |---------------------------|-------------------------------------------------|
+/// | [`and_then`]              | Sequence: `A` then `f(result_a)`.               |
+/// | [`and_then_with_context`] | Like `and_then` but the closure sees the stream.|
+/// | [`apply`]                 | Alias for `and_then`.                           |
+/// | [`arc`]                   | Wraps the output in `Arc<T>`.                   |
+/// | `zip!`                  | Runs two or three operations, returns a tuple.  |
+/// | `unzip!`                | Splits a tuple-producing operation.             |
+///
+/// # Executing operations
+///
+/// | Method       | Picks stream via         | Blocks? | Async? | `unsafe`? |
+/// |--------------|--------------------------|---------|--------|-----------|
+/// | [`schedule`] | `SchedulingPolicy`       | No      | Yes    | No        |
+/// | `.await`     | Default policy           | No      | Yes    | No        |
+/// | [`sync`]     | Default policy           | Yes     | No     | No        |
+/// | [`sync_on`]  | Caller-provided stream   | Yes     | No     | No        |
+/// | [`async_on`] | Caller-provided stream   | No      | No     | **`unsafe`** |
+///
+/// [`async_on`] is the only one that is `unsafe`, and it is the only one that
+/// returns while GPU work may still be in flight: the caller must synchronize
+/// the stream before consuming device-side outputs. The other four either block
+/// or hand back a future that does the waiting.
+///
+/// # Implementors
+///
+/// Implement [`execute`] to describe the GPU work. The blanket [`IntoFuture`]
+/// impl must also be provided (typically via the same boilerplate that
+/// delegates to `with_default_device_policy`).
+///
+/// [`and_then`]: DeviceOperation::and_then
+/// [`and_then_with_context`]: DeviceOperation::and_then_with_context
+/// [`apply`]: DeviceOperation::apply
+/// [`arc`]: DeviceOperation::arc
+/// [`schedule`]: DeviceOperation::schedule
+/// [`sync`]: DeviceOperation::sync
+/// [`sync_on`]: DeviceOperation::sync_on
+/// [`async_on`]: DeviceOperation::async_on
+/// [`execute`]: DeviceOperation::execute
+pub trait DeviceOperation:
+    Send + Sized + IntoFuture<Output = Result<<Self as DeviceOperation>::Output, DeviceError>>
+{
+    /// The value produced when the operation completes successfully.
+    ///
+    /// The `'static` bound exists because a cancelled in-flight result is
+    /// parked in the [`reclaim`](crate::simt::reclaim) limbo and dropped only
+    /// after the GPU work completes, which can be after any non-`'static`
+    /// borrow it carries would have expired.
+    type Output: Send + 'static;
+
+    /// Submits GPU work to the stream in `context` and returns the result.
+    ///
+    /// # Safety
+    ///
+    /// GPU work may still be in flight when this returns. The caller must
+    /// synchronize the stream before reading device-side outputs.
+    unsafe fn execute(
+        self,
+        context: &ExecutionContext,
+    ) -> Result<<Self as DeviceOperation>::Output, DeviceError>;
+
+    /// Pairs this operation with a stream chosen by `policy` and returns a
+    /// [`DeviceFuture`] that can be `.await`-ed.
+    fn schedule<P: SchedulingPolicy>(
+        self,
+        policy: &P,
+    ) -> Result<DeviceFuture<<Self as DeviceOperation>::Output, Self>, DeviceError> {
+        policy.schedule(self)
+    }
+
+    /// Chains a dependent operation: executes `self`, then passes its output
+    /// to `f` to produce the next operation.
+    fn and_then<O: Send, DO, F>(
+        self,
+        f: F,
+    ) -> AndThen<<Self as DeviceOperation>::Output, Self, O, DO, F>
+    where
+        DO: DeviceOperation<Output = O>,
+        F: FnOnce(<Self as DeviceOperation>::Output) -> DO,
+    {
+        AndThen {
+            op: self,
+            closure: f,
+        }
+    }
+
+    /// Like [`and_then`](Self::and_then), but the closure also receives the
+    /// [`ExecutionContext`] so it can inspect the stream or device.
+    fn and_then_with_context<O: Send, DO, F>(
+        self,
+        f: F,
+    ) -> AndThenWithContext<<Self as DeviceOperation>::Output, Self, O, DO, F>
+    where
+        DO: DeviceOperation<Output = O>,
+        F: FnOnce(&ExecutionContext, <Self as DeviceOperation>::Output) -> DO,
+    {
+        AndThenWithContext {
+            op: self,
+            closure: f,
+        }
+    }
+
+    /// Wraps the output in an [`Arc`], useful when the result must be shared
+    /// across multiple consumers.
+    fn arc(self) -> DeviceOperationArc<<Self as DeviceOperation>::Output, Self>
+    where
+        <Self as DeviceOperation>::Output: Sync,
+    {
+        DeviceOperationArc { op: self }
+    }
+
+    /// Alias for [`and_then`](Self::and_then).
+    fn apply<O: Send, DO, F>(
+        self,
+        f: F,
+    ) -> AndThen<<Self as DeviceOperation>::Output, Self, O, DO, F>
+    where
+        DO: DeviceOperation<Output = O>,
+        F: FnOnce(<Self as DeviceOperation>::Output) -> DO,
+    {
+        self.and_then(f)
+    }
+
+    /// Executes the operation synchronously on the default device using the
+    /// thread-local scheduling policy. Blocks until the stream is idle.
+    fn sync(self) -> Result<<Self as DeviceOperation>::Output, DeviceError> {
+        with_default_device_policy(|policy| policy.sync(self))?
+    }
+
+    /// Executes the operation on `stream` **without** synchronizing.
+    ///
+    /// # Safety
+    ///
+    /// GPU work may still be in flight when this returns. The caller must
+    /// synchronize `stream` before consuming device-side outputs.
+    unsafe fn async_on(
+        self,
+        stream: &Arc<CudaStream>,
+    ) -> Result<<Self as DeviceOperation>::Output, DeviceError> {
+        let ctx = ExecutionContext::new(Arc::clone(stream));
+        unsafe { self.execute(&ctx) }
+    }
+
+    /// Executes the operation on `stream` and synchronizes before returning.
+    fn sync_on(
+        self,
+        stream: &Arc<CudaStream>,
+    ) -> Result<<Self as DeviceOperation>::Output, DeviceError> {
+        let ctx = ExecutionContext::new(Arc::clone(stream));
+        let res = unsafe { self.execute(&ctx) };
+        finish_sync(res, stream.synchronize())
+    }
+}
+
+fn finish_sync<T>(
+    operation_result: Result<T, DeviceError>,
+    synchronize_result: Result<(), cuda_core::DriverError>,
+) -> Result<T, DeviceError> {
+    let output = operation_result?;
+    synchronize_result.map_err(DeviceError::Driver)?;
+    Ok(output)
+}
+
+// --- Combinators ---
+
+/// Wraps a [`DeviceOperation`] whose output is `Arc`-wrapped.
+///
+/// Produced by [`DeviceOperation::arc`].
+pub struct DeviceOperationArc<I: Send + Sync, DI: DeviceOperation<Output = I>> {
+    /// The inner operation whose result will be wrapped in [`Arc`].
+    op: DI,
+}
+
+/// # Safety
+///
+/// `DI` is `Send` (required by `DeviceOperation`), and `I: Send + Sync`
+/// ensures the `Arc<I>` output is safe to transfer.
+unsafe impl<I: Send + Sync, DI: DeviceOperation<Output = I>> Send for DeviceOperationArc<I, DI> {}
+
+/// Executes the inner operation and wraps the result in [`Arc`].
+impl<I: Send + Sync + 'static, DI: DeviceOperation<Output = I>> DeviceOperation
+    for DeviceOperationArc<I, DI>
+{
+    type Output = Arc<I>;
+
+    unsafe fn execute(self, context: &ExecutionContext) -> Result<Arc<I>, DeviceError> {
+        unsafe {
+            let val = self.op.execute(context)?;
+            Ok(Arc::new(val))
+        }
+    }
+}
+
+/// Schedules via the thread-local default policy.
+impl<I: Send + Sync + 'static, DI: DeviceOperation<Output = I>> IntoFuture
+    for DeviceOperationArc<I, DI>
+{
+    type Output = Result<Arc<I>, DeviceError>;
+    type IntoFuture = DeviceFuture<Arc<I>, DeviceOperationArc<I, DI>>;
+    fn into_future(self) -> Self::IntoFuture {
+        match with_default_device_policy(|policy| policy.schedule(self)) {
+            Ok(Ok(future)) => future,
+            Ok(Err(e)) | Err(e) => DeviceFuture::failed(e),
+        }
+    }
+}
+
+/// Sequential composition: execute `DI`, then pass its output through `F` to
+/// produce a second operation `DO`, and execute that.
+///
+/// Produced by [`DeviceOperation::and_then`].
+pub struct AndThen<I: Send, DI, O: Send, DO, F>
+where
+    DI: DeviceOperation<Output = I>,
+    DO: DeviceOperation<Output = O>,
+    F: FnOnce(I) -> DO,
+{
+    /// First operation.
+    op: DI,
+    /// Closure mapping the first operation's output to the second operation.
+    closure: F,
+}
+
+/// # Safety
+///
+/// Both `DI` and `F` are `Send`. The struct owns them exclusively, so
+/// transferring across threads is safe.
+unsafe impl<I: Send, DI, O: Send, DO, F> Send for AndThen<I, DI, O, DO, F>
+where
+    DI: DeviceOperation<Output = I>,
+    DO: DeviceOperation<Output = O>,
+    F: FnOnce(I) -> DO + Send,
+{
+}
+
+/// Executes the first operation, feeds its result to the closure, then
+/// executes the resulting second operation on the same stream.
+impl<I: Send, DI, O: Send + 'static, DO, F> DeviceOperation for AndThen<I, DI, O, DO, F>
+where
+    DI: DeviceOperation<Output = I>,
+    DO: DeviceOperation<Output = O>,
+    F: FnOnce(I) -> DO + Send,
+{
+    type Output = O;
+
+    unsafe fn execute(self, context: &ExecutionContext) -> Result<O, DeviceError> {
+        unsafe {
+            let input = self.op.execute(context)?;
+            let output_op = (self.closure)(input);
+            output_op.execute(context)
+        }
+    }
+}
+
+/// Schedules via the thread-local default policy.
+impl<I: Send, DI, O: Send + 'static, DO, F> IntoFuture for AndThen<I, DI, O, DO, F>
+where
+    DI: DeviceOperation<Output = I>,
+    DO: DeviceOperation<Output = O>,
+    F: FnOnce(I) -> DO + Send,
+{
+    type Output = Result<O, DeviceError>;
+    type IntoFuture = DeviceFuture<O, AndThen<I, DI, O, DO, F>>;
+    fn into_future(self) -> Self::IntoFuture {
+        match with_default_device_policy(|policy| policy.schedule(self)) {
+            Ok(Ok(future)) => future,
+            Ok(Err(e)) | Err(e) => DeviceFuture::failed(e),
+        }
+    }
+}
+
+/// Like [`AndThen`] but the closure additionally receives the
+/// [`ExecutionContext`], giving access to the stream and device.
+///
+/// Produced by [`DeviceOperation::and_then_with_context`].
+pub struct AndThenWithContext<I: Send, DI, O: Send, DO, F>
+where
+    DI: DeviceOperation<Output = I>,
+    DO: DeviceOperation<Output = O>,
+    F: FnOnce(&ExecutionContext, I) -> DO,
+{
+    /// First operation.
+    op: DI,
+    /// Closure mapping `(context, result)` to the second operation.
+    closure: F,
+}
+
+/// # Safety
+///
+/// Both `DI` and `F` are `Send`. The struct owns them exclusively.
+unsafe impl<I: Send, DI, O: Send, DO, F> Send for AndThenWithContext<I, DI, O, DO, F>
+where
+    DI: DeviceOperation<Output = I>,
+    DO: DeviceOperation<Output = O>,
+    F: FnOnce(&ExecutionContext, I) -> DO + Send,
+{
+}
+
+/// Executes the first operation, then passes `(context, result)` to the
+/// closure and executes the resulting second operation.
+impl<I: Send, DI, O: Send + 'static, DO, F> DeviceOperation for AndThenWithContext<I, DI, O, DO, F>
+where
+    DI: DeviceOperation<Output = I>,
+    DO: DeviceOperation<Output = O>,
+    F: FnOnce(&ExecutionContext, I) -> DO + Send,
+{
+    type Output = O;
+
+    unsafe fn execute(self, context: &ExecutionContext) -> Result<O, DeviceError> {
+        unsafe {
+            let input = self.op.execute(context)?;
+            let output_op = (self.closure)(context, input);
+            output_op.execute(context)
+        }
+    }
+}
+
+/// Schedules via the thread-local default policy.
+impl<I: Send, DI, O: Send + 'static, DO, F> IntoFuture for AndThenWithContext<I, DI, O, DO, F>
+where
+    DI: DeviceOperation<Output = I>,
+    DO: DeviceOperation<Output = O>,
+    F: FnOnce(&ExecutionContext, I) -> DO + Send,
+{
+    type Output = Result<O, DeviceError>;
+    type IntoFuture = DeviceFuture<O, AndThenWithContext<I, DI, O, DO, F>>;
+    fn into_future(self) -> Self::IntoFuture {
+        match with_default_device_policy(|policy| policy.schedule(self)) {
+            Ok(Ok(future)) => future,
+            Ok(Err(e)) | Err(e) => DeviceFuture::failed(e),
+        }
+    }
+}
+
+/// A [`DeviceOperation`] that immediately returns a pre-computed value without
+/// touching the GPU.
+pub struct Value<T>(T);
+
+/// # Safety
+///
+/// `Value` holds only the inner `T`. If `T` is `Send` the wrapper is too;
+/// the bound is enforced by the `DeviceOperation` impl.
+unsafe impl<T> Send for Value<T> {}
+
+/// Returns the wrapped value directly -- no GPU work is performed.
+impl<T: Send + 'static> DeviceOperation for Value<T> {
+    type Output = T;
+
+    unsafe fn execute(self, _context: &ExecutionContext) -> Result<T, DeviceError> {
+        Ok(self.0)
+    }
+}
+
+/// Schedules via the thread-local default policy.
+impl<T: Send + 'static> IntoFuture for Value<T> {
+    type Output = Result<T, DeviceError>;
+    type IntoFuture = DeviceFuture<T, Value<T>>;
+    fn into_future(self) -> Self::IntoFuture {
+        match with_default_device_policy(|policy| policy.schedule(self)) {
+            Ok(Ok(future)) => future,
+            Ok(Err(e)) | Err(e) => DeviceFuture::failed(e),
+        }
+    }
+}
+
+/// Wraps `x` in a [`Value`] operation that returns it immediately.
+pub fn value<T: Send>(x: T) -> Value<T> {
+    Value(x)
+}
+
+/// Converts any `Send` value into a no-op [`DeviceOperation`] via [`value`].
+pub trait IntoDeviceOperation<T: Send> {
+    /// Wraps `self` into a [`Value`] device operation.
+    fn device_operation(self) -> Value<T>;
+}
+
+impl<T: Send> IntoDeviceOperation<T> for T {
+    fn device_operation(self) -> Value<T> {
+        value(self)
+    }
+}
+
+/// Deferred-closure operation: the closure produces the real operation at
+/// execution time rather than at construction time.
+///
+/// Useful when building the inner operation requires state only available
+/// after scheduling (though it does not receive the [`ExecutionContext`] --
+/// see [`StreamOperation`] for that).
+pub struct Empty<O: Send, DO: DeviceOperation<Output = O>, F: FnOnce() -> DO> {
+    /// Closure that produces the inner operation.
+    closure: F,
+}
+
+/// Wraps a closure in an [`Empty`] deferred operation.
+pub fn empty<O: Send, DO: DeviceOperation<Output = O>, F: FnOnce() -> DO>(
+    closure: F,
+) -> Empty<O, DO, F> {
+    Empty { closure }
+}
+
+/// # Safety
+///
+/// The closure `F` and its produced operation `DO` are both `Send`. The
+/// struct owns the closure exclusively.
+unsafe impl<O: Send, DO: DeviceOperation<Output = O>, F: FnOnce() -> DO> Send for Empty<O, DO, F> {}
+
+/// Invokes the closure to produce the inner operation, then executes it.
+impl<O: Send + 'static, DO: DeviceOperation<Output = O>, F: FnOnce() -> DO> DeviceOperation
+    for Empty<O, DO, F>
+{
+    type Output = O;
+
+    unsafe fn execute(self, context: &ExecutionContext) -> Result<O, DeviceError> {
+        unsafe {
+            let op = (self.closure)();
+            op.execute(context)
+        }
+    }
+}
+
+/// Schedules via the thread-local default policy.
+impl<O: Send + 'static, DO: DeviceOperation<Output = O>, F: FnOnce() -> DO> IntoFuture
+    for Empty<O, DO, F>
+{
+    type Output = Result<O, DeviceError>;
+    type IntoFuture = DeviceFuture<O, Empty<O, DO, F>>;
+    fn into_future(self) -> Self::IntoFuture {
+        match with_default_device_policy(|policy| policy.schedule(self)) {
+            Ok(Ok(future)) => future,
+            Ok(Err(e)) | Err(e) => DeviceFuture::failed(e),
+        }
+    }
+}
+
+/// Pair combinator: executes two operations sequentially on the same stream
+/// and returns both results as a tuple.
+///
+/// Constructed via `_zip` or the `zip!` macro.
+pub struct Zip<T1: Send, T2: Send, A: DeviceOperation<Output = T1>, B: DeviceOperation<Output = T2>>
+{
+    phantom: PhantomData<(T1, T2)>,
+    /// First operation.
+    a: A,
+    /// Second operation.
+    b: B,
+}
+
+/// # Safety
+///
+/// Both `A` and `B` are `Send` (required by `DeviceOperation`).
+unsafe impl<T1: Send, T2: Send, A: DeviceOperation<Output = T1>, B: DeviceOperation<Output = T2>>
+    Send for Zip<T1, T2, A, B>
+{
+}
+
+/// Constructs a [`Zip`] from two operations.
+fn _zip<T1: Send, T2: Send, A: DeviceOperation<Output = T1>, B: DeviceOperation<Output = T2>>(
+    a: A,
+    b: B,
+) -> Zip<T1, T2, A, B> {
+    Zip {
+        phantom: PhantomData,
+        a,
+        b,
+    }
+}
+
+/// Executes `a` then `b` on the same stream, returning `(T1, T2)`.
+impl<
+        T1: Send + 'static,
+        T2: Send + 'static,
+        A: DeviceOperation<Output = T1>,
+        B: DeviceOperation<Output = T2>,
+    > DeviceOperation for Zip<T1, T2, A, B>
+{
+    type Output = (T1, T2);
+
+    unsafe fn execute(self, context: &ExecutionContext) -> Result<(T1, T2), DeviceError> {
+        unsafe {
+            let a = self.a.execute(context)?;
+            let b = self.b.execute(context)?;
+            Ok((a, b))
+        }
+    }
+}
+
+/// Schedules via the thread-local default policy.
+impl<
+        T1: Send + 'static,
+        T2: Send + 'static,
+        A: DeviceOperation<Output = T1>,
+        B: DeviceOperation<Output = T2>,
+    > IntoFuture for Zip<T1, T2, A, B>
+{
+    type Output = Result<(T1, T2), DeviceError>;
+    type IntoFuture = DeviceFuture<(T1, T2), Zip<T1, T2, A, B>>;
+    fn into_future(self) -> Self::IntoFuture {
+        match with_default_device_policy(|policy| policy.schedule(self)) {
+            Ok(Ok(future)) => future,
+            Ok(Err(e)) | Err(e) => DeviceFuture::failed(e),
+        }
+    }
+}
+
+/// Trait enabling `.zip()` on tuples of [`DeviceOperation`]s.
+///
+/// Implemented for 2-tuples and 3-tuples.
+pub trait Zippable<I, O: Send> {
+    /// Combines the operations into a single operation returning a tuple of
+    /// results.
+    fn zip(self) -> impl DeviceOperation<Output = O>;
+}
+
+/// Zips two operations into a pair.
+impl<
+        T0: Send + 'static,
+        T1: Send + 'static,
+        DI0: DeviceOperation<Output = T0>,
+        DI1: DeviceOperation<Output = T1>,
+    > Zippable<(DI0, DI1), (T0, T1)> for (DI0, DI1)
+{
+    fn zip(self) -> impl DeviceOperation<Output = (T0, T1)> {
+        _zip(self.0, self.1)
+    }
+}
+
+/// Zips three operations into a triple by nesting two binary zips.
+impl<
+        T0: Send + 'static,
+        T1: Send + 'static,
+        T2: Send + 'static,
+        DI0: DeviceOperation<Output = T0>,
+        DI1: DeviceOperation<Output = T1>,
+        DI2: DeviceOperation<Output = T2>,
+    > Zippable<(DI0, DI1, DI2), (T0, T1, T2)> for (DI0, DI1, DI2)
+{
+    fn zip(self) -> impl DeviceOperation<Output = (T0, T1, T2)> {
+        let cons = _zip(self.1, self.2);
+        let cons = _zip(self.0, cons);
+        cons.and_then(|(arg0, (arg1, arg2))| value((arg0, arg1, arg2)))
+    }
+}
+
+/// Zips one, two, or three [`DeviceOperation`]s into a single operation
+/// returning a tuple of results.
+///
+/// ```ignore
+/// let (a, b) = zip!(op_a, op_b).sync()?;
+/// let (x, y, z) = zip!(op_x, op_y, op_z).sync()?;
+/// ```
+#[allow(unused_macros)] // collides with this crate's exported zip!; reconcile at merge
+macro_rules! zip {
+    ($arg0:expr) => {
+        $arg0
+    };
+    ($arg0:expr, $arg1:expr) => {
+        ($arg0, $arg1).zip()
+    };
+    ($arg0:expr, $arg1:expr, $arg2:expr) => {
+        ($arg0, $arg1, $arg2).zip()
+    };
+}
+#[allow(unused_imports)] // kept for parity with oxide's exported form
+pub(crate) use zip;
+
+/// Deferred operation that receives the [`ExecutionContext`] before producing
+/// the inner operation.
+///
+/// Unlike [`Empty`], the closure has access to the stream and device, making
+/// it possible to build context-dependent operations at execution time.
+pub struct StreamOperation<
+    O: Send,
+    DO: DeviceOperation<Output = O>,
+    F: FnOnce(&ExecutionContext) -> DO + Send,
+> {
+    /// Closure that receives the execution context and produces the inner op.
+    f: F,
+}
+
+/// Calls the closure with the context, then executes the resulting operation.
+impl<
+        O: Send + 'static,
+        DO: DeviceOperation<Output = O>,
+        F: FnOnce(&ExecutionContext) -> DO + Send,
+    > DeviceOperation for StreamOperation<O, DO, F>
+{
+    type Output = O;
+
+    unsafe fn execute(self, context: &ExecutionContext) -> Result<O, DeviceError> {
+        unsafe {
+            let op = (self.f)(context);
+            op.execute(context)
+        }
+    }
+}
+
+/// Wraps a closure that needs the [`ExecutionContext`] into a
+/// [`DeviceOperation`].
+///
+/// The closure is invoked at execution time with the stream and context,
+/// and must return a `DeviceOperation` that will be immediately executed.
+pub fn with_context<
+    O: Send + 'static,
+    DO: DeviceOperation<Output = O>,
+    F: FnOnce(&ExecutionContext) -> DO + Send,
+>(
+    f: F,
+) -> impl DeviceOperation<Output = O> {
+    StreamOperation { f }
+}
+
+/// Schedules via the thread-local default policy.
+impl<
+        O: Send + 'static,
+        DO: DeviceOperation<Output = O>,
+        F: FnOnce(&ExecutionContext) -> DO + Send,
+    > IntoFuture for StreamOperation<O, DO, F>
+{
+    type Output = Result<O, DeviceError>;
+    type IntoFuture = DeviceFuture<O, StreamOperation<O, DO, F>>;
+    fn into_future(self) -> Self::IntoFuture {
+        match with_default_device_policy(|policy| policy.schedule(self)) {
+            Ok(Ok(future)) => future,
+            Ok(Err(e)) | Err(e) => DeviceFuture::failed(e),
+        }
+    }
+}
+
+/// Shared state backing the [`SelectLeft`] / [`SelectRight`] split.
+///
+/// Holds the source operation and its memoized results. The first selector
+/// to execute triggers the source; subsequent selectors read the cached
+/// values. Interior mutability is used via [`UnsafeCell`] because execution
+/// is always sequential within a single stream.
+pub struct Select<T1: Send, T2: Send, DI: DeviceOperation<Output = (T1, T2)>> {
+    /// Guards one-shot execution of the source operation.
+    computed: AtomicBool,
+    /// Source operation. Consumed on the first call to [`execute`](Self::execute).
+    input: UnsafeCell<Option<DI>>,
+    /// Cached left result.
+    left: UnsafeCell<Option<T1>>,
+    /// Cached right result.
+    right: UnsafeCell<Option<T2>>,
+}
+
+impl<T1: Send, T2: Send, DI: DeviceOperation<Output = (T1, T2)>> Select<T1, T2, DI> {
+    /// Executes the source operation if it has not been executed yet, caching
+    /// both halves of the tuple.
+    ///
+    /// # Safety
+    ///
+    /// Must only be called from within a single-stream execution context.
+    /// Concurrent calls from different threads would race on the `UnsafeCell`s.
+    unsafe fn execute(self: &Arc<Self>, context: &ExecutionContext) -> Result<(), DeviceError> {
+        unsafe {
+            if !self.computed.load(Ordering::Acquire) {
+                let input = self.input.get();
+                let input = input.as_mut();
+                let input = input.unwrap().take().ok_or_else(|| {
+                    crate::simt::error::device_error(
+                        context.get_device_id(),
+                        "Select operation failed.",
+                    )
+                })?;
+                let (left, right) = input.execute(context)?;
+                *self.left.get() = Some(left);
+                *self.right.get() = Some(right);
+                self.computed.store(true, Ordering::Release);
+            }
+            Ok(())
+        }
+    }
+
+    /// Takes the cached left value. Must be called after [`execute`](Self::execute).
+    ///
+    /// # Safety
+    ///
+    /// Caller must ensure `execute` has completed and this is called at most once.
+    unsafe fn left(&self) -> T1 {
+        let cell = self.left.get();
+        let cell = unsafe { cell.as_mut() };
+        cell.unwrap().take().unwrap()
+    }
+
+    /// Takes the cached right value. Must be called after [`execute`](Self::execute).
+    ///
+    /// # Safety
+    ///
+    /// Caller must ensure `execute` has completed and this is called at most once.
+    unsafe fn right(&self) -> T2 {
+        let cell = self.right.get();
+        let cell = unsafe { cell.as_mut() };
+        cell.unwrap().take().unwrap()
+    }
+}
+
+/// Operation that extracts the **left** element of an unzipped pair.
+///
+/// Shares a [`Select`] with its corresponding [`SelectRight`] so the source
+/// operation is executed at most once.
+pub struct SelectLeft<T1: Send, T2: Send, DI: DeviceOperation<Output = (T1, T2)>> {
+    /// Shared memoization state.
+    select: Arc<Select<T1, T2, DI>>,
+}
+
+/// # Safety
+///
+/// The `Arc<Select<..>>` is safe to send because `Select` is only mutated
+/// through `UnsafeCell` during single-stream execution, never concurrently.
+unsafe impl<T1: Send, T2: Send, DI: DeviceOperation<Output = (T1, T2)>> Send
+    for SelectLeft<T1, T2, DI>
+{
+}
+
+/// Triggers the shared source operation (if not yet done) and returns the
+/// left element.
+impl<T1: Send + 'static, T2: Send + 'static, DI: DeviceOperation<Output = (T1, T2)>> DeviceOperation
+    for SelectLeft<T1, T2, DI>
+{
+    type Output = T1;
+
+    unsafe fn execute(self, context: &ExecutionContext) -> Result<T1, DeviceError> {
+        unsafe {
+            self.select.execute(context)?;
+            Ok(self.select.left())
+        }
+    }
+}
+
+/// Schedules via the thread-local default policy.
+impl<T1: Send + 'static, T2: Send + 'static, DI: DeviceOperation<Output = (T1, T2)>> IntoFuture
+    for SelectLeft<T1, T2, DI>
+{
+    type Output = Result<T1, DeviceError>;
+    type IntoFuture = DeviceFuture<T1, SelectLeft<T1, T2, DI>>;
+    fn into_future(self) -> Self::IntoFuture {
+        match with_default_device_policy(|policy| policy.schedule(self)) {
+            Ok(Ok(future)) => future,
+            Ok(Err(e)) | Err(e) => DeviceFuture::failed(e),
+        }
+    }
+}
+
+/// Operation that extracts the **right** element of an unzipped pair.
+///
+/// Shares a [`Select`] with its corresponding [`SelectLeft`] so the source
+/// operation is executed at most once.
+pub struct SelectRight<T1: Send, T2: Send, DI: DeviceOperation<Output = (T1, T2)>> {
+    /// Shared memoization state.
+    select: Arc<Select<T1, T2, DI>>,
+}
+
+/// # Safety
+///
+/// See [`SelectLeft`]'s `Send` impl.
+unsafe impl<T1: Send, T2: Send, DI: DeviceOperation<Output = (T1, T2)>> Send
+    for SelectRight<T1, T2, DI>
+{
+}
+
+/// Triggers the shared source operation (if not yet done) and returns the
+/// right element.
+impl<T1: Send + 'static, T2: Send + 'static, DI: DeviceOperation<Output = (T1, T2)>> DeviceOperation
+    for SelectRight<T1, T2, DI>
+{
+    type Output = T2;
+
+    unsafe fn execute(self, context: &ExecutionContext) -> Result<T2, DeviceError> {
+        unsafe {
+            self.select.execute(context)?;
+            Ok(self.select.right())
+        }
+    }
+}
+
+/// Schedules via the thread-local default policy.
+impl<T1: Send + 'static, T2: Send + 'static, DI: DeviceOperation<Output = (T1, T2)>> IntoFuture
+    for SelectRight<T1, T2, DI>
+{
+    type Output = Result<T2, DeviceError>;
+    type IntoFuture = DeviceFuture<T2, SelectRight<T1, T2, DI>>;
+    fn into_future(self) -> Self::IntoFuture {
+        match with_default_device_policy(|policy| policy.schedule(self)) {
+            Ok(Ok(future)) => future,
+            Ok(Err(e)) | Err(e) => DeviceFuture::failed(e),
+        }
+    }
+}
+
+/// Splits a tuple-producing operation into two independent operations that
+/// share execution: the source runs at most once, and each selector extracts
+/// one element.
+fn _unzip<T1: Send, T2: Send, DI: DeviceOperation<Output = (T1, T2)>>(
+    input: DI,
+) -> (SelectLeft<T1, T2, DI>, SelectRight<T1, T2, DI>) {
+    let select = Select {
+        computed: AtomicBool::new(false),
+        input: UnsafeCell::new(Some(input)),
+        left: UnsafeCell::new(None),
+        right: UnsafeCell::new(None),
+    };
+    let select = Arc::new(select);
+    let out1 = SelectLeft {
+        select: Arc::clone(&select),
+    };
+    let out2 = SelectRight { select };
+    (out1, out2)
+}
+
+/// Trait enabling `.unzip()` on any [`DeviceOperation`] that produces a
+/// 2-tuple.
+pub trait Unzippable2<T0: Send + 'static, T1: Send + 'static>
+where
+    Self: DeviceOperation<Output = (T0, T1)>,
+{
+    /// Splits this operation into two independent operations, one for each
+    /// tuple element. The source executes at most once.
+    fn unzip(
+        self,
+    ) -> (
+        impl DeviceOperation<Output = T0>,
+        impl DeviceOperation<Output = T1>,
+    ) {
+        _unzip(self)
+    }
+}
+
+/// Blanket impl: any operation producing `(T0, T1)` is unzippable.
+impl<T0: Send + 'static, T1: Send + 'static, DI: DeviceOperation<Output = (T0, T1)>>
+    Unzippable2<T0, T1> for DI
+{
+}
+
+/// Splits a tuple-producing [`DeviceOperation`] into per-element operations.
+///
+/// ```ignore
+/// let (left, right) = unzip!(pair_op);
+/// ```
+#[allow(unused_macros)] // collides with this crate's exported unzip!; reconcile at merge
+macro_rules! unzip {
+    ($arg0:expr) => {
+        $arg0.unzip()
+    };
+}
+#[allow(unused_imports)] // kept for parity with oxide's exported form
+pub(crate) use unzip;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn finish_sync_returns_operation_result_after_successful_synchronize() {
+        let result = finish_sync::<u32>(Ok(7), Ok(()));
+
+        assert_eq!(result, Ok(7));
+    }
+
+    #[test]
+    fn finish_sync_preserves_operation_error_after_successful_synchronize() {
+        let operation_error = DeviceError::Launch("launch failed".to_string());
+        let result = finish_sync::<u32>(Err(operation_error.clone()), Ok(()));
+
+        assert_eq!(result, Err(operation_error));
+    }
+
+    #[test]
+    fn finish_sync_propagates_synchronize_error_instead_of_panicking() {
+        let driver_error =
+            cuda_core::DriverError(cuda_bindings::cudaError_enum_CUDA_ERROR_INVALID_VALUE);
+        let result = finish_sync::<u32>(Ok(7), Err(driver_error));
+
+        assert_eq!(result, Err(DeviceError::Driver(driver_error)));
+    }
+
+    #[test]
+    fn finish_sync_preserves_operation_error_when_synchronize_also_fails() {
+        let operation_error = DeviceError::Launch("launch failed".to_string());
+        let driver_error =
+            cuda_core::DriverError(cuda_bindings::cudaError_enum_CUDA_ERROR_INVALID_VALUE);
+        let result = finish_sync::<u32>(Err(operation_error.clone()), Err(driver_error));
+
+        assert_eq!(result, Err(operation_error));
+    }
+}

--- a/cuda-async/src/simt/error.rs
+++ b/cuda-async/src/simt/error.rs
@@ -1,0 +1,94 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Error types and assertion helpers for CUDA device operations.
+//!
+//! [`DeviceError`] is the unified error type for the `cuda-async` crate. It
+//! captures failures from the CUDA driver, device context management, kernel
+//! cache lookups, scheduling, and kernel launches. Assertion helpers provide a
+//! concise way to produce contextual errors in device-facing code.
+
+use cuda_core::DriverError;
+
+/// Unified error type for all `cuda-async` operations.
+///
+/// Each variant identifies a distinct failure domain so callers can
+/// pattern-match on the error source without parsing messages.
+#[derive(Debug, thiserror::Error, Clone, PartialEq, Eq)]
+pub enum DeviceError {
+    /// Propagated from the CUDA driver API (see [`DriverError`]).
+    #[error("CUDA driver error: {0}")]
+    Driver(#[from] DriverError),
+
+    /// Device context initialization or access failure for a specific device.
+    #[error("device context error (device_id={device_id}): {message}")]
+    Context {
+        /// Ordinal of the device that reported the error.
+        device_id: usize,
+        /// Human-readable description of the failure.
+        message: String,
+    },
+
+    /// Failure during kernel module loading or function cache lookup.
+    #[error("kernel cache error: {0}")]
+    KernelCache(String),
+
+    /// Stream scheduling or policy configuration error.
+    #[error("scheduling error: {0}")]
+    Scheduling(String),
+
+    /// Kernel launch parameter validation or driver-level launch failure.
+    #[error("kernel launch error: {0}")]
+    Launch(String),
+
+    /// Logic error internal to the async runtime.
+    #[error("internal error: {0}")]
+    Internal(String),
+
+    /// Catch-all for errors converted from [`anyhow::Error`].
+    #[error("{0}")]
+    Anyhow(String),
+}
+
+/// Converts an [`anyhow::Error`] by capturing its debug representation.
+impl From<anyhow::Error> for DeviceError {
+    fn from(error: anyhow::Error) -> Self {
+        DeviceError::Anyhow(format!("{:?}", error))
+    }
+}
+
+/// Returns `Err(DeviceError::Launch)` when `pred` is `false`.
+///
+/// Use for precondition checks on kernel launch parameters (grid/block dims,
+/// shared memory size, argument counts, etc.).
+pub fn kernel_launch_assert(pred: bool, message: &str) -> Result<(), DeviceError> {
+    if !pred {
+        Err(DeviceError::Launch(message.to_string()))
+    } else {
+        Ok(())
+    }
+}
+
+/// Returns `Err(DeviceError::Context)` when `pred` is `false`.
+///
+/// Attaches `device_id` to the error for per-device diagnostics.
+pub fn device_assert(device_id: usize, pred: bool, message: &str) -> Result<(), DeviceError> {
+    if !pred {
+        Err(DeviceError::Context {
+            device_id,
+            message: message.to_string(),
+        })
+    } else {
+        Ok(())
+    }
+}
+
+/// Constructs a [`DeviceError::Context`] for the given device and message.
+pub fn device_error(device_id: usize, message: &str) -> DeviceError {
+    DeviceError::Context {
+        device_id,
+        message: message.to_string(),
+    }
+}

--- a/cuda-async/src/simt/launch.rs
+++ b/cuda-async/src/simt/launch.rs
@@ -1,0 +1,570 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! CUDA kernel launch builder with argument marshalling.
+//!
+//! [`AsyncKernelLaunchBuilder`] safely accumulates a kernel function reference,
+//! launch attributes, and type-erased argument pointers. An explicit unsafe
+//! call to [`AsyncKernelLaunchBuilder::finalize_unchecked`] supplies the raw
+//! launch geometry and returns an immutable [`AsyncKernelLaunch`] that can be
+//! scheduled as a [`DeviceOperation`].
+//!
+//! Arguments are heap-allocated via [`KernelArgument::push_arg`] and freed when
+//! the launcher is dropped after submission. This keeps the pointed-to values
+//! alive until `cuLaunchKernel` / `cuLaunchKernelEx` has copied the launch
+//! parameter values out of the host-side argument array.
+//!
+//! [`DeviceOperation`]: crate::simt::device_operation::DeviceOperation
+
+use crate::simt::device_context::with_default_device_policy;
+use crate::simt::device_future::DeviceFuture;
+use crate::simt::device_operation::{DeviceOperation, ExecutionContext};
+use crate::simt::error::DeviceError;
+use crate::simt::scheduling_policies::SchedulingPolicy;
+use cuda_core::simt::LaunchConfig;
+use cuda_core::{CudaFunction, CudaStream};
+use std::ffi::c_void;
+use std::future::IntoFuture;
+use std::marker::PhantomData;
+use std::sync::Arc;
+
+/// Safe, inert builder for an unchecked CUDA kernel launch.
+///
+/// Building a launch does not enqueue GPU work. The builder deliberately does
+/// not implement [`DeviceOperation`] or [`IntoFuture`]: raw launch geometry
+/// must first cross the explicit unsafe boundary at
+/// [`finalize_unchecked`](Self::finalize_unchecked).
+///
+/// ```compile_fail,E0277
+/// use cuda_async::simt::device_operation::DeviceOperation;
+/// use cuda_async::simt::launch::AsyncKernelLaunchBuilder;
+///
+/// fn schedule<O: DeviceOperation>(_operation: O) {}
+///
+/// fn cannot_schedule(builder: AsyncKernelLaunchBuilder<'static>) {
+///     schedule(builder);
+/// }
+/// ```
+///
+/// Builders stay on the thread that assembles their type-erased argument
+/// storage. Only the immutable finalized operation is `Send`:
+///
+/// ```compile_fail,E0277
+/// use cuda_async::simt::launch::AsyncKernelLaunchBuilder;
+///
+/// fn assert_send<T: Send>() {}
+/// assert_send::<AsyncKernelLaunchBuilder<'static>>();
+/// ```
+#[derive(Debug)]
+pub struct AsyncKernelLaunchBuilder<'a> {
+    /// Handle to the compiled device function.
+    func: Arc<CudaFunction>,
+    /// Heap-allocated, type-erased argument storage passed to the CUDA driver.
+    args: KernelArgStorage,
+    /// Optional thread-block cluster dimensions for `cuLaunchKernelEx`.
+    cluster_dim: Option<(u32, u32, u32)>,
+    /// When `true`, launch via `cuLaunchKernelEx` with
+    /// `CU_LAUNCH_ATTRIBUTE_COOPERATIVE` set, which guarantees the whole grid
+    /// is co-resident on the device (required for `cuda_device::grid::sync()`).
+    cooperative: bool,
+    /// Ties borrowed device buffers to the lazy launch operation.
+    _borrows: PhantomData<&'a mut ()>,
+}
+
+/// Immutable, runnable CUDA kernel launch.
+///
+/// This type can only be created by consuming an
+/// [`AsyncKernelLaunchBuilder`]. It exposes no safe geometry or argument
+/// setters, so its safety assumptions cannot be invalidated after the raw
+/// launch configuration has been accepted.
+///
+/// ```compile_fail,E0599
+/// use cuda_async::simt::launch::AsyncKernelLaunch;
+/// use cuda_core::simt::LaunchConfig;
+///
+/// fn cannot_reconfigure(launch: &mut AsyncKernelLaunch<'_>, config: LaunchConfig) {
+///     launch.set_launch_config(config);
+/// }
+/// ```
+#[derive(Debug)]
+pub struct AsyncKernelLaunch<'a> {
+    /// Handle to the compiled device function.
+    func: Arc<CudaFunction>,
+    /// Heap-allocated, type-erased argument storage passed to the CUDA driver.
+    args: KernelArgStorage,
+    /// Complete grid/block dimensions and dynamic shared-memory size.
+    cfg: LaunchConfig,
+    /// Optional thread-block cluster dimensions for `cuLaunchKernelEx`.
+    cluster_dim: Option<(u32, u32, u32)>,
+    /// Whether this launch requests cooperative grid residency.
+    cooperative: bool,
+    /// Ties borrowed device buffers to the lazy launch operation.
+    _borrows: PhantomData<&'a mut ()>,
+}
+
+/// # Safety
+///
+/// The argument pointers refer to heap allocations owned by the launch.
+/// Non-`Copy` values enter that storage only through `KernelArgument: Send`;
+/// copied scalar values have no destructor. The runnable type exposes none of
+/// those erased values to safe Rust. The `Arc<CudaFunction>` is `Send + Sync`,
+/// and `_borrows` preserves source lifetimes captured while building.
+unsafe impl<'a> Send for AsyncKernelLaunch<'a> {}
+
+#[derive(Debug, Default)]
+struct KernelArgStorage {
+    ptrs: Vec<*mut c_void>,
+    drops: Vec<unsafe fn(*mut c_void)>,
+}
+
+impl Drop for KernelArgStorage {
+    fn drop(&mut self) {
+        for (arg, drop_arg) in self.ptrs.drain(..).zip(self.drops.drain(..)) {
+            unsafe { drop_arg(arg) };
+        }
+    }
+}
+
+impl KernelArgStorage {
+    fn push_send_arg<T: Send>(&mut self, arg: Box<T>) {
+        unsafe fn drop_box<T>(arg: *mut c_void) {
+            let _ = unsafe { Box::from_raw(arg as *mut T) };
+        }
+
+        self.ptrs.push(Box::into_raw(arg) as *mut c_void);
+        self.drops.push(drop_box::<T>);
+    }
+
+    fn push_scalar_arg<T: Copy>(&mut self, arg: T) {
+        unsafe fn drop_copy_box<T: Copy>(arg: *mut c_void) {
+            let _ = unsafe { Box::from_raw(arg as *mut T) };
+        }
+
+        self.ptrs.push(Box::into_raw(Box::new(arg)) as *mut c_void);
+        self.drops.push(drop_copy_box::<T>);
+    }
+
+    fn as_mut_slice(&mut self) -> &mut [*mut c_void] {
+        &mut self.ptrs
+    }
+}
+
+impl<'a> AsyncKernelLaunchBuilder<'a> {
+    /// Creates an inert builder for `func` with no arguments or launch
+    /// attributes.
+    pub fn new(func: Arc<CudaFunction>) -> Self {
+        Self {
+            func,
+            args: KernelArgStorage::default(),
+            cluster_dim: None,
+            cooperative: false,
+            _borrows: PhantomData,
+        }
+    }
+
+    /// Appends a by-value `Copy` argument to the kernel launch packet.
+    ///
+    /// This is the typed-module path used for scalar, raw-pointer, custom
+    /// `Copy` structs, and `Copy` closure arguments.
+    #[inline(always)]
+    pub fn push_scalar_arg<T: Copy + 'a>(&mut self, arg: T) -> &mut Self {
+        self.args.push_scalar_arg(arg);
+        self
+    }
+
+    /// Appends a kernel argument. The value is heap-allocated and its pointer
+    /// stored for the driver call.
+    ///
+    /// Scalars like `u32`, `f32`, `u64` etc. are auto-boxed -- no need to
+    /// wrap them in `Box::new`.
+    ///
+    /// The allocated storage remains alive until launch submission finishes or
+    /// the builder is dropped without launching.
+    ///
+    /// Values with thread-affine ownership cannot be hidden in the erased
+    /// storage that will later become a `Send` operation:
+    ///
+    /// ```compile_fail,E0277
+    /// use cuda_async::simt::launch::AsyncKernelLaunchBuilder;
+    /// use std::rc::Rc;
+    ///
+    /// fn reject_rc(mut builder: AsyncKernelLaunchBuilder<'static>) {
+    ///     builder.push_arg(Box::new(Rc::new(1_u32)));
+    /// }
+    /// ```
+    #[inline(always)]
+    pub fn push_arg<T: KernelArgument>(&mut self, arg: T) -> &mut Self {
+        arg.push_arg(self);
+        self
+    }
+
+    /// Appends multiple kernel arguments at once from a tuple.
+    ///
+    /// Equivalent to chained [`push_arg`](Self::push_arg) calls but allows
+    /// grouping all arguments in a single expression:
+    ///
+    /// ```ignore
+    /// launch.push_args((m, n, k, alpha, a_ptr, a_len, b_ptr, b_len, beta, c_ptr, c_len));
+    /// ```
+    ///
+    /// Supports tuples up to 32 elements.
+    #[inline(always)]
+    pub fn push_args<T: KernelArguments>(&mut self, args: T) -> &mut Self {
+        args.push_args(self);
+        self
+    }
+
+    /// Sets thread-block cluster dimensions for a cluster launch.
+    pub fn set_cluster_dim(&mut self, cluster_dim: (u32, u32, u32)) -> &mut Self {
+        self.cluster_dim = Some(cluster_dim);
+        self
+    }
+
+    /// Marks this launch as cooperative (`CU_LAUNCH_ATTRIBUTE_COOPERATIVE`).
+    ///
+    /// A cooperative launch guarantees every block in the grid is co-resident
+    /// on the device, which is the precondition for grid-wide barriers like
+    /// `cuda_device::grid::sync()`. May be combined with
+    /// [`set_cluster_dim`](Self::set_cluster_dim); both attributes are then
+    /// passed to `cuLaunchKernelEx` in the same call.
+    pub fn set_cooperative(&mut self, cooperative: bool) -> &mut Self {
+        self.cooperative = cooperative;
+        self
+    }
+
+    /// Accepts an unverified raw launch configuration and seals this builder
+    /// into an immutable, schedulable operation.
+    ///
+    /// Prefer the generated typed module APIs for application code. They check
+    /// a kernel's declared launch contract before constructing the runnable
+    /// operation.
+    ///
+    /// # Safety
+    ///
+    /// The caller must prove all facts that a typed prepared launch normally
+    /// checks:
+    ///
+    /// - `cfg` must match the kernel's indexing dimensionality, launch bounds,
+    ///   block shape, and dynamic shared-memory requirements;
+    /// - the cluster and cooperative attributes must be legal for the kernel;
+    /// - the function signature must exactly match the arguments, in order,
+    ///   type, size, and alignment;
+    /// - referenced device allocations must remain valid for the complete GPU
+    ///   operation and satisfy Rust's aliasing requirements; and
+    /// - the scheduling policy must select a stream from the CUDA context that
+    ///   owns `func`.
+    ///
+    /// Violating these requirements can cause memory corruption, data races,
+    /// or CUDA driver errors.
+    ///
+    /// ```compile_fail,E0133
+    /// use cuda_async::simt::launch::AsyncKernelLaunchBuilder;
+    /// use cuda_core::simt::LaunchConfig;
+    ///
+    /// fn raw_finalize_requires_unsafe(
+    ///     builder: AsyncKernelLaunchBuilder<'static>,
+    ///     config: LaunchConfig,
+    /// ) {
+    ///     let _ = builder.finalize_unchecked(config);
+    /// }
+    /// ```
+    pub unsafe fn finalize_unchecked(self, cfg: LaunchConfig) -> AsyncKernelLaunch<'a> {
+        AsyncKernelLaunch {
+            func: self.func,
+            args: self.args,
+            cfg,
+            cluster_dim: self.cluster_dim,
+            cooperative: self.cooperative,
+            _borrows: self._borrows,
+        }
+    }
+}
+
+impl<'a> AsyncKernelLaunch<'a> {
+    /// Submits the kernel to `stream` via `cuLaunchKernel`, or via
+    /// `cuLaunchKernelEx` when cluster dimensions or a cooperative launch
+    /// were requested.
+    ///
+    /// # Safety
+    ///
+    /// - `self.func` must refer to a kernel loaded from the same CUDA context
+    ///   that owns `stream`.
+    /// - All argument pointers in `self.args` must point to correctly typed and
+    ///   aligned host-side values for the kernel's formal parameters.
+    /// - The pointed-to argument values must remain valid until launch
+    ///   submission returns. The stream-aware launch helper binds the correct
+    ///   context before calling into the CUDA driver.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DeviceError::Driver`] if context binding or launch submission
+    /// fails.
+    unsafe fn launch(mut self, stream: &Arc<CudaStream>) -> Result<(), DeviceError> {
+        let cfg = self.cfg;
+        let result = match (self.cluster_dim, self.cooperative) {
+            (Some(cluster_dim), true) => unsafe {
+                cuda_core::launch_kernel_ex_cooperative_on_stream(
+                    self.func.as_ref(),
+                    cfg.grid_dim,
+                    cfg.block_dim,
+                    cfg.shared_mem_bytes,
+                    cluster_dim,
+                    stream.as_ref(),
+                    self.args.as_mut_slice(),
+                )
+            },
+            (Some(cluster_dim), false) => unsafe {
+                cuda_core::launch_kernel_ex_on_stream(
+                    self.func.as_ref(),
+                    cfg.grid_dim,
+                    cfg.block_dim,
+                    cfg.shared_mem_bytes,
+                    cluster_dim,
+                    stream.as_ref(),
+                    self.args.as_mut_slice(),
+                )
+            },
+            (None, true) => unsafe {
+                cuda_core::launch_kernel_cooperative_on_stream(
+                    self.func.as_ref(),
+                    cfg.grid_dim,
+                    cfg.block_dim,
+                    cfg.shared_mem_bytes,
+                    stream.as_ref(),
+                    self.args.as_mut_slice(),
+                )
+            },
+            (None, false) => unsafe {
+                cuda_core::launch_kernel_on_stream(
+                    self.func.as_ref(),
+                    cfg.grid_dim,
+                    cfg.block_dim,
+                    cfg.shared_mem_bytes,
+                    stream.as_ref(),
+                    self.args.as_mut_slice(),
+                )
+            },
+        };
+        result.map_err(DeviceError::Driver)?;
+        Ok(())
+    }
+}
+
+/// Owns resources for a lazy async kernel launch and returns them when the GPU
+/// work has completed.
+#[derive(Debug)]
+pub struct OwnedAsyncKernelLaunch<R: Send> {
+    launch: AsyncKernelLaunch<'static>,
+    resources: R,
+}
+
+unsafe impl<R: Send> Send for OwnedAsyncKernelLaunch<R> {}
+
+impl<R: Send> OwnedAsyncKernelLaunch<R> {
+    /// Creates an owned async kernel operation from a prepared launch and the
+    /// resources that must stay alive until completion.
+    pub fn new(launch: AsyncKernelLaunch<'static>, resources: R) -> Self {
+        Self { launch, resources }
+    }
+}
+
+/// Trait for types that can be marshalled into a CUDA kernel argument list.
+///
+/// Implementors heap-allocate the value and push a `*mut c_void` into the
+/// launcher's argument vector.
+///
+/// Implemented for all common scalar primitives (`u8`–`u64`, `i8`–`i64`,
+/// `f32`, `f64`, `usize`, `isize`, `bool`) so callers can write
+/// `.push_arg(42u32)` without manual `Box::new`.
+pub trait KernelArgument: Send {
+    /// Heap-allocates `self` and appends the pointer to `launcher.args`.
+    fn push_arg(self, launcher: &mut AsyncKernelLaunchBuilder<'_>);
+}
+
+/// Passes the box's raw pointer directly as a kernel argument.
+///
+/// This is the low-level escape hatch. Prefer passing scalars directly -- they
+/// are auto-boxed via the blanket scalar impls.
+impl<T: Send + 'static> KernelArgument for Box<T> {
+    fn push_arg(self, launcher: &mut AsyncKernelLaunchBuilder<'_>) {
+        launcher.args.push_send_arg(self);
+    }
+}
+
+macro_rules! impl_scalar_kernel_arg {
+    ($($t:ty),*) => {
+        $(
+            impl KernelArgument for $t {
+                #[inline(always)]
+                fn push_arg(self, launcher: &mut AsyncKernelLaunchBuilder<'_>) {
+                    launcher.push_scalar_arg(self);
+                }
+            }
+        )*
+    };
+}
+
+impl_scalar_kernel_arg!(u8, u16, u32, u64, usize, i8, i16, i32, i64, isize, f32, f64, bool);
+
+// ---------------------------------------------------------------------------
+// KernelArguments — push multiple heterogeneous args in a single call
+// ---------------------------------------------------------------------------
+
+/// Trait for a group of kernel arguments that can be pushed together.
+///
+/// Implemented for tuples of [`KernelArgument`] types up to arity 32, enabling
+/// `launch.push_args((dim_m, dim_n, alpha, ptr, len))` as an alternative to
+/// chained `.push_arg()` calls.
+#[diagnostic::on_unimplemented(
+    message = "cannot push `{Self}` as kernel arguments",
+    note = "KernelArguments is implemented for tuples of KernelArgument types up to 32 elements"
+)]
+pub trait KernelArguments {
+    /// Pushes every element into `launcher` in order.
+    fn push_args(self, launcher: &mut AsyncKernelLaunchBuilder<'_>);
+}
+
+macro_rules! impl_kernel_args_tuple {
+    // Base case: empty tuple
+    () => {
+        impl KernelArguments for () {
+            #[inline(always)]
+            fn push_args(self, _launcher: &mut AsyncKernelLaunchBuilder<'_>) {}
+        }
+    };
+    // Recursive case: (A, B, C, ...) where each element is a KernelArgument
+    ($($idx:tt : $T:ident),+) => {
+        impl<$($T: KernelArgument),+> KernelArguments for ($($T,)+) {
+            #[inline(always)]
+            fn push_args(self, launcher: &mut AsyncKernelLaunchBuilder<'_>) {
+                $(launcher.push_arg(self.$idx);)+
+            }
+        }
+    };
+}
+
+impl_kernel_args_tuple!();
+impl_kernel_args_tuple!(0: A);
+impl_kernel_args_tuple!(0: A, 1: B);
+impl_kernel_args_tuple!(0: A, 1: B, 2: C);
+impl_kernel_args_tuple!(0: A, 1: B, 2: C, 3: D);
+impl_kernel_args_tuple!(0: A, 1: B, 2: C, 3: D, 4: E);
+impl_kernel_args_tuple!(0: A, 1: B, 2: C, 3: D, 4: E, 5: F);
+impl_kernel_args_tuple!(0: A, 1: B, 2: C, 3: D, 4: E, 5: F, 6: G);
+impl_kernel_args_tuple!(0: A, 1: B, 2: C, 3: D, 4: E, 5: F, 6: G, 7: H);
+impl_kernel_args_tuple!(0: A, 1: B, 2: C, 3: D, 4: E, 5: F, 6: G, 7: H, 8: I);
+impl_kernel_args_tuple!(0: A, 1: B, 2: C, 3: D, 4: E, 5: F, 6: G, 7: H, 8: I, 9: J);
+impl_kernel_args_tuple!(0: A, 1: B, 2: C, 3: D, 4: E, 5: F, 6: G, 7: H, 8: I, 9: J, 10: K);
+impl_kernel_args_tuple!(0: A, 1: B, 2: C, 3: D, 4: E, 5: F, 6: G, 7: H, 8: I, 9: J, 10: K, 11: L);
+impl_kernel_args_tuple!(0: A, 1: B, 2: C, 3: D, 4: E, 5: F, 6: G, 7: H, 8: I, 9: J, 10: K, 11: L, 12: M);
+impl_kernel_args_tuple!(0: A, 1: B, 2: C, 3: D, 4: E, 5: F, 6: G, 7: H, 8: I, 9: J, 10: K, 11: L, 12: M, 13: N);
+impl_kernel_args_tuple!(0: A, 1: B, 2: C, 3: D, 4: E, 5: F, 6: G, 7: H, 8: I, 9: J, 10: K, 11: L, 12: M, 13: N, 14: O);
+impl_kernel_args_tuple!(0: A, 1: B, 2: C, 3: D, 4: E, 5: F, 6: G, 7: H, 8: I, 9: J, 10: K, 11: L, 12: M, 13: N, 14: O, 15: P);
+impl_kernel_args_tuple!(0: A, 1: B, 2: C, 3: D, 4: E, 5: F, 6: G, 7: H, 8: I, 9: J, 10: K, 11: L, 12: M, 13: N, 14: O, 15: P, 16: Q);
+impl_kernel_args_tuple!(0: A, 1: B, 2: C, 3: D, 4: E, 5: F, 6: G, 7: H, 8: I, 9: J, 10: K, 11: L, 12: M, 13: N, 14: O, 15: P, 16: Q, 17: R);
+impl_kernel_args_tuple!(0: A, 1: B, 2: C, 3: D, 4: E, 5: F, 6: G, 7: H, 8: I, 9: J, 10: K, 11: L, 12: M, 13: N, 14: O, 15: P, 16: Q, 17: R, 18: S);
+impl_kernel_args_tuple!(0: A, 1: B, 2: C, 3: D, 4: E, 5: F, 6: G, 7: H, 8: I, 9: J, 10: K, 11: L, 12: M, 13: N, 14: O, 15: P, 16: Q, 17: R, 18: S, 19: T);
+impl_kernel_args_tuple!(0: A, 1: B, 2: C, 3: D, 4: E, 5: F, 6: G, 7: H, 8: I, 9: J, 10: K, 11: L, 12: M, 13: N, 14: O, 15: P, 16: Q, 17: R, 18: S, 19: T, 20: U);
+impl_kernel_args_tuple!(0: A, 1: B, 2: C, 3: D, 4: E, 5: F, 6: G, 7: H, 8: I, 9: J, 10: K, 11: L, 12: M, 13: N, 14: O, 15: P, 16: Q, 17: R, 18: S, 19: T, 20: U, 21: V);
+impl_kernel_args_tuple!(0: A, 1: B, 2: C, 3: D, 4: E, 5: F, 6: G, 7: H, 8: I, 9: J, 10: K, 11: L, 12: M, 13: N, 14: O, 15: P, 16: Q, 17: R, 18: S, 19: T, 20: U, 21: V, 22: W);
+impl_kernel_args_tuple!(0: A, 1: B, 2: C, 3: D, 4: E, 5: F, 6: G, 7: H, 8: I, 9: J, 10: K, 11: L, 12: M, 13: N, 14: O, 15: P, 16: Q, 17: R, 18: S, 19: T, 20: U, 21: V, 22: W, 23: X);
+impl_kernel_args_tuple!(0: A, 1: B, 2: C, 3: D, 4: E, 5: F, 6: G, 7: H, 8: I, 9: J, 10: K, 11: L, 12: M, 13: N, 14: O, 15: P, 16: Q, 17: R, 18: S, 19: T, 20: U, 21: V, 22: W, 23: X, 24: Y);
+impl_kernel_args_tuple!(0: A, 1: B, 2: C, 3: D, 4: E, 5: F, 6: G, 7: H, 8: I, 9: J, 10: K, 11: L, 12: M, 13: N, 14: O, 15: P, 16: Q, 17: R, 18: S, 19: T, 20: U, 21: V, 22: W, 23: X, 24: Y, 25: Z);
+impl_kernel_args_tuple!(0: A, 1: B, 2: C, 3: D, 4: E, 5: F, 6: G, 7: H, 8: I, 9: J, 10: K, 11: L, 12: M, 13: N, 14: O, 15: P, 16: Q, 17: R, 18: S, 19: T, 20: U, 21: V, 22: W, 23: X, 24: Y, 25: Z, 26: AA);
+impl_kernel_args_tuple!(0: A, 1: B, 2: C, 3: D, 4: E, 5: F, 6: G, 7: H, 8: I, 9: J, 10: K, 11: L, 12: M, 13: N, 14: O, 15: P, 16: Q, 17: R, 18: S, 19: T, 20: U, 21: V, 22: W, 23: X, 24: Y, 25: Z, 26: AA, 27: AB);
+impl_kernel_args_tuple!(0: A, 1: B, 2: C, 3: D, 4: E, 5: F, 6: G, 7: H, 8: I, 9: J, 10: K, 11: L, 12: M, 13: N, 14: O, 15: P, 16: Q, 17: R, 18: S, 19: T, 20: U, 21: V, 22: W, 23: X, 24: Y, 25: Z, 26: AA, 27: AB, 28: AC);
+impl_kernel_args_tuple!(0: A, 1: B, 2: C, 3: D, 4: E, 5: F, 6: G, 7: H, 8: I, 9: J, 10: K, 11: L, 12: M, 13: N, 14: O, 15: P, 16: Q, 17: R, 18: S, 19: T, 20: U, 21: V, 22: W, 23: X, 24: Y, 25: Z, 26: AA, 27: AB, 28: AC, 29: AD);
+impl_kernel_args_tuple!(0: A, 1: B, 2: C, 3: D, 4: E, 5: F, 6: G, 7: H, 8: I, 9: J, 10: K, 11: L, 12: M, 13: N, 14: O, 15: P, 16: Q, 17: R, 18: S, 19: T, 20: U, 21: V, 22: W, 23: X, 24: Y, 25: Z, 26: AA, 27: AB, 28: AC, 29: AD, 30: AE);
+impl_kernel_args_tuple!(0: A, 1: B, 2: C, 3: D, 4: E, 5: F, 6: G, 7: H, 8: I, 9: J, 10: K, 11: L, 12: M, 13: N, 14: O, 15: P, 16: Q, 17: R, 18: S, 19: T, 20: U, 21: V, 22: W, 23: X, 24: Y, 25: Z, 26: AA, 27: AB, 28: AC, 29: AD, 30: AE, 31: AF);
+
+/// Launches the kernel on the stream bound to the execution context.
+impl<'a> DeviceOperation for AsyncKernelLaunch<'a> {
+    type Output = ();
+
+    unsafe fn execute(self, ctx: &ExecutionContext) -> Result<(), DeviceError> {
+        unsafe { self.launch(ctx.get_cuda_stream()) }
+    }
+}
+
+/// Schedules the kernel launch via the thread-local default scheduling policy.
+impl<'a> IntoFuture for AsyncKernelLaunch<'a> {
+    type Output = Result<(), DeviceError>;
+    type IntoFuture = DeviceFuture<(), AsyncKernelLaunch<'a>>;
+    fn into_future(self) -> Self::IntoFuture {
+        match with_default_device_policy(|policy| policy.schedule(self)) {
+            Ok(Ok(future)) => future,
+            Ok(Err(e)) | Err(e) => DeviceFuture::failed(e),
+        }
+    }
+}
+
+impl<R: Send + 'static> DeviceOperation for OwnedAsyncKernelLaunch<R> {
+    type Output = R;
+
+    unsafe fn execute(self, ctx: &ExecutionContext) -> Result<R, DeviceError> {
+        let Self { launch, resources } = self;
+        unsafe { launch.launch(ctx.get_cuda_stream()) }?;
+        Ok(resources)
+    }
+}
+
+impl<R: Send + 'static> IntoFuture for OwnedAsyncKernelLaunch<R> {
+    type Output = Result<R, DeviceError>;
+    type IntoFuture = DeviceFuture<R, OwnedAsyncKernelLaunch<R>>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        match with_default_device_policy(|policy| policy.schedule(self)) {
+            Ok(Ok(future)) => future,
+            Ok(Err(e)) | Err(e) => DeviceFuture::failed(e),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[repr(C)]
+    #[derive(Clone, Copy, Debug, PartialEq)]
+    struct TestParams {
+        scale: f32,
+        bias: i32,
+    }
+
+    #[test]
+    fn scalar_arg_storage_accepts_custom_copy_value() {
+        let mut storage = KernelArgStorage::default();
+        let params = TestParams {
+            scale: 2.0,
+            bias: 3,
+        };
+
+        storage.push_scalar_arg(params);
+
+        assert_eq!(storage.ptrs.len(), 1);
+        assert_eq!(unsafe { *(storage.ptrs[0] as *const TestParams) }, params);
+    }
+
+    #[test]
+    fn arg_storage_drops_values_with_their_original_type() {
+        struct DropCounter(Arc<AtomicUsize>);
+
+        impl Drop for DropCounter {
+            fn drop(&mut self) {
+                self.0.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+
+        let drops = Arc::new(AtomicUsize::new(0));
+        let mut storage = KernelArgStorage::default();
+
+        storage.push_send_arg(Box::new(DropCounter(Arc::clone(&drops))));
+        assert_eq!(drops.load(Ordering::Relaxed), 0);
+
+        drop(storage);
+        assert_eq!(drops.load(Ordering::Relaxed), 1);
+    }
+}

--- a/cuda-async/src/simt/mod.rs
+++ b/cuda-async/src/simt/mod.rs
@@ -1,0 +1,27 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! The cuda-oxide async surface.
+//!
+//! Everything under this module is the cuda-oxide `cuda-async` API, brought
+//! over as-is for the shared host-crate migration. The two async stacks fork
+//! the same ancestor, so they share most type names with diverged
+//! definitions; nothing here is re-exported at the crate root, and consumers
+//! address it as `cuda_async::simt::<module>::<item>`, mirroring oxide's
+//! `cuda_async::<module>::<item>`. Reconciliation happens after the
+//! repository migration, and this module is deletable as a unit.
+//!
+//! One departure, recorded for the reconciliation: oxide's `zip!` and
+//! `unzip!` macros are present but not exported, since this crate already
+//! exports macros with those names.
+
+pub mod device_box;
+pub mod device_context;
+pub mod device_future;
+pub mod device_operation;
+pub mod error;
+pub mod launch;
+pub mod reclaim;
+pub mod scheduling_policies;

--- a/cuda-async/src/simt/reclaim.rs
+++ b/cuda-async/src/simt/reclaim.rs
@@ -1,0 +1,308 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Deferred reclamation of results cancelled while GPU work is in flight.
+//!
+//! Cancelling a [`DeviceFuture`] cannot cancel GPU work that has already
+//! been submitted: kernels run to completion regardless of what the host
+//! does. What cancellation *can* do is decide when the host releases the
+//! resources the kernel is still using. Dropping them immediately is
+//! unsound (the stream-ordered allocator may hand the memory to the next
+//! allocation while the kernel still writes to it), and synchronizing the
+//! stream inside `Drop` blocks executor threads for an unbounded time.
+//!
+//! Instead, cancelled in-flight results are *parked* here together with a
+//! completion gate (a CUDA event recorded on the assigned stream after the
+//! submitted work):
+//!
+//! ```text
+//! drop(future)                 later sweep (poll / drop / drain)
+//!   record event on stream       event passed?  -> drop the result
+//!   park (event, result)         still running? -> keep it parked
+//! ```
+//!
+//! Parked results are swept opportunistically on subsequent future polls
+//! and drops, or deterministically via [`drain`]. Payloads are never
+//! dropped inside a CUDA host callback (callbacks must not call CUDA APIs,
+//! and dropping a device buffer enqueues an async free), and a sweep never
+//! blocks on GPU progress.
+//!
+//! Entries that are still parked at process exit are leaked; the driver
+//! reclaims device memory at process teardown, while dropping them early
+//! could corrupt memory that is still in use.
+//!
+//! [`DeviceFuture`]: crate::simt::device_future::DeviceFuture
+
+use cuda_core::{CudaEvent, DriverError};
+use std::io::{self, Write};
+use std::mem;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Mutex, MutexGuard};
+
+/// Completion gate guarding a parked result.
+///
+/// Production code uses a [`CudaEvent`] recorded on the stream that runs
+/// the cancelled work. Tests substitute host-side mocks.
+pub(crate) trait ReclaimGate: Send {
+    /// Returns `true` when the device timeline has passed the gate.
+    /// Must never block.
+    fn passed(&self) -> Result<bool, DriverError>;
+
+    /// Blocks until the device timeline has passed the gate.
+    fn wait(&self) -> Result<(), DriverError>;
+}
+
+impl ReclaimGate for CudaEvent {
+    fn passed(&self) -> Result<bool, DriverError> {
+        self.query()
+    }
+
+    fn wait(&self) -> Result<(), DriverError> {
+        self.synchronize()
+    }
+}
+
+/// A parked result and the gate that decides when it may be dropped.
+struct LimboEntry {
+    /// Completion gate; the payload may only drop after it has passed.
+    gate: Box<dyn ReclaimGate>,
+    /// Type-erased result kept alive on behalf of the cancelled future.
+    payload: Box<dyn Send>,
+}
+
+/// Number of parked entries. Mirrors `LIMBO.len()`; updated only while the
+/// limbo lock is held, read lock-free as the sweep fast path.
+static PENDING: AtomicUsize = AtomicUsize::new(0);
+
+/// All currently parked entries, across every device and thread.
+static LIMBO: Mutex<Vec<LimboEntry>> = Mutex::new(Vec::new());
+
+/// Locks the limbo list, recovering from poisoning.
+///
+/// A poisoned lock only means another thread panicked while holding it;
+/// the list itself stays consistent because payloads are always dropped
+/// outside the lock.
+fn limbo() -> MutexGuard<'static, Vec<LimboEntry>> {
+    LIMBO
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+/// Parks `payload` until `gate` reports completion.
+pub(crate) fn park(gate: impl ReclaimGate + 'static, payload: Box<dyn Send>) {
+    let mut entries = limbo();
+    entries.push(LimboEntry {
+        gate: Box::new(gate),
+        payload,
+    });
+    PENDING.store(entries.len(), Ordering::Release);
+}
+
+/// Number of results currently parked awaiting reclamation.
+pub fn pending() -> usize {
+    PENDING.load(Ordering::Acquire)
+}
+
+/// Drops every parked result whose gate has passed. Never blocks on GPU
+/// progress. Returns the number of results reclaimed.
+///
+/// Called automatically on every [`DeviceFuture`] poll and drop; safe to
+/// call manually at any time.
+///
+/// [`DeviceFuture`]: crate::simt::device_future::DeviceFuture
+pub fn sweep() -> usize {
+    if PENDING.load(Ordering::Acquire) == 0 {
+        return 0;
+    }
+    let completed: Vec<LimboEntry> = {
+        let mut entries = limbo();
+        let mut kept = Vec::with_capacity(entries.len());
+        let mut done = Vec::new();
+        for entry in entries.drain(..) {
+            match entry.gate.passed() {
+                Ok(true) => done.push(entry),
+                // Still in flight, or the query failed. Dropping early
+                // would release memory the device may still be using, so
+                // the entry stays parked.
+                Ok(false) | Err(_) => kept.push(entry),
+            }
+        }
+        *entries = kept;
+        PENDING.store(entries.len(), Ordering::Release);
+        done
+    };
+    // Dropped outside the lock: a payload's own drop may park or sweep.
+    let reclaimed = completed.len();
+    drop(completed);
+    reclaimed
+}
+
+/// Blocking drain: waits for every parked gate to pass, then drops the
+/// payload. Returns the number of results reclaimed.
+///
+/// When even the blocking wait fails, the payload is deliberately leaked
+/// with a message on stderr: if the driver cannot prove the GPU work
+/// finished, leaking is safer than freeing memory the device may still
+/// write to.
+///
+/// Call this before tearing down a process or test when deterministic
+/// reclamation is required. It must not be called from a CUDA host
+/// callback or while holding a thread-local device-context borrow.
+pub fn drain() -> usize {
+    let entries: Vec<LimboEntry> = {
+        let mut entries = limbo();
+        let drained = mem::take(&mut *entries);
+        PENDING.store(0, Ordering::Release);
+        drained
+    };
+    let mut reclaimed = 0;
+    for entry in entries {
+        let waited = match entry.gate.passed() {
+            Ok(true) => Ok(()),
+            _ => entry.gate.wait(),
+        };
+        match waited {
+            Ok(()) => {
+                drop(entry.payload);
+                reclaimed += 1;
+            }
+            Err(error) => {
+                let mut stderr = io::stderr().lock();
+                let _ = writeln!(
+                    stderr,
+                    "cuda-async: leaking a cancelled in-flight result; the driver \
+                     could not prove the GPU work finished: {error}"
+                );
+                mem::forget(entry.payload);
+            }
+        }
+    }
+    reclaimed
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::AtomicBool;
+    use std::sync::Arc;
+
+    /// Serializes the tests in this module: they share the global limbo,
+    /// and `drain` consumes (and waits on) every parked entry.
+    static TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    fn test_lock() -> MutexGuard<'static, ()> {
+        TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    /// Host-side stand-in for a recorded CUDA event.
+    struct MockGate {
+        /// Mirrors "the device timeline has passed the recorded event".
+        passed: Arc<AtomicBool>,
+        /// When `true`, the blocking wait reports a driver failure.
+        wait_fails: bool,
+    }
+
+    impl ReclaimGate for MockGate {
+        fn passed(&self) -> Result<bool, DriverError> {
+            Ok(self.passed.load(Ordering::Relaxed))
+        }
+
+        fn wait(&self) -> Result<(), DriverError> {
+            if self.wait_fails {
+                Err(DriverError(
+                    cuda_bindings::cudaError_enum_CUDA_ERROR_INVALID_VALUE,
+                ))
+            } else {
+                self.passed.store(true, Ordering::Relaxed);
+                Ok(())
+            }
+        }
+    }
+
+    struct CountDrop(Arc<AtomicUsize>);
+
+    impl Drop for CountDrop {
+        fn drop(&mut self) {
+            self.0.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    #[test]
+    fn sweep_keeps_payload_parked_until_gate_passes() {
+        let _guard = test_lock();
+        let drops = Arc::new(AtomicUsize::new(0));
+        let gate_passed = Arc::new(AtomicBool::new(false));
+
+        park(
+            MockGate {
+                passed: Arc::clone(&gate_passed),
+                wait_fails: false,
+            },
+            Box::new(CountDrop(Arc::clone(&drops))),
+        );
+
+        sweep();
+        assert_eq!(
+            drops.load(Ordering::Relaxed),
+            0,
+            "payload must stay parked while the GPU work is in flight"
+        );
+
+        gate_passed.store(true, Ordering::Relaxed);
+        sweep();
+        assert_eq!(
+            drops.load(Ordering::Relaxed),
+            1,
+            "payload must drop once the gate reports completion"
+        );
+    }
+
+    #[test]
+    fn drain_waits_for_gate_then_drops_payload() {
+        let _guard = test_lock();
+        let drops = Arc::new(AtomicUsize::new(0));
+        let gate_passed = Arc::new(AtomicBool::new(false));
+
+        park(
+            MockGate {
+                passed: Arc::clone(&gate_passed),
+                wait_fails: false,
+            },
+            Box::new(CountDrop(Arc::clone(&drops))),
+        );
+
+        let reclaimed = drain();
+        assert_eq!(reclaimed, 1);
+        assert_eq!(drops.load(Ordering::Relaxed), 1);
+        assert!(
+            gate_passed.load(Ordering::Relaxed),
+            "drain must have waited on the gate before dropping"
+        );
+    }
+
+    #[test]
+    fn drain_leaks_payload_when_wait_fails() {
+        let _guard = test_lock();
+        let drops = Arc::new(AtomicUsize::new(0));
+
+        park(
+            MockGate {
+                passed: Arc::new(AtomicBool::new(false)),
+                wait_fails: true,
+            },
+            Box::new(CountDrop(Arc::clone(&drops))),
+        );
+
+        let reclaimed = drain();
+        assert_eq!(reclaimed, 0);
+        assert_eq!(
+            drops.load(Ordering::Relaxed),
+            0,
+            "an unprovable gate must leak the payload, never drop it early"
+        );
+    }
+}

--- a/cuda-async/src/simt/scheduling_policies.rs
+++ b/cuda-async/src/simt/scheduling_policies.rs
@@ -1,0 +1,251 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Stream scheduling policies that control how [`DeviceOperation`]s are
+//! assigned to CUDA streams.
+//!
+//! A [`SchedulingPolicy`] decouples operation construction from stream
+//! selection. The policy chooses a stream when an operation is scheduled or
+//! executed synchronously, enabling transparent overlap of independent work.
+//!
+//! | Policy                   | Behaviour                                    |
+//! |--------------------------|----------------------------------------------|
+//! | [`StreamPoolRoundRobin`] | Rotates across *N* streams for HW overlap    |
+//! | [`SingleStream`]         | Serialises all work onto one stream          |
+//!
+//! [`DeviceOperation`]: crate::simt::device_operation::DeviceOperation
+
+use crate::simt::device_future::DeviceFuture;
+use crate::simt::device_operation::{DeviceOperation, ExecutionContext};
+use crate::simt::error::{device_error, DeviceError};
+use cuda_core::{CudaContext, CudaStream};
+use std::sync::atomic::AtomicUsize;
+use std::sync::Arc;
+
+/// Top-level enum wrapping all supported scheduling policy implementations.
+///
+/// Used as the concrete policy type stored in
+/// [`AsyncDeviceContext`](crate::simt::device_context::AsyncDeviceContext).
+pub enum GlobalSchedulingPolicy {
+    /// Round-robin across a pool of CUDA streams.
+    RoundRobin(StreamPoolRoundRobin),
+}
+
+impl GlobalSchedulingPolicy {
+    /// Returns a reference to the inner policy as a trait object.
+    pub fn as_scheduling_policy(&self) -> Result<&impl SchedulingPolicy, DeviceError> {
+        match self {
+            GlobalSchedulingPolicy::RoundRobin(rr) => Ok(rr),
+        }
+    }
+}
+
+/// Delegates to the inner policy variant.
+impl SchedulingPolicy for GlobalSchedulingPolicy {
+    fn init(&mut self, ctx: &Arc<CudaContext>) -> Result<(), DeviceError> {
+        match self {
+            GlobalSchedulingPolicy::RoundRobin(rr) => rr.init(ctx),
+        }
+    }
+    fn schedule<T: Send, O: DeviceOperation<Output = T>>(
+        &self,
+        op: O,
+    ) -> Result<DeviceFuture<T, O>, DeviceError> {
+        match self {
+            GlobalSchedulingPolicy::RoundRobin(rr) => rr.schedule(op),
+        }
+    }
+    fn sync<T: Send, O: DeviceOperation<Output = T>>(&self, op: O) -> Result<T, DeviceError> {
+        match self {
+            GlobalSchedulingPolicy::RoundRobin(rr) => rr.sync(op),
+        }
+    }
+}
+
+/// `Arc`-wrapped policy delegates scheduling but rejects re-initialization,
+/// since the inner data cannot be mutated through an `Arc`.
+impl SchedulingPolicy for Arc<GlobalSchedulingPolicy> {
+    fn init(&mut self, _ctx: &Arc<CudaContext>) -> Result<(), DeviceError> {
+        Err(DeviceError::Scheduling(
+            "Cannot initialize scheduling policy inside an Arc.".to_string(),
+        ))
+    }
+    fn schedule<T: Send, O: DeviceOperation<Output = T>>(
+        &self,
+        op: O,
+    ) -> Result<DeviceFuture<T, O>, DeviceError> {
+        match self.as_ref() {
+            GlobalSchedulingPolicy::RoundRobin(rr) => rr.schedule(op),
+        }
+    }
+    fn sync<T: Send, O: DeviceOperation<Output = T>>(&self, op: O) -> Result<T, DeviceError> {
+        match self.as_ref() {
+            GlobalSchedulingPolicy::RoundRobin(rr) => rr.sync(op),
+        }
+    }
+}
+
+/// Strategy for assigning [`DeviceOperation`]s to CUDA streams.
+///
+/// Implementations must be `Sync` because the policy is shared across all
+/// operations on a device context.
+///
+/// [`DeviceOperation`]: crate::simt::device_operation::DeviceOperation
+pub trait SchedulingPolicy: Sync {
+    /// One-time initialization with the CUDA context (creates streams, etc.).
+    fn init(&mut self, ctx: &Arc<CudaContext>) -> Result<(), DeviceError>;
+
+    /// Assigns a stream to `op` and returns a [`DeviceFuture`] ready to be
+    /// polled.
+    fn schedule<T: Send, O: DeviceOperation<Output = T>>(
+        &self,
+        op: O,
+    ) -> Result<DeviceFuture<T, O>, DeviceError>;
+
+    /// Executes `op` synchronously on a policy-chosen stream and blocks until
+    /// the stream is idle.
+    fn sync<T: Send, O: DeviceOperation<Output = T>>(&self, op: O) -> Result<T, DeviceError>;
+}
+
+/// Round-robin scheduler over a fixed-size pool of CUDA streams.
+///
+/// Each call to [`schedule`](SchedulingPolicy::schedule) or
+/// [`sync`](SchedulingPolicy::sync) atomically advances the stream index,
+/// distributing work across streams to enable hardware-level overlap of
+/// independent kernels and memory transfers.
+#[derive(Debug)]
+pub struct StreamPoolRoundRobin {
+    /// Device ordinal this pool belongs to.
+    device_id: usize,
+    /// Monotonically increasing counter; wrapped with `% num_streams`.
+    next_stream_idx: AtomicUsize,
+    /// Number of streams in the pool.
+    pub(crate) num_streams: usize,
+    /// `None` until [`init`](SchedulingPolicy::init) is called.
+    pub(crate) stream_pool: Option<Vec<Arc<CudaStream>>>,
+}
+
+impl StreamPoolRoundRobin {
+    /// Creates an un-initialized round-robin policy for `device_id` with
+    /// `num_streams` streams.
+    ///
+    /// # Safety
+    ///
+    /// The caller must call [`SchedulingPolicy::init`] before scheduling any
+    /// operations. Using the policy before initialization produces an error.
+    pub unsafe fn new(device_id: usize, num_streams: usize) -> Self {
+        Self {
+            device_id,
+            num_streams,
+            stream_pool: None,
+            next_stream_idx: AtomicUsize::new(0),
+        }
+    }
+}
+
+impl SchedulingPolicy for StreamPoolRoundRobin {
+    /// Allocates `num_streams` CUDA streams on the provided context.
+    fn init(&mut self, ctx: &Arc<CudaContext>) -> Result<(), DeviceError> {
+        let mut pool = vec![];
+        for _ in 0..self.num_streams {
+            pool.push(ctx.new_stream()?);
+        }
+        self.stream_pool = Some(pool);
+        Ok(())
+    }
+
+    /// Picks the next stream (round-robin), executes `op`, and synchronizes.
+    fn sync<T: Send, O: DeviceOperation<Output = T>>(&self, op: O) -> Result<T, DeviceError> {
+        let idx = self
+            .next_stream_idx
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+            % self.num_streams;
+        let pool = self
+            .stream_pool
+            .as_ref()
+            .ok_or_else(|| device_error(self.device_id, "Stream pool not initialized."))?;
+        op.sync_on(&pool[idx])
+    }
+
+    /// Picks the next stream (round-robin) and wraps `op` in a
+    /// [`DeviceFuture`].
+    fn schedule<T: Send, O: DeviceOperation<Output = T>>(
+        &self,
+        op: O,
+    ) -> Result<DeviceFuture<T, O>, DeviceError> {
+        let idx = self
+            .next_stream_idx
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+            % self.num_streams;
+        let pool = self
+            .stream_pool
+            .as_ref()
+            .ok_or_else(|| device_error(self.device_id, "Stream pool not initialized."))?;
+        // `DeviceFuture` implements `Drop`, so functional-update syntax
+        // (`..Default::default()`) would move fields out of a droppable
+        // value (E0509). Spell every field out instead.
+        Ok(DeviceFuture {
+            device_operation: Some(op),
+            execution_context: Some(ExecutionContext::new(Arc::clone(&pool[idx]))),
+            result: None,
+            error: None,
+            state: Default::default(),
+            callback_state: None,
+        })
+    }
+}
+
+/// Single-stream scheduler that serialises all work onto one CUDA stream.
+///
+/// Useful for debugging or when ordering guarantees are required between
+/// all operations on a device.
+#[derive(Debug)]
+pub struct SingleStream {
+    /// The single stream. `None` until [`init`](SchedulingPolicy::init).
+    pub stream: Option<Arc<CudaStream>>,
+}
+
+impl SingleStream {
+    /// Creates an un-initialized single-stream policy.
+    ///
+    /// # Safety
+    ///
+    /// The caller must call [`SchedulingPolicy::init`] before use.
+    pub unsafe fn new() -> Self {
+        Self { stream: None }
+    }
+}
+
+impl SchedulingPolicy for SingleStream {
+    /// Allocates one CUDA stream on `ctx`.
+    fn init(&mut self, ctx: &Arc<CudaContext>) -> Result<(), DeviceError> {
+        self.stream = Some(ctx.new_stream()?);
+        Ok(())
+    }
+
+    /// Wraps `op` in a [`DeviceFuture`] bound to the single stream.
+    fn schedule<T: Send, O: DeviceOperation<Output = T>>(
+        &self,
+        op: O,
+    ) -> Result<DeviceFuture<T, O>, DeviceError> {
+        let stream = self.stream.as_ref().unwrap();
+        // See `StreamPoolRoundRobin::schedule` for why the fields are
+        // spelled out instead of using `..Default::default()`.
+        Ok(DeviceFuture {
+            device_operation: Some(op),
+            execution_context: Some(ExecutionContext::new(Arc::clone(stream))),
+            result: None,
+            error: None,
+            state: Default::default(),
+            callback_state: None,
+        })
+    }
+
+    /// Executes `op` synchronously on the single stream.
+    fn sync<T: Send, O: DeviceOperation<Output = T>>(&self, op: O) -> Result<T, DeviceError> {
+        let stream = self.stream.as_ref().unwrap();
+        op.sync_on(stream)
+    }
+}

--- a/cuda-bindings/build.rs
+++ b/cuda-bindings/build.rs
@@ -18,7 +18,7 @@ use syn::{
     TypeBareFn,
 };
 
-const MIN_CUDA_VERSION: u32 = 13020;
+const MIN_CUDA_VERSION: u32 = 13000;
 const CUDA_TOOLKIT_PATH_ENV: &str = "CUDA_TOOLKIT_PATH";
 const SETUP_DIAGNOSTICS_ENV: &str = "CUTILE_SETUP_DIAGNOSTICS";
 
@@ -30,7 +30,12 @@ struct ApiSpec {
     library_name: &'static str,
     api_type: &'static str,
     loader_fn: &'static str,
-    fallback_expr: &'static str,
+    /// Returned when the library itself could not be loaded.
+    not_loaded_expr: &'static str,
+    /// Returned when the library loaded but this symbol is absent
+    /// (older driver). Matches cuGetProcAddress's own convention of
+    /// reporting absent symbols distinctly.
+    missing_symbol_expr: &'static str,
     function_pattern: &'static str,
 }
 
@@ -43,7 +48,8 @@ const API_SPECS: &[ApiSpec] = &[
         library_name: "CudaDriverApi",
         api_type: "CudaDriverApi",
         loader_fn: "cuda_driver",
-        fallback_expr: "cudaError_enum_CUDA_ERROR_SHARED_OBJECT_INIT_FAILED",
+        not_loaded_expr: "cudaError_enum_CUDA_ERROR_NOT_INITIALIZED",
+        missing_symbol_expr: "cudaError_enum_CUDA_ERROR_NOT_FOUND",
         function_pattern: "^cu.*",
     },
     ApiSpec {
@@ -54,7 +60,9 @@ const API_SPECS: &[ApiSpec] = &[
         library_name: "CurandApi",
         api_type: "CurandApi",
         loader_fn: "curand_api",
-        fallback_expr: "curandStatus_CURAND_STATUS_NOT_INITIALIZED",
+        // curand has no NOT_FOUND analogue; NOT_INITIALIZED covers both.
+        not_loaded_expr: "curandStatus_CURAND_STATUS_NOT_INITIALIZED",
+        missing_symbol_expr: "curandStatus_CURAND_STATUS_NOT_INITIALIZED",
         function_pattern: "^curand.*",
     },
 ];
@@ -74,6 +82,24 @@ fn run() -> Result<(), Box<dyn Error>> {
     let cuda_toolkit = resolve_cuda_toolkit()?;
     let cuda_toolkit = cuda_toolkit.to_string_lossy().into_owned();
     println!("cargo:rustc-env=CUTILE_RESOLVED_CUDA_TOOLKIT_PATH={cuda_toolkit}");
+
+    // CUDA 12.8 renamed the event elapsed-time entry point to
+    // cuEventElapsedTime_v2; earlier toolkits only declare
+    // cuEventElapsedTime. Probe the resolved headers so src/lib.rs can
+    // dispatch to whichever symbol this build's toolkit declares.
+    println!("cargo::rustc-check-cfg=cfg(cuda_has_cuEventElapsedTime_v2)");
+    println!("cargo::rustc-check-cfg=cfg(cuda_has_cuLaunchHostFunc_v2)");
+    let resolved_cuda_h = std::path::Path::new(&cuda_toolkit)
+        .join("include")
+        .join("cuda.h");
+    if let Ok(header) = fs::read_to_string(&resolved_cuda_h) {
+        if header.contains("cuEventElapsedTime_v2") {
+            println!("cargo:rustc-cfg=cuda_has_cuEventElapsedTime_v2");
+        }
+        if header.contains("cuLaunchHostFunc_v2") {
+            println!("cargo:rustc-cfg=cuda_has_cuLaunchHostFunc_v2");
+        }
+    }
     let out_dir = env::var("OUT_DIR")?;
     let out_dir = Path::new(&out_dir);
 
@@ -88,7 +114,7 @@ fn run() -> Result<(), Box<dyn Error>> {
 fn resolve_cuda_toolkit() -> Result<PathBuf, Box<dyn Error>> {
     match env::var_os(CUDA_TOOLKIT_PATH_ENV) {
         Some(value) if value.is_empty() => Err(format!(
-            "{CUDA_TOOLKIT_PATH_ENV} is set to an empty string. Set it to a CUDA 13.2+ toolkit directory."
+            "{CUDA_TOOLKIT_PATH_ENV} is set to an empty string. Set it to a CUDA 13.0+ toolkit directory."
         )
         .into()),
         Some(value) => resolve_explicit_cuda_toolkit(value),
@@ -135,7 +161,7 @@ fn find_default_cuda_toolkit() -> Result<PathBuf, Box<dyn Error>> {
     }
 
     Err(format!(
-        "{CUDA_TOOLKIT_PATH_ENV} is not set, and no CUDA 13.2+ toolkit was found in default locations:\n{}\nSet {CUDA_TOOLKIT_PATH_ENV} to a CUDA 13.2+ toolkit directory.",
+        "{CUDA_TOOLKIT_PATH_ENV} is not set, and no CUDA 13.0+ toolkit was found in default locations:\n{}\nSet {CUDA_TOOLKIT_PATH_ENV} to a CUDA 13.0+ toolkit directory.",
         rejected.join("\n")
     )
     .into())
@@ -154,6 +180,7 @@ fn default_cuda_toolkit_candidates() -> &'static [PathBuf] {
             "/usr/local/cuda-13.3",
             "/usr/local/cuda-13.2",
             "/usr/local/cuda-13",
+            "/usr/local/cuda-12",
             "/usr/local/cuda",
         ];
 
@@ -177,7 +204,7 @@ fn validate_cuda_toolkit(cuda_toolkit: &Path) -> Result<u32, String> {
     let version = cuda_version_from_header(&cuda_h).map_err(|error| error.to_string())?;
     if version < MIN_CUDA_VERSION {
         return Err(format!(
-            "CUDA toolkit {} is too old. cuTile requires CUDA 13.2+ and recommends CUDA 13.3",
+            "CUDA toolkit {} is too old. The CUDA host-side crates require CUDA 13.0+ (the Tile compiler needs 13.2+)",
             format_cuda_version(version)
         ));
     }
@@ -198,7 +225,7 @@ fn cuda_version_from_header(cuda_h: &Path) -> Result<u32, Box<dyn Error>> {
         })
         .ok_or_else(|| {
             format!(
-                "could not find CUDA_VERSION in {}. Set CUDA_TOOLKIT_PATH to a CUDA 13.2+ toolkit directory.",
+                "could not find CUDA_VERSION in {}. Set CUDA_TOOLKIT_PATH to a CUDA 13.0+ toolkit directory.",
                 cuda_h.display()
             )
             .into()
@@ -303,8 +330,14 @@ fn generate_shims_from_generated_api(
     })?;
 
     let loader_fn = format_ident!("{}", spec.loader_fn);
-    let fallback_expr = syn::parse_str::<Expr>(spec.fallback_expr)?;
-    let shims = generate_field_shims(item_struct, &loader_fn, &fallback_expr);
+    let not_loaded_expr = syn::parse_str::<Expr>(spec.not_loaded_expr)?;
+    let missing_symbol_expr = syn::parse_str::<Expr>(spec.missing_symbol_expr)?;
+    let shims = generate_field_shims(
+        item_struct,
+        &loader_fn,
+        &not_loaded_expr,
+        &missing_symbol_expr,
+    );
     let shim_file = syn::parse2::<File>(quote!(#shims))?;
 
     fs::write(output_path, prettyplease::unparse(&shim_file))?;
@@ -321,7 +354,8 @@ fn find_api_struct<'a>(file: &'a File, api_type: &str) -> Option<&'a ItemStruct>
 fn generate_field_shims(
     item_struct: &ItemStruct,
     loader_fn: &proc_macro2::Ident,
-    fallback_expr: &Expr,
+    not_loaded_expr: &Expr,
+    missing_symbol_expr: &Expr,
 ) -> TokenStream {
     let Fields::Named(fields) = &item_struct.fields else {
         return TokenStream::new();
@@ -351,19 +385,25 @@ fn generate_field_shims(
             ReturnType::Type(_, ty) => quote!(-> #ty),
         };
 
+        // `extern "C"` so a wrapper item coerces to a C function pointer,
+        // matching cuda-oxide's original bindings surface (deliberately not
+        // "C-unwind": that is a different fn-pointer type and breaks the
+        // coercion). Unwinding out of extern "C" aborts, so these bodies
+        // must be panic-free: both failure paths return the API's own
+        // error codes instead.
         Some(quote! {
             #[allow(non_snake_case)]
             #[allow(clippy::missing_safety_doc)]
             #[allow(clippy::too_many_arguments)]
             #[allow(clippy::missing_inline_in_public_items)]
             #[inline]
-            pub unsafe fn #field_name(#(#arg_defs),*) #ret {
+            pub unsafe extern "C" fn #field_name(#(#arg_defs),*) #ret {
                 match #loader_fn() {
                     Ok(api) => match &api.#field_name {
                         Ok(loaded_fn) => unsafe { (*loaded_fn)(#(#arg_names),*) },
-                        Err(_) => #fallback_expr,
+                        Err(_) => #missing_symbol_expr,
                     },
-                    Err(_) => #fallback_expr,
+                    Err(_) => #not_loaded_expr,
                 }
             }
         })

--- a/cuda-bindings/src/dyn_load.rs
+++ b/cuda-bindings/src/dyn_load.rs
@@ -77,6 +77,13 @@ const CURAND_LIB_NAMES: &[&str] = &["curand64_10.dll"];
 #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
 const CURAND_LIB_NAMES: &[&str] = &["libcurand.so"];
 
+// The generated shims are `extern "C"`, so nothing reachable from them may
+// panic (unwinding out of extern "C" aborts). `load_api`'s expect below is
+// reachable from every shim; these make its precondition a compile-time
+// fact rather than a runtime hope.
+const _: () = assert!(!CUDA_LIB_NAMES.is_empty());
+const _: () = assert!(!CURAND_LIB_NAMES.is_empty());
+
 trait GeneratedApi: Sized {
     unsafe fn open(path: &str) -> Result<Self, libloading::Error>;
 }

--- a/cuda-bindings/src/lib.rs
+++ b/cuda-bindings/src/lib.rs
@@ -47,6 +47,71 @@ pub fn cuda_toolkit_dir() -> String {
     env!("CUTILE_RESOLVED_CUDA_TOOLKIT_PATH").to_string()
 }
 
+/// Host-task sync modes for [`cu_launch_host_func`], defined as literals so
+/// consumers compile against any toolkit: the `CUhostTaskSyncMode` enum only
+/// exists in CUDA 13.x headers.
+pub const CU_HOST_TASK_BLOCKING: ::core::ffi::c_uint = 0;
+pub const CU_HOST_TASK_SPINWAIT: ::core::ffi::c_uint = 1;
+
+/// Enqueues a host function on the stream, with a sync mode where the
+/// toolkit supports one.
+///
+/// CUDA 13.x adds `cuLaunchHostFunc_v2`, whose `sync_mode` selects between
+/// the blocking default and a spin-waiting host task (lower callback latency,
+/// one busy core). On older toolkits the entry point does not exist and the
+/// call degrades to `cuLaunchHostFunc`: spin-wait is a latency optimization,
+/// so the degraded call keeps the same semantics at the default latency.
+///
+/// # Safety
+///
+/// Same contract as the underlying driver call: `func` and `arg` must remain
+/// valid until the callback executes, and `stream` must be a valid stream.
+pub unsafe fn cu_launch_host_func(
+    stream: CUstream,
+    func: ::core::option::Option<unsafe extern "C" fn(*mut ::core::ffi::c_void)>,
+    arg: *mut ::core::ffi::c_void,
+    sync_mode: ::core::ffi::c_uint,
+) -> CUresult {
+    #[cfg(cuda_has_cuLaunchHostFunc_v2)]
+    {
+        unsafe { cuLaunchHostFunc_v2(stream, func, arg, sync_mode) }
+    }
+    #[cfg(not(cuda_has_cuLaunchHostFunc_v2))]
+    {
+        let _ = sync_mode;
+        unsafe { cuLaunchHostFunc(stream, func, arg) }
+    }
+}
+
+/// Reports the elapsed time in milliseconds between two recorded events.
+///
+/// CUDA 12.8 renamed the driver entry point to `cuEventElapsedTime_v2`;
+/// earlier toolkits only declare `cuEventElapsedTime`. The build script
+/// probes the resolved `cuda.h` and sets `cuda_has_cuEventElapsedTime_v2`,
+/// so callers stay source-compatible across toolkit versions. The helper
+/// exists for source compatibility with cuda-oxide's bindings, which expose
+/// the same one.
+///
+/// # Safety
+///
+/// Same contract as the underlying driver call: `elapsed_ms` must be valid
+/// for an `f32` write, and `start`/`end` must be valid event handles recorded
+/// in the current context.
+pub unsafe fn cu_event_elapsed_time(
+    elapsed_ms: *mut f32,
+    start: CUevent,
+    end: CUevent,
+) -> CUresult {
+    #[cfg(cuda_has_cuEventElapsedTime_v2)]
+    {
+        unsafe { cuEventElapsedTime_v2(elapsed_ms, start, end) }
+    }
+    #[cfg(not(cuda_has_cuEventElapsedTime_v2))]
+    {
+        unsafe { cuEventElapsedTime(elapsed_ms, start, end) }
+    }
+}
+
 #[cfg(test)]
 mod cuda_tests {
     use super::*;
@@ -91,6 +156,13 @@ mod cuda_tests {
 
     unsafe fn set_seed(gen: curandGenerator_t, seed: u64) {
         assert!(curandSetPseudoRandomGeneratorSeed(gen, c_ulonglong::from(seed)) == 0);
+    }
+
+    #[test]
+    fn cu_event_elapsed_time_helper_signature() {
+        // Compile-time check that the helper keeps the signature cuda-oxide's
+        // bindings expose.
+        let _: unsafe fn(*mut f32, CUevent, CUevent) -> CUresult = cu_event_elapsed_time;
     }
 
     #[test]

--- a/cuda-bindings/tests/fn_ptr_coercion.rs
+++ b/cuda-bindings/tests/fn_ptr_coercion.rs
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! The generated per-symbol wrappers must be `unsafe extern "C" fn` items so
+//! they coerce to C function pointers — cuda-oxide's original bindings
+//! surface, and how downstream code stores driver entry points in tables.
+//! `extern "C"` exactly (not "C-unwind"): the unwind variant is a different
+//! fn-pointer type and this coercion is what would break.
+
+use cuda_bindings::CUresult;
+
+#[test]
+fn generated_wrappers_coerce_to_c_fn_pointers() {
+    let _: unsafe extern "C" fn(u32) -> CUresult = cuda_bindings::cuInit;
+}

--- a/cuda-core-derive/Cargo.toml
+++ b/cuda-core-derive/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "cuda-core-derive"
+description = "Derive macro for cuda-core's DeviceCopy trait."
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
+syn = { workspace = true }

--- a/cuda-core-derive/src/device_copy.rs
+++ b/cuda-core-derive/src/device_copy.rs
@@ -1,0 +1,121 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! `#[derive(DeviceCopy)]` proc-macro.
+//!
+//! Emits the `unsafe impl DeviceCopy` plus a hidden field-type-check function
+//! that fails to compile if any field is not itself `DeviceCopy`.
+
+use proc_macro2::{Ident, Span, TokenStream};
+use quote::quote;
+use syn::{
+    parse_str, Data, DataStruct, DataUnion, DeriveInput, Field, Fields, Generics, TypeParamBound,
+};
+
+pub fn impl_device_copy(input: &DeriveInput, import: TokenStream) -> TokenStream {
+    let input_type = &input.ident;
+
+    // Generate the code to type-check all fields of the derived struct/union. We can't perform
+    // type checking at expansion-time, so instead we generate a dummy nested function with a
+    // type-bound on DeviceCopy and call it with every type that's in the struct/union.
+    // This will fail to compile if any of the nested types doesn't implement DeviceCopy.
+    //
+    // Enums are deliberately rejected: `DeviceCopy`'s safety contract requires
+    // every bit pattern, including the all-zero pattern written by
+    // `DeviceBuffer::zeroed`, to be a valid value of the type. That holds for
+    // product types (structs/unions) when every field is `DeviceCopy`, but NOT
+    // for enums, whose discriminant leaves most byte patterns invalid. A zeroed
+    // or device-written buffer could then materialize an out-of-range
+    // discriminant (undefined behavior). This is the same reason `bool`, `char`,
+    // and `NonZeroU32` are not `DeviceCopy`. Per-field checking is necessary but
+    // not sufficient for enums, so we refuse rather than emit an unsound impl.
+    let check_types_code = match input.data {
+        Data::Struct(ref data_struct) => type_check_struct(data_struct),
+        Data::Union(ref data_union) => type_check_union(data_union),
+        Data::Enum(_) => {
+            return syn::Error::new_spanned(
+                input_type,
+                "`#[derive(DeviceCopy)]` cannot be applied to enums: `DeviceCopy` requires \
+                 every bit pattern (including the all-zero pattern written by \
+                 `DeviceBuffer::zeroed`) to be a valid value, but an enum's discriminant \
+                 leaves most byte patterns invalid, so a zeroed or device-written buffer \
+                 could materialize an out-of-range discriminant (undefined behavior). If you \
+                 can guarantee every device-produced byte pattern is a valid variant, write \
+                 `unsafe impl DeviceCopy for ... {}` by hand.",
+            )
+            .to_compile_error();
+        }
+    };
+
+    // We need a function for the type-checking code to live in, so generate a complicated and
+    // hopefully-unique name for that. The type identifier is used verbatim (not lowercased) so
+    // distinct types differing only in case (e.g. `Foo` and `foo`) get distinct helper names
+    // instead of colliding; the `non_snake_case` allow covers the casing.
+    let type_test_func_name = format!("__verify_{input_type}_can_implement_devicecopy");
+    let type_test_func_ident = Ident::new(&type_test_func_name, Span::call_site());
+
+    // If the struct/enum/union is generic, we need to add the DeviceCopy bound to the generics
+    // when implementing DeviceCopy.
+    let generics = add_bound_to_generics(&input.generics, import.clone());
+    let (impl_generics, type_generics, where_clause) = generics.split_for_impl();
+
+    // Finally, generate the unsafe impl and the type-checking function.
+    let generated_code = quote! {
+        unsafe impl #impl_generics #import for #input_type #type_generics #where_clause {}
+
+        #[doc(hidden)]
+        #[allow(non_snake_case, dead_code, unused_variables)]
+        fn #type_test_func_ident #impl_generics(value: &#input_type #type_generics) #where_clause {
+            fn assert_impl<T: #import>() {}
+            #check_types_code
+        }
+    };
+
+    generated_code
+}
+
+fn add_bound_to_generics(generics: &Generics, import: TokenStream) -> Generics {
+    let mut new_generics = generics.clone();
+    let bound: TypeParamBound = parse_str(&quote! {#import}.to_string()).unwrap();
+
+    for type_param in &mut new_generics.type_params_mut() {
+        type_param.bounds.push(bound.clone())
+    }
+
+    new_generics
+}
+
+fn type_check_struct(s: &DataStruct) -> TokenStream {
+    let checks = match s.fields {
+        Fields::Named(ref named_fields) => {
+            let fields: Vec<&Field> = named_fields.named.iter().collect();
+            check_fields(&fields)
+        }
+        Fields::Unnamed(ref unnamed_fields) => {
+            let fields: Vec<&Field> = unnamed_fields.unnamed.iter().collect();
+            check_fields(&fields)
+        }
+        Fields::Unit => vec![],
+    };
+    quote!(
+        #(#checks)*
+    )
+}
+
+fn type_check_union(s: &DataUnion) -> TokenStream {
+    let fields: Vec<&Field> = s.fields.named.iter().collect();
+    let checks = check_fields(&fields);
+    quote!(
+        #(#checks)*
+    )
+}
+
+fn check_fields(fields: &[&Field]) -> Vec<TokenStream> {
+    fields
+        .iter()
+        .map(|field| {
+            let field_type = &field.ty;
+            quote! {assert_impl::<#field_type>();}
+        })
+        .collect()
+}

--- a/cuda-core-derive/src/lib.rs
+++ b/cuda-core-derive/src/lib.rs
@@ -1,0 +1,24 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! `#[derive(DeviceCopy)]` for `cuda_core::DeviceCopy`.
+//!
+//! Extracted from cuda-oxide's `cuda-macros` so the shared `cuda-core` can
+//! re-export the derive next to the trait (the serde trait+derive pattern)
+//! from a publishable crate.
+
+mod device_copy;
+
+use proc_macro::TokenStream;
+use quote::quote;
+
+/// Derive `cuda_core::DeviceCopy` for a type whose fields are all themselves
+/// `DeviceCopy`.
+#[proc_macro_derive(DeviceCopy)]
+pub fn device_copy(input: TokenStream) -> TokenStream {
+    let ast = syn::parse(input).unwrap();
+    let code = device_copy::impl_device_copy(&ast, quote!(::cuda_core::DeviceCopy));
+    code.into()
+}

--- a/cuda-core/Cargo.toml
+++ b/cuda-core/Cargo.toml
@@ -11,5 +11,14 @@ readme = "README.md"
 
 [dependencies]
 cuda-bindings = { workspace = true }
+cuda-core-derive = { version = "0.3", path = "../cuda-core-derive" }
 anyhow = { workspace = true }
 half = { workspace = true }
+oxide-artifacts = { version = "0.2.1", features = ["object-read"] }
+
+[dev-dependencies]
+trybuild = "1"
+
+[features]
+# Nightly-only: DeviceCopy for the unstable f16 primitive.
+f16 = []

--- a/cuda-core/build.rs
+++ b/cuda-core/build.rs
@@ -1,0 +1,95 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Probes the CUDA headers for the multicast driver API (CUDA 12.1+).
+//!
+//! The `cuMulticast*` entry points first appeared in CUDA 12.1, and
+//! `cuda-bindings` binds whatever the host `cuda.h` declares, so building
+//! against a CUDA 12.0 toolkit would otherwise fail to compile all of
+//! `cuda-core`. The `cuda_has_multicast` cfg gates the multicast surface of
+//! `vmm` to toolkits that declare the API, mirroring the
+//! `cuda_has_cuEventElapsedTime_v2` probe in `cuda-bindings`.
+//!
+//! Toolkit discovery matches `cuda-bindings/build.rs`: the first set
+//! variable among `CUDA_TOOLKIT_PATH` and `CUDA_HOME`, else
+//! `/usr/local/cuda`, with both the standard `include/` and the
+//! redistributable `targets/<dir>/include/` layouts probed. A missing or
+//! unreadable `cuda.h` leaves the cfg unset (multicast unavailable) rather
+//! than erroring; `cuda-bindings` reports the authoritative failure for a
+//! genuinely broken toolkit.
+
+use std::env;
+use std::path::{Path, PathBuf};
+
+const TOOLKIT_ENV_VARS: &[&str] = &["CUDA_TOOLKIT_PATH", "CUDA_HOME"];
+const DEFAULT_TOOLKIT_DIR: &str = "/usr/local/cuda";
+
+/// Overrides the `targets/<dir>` selection with a single directory name,
+/// like nvcc's `-target-dir`; matches `cuda-bindings`.
+const TOOLKIT_TARGET_DIR_ENV: &str = "CUDA_TOOLKIT_TARGET_DIR";
+
+fn main() {
+    println!("cargo::rustc-check-cfg=cfg(cuda_has_multicast)");
+    for var in TOOLKIT_ENV_VARS {
+        println!("cargo:rerun-if-env-changed={var}");
+    }
+    println!("cargo:rerun-if-env-changed={TOOLKIT_TARGET_DIR_ENV}");
+
+    let Some(cuda_h) = find_cuda_header() else {
+        return;
+    };
+    println!("cargo:rerun-if-changed={}", cuda_h.display());
+    if std::fs::read_to_string(&cuda_h).is_ok_and(|header| header.contains("cuMulticastCreate")) {
+        println!("cargo:rustc-cfg=cuda_has_multicast");
+    }
+}
+
+/// CUDA toolkit `targets/` directory names to probe for cargo's build
+/// target, most specific first.
+///
+/// Kept in lockstep BY HAND with the selection table in
+/// `crates/cuda-bindings/toolkit_target.rs` (`resolve_toolkit_target_dirs`):
+/// build scripts cannot import each other's sources across crates. If the
+/// selection there changes, mirror it here. CUDA names these layouts after
+/// the GPU platform, not the Rust triple, and an aarch64 Linux triple is
+/// ambiguous between servers (`sbsa-linux`) and Tegra (`aarch64-linux`), so
+/// both are probed in that order. A non-blank [`TOOLKIT_TARGET_DIR_ENV`]
+/// replaces the table with that single directory.
+fn toolkit_target_dirs() -> Vec<String> {
+    if let Some(dir) = env::var(TOOLKIT_TARGET_DIR_ENV)
+        .ok()
+        .filter(|dir| !dir.trim().is_empty())
+    {
+        return vec![dir];
+    }
+    let arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
+    let os = env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    if os != "linux" {
+        return vec![];
+    }
+    match arch.as_str() {
+        "x86_64" => vec!["x86_64-linux".to_string()],
+        "aarch64" => vec!["sbsa-linux".to_string(), "aarch64-linux".to_string()],
+        _ => vec![],
+    }
+}
+
+/// Returns the path of `cuda.h`: `{toolkit}/include` for standard installs,
+/// or `{toolkit}/targets/<dir>/include` for redistributable layouts.
+fn find_cuda_header() -> Option<PathBuf> {
+    let toolkit = TOOLKIT_ENV_VARS
+        .iter()
+        .find_map(|var| env::var(var).ok())
+        .unwrap_or_else(|| DEFAULT_TOOLKIT_DIR.to_string());
+    let base = Path::new(&toolkit);
+    let mut candidates = vec![base.join("include")];
+    for target_dir in toolkit_target_dirs() {
+        candidates.push(base.join("targets").join(target_dir).join("include"));
+    }
+    candidates
+        .into_iter()
+        .map(|dir| dir.join("cuda.h"))
+        .find(|header| header.is_file())
+}

--- a/cuda-core/src/cudarc_shim.rs
+++ b/cuda-core/src/cudarc_shim.rs
@@ -320,7 +320,7 @@ pub(crate) mod stream {
         arg: *mut c_void,
         sync_mode: ::core::ffi::c_uint,
     ) -> Result<(), DriverError> {
-        cuda_bindings::cuLaunchHostFunc_v2(stream, Some(func), arg, sync_mode).result()
+        cuda_bindings::cu_launch_host_func(stream, Some(func), arg, sync_mode).result()
     }
 
     /// Begins stream capture for graph construction.

--- a/cuda-core/src/error.rs
+++ b/cuda-core/src/error.rs
@@ -17,6 +17,15 @@ use std::{
 pub struct DriverError(pub cuda_bindings::CUresult);
 
 impl DriverError {
+    /// Returns true when the driver cannot JIT the PTX version in a module.
+    ///
+    /// This usually means the selected CUDA toolkit is newer than the
+    /// installed driver. PTX requires direct driver support even when other
+    /// parts of the toolkit can use CUDA minor-version compatibility.
+    pub fn is_unsupported_ptx_version(&self) -> bool {
+        self.0 == cuda_bindings::cudaError_enum_CUDA_ERROR_UNSUPPORTED_PTX_VERSION
+    }
+
     fn _fmt(&self, formatter: &mut Formatter) -> fmt::Result {
         if self.0 == cuda_bindings::cudaError_enum_CUDA_ERROR_SHARED_OBJECT_INIT_FAILED {
             if let Some(load_error) = cuda_bindings::cuda_driver_load_error() {
@@ -28,18 +37,23 @@ impl DriverError {
             }
         }
 
+        let help = "the CUDA driver cannot JIT PTX from the selected toolkit; upgrade the driver \
+                    or select a compatible toolkit with CUDA_TOOLKIT_PATH or CUDA_HOME";
+
+        let mut output = formatter.debug_tuple("DriverError");
+        output.field(&self.0);
         match self.error_string() {
-            Ok(err_str) => formatter
-                .debug_tuple("DriverError")
-                .field(&self.0)
-                .field(&err_str)
-                .finish(),
-            Err(_) => formatter
-                .debug_tuple("DriverError")
-                .field(&self.0)
-                .field(&"<Failure when calling cuGetErrorString()>")
-                .finish(),
+            Ok(err_str) => {
+                output.field(&err_str);
+            }
+            Err(_) => {
+                output.field(&"<Failure when calling cuGetErrorString()>");
+            }
         }
+        if self.is_unsupported_ptx_version() {
+            output.field(&help);
+        }
+        output.finish()
     }
 }
 
@@ -115,6 +129,16 @@ impl DriverError {
 #[cfg(test)]
 mod tests {
     use super::DriverError;
+
+    #[test]
+    fn identifies_unsupported_ptx_version() {
+        let unsupported =
+            DriverError(cuda_bindings::cudaError_enum_CUDA_ERROR_UNSUPPORTED_PTX_VERSION);
+        let unrelated = DriverError(cuda_bindings::cudaError_enum_CUDA_ERROR_INVALID_VALUE);
+
+        assert!(unsupported.is_unsupported_ptx_version());
+        assert!(!unrelated.is_unsupported_ptx_version());
+    }
 
     #[test]
     fn shared_object_init_failed_includes_loader_error_when_driver_is_missing() {

--- a/cuda-core/src/lib.rs
+++ b/cuda-core/src/lib.rs
@@ -5,15 +5,35 @@
 
 //! Low-level CUDA driver API bindings and safe wrappers.
 
+#![cfg_attr(feature = "f16", feature(f16))]
+
 mod api;
 pub(crate) mod cudarc_shim;
 mod dtype;
 mod error;
 mod runtime;
+pub mod simt;
+pub mod vmm;
 
 pub use api::*;
 pub use cuda_bindings as sys;
 pub use dtype::*;
 pub use error::*;
 pub use runtime::*;
-pub mod vmm;
+
+// The cuda-oxide surface, re-exported at the root where its consumers
+// expect it. `simt::LaunchConfig` and `simt::vmm` are deliberately absent:
+// they collide with this crate's own `LaunchConfig` and with the reviewed
+// `vmm` module above (both forks of the same cuda-oxide ancestor), and stay
+// reachable only through `simt::`.
+pub use simt::embedded;
+pub use simt::{
+    launch_kernel_cooperative, launch_kernel_cooperative_on_stream, launch_kernel_ex,
+    launch_kernel_ex_cooperative, launch_kernel_ex_cooperative_on_stream,
+    launch_kernel_ex_on_stream, launch_kernel_on_stream, BlockRequirement, ConstantHandle,
+    ContextLimit, CudaContext, CudaEvent, CudaFunction, CudaModule, CudaStream, DeviceBuffer,
+    DeviceCopy, DeviceLaunchLimits, DynamicSharedMemoryRequirement, EmbeddedModule,
+    EmbeddedModuleError, KernelLaunchConfig, KernelLaunchContract, LaunchAxis, LaunchConfig1D,
+    LaunchConfig2D, LaunchConfig3D, LaunchContractError, LaunchContractSpec, LaunchDimension,
+    PinnedHostBuffer, PreparedLaunch, StreamPriorityRange, SyncPolicy,
+};

--- a/cuda-core/src/simt/context.rs
+++ b/cuda-core/src/simt/context.rs
@@ -1,0 +1,773 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! CUDA context management (primary context, RAII).
+//!
+//! [`CudaContext`] retains the **primary context** for a given device ordinal
+//! via `cuDevicePrimaryCtxRetain` and releases it on [`Drop`]. The primary
+//! context is shared across the process; multiple `CudaContext` instances for
+//! the same device share the same underlying `CUcontext`.
+//!
+//! # Thread binding
+//!
+//! CUDA driver calls are context-scoped and thread-local. [`CudaContext`]
+//! transparently calls `cuCtxSetCurrent` before any driver operation, so
+//! callers do not need to manage the context stack manually.
+
+use crate::error::{DriverError, IntoResult};
+use crate::simt::launch::DeviceLaunchLimits;
+use crate::simt::stream::CudaStream;
+use std::ffi::c_int;
+use std::mem::MaybeUninit;
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicUsize, Ordering};
+use std::sync::Arc;
+
+/// Owns a reference to a CUDA device's primary context.
+///
+/// Created via [`CudaContext::new`] and typically held in an `Arc` so streams,
+/// events, and modules can share the same context. Dropping the last reference
+/// releases the primary context (`cuDevicePrimaryCtxRelease`).
+///
+/// Tracks live stream count and accumulated error state atomically for
+/// cross-thread diagnostics.
+#[derive(Debug)]
+pub struct CudaContext {
+    /// Raw CUDA device handle (`CUdevice`).
+    pub(crate) cu_device: cuda_bindings::CUdevice,
+    /// Raw CUDA context handle (`CUcontext`). Set to null on drop.
+    pub(crate) cu_ctx: cuda_bindings::CUcontext,
+    /// Zero-based device ordinal passed to [`CudaContext::new`].
+    pub(crate) ordinal: usize,
+    /// Number of live [`CudaStream`] instances sharing this context.
+    pub(crate) num_streams: AtomicUsize,
+    /// When `true`, the first [`new_stream`](CudaContext::new_stream) call
+    /// synchronizes the context to establish a clean ordering baseline.
+    pub(crate) event_tracking: AtomicBool,
+    /// Sticky error state recorded by [`record_err`](CudaContext::record_err).
+    /// Stores the raw `CUresult` value, or `0` if no error.
+    pub(crate) error_state: AtomicU32,
+}
+
+/// # Safety
+///
+/// `CUdevice` and `CUcontext` are process-wide handles. All mutable state
+/// (`num_streams`, `event_tracking`, `error_state`) uses atomics. The CUDA
+/// driver itself is thread-safe for distinct contexts, and the
+/// [`bind_to_thread`](CudaContext::bind_to_thread) mechanism ensures the
+/// correct context is current before each call.
+unsafe impl Send for CudaContext {}
+/// See [`Send`] impl.
+unsafe impl Sync for CudaContext {}
+
+/// Releases the primary context on drop.
+///
+/// Binds the context to the current thread first (required by
+/// `cuDevicePrimaryCtxRelease`). Errors during teardown are recorded via
+/// [`record_err`](CudaContext::record_err) rather than panicking.
+impl Drop for CudaContext {
+    fn drop(&mut self) {
+        self.record_err(self.bind_to_thread());
+        let ctx = std::mem::replace(&mut self.cu_ctx, std::ptr::null_mut());
+        if !ctx.is_null() {
+            self.record_err(unsafe {
+                cuda_bindings::cuDevicePrimaryCtxRelease_v2(self.cu_device).result()
+            });
+        }
+    }
+}
+
+/// Equality is based on device handle, context handle, and ordinal.
+impl PartialEq for CudaContext {
+    fn eq(&self, other: &Self) -> bool {
+        self.cu_device == other.cu_device
+            && self.cu_ctx == other.cu_ctx
+            && self.ordinal == other.ordinal
+    }
+}
+impl Eq for CudaContext {}
+
+/// The device's meaningful stream priorities, from
+/// [`CudaContext::stream_priority_range`].
+///
+/// CUDA orders priorities the opposite way round to intuition: **a lower
+/// number is a higher priority**, so the range runs from
+/// [`greatest`](Self::greatest) up to [`least`](Self::least) and
+/// `greatest <= least` always holds.
+///
+/// A priority outside the range is not refused when a stream is created. The
+/// driver clamps it to the nearest end and reports nothing, so a caller that
+/// wants to know what it will get should ask [`clamp`](Self::clamp) rather
+/// than assume the request survived.
+///
+/// A device without priority support reports `0` for both ends, which
+/// [`is_supported`](Self::is_supported) reads as unsupported. Creating a
+/// stream still succeeds there; every priority simply collapses to the same
+/// one.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct StreamPriorityRange {
+    /// Numerically largest value, the *lowest* priority.
+    least: i32,
+    /// Numerically smallest value, the *highest* priority.
+    greatest: i32,
+}
+
+impl StreamPriorityRange {
+    /// The lowest priority, which is the numerically largest value.
+    pub fn least(&self) -> i32 {
+        self.least
+    }
+
+    /// The highest priority, which is the numerically smallest value.
+    pub fn greatest(&self) -> i32 {
+        self.greatest
+    }
+
+    /// Whether this device implements stream priorities at all.
+    ///
+    /// False when the driver reports `0` for both ends, which is how
+    /// `cuCtxGetStreamPriorityRange` answers on a device without support.
+    /// A device with support always reports a range wider than one value.
+    pub fn is_supported(&self) -> bool {
+        self.least != self.greatest
+    }
+
+    /// Whether `priority` lies inside the range, and so survives stream
+    /// creation unchanged.
+    pub fn contains(&self, priority: i32) -> bool {
+        (self.greatest..=self.least).contains(&priority)
+    }
+
+    /// The value the driver will actually apply for a request of `priority`.
+    ///
+    /// Answers the silent clamp in
+    /// [`CudaContext::new_stream_with_priority`] ahead of the call.
+    pub fn clamp(&self, priority: i32) -> i32 {
+        priority.clamp(self.greatest, self.least)
+    }
+}
+
+/// A per-context device limit (`CU_LIMIT_*`), read with
+/// [`CudaContext::limit`] and written with [`CudaContext::set_limit`].
+///
+/// Every limit is state on the device's **primary** context, so it is shared
+/// by every [`CudaContext`] for that device, by any runtime-API user of the
+/// same device in this process, and across library boundaries. A limit set
+/// here is not scoped to the handle that set it.
+///
+/// The driver is free to clamp or round a request. Read the limit back after
+/// setting it to observe what was actually applied.
+///
+/// # Ordering constraints
+///
+/// [`PrintfFifoSize`](Self::PrintfFifoSize) and
+/// [`MallocHeapSize`](Self::MallocHeapSize) must be set **before the first
+/// kernel launch in the process that uses `printf` or device `malloc`**;
+/// afterwards the driver rejects the write with `CUDA_ERROR_INVALID_VALUE`.
+/// Because the limit lives on the shared primary context, "first launch"
+/// counts launches made through any handle, not just this one.
+///
+/// # Omitted variants
+///
+/// `CU_LIMIT_SHMEM_SIZE`, `CU_LIMIT_CIG_ENABLED` and
+/// `CU_LIMIT_CIG_SHMEM_FALLBACK_ENABLED` are absent. The first two are
+/// query-only, all three concern CIG (graphics-interop) contexts, and none
+/// predates CUDA 12.5, so naming them would need a header probe and a `cfg`
+/// in the manner of `cuda_has_cuEventElapsedTime_v2`. The seven variants
+/// below have been present since CUDA 11 and are the ones
+/// `cuCtxSetLimit`'s own documentation specifies.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ContextLimit {
+    /// Stack size in bytes for each GPU thread (`CU_LIMIT_STACK_SIZE`).
+    ///
+    /// The driver raises this on its own whenever a launched kernel needs a
+    /// larger frame and **does not lower it again**, so a read reflects the
+    /// high-water mark of everything launched in this context so far. The
+    /// reservation scales as roughly `bytes * mp_count * threads_per_mp` and
+    /// is invisible to the allocation APIs: it simply reduces the device
+    /// memory a later allocation can obtain. Lowering it after a deep-frame
+    /// kernel has raised it is how that memory is handed back.
+    StackSize,
+    /// Size in bytes of the FIFO backing the device `printf`
+    /// (`CU_LIMIT_PRINTF_FIFO_SIZE`).
+    ///
+    /// The FIFO is circular: once a launch fills it, the **oldest** output is
+    /// overwritten and lost silently, with no error and no marker in the
+    /// stream the host prints. Raising this is the only fix for a kernel
+    /// whose output is truncated. Subject to the ordering constraint above.
+    PrintfFifoSize,
+    /// Size in bytes of the heap backing device `malloc` and `free`
+    /// (`CU_LIMIT_MALLOC_HEAP_SIZE`). Subject to the ordering constraint
+    /// above.
+    MallocHeapSize,
+    /// Maximum grid nesting depth at which a device-runtime thread may call
+    /// `cudaDeviceSynchronize` (`CU_LIMIT_DEV_RUNTIME_SYNC_DEPTH`).
+    ///
+    /// Applies only to devices of compute capability below 9.0; elsewhere the
+    /// driver returns `CUDA_ERROR_UNSUPPORTED_LIMIT`. Each level of depth
+    /// reserves device memory, so a request the driver cannot back fails with
+    /// `CUDA_ERROR_OUT_OF_MEMORY` and leaves the limit settable at a lower
+    /// value.
+    DevRuntimeSyncDepth,
+    /// Maximum number of outstanding device-runtime launches from this
+    /// context (`CU_LIMIT_DEV_RUNTIME_PENDING_LAUNCH_COUNT`), default 2048.
+    ///
+    /// Reserves device memory in proportion, and fails the same way as
+    /// [`DevRuntimeSyncDepth`](Self::DevRuntimeSyncDepth) when the
+    /// reservation cannot be met.
+    DevRuntimePendingLaunchCount,
+    /// L2 fetch granularity in bytes, 0 to 128
+    /// (`CU_LIMIT_MAX_L2_FETCH_GRANULARITY`). A hint: the platform may ignore
+    /// or clamp it, and a read need not return what was written.
+    MaxL2FetchGranularity,
+    /// Bytes of L2 set aside for persisting lines
+    /// (`CU_LIMIT_PERSISTING_L2_CACHE_SIZE`). A hint, with the same caveat as
+    /// [`MaxL2FetchGranularity`](Self::MaxL2FetchGranularity).
+    PersistingL2CacheSize,
+}
+
+impl ContextLimit {
+    /// Maps to the raw `CUlimit` the driver expects.
+    fn to_raw(self) -> cuda_bindings::CUlimit {
+        match self {
+            ContextLimit::StackSize => cuda_bindings::CUlimit_enum_CU_LIMIT_STACK_SIZE,
+            ContextLimit::PrintfFifoSize => cuda_bindings::CUlimit_enum_CU_LIMIT_PRINTF_FIFO_SIZE,
+            ContextLimit::MallocHeapSize => cuda_bindings::CUlimit_enum_CU_LIMIT_MALLOC_HEAP_SIZE,
+            ContextLimit::DevRuntimeSyncDepth => {
+                cuda_bindings::CUlimit_enum_CU_LIMIT_DEV_RUNTIME_SYNC_DEPTH
+            }
+            ContextLimit::DevRuntimePendingLaunchCount => {
+                cuda_bindings::CUlimit_enum_CU_LIMIT_DEV_RUNTIME_PENDING_LAUNCH_COUNT
+            }
+            ContextLimit::MaxL2FetchGranularity => {
+                cuda_bindings::CUlimit_enum_CU_LIMIT_MAX_L2_FETCH_GRANULARITY
+            }
+            ContextLimit::PersistingL2CacheSize => {
+                cuda_bindings::CUlimit_enum_CU_LIMIT_PERSISTING_L2_CACHE_SIZE
+            }
+        }
+    }
+}
+
+/// Context scheduling policy (`CU_CTX_SCHED_*`), governing how the driver
+/// waits when the calling host thread blocks on GPU work (a stream or
+/// context synchronize).
+///
+/// Set via [`CudaContext::set_sync_policy`], read via
+/// [`CudaContext::sync_policy`]. The trade-off is host CPU against wake
+/// latency: [`Spin`](Self::Spin) burns a full core for the lowest latency,
+/// [`BlockingSync`](Self::BlockingSync) frees the core but wakes later. On a
+/// host with spare cores this trade rarely matters; on a CPU-constrained one
+/// (few physical cores, a sync-heavy pipeline) it can cost double-digit
+/// percentages of host CPU for no wall-clock benefit, which is the case
+/// [`BlockingSync`](Self::BlockingSync) exists to fix.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SyncPolicy {
+    /// Driver-chosen default: spin if the process has more logical CPUs than
+    /// active contexts, otherwise yield.
+    Auto,
+    /// Spin the calling thread while waiting. Lowest latency, highest CPU use.
+    Spin,
+    /// Yield the calling thread's timeslice while waiting.
+    Yield,
+    /// Block the calling thread on a synchronization primitive while
+    /// waiting. Lowest CPU use, highest wake latency.
+    BlockingSync,
+}
+
+impl SyncPolicy {
+    fn to_raw(self) -> cuda_bindings::CUctx_flags_enum {
+        match self {
+            SyncPolicy::Auto => cuda_bindings::CUctx_flags_enum_CU_CTX_SCHED_AUTO,
+            SyncPolicy::Spin => cuda_bindings::CUctx_flags_enum_CU_CTX_SCHED_SPIN,
+            SyncPolicy::Yield => cuda_bindings::CUctx_flags_enum_CU_CTX_SCHED_YIELD,
+            SyncPolicy::BlockingSync => cuda_bindings::CUctx_flags_enum_CU_CTX_SCHED_BLOCKING_SYNC,
+        }
+    }
+
+    /// Decodes the scheduling bits (`CU_CTX_SCHED_MASK`) out of a raw flags
+    /// word. `None` for a driver-reserved combination this enum does not
+    /// name (the mask is 3 bits wide; only 4 of 8 values are assigned today).
+    fn from_raw(raw: cuda_bindings::CUctx_flags_enum) -> Option<Self> {
+        match raw & cuda_bindings::CUctx_flags_enum_CU_CTX_SCHED_MASK {
+            cuda_bindings::CUctx_flags_enum_CU_CTX_SCHED_AUTO => Some(SyncPolicy::Auto),
+            cuda_bindings::CUctx_flags_enum_CU_CTX_SCHED_SPIN => Some(SyncPolicy::Spin),
+            cuda_bindings::CUctx_flags_enum_CU_CTX_SCHED_YIELD => Some(SyncPolicy::Yield),
+            cuda_bindings::CUctx_flags_enum_CU_CTX_SCHED_BLOCKING_SYNC => {
+                Some(SyncPolicy::BlockingSync)
+            }
+            _ => None,
+        }
+    }
+}
+
+impl CudaContext {
+    fn device_attribute(
+        &self,
+        attribute: cuda_bindings::CUdevice_attribute,
+    ) -> Result<u32, DriverError> {
+        self.bind_to_thread()?;
+        let mut value = MaybeUninit::uninit();
+        unsafe {
+            cuda_bindings::cuDeviceGetAttribute(value.as_mut_ptr(), attribute, self.cu_device)
+                .result()?;
+            u32::try_from(value.assume_init())
+                .map_err(|_| DriverError(cuda_bindings::cudaError_enum_CUDA_ERROR_INVALID_VALUE))
+        }
+    }
+
+    /// Creates a new context for the device at `ordinal`.
+    ///
+    /// Calls [`cuInit`](crate::init), obtains the device handle, retains the
+    /// primary context, and binds it to the calling thread. Returns the context
+    /// wrapped in an `Arc` for shared ownership across streams, events, and
+    /// modules.
+    pub fn new(ordinal: usize) -> Result<Arc<Self>, DriverError> {
+        unsafe { crate::init(0)? };
+
+        let cu_device = unsafe {
+            let mut cu_device = MaybeUninit::uninit();
+            cuda_bindings::cuDeviceGet(cu_device.as_mut_ptr(), ordinal as c_int).result()?;
+            cu_device.assume_init()
+        };
+
+        let cu_ctx = unsafe {
+            let mut cu_ctx = MaybeUninit::uninit();
+            cuda_bindings::cuDevicePrimaryCtxRetain(cu_ctx.as_mut_ptr(), cu_device).result()?;
+            cu_ctx.assume_init()
+        };
+
+        let ctx = Arc::new(CudaContext {
+            cu_device,
+            cu_ctx,
+            ordinal,
+            num_streams: AtomicUsize::new(0),
+            event_tracking: AtomicBool::new(true),
+            error_state: AtomicU32::new(0),
+        });
+        ctx.bind_to_thread()?;
+        Ok(ctx)
+    }
+
+    /// Returns the zero-based device ordinal.
+    pub fn ordinal(&self) -> usize {
+        self.ordinal
+    }
+
+    /// Returns the raw `CUdevice` handle.
+    pub fn cu_device(&self) -> cuda_bindings::CUdevice {
+        self.cu_device
+    }
+
+    /// Returns the raw `CUcontext` handle.
+    pub fn cu_ctx(&self) -> cuda_bindings::CUcontext {
+        self.cu_ctx
+    }
+
+    /// Binds this context to the calling thread if not already current.
+    ///
+    /// Checks [`check_err`](Self::check_err) first and propagates any sticky
+    /// error. Skips the `cuCtxSetCurrent` call when the context is already
+    /// bound, avoiding an unnecessary driver round-trip.
+    ///
+    /// Most methods on [`CudaStream`], [`CudaEvent`](crate::CudaEvent), and
+    /// [`CudaModule`](crate::CudaModule) call this internally.
+    ///
+    /// CUcontext is the backing runtime object, and CUmodule / CUfunction / CUstream
+    /// are opaque handles to objects created under that context. bind_to_thread()
+    /// makes that context, the one, the current host thread is operating against.
+    /// If the thread is currently bound to some other context, using those handles
+    /// can fail.
+    pub fn bind_to_thread(&self) -> Result<(), DriverError> {
+        self.check_err()?;
+        let mut current = MaybeUninit::uninit();
+        unsafe {
+            cuda_bindings::cuCtxGetCurrent(current.as_mut_ptr()).result()?;
+            let current = current.assume_init();
+            if current.is_null() || current != self.cu_ctx {
+                cuda_bindings::cuCtxSetCurrent(self.cu_ctx).result()?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Blocks the calling thread until all preceding work in this context
+    /// completes.
+    ///
+    /// Binds the context first, then calls `cuCtxSynchronize`.
+    pub fn synchronize(&self) -> Result<(), DriverError> {
+        self.bind_to_thread()?;
+        unsafe { cuda_bindings::cuCtxSynchronize() }.result()
+    }
+
+    /// Returns a handle to the per-context default stream (stream `0`).
+    ///
+    /// The default stream implicitly synchronizes with all blocking streams in
+    /// the same context. The returned [`CudaStream`] holds a null `CUstream`
+    /// pointer, which the driver interprets as the default stream.
+    pub fn default_stream(self: &Arc<Self>) -> Arc<CudaStream> {
+        Arc::new(CudaStream {
+            cu_stream: std::ptr::null_mut(),
+            ctx: self.clone(),
+        })
+    }
+
+    /// Creates a new non-blocking stream in this context.
+    ///
+    /// The stream is created with `CU_STREAM_NON_BLOCKING`, so it does not
+    /// implicitly synchronize with the default stream.
+    ///
+    /// On the first call (when `num_streams` transitions from 0 to 1), the
+    /// context is synchronized to establish a clean ordering baseline if
+    /// `event_tracking` is enabled.
+    pub fn new_stream(self: &Arc<Self>) -> Result<Arc<CudaStream>, DriverError> {
+        self.create_stream(None)
+    }
+
+    /// Creates a new non-blocking stream at `priority` in this context.
+    ///
+    /// As [`new_stream`](Self::new_stream), with the stream created through
+    /// `cuStreamCreateWithPriority`.
+    ///
+    /// **Lower numbers are higher priorities**, and a value outside the
+    /// device's range is **clamped silently** to the nearest end of it rather
+    /// than refused, so passing [`i32::MIN`] yields the greatest priority the
+    /// device supports and reports nothing. Read
+    /// [`CudaStream::priority`] back to see what the driver applied, or
+    /// consult [`stream_priority_range`](Self::stream_priority_range) first.
+    ///
+    /// Priority orders **compute kernels only**. Host-to-device and
+    /// device-to-host transfers are unaffected, so a high-priority stream does
+    /// not jump a queue of copies. On a device without priority support every
+    /// priority collapses to the single value 0 and the stream still works.
+    pub fn new_stream_with_priority(
+        self: &Arc<Self>,
+        priority: i32,
+    ) -> Result<Arc<CudaStream>, DriverError> {
+        self.create_stream(Some(priority))
+    }
+
+    /// Shared body of [`new_stream`](Self::new_stream) and
+    /// [`new_stream_with_priority`](Self::new_stream_with_priority).
+    ///
+    /// `None` takes `cuStreamCreate`, which is what the driver documents as
+    /// equivalent to a priority of 0, rather than passing 0 explicitly: on a
+    /// device whose range does not contain 0 those are different requests.
+    fn create_stream(
+        self: &Arc<Self>,
+        priority: Option<i32>,
+    ) -> Result<Arc<CudaStream>, DriverError> {
+        self.bind_to_thread()?;
+        let prev = self.num_streams.fetch_add(1, Ordering::Relaxed);
+        if prev == 0 && self.event_tracking.load(Ordering::Relaxed) {
+            self.synchronize()?;
+        }
+        let flags = cuda_bindings::CUstream_flags_enum_CU_STREAM_NON_BLOCKING;
+        let mut cu_stream = MaybeUninit::uninit();
+        let cu_stream = unsafe {
+            match priority {
+                Some(priority) => cuda_bindings::cuStreamCreateWithPriority(
+                    cu_stream.as_mut_ptr(),
+                    flags,
+                    priority,
+                ),
+                None => cuda_bindings::cuStreamCreate(cu_stream.as_mut_ptr(), flags),
+            }
+            .result()?;
+            cu_stream.assume_init()
+        };
+        Ok(Arc::new(CudaStream {
+            cu_stream,
+            ctx: self.clone(),
+        }))
+    }
+
+    /// Returns the device's meaningful stream priority range.
+    ///
+    /// Wraps `cuCtxGetStreamPriorityRange`. See [`StreamPriorityRange`] for
+    /// the ordering convention and for what a device without priority support
+    /// reports.
+    pub fn stream_priority_range(&self) -> Result<StreamPriorityRange, DriverError> {
+        self.bind_to_thread()?;
+        let mut least = MaybeUninit::uninit();
+        let mut greatest = MaybeUninit::uninit();
+        unsafe {
+            cuda_bindings::cuCtxGetStreamPriorityRange(least.as_mut_ptr(), greatest.as_mut_ptr())
+                .result()?;
+            Ok(StreamPriorityRange {
+                least: least.assume_init(),
+                greatest: greatest.assume_init(),
+            })
+        }
+    }
+
+    /// Queries the device's marketing name (e.g. `"NVIDIA GeForce RTX 5090"`).
+    ///
+    /// Wraps `cuDeviceGetName` with a 256-byte buffer (driver guarantees
+    /// the name fits in 256 bytes including the trailing NUL). Returns the
+    /// decoded UTF-8 string with any trailing NULs stripped.
+    pub fn device_name(&self) -> Result<String, DriverError> {
+        self.bind_to_thread()?;
+        let mut buf = [0; 256];
+        unsafe {
+            cuda_bindings::cuDeviceGetName(buf.as_mut_ptr(), buf.len() as c_int, self.cu_device)
+                .result()?;
+        }
+        let bytes: Vec<u8> = buf
+            .iter()
+            .take_while(|&&c| c != 0)
+            .map(|&c| c as u8)
+            .collect();
+        Ok(String::from_utf8_lossy(&bytes).into_owned())
+    }
+
+    /// Queries the compute capability (SM version) of the device.
+    ///
+    /// Returns `(major, minor)` -- e.g. `(9, 0)` for Hopper H100.
+    pub fn compute_capability(&self) -> Result<(i32, i32), DriverError> {
+        self.bind_to_thread()?;
+        let mut major = MaybeUninit::uninit();
+        let mut minor = MaybeUninit::uninit();
+        unsafe {
+            cuda_bindings::cuDeviceGetAttribute(
+                major.as_mut_ptr(),
+                cuda_bindings::CUdevice_attribute_enum_CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR,
+                self.cu_device,
+            )
+            .result()?;
+            cuda_bindings::cuDeviceGetAttribute(
+                minor.as_mut_ptr(),
+                cuda_bindings::CUdevice_attribute_enum_CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR,
+                self.cu_device,
+            )
+            .result()?;
+            Ok((major.assume_init(), minor.assume_init()))
+        }
+    }
+
+    /// Queries dimension, thread-count, and portable shared-memory launch
+    /// limits for this device.
+    ///
+    /// Cooperative and cluster capabilities are deliberately not queried
+    /// here. Typed launch preparation asks for those newer attributes only
+    /// when the kernel contract requires the corresponding launch mode.
+    pub fn launch_limits(&self) -> Result<DeviceLaunchLimits, DriverError> {
+        Ok(DeviceLaunchLimits {
+            max_threads_per_block: self.device_attribute(
+                cuda_bindings::CUdevice_attribute_enum_CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK,
+            )?,
+            max_block_dim: (
+                self.device_attribute(
+                    cuda_bindings::CUdevice_attribute_enum_CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_X,
+                )?,
+                self.device_attribute(
+                    cuda_bindings::CUdevice_attribute_enum_CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_Y,
+                )?,
+                self.device_attribute(
+                    cuda_bindings::CUdevice_attribute_enum_CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_Z,
+                )?,
+            ),
+            max_grid_dim: (
+                self.device_attribute(
+                    cuda_bindings::CUdevice_attribute_enum_CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_X,
+                )?,
+                self.device_attribute(
+                    cuda_bindings::CUdevice_attribute_enum_CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_Y,
+                )?,
+                self.device_attribute(
+                    cuda_bindings::CUdevice_attribute_enum_CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_Z,
+                )?,
+            ),
+            max_shared_memory_per_block: self.device_attribute(
+                cuda_bindings::CUdevice_attribute_enum_CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK,
+            )?,
+        })
+    }
+
+    /// Queries the non-portable opt-in shared-memory limit per block.
+    ///
+    /// Typed launch preparation calls this only when static plus dynamic
+    /// shared memory exceeds the portable limit.
+    pub fn max_opt_in_shared_memory_per_block(&self) -> Result<u32, DriverError> {
+        self.device_attribute(
+            cuda_bindings::CUdevice_attribute_enum_CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN,
+        )
+    }
+
+    /// Returns whether this device supports cooperative kernel launches.
+    pub fn supports_cooperative_launch(&self) -> Result<bool, DriverError> {
+        self.device_attribute(
+            cuda_bindings::CUdevice_attribute_enum_CU_DEVICE_ATTRIBUTE_COOPERATIVE_LAUNCH,
+        )
+        .map(|value| value != 0)
+    }
+
+    /// Returns whether this device supports thread-block cluster launches.
+    pub fn supports_cluster_launch(&self) -> Result<bool, DriverError> {
+        self.device_attribute(
+            cuda_bindings::CUdevice_attribute_enum_CU_DEVICE_ATTRIBUTE_CLUSTER_LAUNCH,
+        )
+        .map(|value| value != 0)
+    }
+
+    /// Returns the number of streaming multiprocessors on this device.
+    pub fn multiprocessor_count(&self) -> Result<u32, DriverError> {
+        self.device_attribute(
+            cuda_bindings::CUdevice_attribute_enum_CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT,
+        )
+    }
+
+    /// Returns the maximum number of threads resident on one streaming
+    /// multiprocessor.
+    ///
+    /// Together with [`multiprocessor_count`](Self::multiprocessor_count) this
+    /// gives the thread count that
+    /// [`set_stack_size`](Self::set_stack_size) multiplies against.
+    pub fn max_threads_per_multiprocessor(&self) -> Result<u32, DriverError> {
+        self.device_attribute(
+            cuda_bindings::CUdevice_attribute_enum_CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_MULTIPROCESSOR,
+        )
+    }
+
+    /// Reads a device limit off this context.
+    ///
+    /// Wraps `cuCtxGetLimit`. See [`ContextLimit`] for what each limit means,
+    /// which of them the driver treats as a hint, and why the value read back
+    /// need not equal the value written.
+    pub fn limit(&self, limit: ContextLimit) -> Result<usize, DriverError> {
+        self.bind_to_thread()?;
+        let mut value = MaybeUninit::uninit();
+        unsafe {
+            cuda_bindings::cuCtxGetLimit(value.as_mut_ptr(), limit.to_raw()).result()?;
+            Ok(value.assume_init())
+        }
+    }
+
+    /// Writes a device limit on this context.
+    ///
+    /// Wraps `cuCtxSetLimit`. The limit is state on the device's primary
+    /// context and therefore shared process-wide; see [`ContextLimit`] for the
+    /// per-limit restrictions, including the launch-ordering constraint on
+    /// [`PrintfFifoSize`](ContextLimit::PrintfFifoSize) and
+    /// [`MallocHeapSize`](ContextLimit::MallocHeapSize).
+    ///
+    /// The driver may clamp or round the request, so call
+    /// [`limit`](Self::limit) afterwards to observe what was applied. A write
+    /// takes effect immediately and may block until previously submitted work
+    /// completes.
+    pub fn set_limit(&self, limit: ContextLimit, value: usize) -> Result<(), DriverError> {
+        self.bind_to_thread()?;
+        unsafe { cuda_bindings::cuCtxSetLimit(limit.to_raw(), value) }.result()
+    }
+
+    /// Queries the per-thread device stack size, in bytes.
+    ///
+    /// Equivalent to [`limit`](Self::limit) with
+    /// [`ContextLimit::StackSize`], whose documentation describes how the
+    /// driver maintains this value.
+    pub fn stack_size(&self) -> Result<usize, DriverError> {
+        self.limit(ContextLimit::StackSize)
+    }
+
+    /// Sets the per-thread device stack size, in bytes.
+    ///
+    /// Equivalent to [`set_limit`](Self::set_limit) with
+    /// [`ContextLimit::StackSize`]. The driver reserves `bytes` for *every*
+    /// thread that can be resident on the device, so the reservation scales as
+    /// roughly `bytes * mp_count * threads_per_mp`, using
+    /// [`multiprocessor_count`](Self::multiprocessor_count) and
+    /// [`max_threads_per_multiprocessor`](Self::max_threads_per_multiprocessor).
+    ///
+    /// CUDA may clamp or round the request; call
+    /// [`stack_size`](Self::stack_size) afterwards to observe what the driver
+    /// actually applied. The call takes effect immediately and may block until
+    /// previously submitted work completes.
+    pub fn set_stack_size(&self, bytes: usize) -> Result<(), DriverError> {
+        self.set_limit(ContextLimit::StackSize, bytes)
+    }
+
+    /// Sets the context's scheduling policy (`CU_CTX_SCHED_*`).
+    ///
+    /// Wraps `cuDevicePrimaryCtxSetFlags_v2`, scoped to this context's
+    /// device rather than `cuCtxSetFlags`'s "whatever is current on this
+    /// thread": [`CudaContext`] retains and owns a specific device's primary
+    /// context, so the device-scoped call is the one that matches what this
+    /// type actually holds. Read-modify-write: only the 3 scheduling bits
+    /// (`CU_CTX_SCHED_MASK`) are replaced, any other flag bit the process has
+    /// set independently (e.g. `CU_CTX_MAP_HOST`) is preserved.
+    ///
+    /// The policy is process-wide state on the device's primary context:
+    /// it affects every [`CudaContext`] clone of this device, and any
+    /// runtime-API user of the same device in this process, not just this
+    /// handle. The read-modify-write over `CU_CTX_SCHED_MASK` is also not
+    /// atomic: a concurrent flag writer on the same device can interleave
+    /// between the get and the set, and one side's update is then lost.
+    ///
+    /// Historical note: before CUDA 11, `cuDevicePrimaryCtxSetFlags` failed
+    /// with `CUDA_ERROR_PRIMARY_CONTEXT_ACTIVE` once the primary context was
+    /// active. That restriction was lifted; the flags now apply to the
+    /// already-active context.
+    pub fn set_sync_policy(&self, policy: SyncPolicy) -> Result<(), DriverError> {
+        self.bind_to_thread()?;
+        unsafe {
+            let mut current = MaybeUninit::uninit();
+            let mut active = MaybeUninit::uninit();
+            cuda_bindings::cuDevicePrimaryCtxGetState(
+                self.cu_device,
+                current.as_mut_ptr(),
+                active.as_mut_ptr(),
+            )
+            .result()?;
+            let current = current.assume_init();
+            let new_flags =
+                (current & !cuda_bindings::CUctx_flags_enum_CU_CTX_SCHED_MASK) | policy.to_raw();
+            cuda_bindings::cuDevicePrimaryCtxSetFlags_v2(self.cu_device, new_flags).result()
+        }
+    }
+
+    /// Returns the context's current scheduling policy (`CU_CTX_SCHED_*`).
+    ///
+    /// `None` if the driver reports a scheduling value this enum does not
+    /// name (see [`SyncPolicy::from_raw`](SyncPolicy) -- the mask has more
+    /// bit patterns than the driver assigns meanings to today).
+    pub fn sync_policy(&self) -> Result<Option<SyncPolicy>, DriverError> {
+        self.bind_to_thread()?;
+        unsafe {
+            let mut flags = MaybeUninit::uninit();
+            let mut active = MaybeUninit::uninit();
+            cuda_bindings::cuDevicePrimaryCtxGetState(
+                self.cu_device,
+                flags.as_mut_ptr(),
+                active.as_mut_ptr(),
+            )
+            .result()?;
+            Ok(SyncPolicy::from_raw(flags.assume_init()))
+        }
+    }
+
+    /// Atomically reads and clears the sticky error state.
+    ///
+    /// Returns `Ok(())` if no error was recorded, or the stored
+    /// [`DriverError`] otherwise. The error is cleared after this call.
+    pub fn check_err(&self) -> Result<(), DriverError> {
+        let error_state = self.error_state.swap(0, Ordering::Relaxed);
+        if error_state == 0 {
+            Ok(())
+        } else {
+            Err(DriverError(error_state))
+        }
+    }
+
+    /// Records a driver error into the sticky error state.
+    ///
+    /// Used during [`Drop`] paths where returning a `Result` is not possible.
+    /// If `result` is `Err`, the raw error code is stored; subsequent
+    /// [`check_err`](Self::check_err) or [`bind_to_thread`](Self::bind_to_thread)
+    /// calls will surface it. A later store overwrites an earlier one.
+    pub fn record_err<T>(&self, result: Result<T, DriverError>) {
+        if let Err(err) = result {
+            self.error_state.store(err.0, Ordering::Relaxed)
+        }
+    }
+}

--- a/cuda-core/src/simt/device_buffer.rs
+++ b/cuda-core/src/simt/device_buffer.rs
@@ -1,0 +1,990 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Owning device memory buffer with ergonomic host-device transfer methods.
+//!
+//! [`DeviceBuffer<T>`] is analogous to `Vec<T>` on the host: it owns a
+//! contiguous allocation of `len` elements on the device and frees it on
+//! drop. The stream is an explicit parameter on every transfer operation,
+//! making data-flow and synchronization transparent. Buffers allocated with
+//! [`DeviceBuffer::uninitialized_async`] retain their allocation stream for
+//! deallocation.
+//!
+//! Ordinary drop synchronizes the context before freeing an asynchronous
+//! allocation, because safe operations may have submitted work using the
+//! buffer on any stream in that context. The unsafe
+//! [`DeviceBuffer::drop_async`] avoids that host-side synchronization by
+//! freeing on a chosen stream; its caller takes over the obligation to
+//! order every other stream that uses the buffer before that stream.
+//!
+//! # Quick start
+//!
+//! ```ignore
+//! let a_dev = DeviceBuffer::from_host(&stream, &a_host)?;
+//! let c_dev = DeviceBuffer::<f32>::zeroed(&stream, N)?;
+//! // ... kernel launch ...
+//! let c_host = c_dev.to_host_vec(&stream)?;
+//! ```
+
+use std::marker::PhantomData;
+use std::mem::MaybeUninit;
+use std::num::Wrapping;
+use std::sync::Arc;
+
+use cuda_bindings::CUdeviceptr;
+
+use crate::error::DriverError;
+use crate::simt::context::CudaContext;
+use crate::simt::pinned_host_buffer::PinnedHostBuffer;
+use crate::simt::stream::CudaStream;
+
+/// Marker trait for values that can be safely copied between host and device
+/// memory as raw bytes.
+///
+/// Types implementing `DeviceCopy` must not contain Rust-owned allocations,
+/// references, or other values whose validity depends on host-side ownership or
+/// drop semantics. This is the device-memory equivalent of a plain-old-data
+/// contract.
+///
+/// # Safety
+///
+/// Implementors must be safe to duplicate with a byte-for-byte copy. Values
+/// copied back from device memory must have a bit pattern that is valid for
+/// `Self`, and the all-zero bit pattern must also be valid because
+/// [`DeviceBuffer::zeroed`] initializes memory with zero bytes.
+///
+/// `Copy` alone is not enough: types such as `bool`, `char`, and
+/// `NonZeroU32` are `Copy`, but not every byte pattern is a valid value of
+/// those types. `DeviceCopy` is the stronger promise required when
+/// `DeviceBuffer` turns raw device bytes back into initialized Rust values.
+pub unsafe trait DeviceCopy: Copy {}
+
+macro_rules! impl_device_copy {
+    ($($ty:ty),+ $(,)?) => {
+        $(
+            unsafe impl DeviceCopy for $ty {}
+        )+
+    };
+}
+
+impl_device_copy!(
+    (),
+    i8,
+    i16,
+    i32,
+    i64,
+    i128,
+    isize,
+    u8,
+    u16,
+    u32,
+    u64,
+    u128,
+    usize,
+    f32,
+    f64
+);
+
+unsafe impl<T: DeviceCopy, const N: usize> DeviceCopy for [T; N] {}
+unsafe impl<T: ?Sized> DeviceCopy for *const T {}
+unsafe impl<T: ?Sized> DeviceCopy for *mut T {}
+
+// Wrapper types that don't change the byte representation: a value of the
+// wrapper has the same layout and validity invariants as the inner `T`.
+// `PhantomData<T>` is a zero-sized marker -- always trivially copyable
+// regardless of `T`. `MaybeUninit<T>` accepts any bit pattern by design.
+// `Wrapping<T>` is a `#[repr(transparent)]` newtype.
+unsafe impl<T: ?Sized> DeviceCopy for PhantomData<T> {}
+unsafe impl<T: DeviceCopy> DeviceCopy for MaybeUninit<T> {}
+unsafe impl<T: DeviceCopy> DeviceCopy for Wrapping<T> {}
+
+macro_rules! impl_device_copy_tuple {
+    ($($name:ident),+ $(,)?) => {
+        unsafe impl<$($name: DeviceCopy),+> DeviceCopy for ($($name,)+) {}
+    };
+}
+
+impl_device_copy_tuple!(A);
+impl_device_copy_tuple!(A, B);
+impl_device_copy_tuple!(A, B, C);
+impl_device_copy_tuple!(A, B, C, D);
+impl_device_copy_tuple!(A, B, C, D, E);
+impl_device_copy_tuple!(A, B, C, D, E, F);
+impl_device_copy_tuple!(A, B, C, D, E, F, G);
+impl_device_copy_tuple!(A, B, C, D, E, F, G, H);
+
+#[cfg(feature = "f16")]
+unsafe impl DeviceCopy for f16 {}
+unsafe impl DeviceCopy for half::bf16 {}
+unsafe impl DeviceCopy for half::f16 {}
+
+/// Owning handle to a contiguous device allocation of `T` elements.
+///
+/// Holds a raw device pointer, element count, and a reference-counted
+/// context that keeps the CUDA context alive. Synchronous allocations are
+/// freed with `cuMemFree`. Dropping a stream-ordered allocation synchronizes
+/// its context before enqueueing `cuMemFreeAsync` on its retained allocation
+/// stream. Use the unsafe [`DeviceBuffer::drop_async`] when the caller can
+/// provide explicit stream ordering and must avoid that context-wide
+/// synchronization.
+///
+/// Device buffers may only transfer plain device-copyable values. Owning host
+/// types such as [`String`] are rejected because copying their bytes to and
+/// from device memory would not preserve Rust ownership invariants.
+///
+/// ```compile_fail
+/// # use cuda_core::{CudaStream, DeviceBuffer};
+/// # fn rejects_non_device_copy(stream: &CudaStream) {
+/// let _ = DeviceBuffer::<String>::zeroed(stream, 1);
+/// # }
+/// ```
+pub struct DeviceBuffer<T> {
+    ptr: CUdeviceptr,
+    len: usize,
+    num_bytes: usize,
+    ctx: Arc<CudaContext>,
+    /// Retains the allocation stream for a stream-ordered (`cuMemAllocAsync`)
+    /// allocation. Ordinary `Drop` first synchronizes the context so work
+    /// submitted on any stream has completed, then frees on this stream.
+    /// `None` identifies a synchronous (`cuMemAlloc`) allocation.
+    dealloc_stream: Option<Arc<CudaStream>>,
+    _marker: PhantomData<T>,
+}
+
+// SAFETY: CUdeviceptr is a u64 handle valid across threads when the owning
+// context is bound. The PhantomData<T> is Send if T is Send.
+unsafe impl<T: Send> Send for DeviceBuffer<T> {}
+// SAFETY: &DeviceBuffer only exposes cu_deviceptr() and len(), both of which
+// return Copy values. No interior mutability.
+unsafe impl<T: Send + Sync> Sync for DeviceBuffer<T> {}
+
+impl<T> Drop for DeviceBuffer<T> {
+    fn drop(&mut self) {
+        if self.ptr != 0 {
+            self.ctx.record_err(self.ctx.bind_to_thread());
+            // Safe buffer operations can enqueue work on any stream in this
+            // context. Synchronize all of them before implicitly freeing a
+            // stream-ordered allocation.
+            let result = match &self.dealloc_stream {
+                Some(stream) => match self.ctx.synchronize() {
+                    Ok(()) => unsafe {
+                        crate::simt::memory::free_async(self.ptr, stream.cu_stream())
+                    },
+                    Err(error) => Err(error),
+                },
+                None => unsafe { crate::simt::memory::free_sync(self.ptr) },
+            };
+            self.ctx.record_err(result);
+        }
+    }
+}
+
+impl<T> DeviceBuffer<T> {
+    /// Returns the raw `CUdeviceptr` for use in kernel argument lists.
+    #[inline]
+    pub fn cu_deviceptr(&self) -> CUdeviceptr {
+        self.ptr
+    }
+
+    /// Number of `T` elements in the buffer.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Returns `true` if the buffer has zero elements.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Total size in bytes (`len * size_of::<T>()`).
+    #[inline]
+    pub fn num_bytes(&self) -> usize {
+        self.num_bytes
+    }
+
+    /// Returns a reference to the owning context.
+    #[inline]
+    pub fn context(&self) -> &Arc<CudaContext> {
+        &self.ctx
+    }
+
+    /// Constructs a `DeviceBuffer` from pre-existing raw parts.
+    ///
+    /// # Safety
+    ///
+    /// - `ptr` must have been allocated via `cuMemAlloc*` with at least
+    ///   `len * size_of::<T>()` bytes.
+    /// - `ptr` must belong to the same CUDA context as `ctx`.
+    /// - The caller transfers ownership -- `ptr` will be freed on drop.
+    /// - `ptr` is assumed to be a synchronous (`cuMemAlloc`) allocation and is
+    ///   freed with the synchronous `cuMemFree` on drop. Do not pass a
+    ///   stream-ordered (`cuMemAllocAsync`) pointer here.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `len * size_of::<T>()` overflows `usize`.
+    pub unsafe fn from_raw_parts(ptr: CUdeviceptr, len: usize, ctx: Arc<CudaContext>) -> Self {
+        // SAFETY: `from_raw_parts` has the same raw-allocation safety contract,
+        // with no stream-ordered deallocation metadata attached.
+        unsafe { Self::from_raw_parts_with_dealloc_stream(ptr, len, ctx, None) }
+    }
+
+    unsafe fn from_raw_parts_with_dealloc_stream(
+        ptr: CUdeviceptr,
+        len: usize,
+        ctx: Arc<CudaContext>,
+        dealloc_stream: Option<Arc<CudaStream>>,
+    ) -> Self {
+        let num_bytes =
+            allocation_size::<T>(len).expect("DeviceBuffer::from_raw_parts byte size overflow");
+        Self {
+            ptr,
+            len,
+            num_bytes,
+            ctx,
+            dealloc_stream,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Consumes the buffer and returns the raw parts without freeing.
+    ///
+    /// The caller is responsible for eventually freeing `ptr` with the
+    /// allocator that matches how it was created. For stream-ordered
+    /// allocations, this does not return the stored deallocation stream; the
+    /// caller must already know which stream to use for `cuMemFreeAsync`.
+    pub fn into_raw_parts(self) -> (CUdeviceptr, usize, Arc<CudaContext>) {
+        let (ptr, len, ctx, _dealloc_stream) = self.into_all_raw_parts();
+        (ptr, len, ctx)
+    }
+
+    fn into_all_raw_parts(
+        self,
+    ) -> (
+        CUdeviceptr,
+        usize,
+        Arc<CudaContext>,
+        Option<Arc<CudaStream>>,
+    ) {
+        // Suppress the buffer's `Drop` (which would free `ptr`) while still
+        // moving out the heap-owned fields. Callers that do not need
+        // `dealloc_stream` can drop it after this helper returns.
+        let this = std::mem::ManuallyDrop::new(self);
+        let ptr = this.ptr;
+        let len = this.len;
+        // SAFETY: `this` is `ManuallyDrop` and is never used again, so reading
+        // out its non-`Copy` fields takes ownership without a double drop.
+        let ctx = unsafe { std::ptr::read(&this.ctx) };
+        let dealloc_stream = unsafe { std::ptr::read(&this.dealloc_stream) };
+        (ptr, len, ctx, dealloc_stream)
+    }
+
+    /// Reinterpret the element type of this buffer as `A`.
+    ///
+    /// `A` must have the same size and alignment as `T` (e.g. `A` is
+    /// `#[repr(transparent)]` over `T`). This is the "atomic-slice launch
+    /// mapping" for issue #151: allocate and initialize a plain
+    /// `DeviceBuffer<u64>`, then hand it to a kernel that takes
+    /// `&[DeviceAtomicU64]`. The pointer, length, and bytes are unchanged;
+    /// only the element type the kernel sees changes to one whose pointee
+    /// permits shared mutation (so rustc does not mark it `readonly`/`noalias`).
+    ///
+    /// Element counts are preserved because `size_of::<A>() == size_of::<T>()`.
+    pub fn cast_elem<A>(self) -> DeviceBuffer<A> {
+        assert_eq!(
+            std::mem::size_of::<A>(),
+            std::mem::size_of::<T>(),
+            "cast_elem requires the same element size"
+        );
+        assert_eq!(
+            std::mem::align_of::<A>(),
+            std::mem::align_of::<T>(),
+            "cast_elem requires the same element alignment"
+        );
+        let (ptr, len, ctx, dealloc_stream) = self.into_all_raw_parts();
+        // SAFETY: `ptr` came from a valid `DeviceBuffer<T>` allocation of `len`
+        // elements; `A` has identical size and alignment, so the same allocation
+        // is a valid `DeviceBuffer<A>` of the same length and the same byte
+        // extent. Ownership transfers; the original buffer's `Drop` is
+        // suppressed by `into_all_raw_parts`, and the allocation metadata is
+        // preserved for the new element type.
+        unsafe {
+            DeviceBuffer::<A>::from_raw_parts_with_dealloc_stream(ptr, len, ctx, dealloc_stream)
+        }
+    }
+
+    /// Reinterpret this buffer as `A`, adjusting the element count.
+    ///
+    /// Where [`Self::cast_elem`] requires `A` to be layout-identical to `T`,
+    /// this allows a *different* size and alignment and recomputes the length
+    /// from the byte extent. That is what makes it usable for grouping scalars
+    /// into an over-aligned vector element, which is by construction a
+    /// different size and alignment and so cannot go through `cast_elem`.
+    ///
+    /// ```rust,ignore
+    /// // 4N floats become N 16-byte-aligned quads, same allocation.
+    /// let quads: DeviceBuffer<F32x4> = floats.cast_chunks()?;
+    /// ```
+    ///
+    /// # Why this exists
+    ///
+    /// Wide memory transactions require an over-aligned element type. Without a
+    /// length-adjusting cast, adopting one means every producer and consumer of
+    /// a buffer has to agree on the element type simultaneously: in practice
+    /// that meant six kernel signature changes and a dummy buffer to migrate a
+    /// single buffer pair. This lets the element type be chosen at the boundary
+    /// instead, so a kernel that wants wide accesses can take `&[F32x4]` while
+    /// the buffer is still allocated and filled as `f32`.
+    ///
+    /// # Errors
+    ///
+    /// Returns the buffer unchanged if the reinterpretation would not be exact:
+    ///
+    /// - the byte extent is not a whole number of `A`
+    /// - the device pointer is not aligned for `A`
+    /// - `A` is zero-sized
+    ///
+    /// The alignment check is expected to pass: `cuMemAlloc` returns at least
+    /// 256-byte-aligned memory, which satisfies any vector type. It is checked
+    /// rather than assumed because a buffer can also be built from
+    /// [`Self::from_raw_parts`] with a hand-computed pointer, and that is
+    /// exactly the case where being wrong is silent.
+    ///
+    /// Returning the original on failure rather than panicking keeps the
+    /// fallback path available, since a caller that cannot widen usually has a
+    /// scalar version to fall back to.
+    pub fn cast_chunks<A>(self) -> Result<DeviceBuffer<A>, Self> {
+        let bytes = self.len.saturating_mul(std::mem::size_of::<T>());
+        let Some(new_len) = chunk_cast_len(
+            bytes,
+            self.ptr as usize,
+            std::mem::size_of::<A>(),
+            std::mem::align_of::<A>(),
+        ) else {
+            return Err(self);
+        };
+        let (ptr, _len, ctx, dealloc_stream) = self.into_all_raw_parts();
+        // SAFETY: `ptr` came from a valid allocation of `bytes` bytes, checked
+        // above to be exactly `new_len` elements of `A` and to be aligned for
+        // `A`. The allocation and its ownership are unchanged; only the element
+        // type and the count describing the same bytes change. `Drop` on the
+        // original is suppressed by `into_all_raw_parts`.
+        Ok(unsafe {
+            DeviceBuffer::<A>::from_raw_parts_with_dealloc_stream(ptr, new_len, ctx, dealloc_stream)
+        })
+    }
+
+    /// Whether [`Self::cast_chunks`] to `A` would succeed.
+    ///
+    /// For choosing between a wide and a scalar path without consuming the
+    /// buffer to find out.
+    #[must_use]
+    pub fn can_cast_chunks<A>(&self) -> bool {
+        let bytes = self.len.saturating_mul(std::mem::size_of::<T>());
+        chunk_cast_len(
+            bytes,
+            self.ptr as usize,
+            std::mem::size_of::<A>(),
+            std::mem::align_of::<A>(),
+        )
+        .is_some()
+    }
+}
+
+impl<T: DeviceCopy> DeviceBuffer<T> {
+    /// Allocates device memory, copies `data` from the host on `stream`, and
+    /// synchronizes `stream` before returning.
+    ///
+    /// The synchronization keeps this safe for borrowed host slices: `data`
+    /// may be dropped, reused, or mutated immediately after this function
+    /// returns. For true host-device overlap with caller-managed source
+    /// lifetimes, use [`Self::from_host_async_unchecked`].
+    ///
+    /// An empty `data` slice yields an empty buffer without touching the
+    /// driver allocator.
+    ///
+    /// # Allocation safety on error
+    ///
+    /// The buffer takes ownership of the device allocation immediately after
+    /// `malloc_sync`, before the fallible `memcpy_htod_async` enqueue and
+    /// stream synchronization run. If either step fails, the early return
+    /// drops the buffer and its `Drop` impl frees the allocation, so no
+    /// device memory is leaked.
+    pub fn from_host(stream: &CudaStream, data: &[T]) -> Result<Self, DriverError> {
+        let ctx = stream.context().clone();
+        let len = data.len();
+        let num_bytes = allocation_size::<T>(len)?;
+
+        // cuMemAlloc rejects zero-byte requests with CUDA_ERROR_INVALID_VALUE,
+        // so represent an empty buffer as a null pointer (Drop skips it).
+        if num_bytes == 0 {
+            // SAFETY: a null pointer with zero bytes is never dereferenced
+            // and Drop ignores it.
+            return Ok(unsafe { Self::from_raw_parts(0, len, ctx) });
+        }
+
+        let ptr = unsafe { crate::simt::memory::malloc_sync(num_bytes)? };
+        // SAFETY: `ptr` was just allocated with `num_bytes` bytes in the
+        // stream's context; ownership transfers to `buf` here so any early
+        // return below frees it through the buffer's own `Drop`.
+        let buf = unsafe { Self::from_raw_parts(ptr, len, ctx) };
+        let enqueue_result = unsafe {
+            crate::simt::memory::memcpy_htod_async(
+                buf.ptr,
+                data.as_ptr(),
+                num_bytes,
+                stream.cu_stream(),
+            )
+        };
+        let sync_result = stream.synchronize();
+        enqueue_result?;
+        sync_result?;
+        Ok(buf)
+    }
+
+    /// Allocates device memory and enqueues a host-to-device copy from `data`
+    /// on `stream`, returning without synchronizing.
+    ///
+    /// # Safety
+    ///
+    /// This call only enqueues the host-to-device copy and returns; CUDA may
+    /// still be reading from `data` after the borrow is released. The caller
+    /// must ensure `data` is not dropped, freed, mutated, or aliased until the
+    /// enqueued copy has completed, typically after the next
+    /// [`CudaStream::synchronize`] call or a stream-ordered event wait.
+    pub unsafe fn from_host_async_unchecked(
+        stream: &CudaStream,
+        data: &[T],
+    ) -> Result<Self, DriverError> {
+        let ctx = stream.context().clone();
+        let len = data.len();
+        let num_bytes = std::mem::size_of_val(data);
+
+        // cuMemAlloc rejects zero-byte requests with CUDA_ERROR_INVALID_VALUE,
+        // so represent an empty buffer as a null pointer (Drop skips it).
+        if num_bytes == 0 {
+            // SAFETY: a null pointer with zero bytes is never dereferenced
+            // and Drop ignores it.
+            return Ok(unsafe { Self::from_raw_parts(0, len, ctx) });
+        }
+
+        let ptr = unsafe { crate::simt::memory::malloc_sync(num_bytes)? };
+        // SAFETY: `ptr` was just allocated with `num_bytes` bytes in the
+        // stream's context; ownership transfers to `buf` here so any early
+        // return below frees it through the buffer's own `Drop`.
+        let buf = unsafe { Self::from_raw_parts(ptr, len, ctx) };
+        unsafe {
+            crate::simt::memory::memcpy_htod_async(
+                buf.ptr,
+                data.as_ptr(),
+                num_bytes,
+                stream.cu_stream(),
+            )?;
+        }
+        Ok(buf)
+    }
+
+    /// Allocates device memory and enqueues a host-to-device copy from a
+    /// pinned host buffer on `stream`, returning without synchronizing.
+    ///
+    /// Pinned host memory allows CUDA to avoid the pageable-memory staging
+    /// path and is required when host-device copies need true asynchronous
+    /// overlap with other stream work.
+    ///
+    /// `PinnedHostBuffer` currently uses `cuMemAllocHost` without the
+    /// `PORTABLE` flag, so the allocation is only pinned in the context that
+    /// created it. In debug builds this asserts that `data` and `stream`
+    /// share the same [`CudaContext`].
+    ///
+    /// The device-to-host counterparts are [`Self::copy_to_pinned_host`]
+    /// (blocking) and [`Self::copy_to_pinned_host_async`] (non-blocking). To
+    /// refill an existing device buffer instead of allocating a new one, use
+    /// [`Self::copy_from_pinned_host_async`].
+    ///
+    /// # Safety
+    ///
+    /// This call only enqueues the host-to-device copy on `stream` and
+    /// returns; CUDA may still be reading from `data`'s pinned pointer long
+    /// after this function returns. The caller is responsible for ensuring
+    /// `data` is not dropped, freed, mutated, or aliased until the enqueued
+    /// copy has completed, typically after the next
+    /// [`CudaStream::synchronize`] call or a stream-ordered event wait.
+    /// Dropping `data` before that synchronization point calls
+    /// `cuMemFreeHost` while the in-flight transfer is still reading the
+    /// buffer, which is undefined behavior.
+    pub unsafe fn from_pinned_host(
+        stream: &CudaStream,
+        data: &PinnedHostBuffer<T>,
+    ) -> Result<Self, DriverError> {
+        debug_assert!(
+            Arc::ptr_eq(data.context(), stream.context()),
+            "pinned host buffer and stream must belong to the same CUDA context"
+        );
+        // SAFETY: this method's safety contract requires the caller to keep
+        // the pinned source valid until the enqueued copy completes.
+        unsafe { Self::from_host_async_unchecked(stream, data.as_slice()) }
+    }
+
+    /// Allocates zero-initialized device memory of `len` elements, enqueued
+    /// on `stream`.
+    ///
+    /// A `len` of zero (or a zero-sized `T`) yields an empty buffer without
+    /// touching the driver allocator.
+    ///
+    /// # Allocation safety on error
+    ///
+    /// The returned buffer takes ownership of the device allocation
+    /// immediately after `malloc_sync`, before the fallible
+    /// `memset_d8_async` enqueue runs. If the enqueue fails, the early
+    /// return drops the buffer and its `Drop` impl frees the allocation, so
+    /// no device memory is leaked.
+    pub fn zeroed(stream: &CudaStream, len: usize) -> Result<Self, DriverError> {
+        let ctx = stream.context().clone();
+        let num_bytes = allocation_size::<T>(len)?;
+
+        // cuMemAlloc rejects zero-byte requests with CUDA_ERROR_INVALID_VALUE,
+        // so represent an empty buffer as a null pointer (Drop skips it).
+        if num_bytes == 0 {
+            // SAFETY: a null pointer with zero bytes is never dereferenced
+            // and Drop ignores it.
+            return Ok(unsafe { Self::from_raw_parts(0, len, ctx) });
+        }
+
+        let ptr = unsafe { crate::simt::memory::malloc_sync(num_bytes)? };
+        // SAFETY: `ptr` was just allocated with `num_bytes` bytes in the
+        // stream's context; ownership transfers to `buf` here so any early
+        // return below frees it through the buffer's own `Drop`.
+        let buf = unsafe { Self::from_raw_parts(ptr, len, ctx) };
+        unsafe {
+            crate::simt::memory::memset_d8_async(buf.ptr, 0, num_bytes, stream.cu_stream())?;
+        }
+        Ok(buf)
+    }
+
+    /// Copies the entire buffer back to the host, returning a `Vec<T>`.
+    ///
+    /// Synchronizes on `stream` before returning so the host vector is safe
+    /// to read immediately.
+    pub fn to_host_vec(&self, stream: &CudaStream) -> Result<Vec<T>, DriverError> {
+        let mut host = Vec::with_capacity(self.len);
+        unsafe {
+            crate::simt::memory::memcpy_dtoh_async(
+                host.as_mut_ptr(),
+                self.ptr,
+                self.num_bytes(),
+                stream.cu_stream(),
+            )?;
+        }
+        stream.synchronize()?;
+        unsafe { host.set_len(self.len) };
+        Ok(host)
+    }
+
+    /// Copies the buffer contents into an existing host slice.
+    ///
+    /// Synchronizes on `stream` before returning. Panics if
+    /// `dst.len() < self.len()`.
+    pub fn copy_to_host(&self, stream: &CudaStream, dst: &mut [T]) -> Result<(), DriverError> {
+        assert!(
+            dst.len() >= self.len,
+            "destination slice too small: {} < {}",
+            dst.len(),
+            self.len
+        );
+        unsafe {
+            crate::simt::memory::memcpy_dtoh_async(
+                dst.as_mut_ptr(),
+                self.ptr,
+                self.num_bytes(),
+                stream.cu_stream(),
+            )?;
+        }
+        stream.synchronize()
+    }
+
+    /// Copies the buffer contents into an existing pinned host buffer and
+    /// synchronizes `stream` before returning.
+    ///
+    /// Panics if `dst.len() < self.len()`. Use pinned destinations when you
+    /// need the transfer to avoid pageable-memory staging; this helper still
+    /// waits for completion before returning, matching [`Self::copy_to_host`].
+    ///
+    /// For true DtoH overlap, use [`Self::copy_to_pinned_host_async`] and
+    /// synchronize the stream later.
+    pub fn copy_to_pinned_host(
+        &self,
+        stream: &CudaStream,
+        dst: &mut PinnedHostBuffer<T>,
+    ) -> Result<(), DriverError> {
+        // SAFETY: we synchronize the stream below before returning, so the
+        // pinned destination is no longer being written to by CUDA when the
+        // mutable borrow on `dst` is released to the caller.
+        unsafe { self.copy_to_pinned_host_async(stream, dst)? };
+        stream.synchronize()
+    }
+
+    /// Enqueues a device-to-host copy into an existing pinned host buffer and
+    /// returns without synchronizing.
+    ///
+    /// Panics if `dst.len() < self.len()`.
+    ///
+    /// `PinnedHostBuffer` currently uses `cuMemAllocHost` without the
+    /// `PORTABLE` flag, so the allocation is only pinned in the context that
+    /// created it. In debug builds this asserts that `dst` and `stream`
+    /// share the same [`CudaContext`].
+    ///
+    /// # Safety
+    ///
+    /// This call only enqueues the device-to-host copy on `stream` and
+    /// returns; CUDA may still be writing into `dst`'s pinned pointer long
+    /// after this function returns. The caller is responsible for ensuring
+    /// `dst` is not dropped, freed, read, or aliased until the enqueued copy
+    /// has completed, typically after the next [`CudaStream::synchronize`]
+    /// call or a stream-ordered event wait. Dropping `dst` before that
+    /// synchronization point calls `cuMemFreeHost` while the in-flight
+    /// transfer is still writing the buffer, which is undefined behavior.
+    pub unsafe fn copy_to_pinned_host_async(
+        &self,
+        stream: &CudaStream,
+        dst: &mut PinnedHostBuffer<T>,
+    ) -> Result<(), DriverError> {
+        debug_assert!(
+            Arc::ptr_eq(dst.context(), stream.context()),
+            "pinned host buffer and stream must belong to the same CUDA context"
+        );
+        assert!(
+            dst.len() >= self.len,
+            "destination pinned host buffer too small: {} < {}",
+            dst.len(),
+            self.len
+        );
+        unsafe {
+            crate::simt::memory::memcpy_dtoh_async(
+                dst.as_mut_ptr(),
+                self.ptr,
+                self.num_bytes(),
+                stream.cu_stream(),
+            )
+        }
+    }
+
+    /// Enqueues a host-to-device copy from a pinned host buffer into this
+    /// device buffer and returns without synchronizing.
+    ///
+    /// This is the symmetric counterpart of
+    /// [`Self::copy_to_pinned_host_async`]: it refills an existing device
+    /// allocation from rotating pinned host stagers instead of allocating a
+    /// fresh device buffer per refresh, which is the typical shape for
+    /// asynchronous overlap pipelines.
+    ///
+    /// Panics if `src.len() > self.len()`.
+    ///
+    /// `PinnedHostBuffer` currently uses `cuMemAllocHost` without the
+    /// `PORTABLE` flag, so the allocation is only pinned in the context that
+    /// created it. In debug builds this asserts that `src` and `stream`
+    /// share the same [`CudaContext`].
+    ///
+    /// # Safety
+    ///
+    /// This call only enqueues the host-to-device copy on `stream` and
+    /// returns; CUDA may still be reading from `src`'s pinned pointer long
+    /// after this function returns. The caller is responsible for ensuring
+    /// `src` is not dropped, freed, mutated, or aliased until the enqueued
+    /// copy has completed, typically after the next
+    /// [`CudaStream::synchronize`] call or a stream-ordered event wait.
+    /// Dropping `src` before that synchronization point calls
+    /// `cuMemFreeHost` while the in-flight transfer is still reading the
+    /// buffer, which is undefined behavior.
+    pub unsafe fn copy_from_pinned_host_async(
+        &mut self,
+        stream: &CudaStream,
+        src: &PinnedHostBuffer<T>,
+    ) -> Result<(), DriverError> {
+        debug_assert!(
+            Arc::ptr_eq(src.context(), stream.context()),
+            "pinned host buffer and stream must belong to the same CUDA context"
+        );
+        assert!(
+            src.len() <= self.len,
+            "source pinned host buffer too large: {} > {}",
+            src.len(),
+            self.len
+        );
+        let num_bytes = src.num_bytes();
+        unsafe {
+            crate::simt::memory::memcpy_htod_async(
+                self.ptr,
+                src.as_ptr(),
+                num_bytes,
+                stream.cu_stream(),
+            )
+        }
+    }
+
+    /// Allocates `len` elements of uninitialized device memory, enqueued on
+    /// `stream`.
+    ///
+    /// Unlike [`Self::zeroed`], no `cuMemsetD8` is enqueued. The contents of
+    /// the returned buffer are undefined until the caller writes them.
+    ///
+    /// The buffer co-owns `stream` (via the `Arc`) so its implicit `Drop` can
+    /// release the stream-ordered allocation after synchronizing the context.
+    /// Call the unsafe [`Self::drop_async`] to free explicitly on a chosen
+    /// stream without a context-wide synchronization.
+    ///
+    /// # Safety
+    ///
+    /// Reading from the returned buffer before any kernel or memcpy has
+    /// written it is undefined behavior.
+    pub unsafe fn uninitialized_async(
+        stream: &Arc<CudaStream>,
+        len: usize,
+    ) -> Result<Self, DriverError> {
+        let ctx = stream.context().clone();
+        let num_bytes = allocation_size::<T>(len)?;
+        if num_bytes == 0 {
+            // SAFETY: a null pointer with zero bytes is never dereferenced
+            // and Drop/drop_async ignore it.
+            return Ok(unsafe { Self::from_raw_parts(0, len, ctx) });
+        }
+
+        let ptr = unsafe { crate::simt::memory::malloc_async(stream.cu_stream(), num_bytes)? };
+        Ok(Self {
+            ptr,
+            len,
+            num_bytes,
+            ctx,
+            dealloc_stream: Some(stream.clone()),
+            _marker: PhantomData,
+        })
+    }
+
+    /// Copies `other` into `self` device-to-device, enqueued on `stream`.
+    ///
+    /// Panics if `other.len() != self.len()`.
+    pub fn copy_from_device_async(
+        &mut self,
+        other: &DeviceBuffer<T>,
+        stream: &CudaStream,
+    ) -> Result<(), DriverError> {
+        assert_eq!(
+            self.len, other.len,
+            "device-to-device copy length mismatch: dst {} != src {}",
+            self.len, other.len
+        );
+        if self.num_bytes() == 0 {
+            return Ok(());
+        }
+        unsafe {
+            crate::simt::memory::memcpy_dtod_async(
+                self.ptr,
+                other.ptr,
+                self.num_bytes(),
+                stream.cu_stream(),
+            )
+        }
+    }
+
+    /// Copies `src` into `self` host-to-device on `stream` and synchronizes
+    /// `stream` before returning.
+    ///
+    /// The synchronization keeps this safe for borrowed host slices: `src`
+    /// may be dropped, reused, or mutated immediately after this function
+    /// returns. Panics if `src.len() != self.len()`.
+    pub fn copy_from_host(&mut self, stream: &CudaStream, src: &[T]) -> Result<(), DriverError> {
+        // SAFETY: this safe wrapper synchronizes `stream` before returning,
+        // so the borrowed host slice cannot be used by CUDA after this call.
+        let enqueue_result = unsafe { self.copy_from_host_async_unchecked(stream, src) };
+        let sync_result = if self.num_bytes() == 0 {
+            Ok(())
+        } else {
+            stream.synchronize()
+        };
+        enqueue_result?;
+        sync_result
+    }
+
+    /// Copies `src` into `self` host-to-device, enqueued on `stream`, and
+    /// returns without synchronizing.
+    ///
+    /// # Safety
+    ///
+    /// This call only enqueues the host-to-device copy and returns; CUDA may
+    /// still be reading from `src` after the borrow is released. The caller
+    /// must ensure `src` is not dropped, freed, mutated, or aliased until the
+    /// enqueued copy has completed, typically after the next
+    /// [`CudaStream::synchronize`] call or a stream-ordered event wait.
+    /// Panics if `src.len() != self.len()`.
+    pub unsafe fn copy_from_host_async_unchecked(
+        &mut self,
+        stream: &CudaStream,
+        src: &[T],
+    ) -> Result<(), DriverError> {
+        assert_eq!(
+            self.len,
+            src.len(),
+            "host-to-device copy length mismatch: dst {} != src {}",
+            self.len,
+            src.len()
+        );
+        if self.num_bytes() == 0 {
+            return Ok(());
+        }
+        unsafe {
+            crate::simt::memory::memcpy_htod_async(
+                self.ptr,
+                src.as_ptr(),
+                self.num_bytes(),
+                stream.cu_stream(),
+            )
+        }
+    }
+
+    /// Consumes the buffer and frees it asynchronously on `stream`.
+    ///
+    /// For a stream-ordered allocation, this method makes `stream` wait for
+    /// work already submitted on the allocation stream before enqueueing the
+    /// free.
+    ///
+    /// Returns [`CUDA_ERROR_INVALID_CONTEXT`](cuda_bindings::cudaError_enum_CUDA_ERROR_INVALID_CONTEXT)
+    /// if `stream` belongs to a different context. Validation and allocation
+    /// stream ordering happen before the buffer is disarmed, so an error in
+    /// either step leaves ordinary [`Drop`] responsible for cleanup. Once
+    /// disarmed immediately before `cuMemFreeAsync`, an enqueue error leaks
+    /// the allocation instead of attempting an unordered fallback free.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that every stream other than the allocation
+    /// stream that has pending work touching this buffer is ordered before
+    /// `stream` (for example via [`CudaStream::join`]). Only the allocation
+    /// stream is joined automatically; an unordered third stream still
+    /// racing the free is a driver-level use-after-free. This is the same
+    /// deferred-use contract as [`Self::copy_from_host_async_unchecked`]:
+    /// ordinary [`Drop`] is the safe alternative and synchronizes the whole
+    /// context first.
+    pub unsafe fn drop_async(mut self, stream: &CudaStream) -> Result<(), DriverError> {
+        if self.ctx.as_ref() != stream.context().as_ref() {
+            return Err(DriverError(
+                cuda_bindings::cudaError_enum_CUDA_ERROR_INVALID_CONTEXT,
+            ));
+        }
+        if self.ptr == 0 {
+            return Ok(());
+        }
+
+        self.ctx.bind_to_thread()?;
+        if let Some(allocation_stream) = &self.dealloc_stream {
+            if allocation_stream.as_ref() != stream {
+                stream.join(allocation_stream)?;
+            }
+        }
+
+        let ptr = self.ptr;
+        self.ptr = 0;
+        unsafe { crate::simt::memory::free_async(ptr, stream.cu_stream()) }
+    }
+
+    /// Zeroes every byte in the buffer asynchronously on `stream`.
+    pub fn zero_async(&mut self, stream: &CudaStream) -> Result<(), DriverError> {
+        if self.num_bytes() == 0 {
+            return Ok(());
+        }
+        unsafe {
+            crate::simt::memory::memset_d8_async(self.ptr, 0, self.num_bytes(), stream.cu_stream())
+        }
+    }
+}
+
+fn allocation_size<T>(len: usize) -> Result<usize, DriverError> {
+    len.checked_mul(std::mem::size_of::<T>()).ok_or(DriverError(
+        cuda_bindings::cudaError_enum_CUDA_ERROR_INVALID_VALUE,
+    ))
+}
+
+/// Element count for reinterpreting `bytes` at `addr` as elements of size
+/// `elem_size` and alignment `align`, or `None` if it would not be exact.
+///
+/// Split out so [`DeviceBuffer::cast_chunks`] and
+/// [`DeviceBuffer::can_cast_chunks`] cannot disagree, and so the decision is
+/// testable without a device.
+fn chunk_cast_len(bytes: usize, addr: usize, elem_size: usize, align: usize) -> Option<usize> {
+    if elem_size == 0 || align == 0 {
+        return None;
+    }
+    if !bytes.is_multiple_of(elem_size) {
+        return None;
+    }
+    if !addr.is_multiple_of(align) {
+        return None;
+    }
+    Some(bytes / elem_size)
+}
+
+#[cfg(test)]
+mod chunk_cast_tests {
+    use super::chunk_cast_len;
+
+    /// A device allocation is at least 256-byte aligned, so the alignment check
+    /// is expected to pass; these pin that it does, and that a hand-computed
+    /// pointer is still rejected.
+    #[test]
+    fn accepts_an_aligned_allocation_that_divides() {
+        // 1024 f32 viewed as 256 quads of 16 bytes.
+        assert_eq!(chunk_cast_len(4096, 0x1000, 16, 16), Some(256));
+        // 8-byte pairs out of the same buffer.
+        assert_eq!(chunk_cast_len(4096, 0x1000, 8, 8), Some(512));
+        // Identity cast.
+        assert_eq!(chunk_cast_len(4096, 0x1000, 4, 4), Some(1024));
+    }
+
+    /// A length that is not a whole number of elements is refused rather than
+    /// truncated, so a dropped tail cannot go unnoticed.
+    #[test]
+    fn refuses_a_byte_extent_that_does_not_divide() {
+        assert_eq!(
+            chunk_cast_len(12, 0x1000, 16, 16),
+            None,
+            "3 f32 into a quad"
+        );
+        assert_eq!(chunk_cast_len(4100, 0x1000, 16, 16), None);
+        assert_eq!(chunk_cast_len(4088, 0x1000, 16, 16), None);
+    }
+
+    /// The case the check exists for: a pointer that did not come from
+    /// `cuMemAlloc`, such as one offset by hand into a larger allocation.
+    #[test]
+    fn refuses_a_misaligned_base() {
+        assert_eq!(chunk_cast_len(4096, 0x1004, 16, 16), None, "4-byte offset");
+        assert_eq!(chunk_cast_len(4096, 0x1008, 16, 16), None, "8-byte offset");
+        // Still fine for a narrower element.
+        assert_eq!(chunk_cast_len(4096, 0x1008, 8, 8), Some(512));
+        assert_eq!(chunk_cast_len(4096, 0x1004, 4, 4), Some(1024));
+    }
+
+    /// Every 256-byte-aligned base satisfies every vector alignment, which is
+    /// why the check is expected to pass for a real allocation.
+    #[test]
+    fn a_cuda_allocation_alignment_satisfies_every_vector_type() {
+        for base in [0usize, 256, 512, 4096, 1 << 20] {
+            for align in [4usize, 8, 16] {
+                assert!(
+                    chunk_cast_len(4096, base, align, align).is_some(),
+                    "base {base:#x} should satisfy align {align}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn rejects_degenerate_parameters() {
+        assert_eq!(chunk_cast_len(4096, 0x1000, 0, 16), None, "zero-sized");
+        assert_eq!(chunk_cast_len(4096, 0x1000, 16, 0), None);
+        // An empty buffer casts to an empty buffer.
+        assert_eq!(chunk_cast_len(0, 0x1000, 16, 16), Some(0));
+    }
+}

--- a/cuda-core/src/simt/embedded.rs
+++ b/cuda-core/src/simt/embedded.rs
@@ -1,0 +1,281 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Loading CUDA modules from embedded device artifact bundles.
+
+use crate::{CudaContext, CudaModule, DriverError};
+use oxide_artifacts::ArtifactError;
+pub use oxide_artifacts::{
+    ArtifactCompileOptions, ArtifactDebugPolicy, ArtifactPayloadKind, OwnedArtifactBundle,
+    COMPILE_OPTIONS_TARGET_MARKER,
+};
+use std::fmt;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EmbeddedModule {
+    bundle: OwnedArtifactBundle,
+}
+
+impl EmbeddedModule {
+    pub fn new(bundle: OwnedArtifactBundle) -> Option<Self> {
+        loadable_payload(&bundle)
+            .is_some()
+            .then_some(Self { bundle })
+    }
+
+    pub fn name(&self) -> &str {
+        &self.bundle.name
+    }
+
+    pub fn target(&self) -> &str {
+        &self.bundle.target
+    }
+
+    pub fn bundle(&self) -> &OwnedArtifactBundle {
+        &self.bundle
+    }
+
+    pub fn payload(&self, kind: ArtifactPayloadKind) -> Option<&[u8]> {
+        self.bundle.payload(kind)
+    }
+
+    pub fn load(&self, ctx: &Arc<CudaContext>) -> Result<Arc<CudaModule>, EmbeddedModuleError> {
+        let image =
+            loadable_payload(&self.bundle).expect("EmbeddedModule always has a loadable payload");
+        ctx.load_module_from_image(image)
+            .map_err(EmbeddedModuleError::Driver)
+    }
+}
+
+pub fn artifact_bundles_from_current_exe() -> Result<Vec<OwnedArtifactBundle>, EmbeddedModuleError>
+{
+    let path =
+        std::env::current_exe().map_err(|source| EmbeddedModuleError::CurrentExe { source })?;
+    artifact_bundles_from_binary_path(path)
+}
+
+pub fn artifact_bundles_from_binary_path(
+    path: impl AsRef<Path>,
+) -> Result<Vec<OwnedArtifactBundle>, EmbeddedModuleError> {
+    let path = path.as_ref();
+    let bytes = std::fs::read(path).map_err(|source| EmbeddedModuleError::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    oxide_artifacts::read_artifact_bundles_from_object_bytes(&bytes)
+        .map_err(EmbeddedModuleError::Artifacts)
+}
+
+pub fn embedded_modules_from_current_exe() -> Result<Vec<EmbeddedModule>, EmbeddedModuleError> {
+    Ok(artifact_bundles_from_current_exe()?
+        .into_iter()
+        .filter_map(EmbeddedModule::new)
+        .collect())
+}
+
+pub fn load_embedded_module(
+    ctx: &Arc<CudaContext>,
+    name: &str,
+) -> Result<Arc<CudaModule>, EmbeddedModuleError> {
+    let module = embedded_modules_from_current_exe()?
+        .into_iter()
+        .find(|module| module.name() == name)
+        .ok_or_else(|| EmbeddedModuleError::ModuleNotFound {
+            name: name.to_string(),
+        })?;
+    module.load(ctx)
+}
+
+pub fn load_first_embedded_module(
+    ctx: &Arc<CudaContext>,
+) -> Result<Arc<CudaModule>, EmbeddedModuleError> {
+    let module = embedded_modules_from_current_exe()?
+        .into_iter()
+        .next()
+        .ok_or(EmbeddedModuleError::NoModules)?;
+    module.load(ctx)
+}
+
+fn loadable_payload(bundle: &OwnedArtifactBundle) -> Option<&[u8]> {
+    bundle
+        .payload(ArtifactPayloadKind::Cubin)
+        .or_else(|| bundle.payload(ArtifactPayloadKind::Ptx))
+}
+
+#[derive(Debug)]
+pub enum EmbeddedModuleError {
+    CurrentExe {
+        source: std::io::Error,
+    },
+    Io {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+    Artifacts(ArtifactError),
+    ModuleNotFound {
+        name: String,
+    },
+    NoModules,
+    Driver(DriverError),
+}
+
+impl fmt::Display for EmbeddedModuleError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::CurrentExe { source } => {
+                write!(f, "failed to resolve the current executable: {source}")
+            }
+            Self::Io { path, source } => write!(f, "failed to read {}: {source}", path.display()),
+            Self::Artifacts(error) => write!(f, "failed to read embedded artifacts: {error}"),
+            Self::ModuleNotFound { name } => {
+                write!(f, "embedded CUDA module '{name}' was not found")
+            }
+            Self::NoModules => f.write_str("no embedded CUDA modules were found"),
+            Self::Driver(error) => write!(f, "failed to load embedded CUDA module: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for EmbeddedModuleError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::CurrentExe { source } | Self::Io { source, .. } => Some(source),
+            Self::Artifacts(error) => Some(error),
+            Self::Driver(error) => Some(error),
+            Self::ModuleNotFound { .. } | Self::NoModules => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use oxide_artifacts::{
+        build_artifact_blob, build_host_object_for_target, ArtifactBundleSpec, ArtifactPayloadSpec,
+        OwnedArtifactPayload,
+    };
+
+    #[test]
+    fn embedded_module_filters_unloadable_bundles() {
+        let bundle = OwnedArtifactBundle {
+            name: "demo".to_string(),
+            target: "sm_90".to_string(),
+            compile_options: ArtifactCompileOptions::new(),
+            payloads: Vec::new(),
+            entries: Vec::new(),
+        };
+
+        assert!(EmbeddedModule::new(bundle).is_none());
+    }
+
+    #[test]
+    fn embedded_module_accepts_ptx_payload() {
+        let bundle = OwnedArtifactBundle {
+            name: "demo".to_string(),
+            target: "sm_90".to_string(),
+            compile_options: ArtifactCompileOptions::new(),
+            payloads: vec![OwnedArtifactPayload {
+                kind: ArtifactPayloadKind::Ptx,
+                name: "demo.ptx".to_string(),
+                bytes: b"ptx".to_vec(),
+            }],
+            entries: Vec::new(),
+        };
+
+        let module = EmbeddedModule::new(bundle).unwrap();
+        assert_eq!(module.name(), "demo");
+        assert_eq!(module.payload(ArtifactPayloadKind::Ptx), Some(&b"ptx"[..]));
+    }
+
+    #[test]
+    fn embedded_module_accepts_cubin_payload() {
+        let bundle = OwnedArtifactBundle {
+            name: "demo".to_string(),
+            target: "sm_90".to_string(),
+            compile_options: ArtifactCompileOptions::new(),
+            payloads: vec![OwnedArtifactPayload {
+                kind: ArtifactPayloadKind::Cubin,
+                name: "demo.cubin".to_string(),
+                bytes: b"cubin".to_vec(),
+            }],
+            entries: Vec::new(),
+        };
+
+        let module = EmbeddedModule::new(bundle).unwrap();
+        assert_eq!(module.name(), "demo");
+        assert_eq!(
+            module.payload(ArtifactPayloadKind::Cubin),
+            Some(&b"cubin"[..])
+        );
+    }
+
+    #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+    #[test]
+    fn artifact_bundles_from_binary_path_reads_linked_executable() {
+        let temp_dir = unique_temp_dir("cuda-core-embedded-artifacts");
+        std::fs::create_dir_all(&temp_dir).unwrap();
+
+        let source_path = temp_dir.join("main.rs");
+        let object_path = temp_dir.join("artifact.o");
+        let exe_path = temp_dir.join("host");
+
+        let blob = build_artifact_blob(&ArtifactBundleSpec::new("linked", "sm_90").with_payload(
+            ArtifactPayloadSpec::new(ArtifactPayloadKind::Ptx, "linked.ptx", b"ptx"),
+        ))
+        .unwrap();
+        // Mirror production: the backend always defines a link-anchor
+        // symbol in the artifact object. The linked-executable round trip
+        // must keep working with that symbol present.
+        // `reserved_oxide_symbols::artifact_anchor_symbol("linked", "0.0.0")`,
+        // precomputed: that crate is cuda-oxide-internal and not a
+        // dependency here. Format: prefix + sanitized(name) + '_' +
+        // sanitized(version), non-alphanumerics mapped to '_'.
+        let anchor = "cuda_oxide_artifact_anchor_246e25db_linked_0_0_0".to_string();
+        let object =
+            build_host_object_for_target(&blob, "x86_64-unknown-linux-gnu", Some(anchor.as_str()))
+                .unwrap();
+        std::fs::write(&source_path, "fn main() {}\n").unwrap();
+        std::fs::write(&object_path, object).unwrap();
+
+        let rustc = std::env::var_os("RUSTC").unwrap_or_else(|| "rustc".into());
+        let output = std::process::Command::new(rustc)
+            .arg(&source_path)
+            .arg("-C")
+            .arg(format!("link-arg={}", object_path.display()))
+            .arg("-o")
+            .arg(&exe_path)
+            .output()
+            .unwrap();
+
+        if !output.status.success() {
+            panic!(
+                "failed to link artifact test executable\nstdout:\n{}\nstderr:\n{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+
+        let bundles = artifact_bundles_from_binary_path(&exe_path).unwrap();
+        assert_eq!(bundles.len(), 1);
+        assert_eq!(bundles[0].name, "linked");
+        assert_eq!(
+            bundles[0].payload(ArtifactPayloadKind::Ptx),
+            Some(&b"ptx"[..])
+        );
+
+        let _ = std::fs::remove_dir_all(temp_dir);
+    }
+
+    #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+    fn unique_temp_dir(name: &str) -> PathBuf {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!("{name}-{}-{nanos}", std::process::id()))
+    }
+}

--- a/cuda-core/src/simt/event.rs
+++ b/cuda-core/src/simt/event.rs
@@ -1,0 +1,144 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! CUDA event management (RAII, timing, synchronization).
+//!
+//! A [`CudaEvent`] wraps a `CUevent` handle and ties its lifetime to its
+//! parent [`CudaContext`]. Events are the fundamental synchronization
+//! primitive between CUDA streams: record an event on one stream, then wait
+//! on it from another to establish ordering.
+//!
+//! # Timing
+//!
+//! By default, events are created with `CU_EVENT_DISABLE_TIMING` for lower
+//! overhead. Pass `Some(CU_EVENT_DEFAULT)` to
+//! [`CudaContext::new_event`] or [`CudaStream::record_event`] if you
+//! need [`elapsed_ms`](CudaEvent::elapsed_ms).
+
+use crate::error::{DriverError, IntoResult};
+use crate::simt::context::CudaContext;
+use crate::simt::stream::CudaStream;
+use std::mem::MaybeUninit;
+use std::sync::Arc;
+
+/// An RAII wrapper around a `CUevent` handle.
+///
+/// Holds an `Arc<CudaContext>` to ensure the context outlives the event.
+/// Destroyed automatically via `cuEventDestroy` on [`Drop`].
+#[derive(Debug)]
+pub struct CudaEvent {
+    /// Raw CUDA event handle.
+    pub(crate) cu_event: cuda_bindings::CUevent,
+    /// Owning context. Kept alive for the lifetime of this event.
+    pub(crate) ctx: Arc<CudaContext>,
+}
+
+/// # Safety
+///
+/// `CUevent` handles are not thread-local. The CUDA driver permits recording
+/// and waiting on events from any thread, provided the owning context is bound.
+unsafe impl Send for CudaEvent {}
+/// See [`Send`] impl.
+unsafe impl Sync for CudaEvent {}
+
+/// Destroys the underlying `CUevent` on drop.
+///
+/// Binds the context to the current thread first (required by
+/// `cuEventDestroy`). Errors are recorded on the context rather than
+/// panicking.
+impl Drop for CudaEvent {
+    fn drop(&mut self) {
+        self.ctx.record_err(self.ctx.bind_to_thread());
+        self.ctx
+            .record_err(unsafe { cuda_bindings::cuEventDestroy_v2(self.cu_event).result() });
+    }
+}
+
+impl CudaContext {
+    /// Creates a new CUDA event in this context.
+    ///
+    /// `flags` defaults to `CU_EVENT_DISABLE_TIMING` when `None`. Use
+    /// `Some(CU_EVENT_DEFAULT)` to enable timing queries via
+    /// [`CudaEvent::elapsed_ms`].
+    pub fn new_event(
+        self: &Arc<Self>,
+        flags: Option<cuda_bindings::CUevent_flags>,
+    ) -> Result<CudaEvent, DriverError> {
+        let flags = flags.unwrap_or(cuda_bindings::CUevent_flags_enum_CU_EVENT_DISABLE_TIMING);
+        self.bind_to_thread()?;
+        let mut cu_event = MaybeUninit::uninit();
+        let cu_event = unsafe {
+            cuda_bindings::cuEventCreate(cu_event.as_mut_ptr(), flags).result()?;
+            cu_event.assume_init()
+        };
+        Ok(CudaEvent {
+            cu_event,
+            ctx: self.clone(),
+        })
+    }
+}
+
+impl CudaEvent {
+    /// Returns the raw `CUevent` handle.
+    pub fn cu_event(&self) -> cuda_bindings::CUevent {
+        self.cu_event
+    }
+
+    /// Returns the parent [`CudaContext`].
+    pub fn context(&self) -> &Arc<CudaContext> {
+        &self.ctx
+    }
+
+    /// Records this event on `stream`.
+    ///
+    /// The event captures the point in the stream's work queue at the time of
+    /// the call. A subsequent [`CudaStream::wait`] on this event will block
+    /// the waiting stream until all work prior to the record point completes.
+    pub fn record(&self, stream: &CudaStream) -> Result<(), DriverError> {
+        self.ctx.bind_to_thread()?;
+        unsafe { cuda_bindings::cuEventRecord(self.cu_event, stream.cu_stream()).result() }
+    }
+
+    /// Blocks the calling thread until this event has been recorded and all
+    /// preceding stream work has completed.
+    pub fn synchronize(&self) -> Result<(), DriverError> {
+        self.ctx.bind_to_thread()?;
+        unsafe { cuda_bindings::cuEventSynchronize(self.cu_event).result() }
+    }
+
+    /// Returns `true` when all work captured by this event has completed,
+    /// `false` when it is still in flight. Never blocks.
+    ///
+    /// Wraps `cuEventQuery`, mapping `CUDA_SUCCESS` to `Ok(true)` and
+    /// `CUDA_ERROR_NOT_READY` to `Ok(false)`. Any other code is a real
+    /// driver error.
+    pub fn query(&self) -> Result<bool, DriverError> {
+        self.ctx.bind_to_thread()?;
+        match unsafe { cuda_bindings::cuEventQuery(self.cu_event) } {
+            cuda_bindings::cudaError_enum_CUDA_SUCCESS => Ok(true),
+            cuda_bindings::cudaError_enum_CUDA_ERROR_NOT_READY => Ok(false),
+            err => Err(DriverError(err)),
+        }
+    }
+
+    /// Returns the elapsed time in milliseconds between `self` (start) and
+    /// `end`.
+    ///
+    /// Both events are synchronized before querying. Both events must have
+    /// been created **without** `CU_EVENT_DISABLE_TIMING`; otherwise the
+    /// driver returns `CUDA_ERROR_INVALID_HANDLE`.
+    ///
+    /// `self` must have been recorded before `end` in wall-clock time.
+    pub fn elapsed_ms(&self, end: &Self) -> Result<f32, DriverError> {
+        self.synchronize()?;
+        end.synchronize()?;
+        let mut ms: f32 = 0.0;
+        unsafe {
+            cuda_bindings::cu_event_elapsed_time(&mut ms as *mut _, self.cu_event, end.cu_event)
+                .result()?;
+        }
+        Ok(ms)
+    }
+}

--- a/cuda-core/src/simt/launch.rs
+++ b/cuda-core/src/simt/launch.rs
@@ -1,0 +1,1895 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Kernel launch configuration.
+//!
+//! [`LaunchConfig`] bundles raw grid dimensions, block dimensions, and dynamic
+//! shared memory size. Constructing one is harmless, but submitting it without
+//! proving that it matches a kernel is unsafe. Use a rank-preserving config and
+//! [`PreparedLaunch`] for the checked path.
+
+use crate::{CudaFunction, CudaStream, DriverError};
+use std::error::Error;
+use std::fmt::{self, Display, Formatter};
+use std::marker::PhantomData;
+
+/// Grid and block dimensions plus dynamic shared memory size for a kernel
+/// launch.
+///
+/// Each dimension tuple is `(x, y, z)`. This is inert configuration data: it
+/// does not know which kernel will consume it and therefore cannot prove the
+/// kernel's indexing, resource, or synchronization assumptions. Passing it to
+/// a raw launch is an unsafe operation.
+#[derive(Clone, Copy, Debug)]
+pub struct LaunchConfig {
+    /// Grid dimensions `(x, y, z)` in blocks.
+    pub grid_dim: (u32, u32, u32),
+    /// Block dimensions `(x, y, z)` in threads.
+    pub block_dim: (u32, u32, u32),
+    /// Bytes of dynamic shared memory allocated per block.
+    pub shared_mem_bytes: u32,
+}
+
+impl LaunchConfig {
+    /// Creates a 1-D launch configuration for `n` elements.
+    ///
+    /// Uses a block size of 256 threads and computes the grid size via
+    /// ceiling division. No dynamic shared memory is requested.
+    ///
+    /// Suitable for simple element-wise kernels where thread index maps
+    /// directly to element index. The helper does not inspect a kernel, so it
+    /// does not by itself make a raw launch safe.
+    pub fn for_num_elems(n: u32) -> Self {
+        const DEFAULT_BLOCK_SIZE: u32 = 256;
+        let grid_x = n.div_ceil(DEFAULT_BLOCK_SIZE);
+        LaunchConfig {
+            grid_dim: (grid_x, 1, 1),
+            block_dim: (DEFAULT_BLOCK_SIZE, 1, 1),
+            shared_mem_bytes: 0,
+        }
+    }
+}
+
+mod sealed {
+    pub trait Sealed {}
+}
+
+/// A rank-preserving launch configuration accepted by a typed kernel contract.
+///
+/// This trait is sealed. Use [`LaunchConfig1D`], [`LaunchConfig2D`], or
+/// [`LaunchConfig3D`]; downstream crates cannot provide a configuration that
+/// bypasses their fixed trailing dimensions.
+pub trait KernelLaunchConfig: sealed::Sealed + Copy {
+    #[doc(hidden)]
+    fn __raw(self) -> LaunchConfig;
+}
+
+/// A one-dimensional launch configuration.
+///
+/// The hidden `y` and `z` grid and block dimensions are always `1`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct LaunchConfig1D {
+    grid_x: u32,
+    block_x: u32,
+    shared_mem_bytes: u32,
+}
+
+impl LaunchConfig1D {
+    /// Creates a one-dimensional launch configuration.
+    ///
+    /// Zero dimensions are reported when the configuration is prepared for a
+    /// concrete kernel, where the error can include that kernel's name.
+    pub const fn new(grid_x: u32, block_x: u32, shared_mem_bytes: u32) -> Self {
+        Self {
+            grid_x,
+            block_x,
+            shared_mem_bytes,
+        }
+    }
+}
+
+impl sealed::Sealed for LaunchConfig1D {}
+
+impl KernelLaunchConfig for LaunchConfig1D {
+    fn __raw(self) -> LaunchConfig {
+        LaunchConfig {
+            grid_dim: (self.grid_x, 1, 1),
+            block_dim: (self.block_x, 1, 1),
+            shared_mem_bytes: self.shared_mem_bytes,
+        }
+    }
+}
+
+/// A two-dimensional launch configuration.
+///
+/// The hidden `z` grid and block dimensions are always `1`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct LaunchConfig2D {
+    grid: (u32, u32),
+    block: (u32, u32),
+    shared_mem_bytes: u32,
+}
+
+impl LaunchConfig2D {
+    /// Creates a two-dimensional launch configuration.
+    pub const fn new(grid: (u32, u32), block: (u32, u32), shared_mem_bytes: u32) -> Self {
+        Self {
+            grid,
+            block,
+            shared_mem_bytes,
+        }
+    }
+}
+
+impl sealed::Sealed for LaunchConfig2D {}
+
+impl KernelLaunchConfig for LaunchConfig2D {
+    fn __raw(self) -> LaunchConfig {
+        LaunchConfig {
+            grid_dim: (self.grid.0, self.grid.1, 1),
+            block_dim: (self.block.0, self.block.1, 1),
+            shared_mem_bytes: self.shared_mem_bytes,
+        }
+    }
+}
+
+/// A three-dimensional launch configuration.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct LaunchConfig3D {
+    grid: (u32, u32, u32),
+    block: (u32, u32, u32),
+    shared_mem_bytes: u32,
+}
+
+impl LaunchConfig3D {
+    /// Creates a three-dimensional launch configuration.
+    pub const fn new(grid: (u32, u32, u32), block: (u32, u32, u32), shared_mem_bytes: u32) -> Self {
+        Self {
+            grid,
+            block,
+            shared_mem_bytes,
+        }
+    }
+}
+
+impl sealed::Sealed for LaunchConfig3D {}
+
+impl KernelLaunchConfig for LaunchConfig3D {
+    fn __raw(self) -> LaunchConfig {
+        LaunchConfig {
+            grid_dim: self.grid,
+            block_dim: self.block,
+            shared_mem_bytes: self.shared_mem_bytes,
+        }
+    }
+}
+
+/// The block shapes accepted by a kernel.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BlockRequirement {
+    /// The launch must use exactly these `(x, y, z)` block dimensions.
+    ///
+    /// A kernel compiled by cuda-oxide also carries this shape as PTX
+    /// `.reqntid`, so the CUDA driver rejects a differing block on any axis
+    /// independently of this check. Preparation still reports the mismatch
+    /// first, with the kernel name and both shapes.
+    Exact((u32, u32, u32)),
+    /// The block may contain at most this many threads in total.
+    ///
+    /// This matches CUDA `__launch_bounds__` / PTX `.maxntid` semantics: the
+    /// product `block.x * block.y * block.z` is bounded, not each axis.
+    /// `MaxThreads(256)` therefore accepts both `(256, 1, 1)` and
+    /// `(16, 16, 1)`.
+    MaxThreads(u32),
+}
+
+/// The dynamic shared-memory sizes accepted by a kernel.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DynamicSharedMemoryRequirement {
+    /// The launch must allocate exactly `bytes` bytes.
+    Exact {
+        /// Required bytes per block.
+        bytes: u32,
+        /// Minimum alignment assumed by the generated device code.
+        min_alignment: u32,
+    },
+    /// The launch may allocate any size in the inclusive range.
+    ///
+    /// Preparation requires the live function/device to support `max_bytes`,
+    /// even when one prepared configuration chooses fewer bytes. This proves
+    /// the function's dynamic-memory capacity for the full interval and lets
+    /// concurrent preparations install one monotonic, race-safe maximum.
+    /// Geometry-dependent cluster or cooperative occupancy is still checked
+    /// for each concrete prepared configuration.
+    Range {
+        /// Smallest valid allocation in bytes.
+        min_bytes: u32,
+        /// Largest valid allocation in bytes.
+        max_bytes: u32,
+        /// Minimum alignment assumed by the generated device code.
+        min_alignment: u32,
+    },
+}
+
+/// Coordinate widths whose range is guaranteed by launch preparation.
+///
+/// `U32` does not change CUDA's grid or block dimensions. It proves that each
+/// per-axis global coordinate fits in `u32`, allowing a contracted kernel to
+/// keep coordinate arithmetic narrow until the final address calculation.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum CoordinateRequirement {
+    /// Make no narrower-coordinate promise.
+    #[default]
+    Native,
+    /// Every active-axis coordinate is representable by `u32`.
+    U32,
+}
+
+/// An immutable description of a kernel's launch-time assumptions.
+///
+/// Macro-generated contract marker types expose one of these through
+/// [`KernelLaunchContract::SPEC`]. The name is retained in every validation
+/// error so failures point at the kernel whose assumptions were violated.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct LaunchContractSpec {
+    kernel_name: &'static str,
+    block: BlockRequirement,
+    dynamic_shared_memory: DynamicSharedMemoryRequirement,
+    cluster: Option<(u32, u32, u32)>,
+    cooperative: bool,
+    min_compute_capability: Option<(u32, u32)>,
+    coordinates: CoordinateRequirement,
+}
+
+impl LaunchContractSpec {
+    /// Creates a contract without cluster, cooperative, or architecture
+    /// requirements.
+    pub const fn new(
+        kernel_name: &'static str,
+        block: BlockRequirement,
+        dynamic_shared_memory: DynamicSharedMemoryRequirement,
+    ) -> Self {
+        Self {
+            kernel_name,
+            block,
+            dynamic_shared_memory,
+            cluster: None,
+            cooperative: false,
+            min_compute_capability: None,
+            coordinates: CoordinateRequirement::Native,
+        }
+    }
+
+    /// Requires fixed thread-block cluster dimensions.
+    #[must_use]
+    pub const fn with_cluster(mut self, cluster: (u32, u32, u32)) -> Self {
+        self.cluster = Some(cluster);
+        self
+    }
+
+    /// Requires a cooperative launch.
+    #[must_use]
+    pub const fn with_cooperative(mut self) -> Self {
+        self.cooperative = true;
+        self
+    }
+
+    /// Requires at least the supplied CUDA compute capability.
+    #[must_use]
+    pub const fn with_min_compute_capability(mut self, major: u32, minor: u32) -> Self {
+        self.min_compute_capability = Some((major, minor));
+        self
+    }
+
+    /// Proves that every global coordinate fits in `u32`.
+    ///
+    /// Preparation checks `grid_axis * block_axis <= 2^32` independently for
+    /// X, Y, and Z. Exactly `2^32` positions is valid because the largest
+    /// zero-based coordinate is `u32::MAX`.
+    #[must_use]
+    pub const fn with_u32_coordinates(mut self) -> Self {
+        self.coordinates = CoordinateRequirement::U32;
+        self
+    }
+
+    /// Returns the diagnostic kernel name.
+    pub const fn kernel_name(&self) -> &'static str {
+        self.kernel_name
+    }
+
+    /// Returns the block-shape requirement.
+    pub const fn block(&self) -> BlockRequirement {
+        self.block
+    }
+
+    /// Returns the dynamic shared-memory requirement.
+    pub const fn dynamic_shared_memory(&self) -> DynamicSharedMemoryRequirement {
+        self.dynamic_shared_memory
+    }
+
+    /// Returns the required cluster dimensions, if any.
+    pub const fn cluster(&self) -> Option<(u32, u32, u32)> {
+        self.cluster
+    }
+
+    /// Returns whether the kernel requires a cooperative launch.
+    pub const fn cooperative(&self) -> bool {
+        self.cooperative
+    }
+
+    /// Returns the minimum compute capability, if one was declared.
+    pub const fn min_compute_capability(&self) -> Option<(u32, u32)> {
+        self.min_compute_capability
+    }
+
+    /// Returns the coordinate-width requirement.
+    pub const fn coordinates(&self) -> CoordinateRequirement {
+        self.coordinates
+    }
+}
+
+/// A macro-generated kernel marker implements this trait to bind a launch
+/// rank to one immutable contract.
+pub trait KernelLaunchContract {
+    /// Rank-preserving host launch configuration for this kernel.
+    type Config: KernelLaunchConfig;
+
+    /// Compile-time launch assumptions emitted by the kernel macro.
+    const SPEC: LaunchContractSpec;
+}
+
+/// Device launch limits that apply independently of a particular kernel.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct DeviceLaunchLimits {
+    pub(crate) max_threads_per_block: u32,
+    pub(crate) max_block_dim: (u32, u32, u32),
+    pub(crate) max_grid_dim: (u32, u32, u32),
+    pub(crate) max_shared_memory_per_block: u32,
+}
+
+impl DeviceLaunchLimits {
+    /// Maximum threads in one block.
+    pub const fn max_threads_per_block(&self) -> u32 {
+        self.max_threads_per_block
+    }
+
+    /// Maximum block dimensions `(x, y, z)`.
+    pub const fn max_block_dim(&self) -> (u32, u32, u32) {
+        self.max_block_dim
+    }
+
+    /// Maximum grid dimensions `(x, y, z)`.
+    pub const fn max_grid_dim(&self) -> (u32, u32, u32) {
+        self.max_grid_dim
+    }
+
+    /// Portable shared-memory limit per block, including static and dynamic
+    /// shared memory.
+    pub const fn max_shared_memory_per_block(&self) -> u32 {
+        self.max_shared_memory_per_block
+    }
+}
+
+/// Which launch dimension is named by a validation error.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum LaunchDimension {
+    /// Grid dimensions, measured in blocks.
+    Grid,
+    /// Block dimensions, measured in threads.
+    Block,
+    /// Thread-block cluster dimensions, measured in blocks.
+    Cluster,
+}
+
+/// Axis named by a dimension validation error.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum LaunchAxis {
+    /// X axis.
+    X,
+    /// Y axis.
+    Y,
+    /// Z axis.
+    Z,
+}
+
+/// Why preparation of a typed kernel launch failed.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum LaunchContractError {
+    /// The contract omitted a useful kernel name.
+    EmptyKernelName,
+    /// A grid, block, or cluster dimension was zero.
+    ZeroDimension {
+        /// Kernel being prepared.
+        kernel: &'static str,
+        /// Dimension group containing the zero.
+        dimension: LaunchDimension,
+        /// Axis containing the zero.
+        axis: LaunchAxis,
+    },
+    /// Multiplying a three-dimensional shape exceeded the representable range.
+    DimensionProductOverflow {
+        /// Kernel being prepared.
+        kernel: &'static str,
+        /// Shape whose product overflowed.
+        dimension: LaunchDimension,
+    },
+    /// A per-axis global coordinate cannot be represented by `u32`.
+    CoordinateRangeExceedsU32 {
+        /// Kernel being prepared.
+        kernel: &'static str,
+        /// Axis whose coordinate range is too large.
+        axis: LaunchAxis,
+        /// Number of blocks on this axis.
+        grid: u32,
+        /// Number of threads per block on this axis.
+        block: u32,
+        /// Number of coordinate values required on this axis.
+        positions: u64,
+    },
+    /// A shared-memory alignment was not a nonzero power of two.
+    InvalidSharedMemoryAlignment {
+        /// Kernel being prepared.
+        kernel: &'static str,
+        /// Invalid alignment.
+        alignment: u32,
+    },
+    /// A shared-memory range had its endpoints reversed.
+    InvalidSharedMemoryRange {
+        /// Kernel being prepared.
+        kernel: &'static str,
+        /// Inclusive lower bound.
+        min_bytes: u32,
+        /// Inclusive upper bound.
+        max_bytes: u32,
+    },
+    /// The launch block did not equal the contract's exact block.
+    BlockShapeMismatch {
+        /// Kernel being prepared.
+        kernel: &'static str,
+        /// Required block dimensions.
+        required: (u32, u32, u32),
+        /// Requested block dimensions.
+        actual: (u32, u32, u32),
+    },
+    /// The block contained more threads than the contract permits.
+    BlockThreadsExceedContract {
+        /// Kernel being prepared.
+        kernel: &'static str,
+        /// Requested threads per block.
+        actual: u64,
+        /// Contract maximum threads per block.
+        max: u32,
+    },
+    /// Dynamic shared memory did not equal the contract's exact size.
+    DynamicSharedMemoryExactMismatch {
+        /// Kernel being prepared.
+        kernel: &'static str,
+        /// Required byte count.
+        required: u32,
+        /// Requested byte count.
+        actual: u32,
+    },
+    /// Dynamic shared memory fell outside the contract's inclusive range.
+    DynamicSharedMemoryOutsideRange {
+        /// Kernel being prepared.
+        kernel: &'static str,
+        /// Inclusive lower bound.
+        min: u32,
+        /// Inclusive upper bound.
+        max: u32,
+        /// Requested byte count.
+        actual: u32,
+    },
+    /// A cluster axis did not evenly divide the corresponding grid axis.
+    ClusterDoesNotDivideGrid {
+        /// Kernel being prepared.
+        kernel: &'static str,
+        /// Axis that is not divisible.
+        axis: LaunchAxis,
+        /// Requested grid axis size.
+        grid: u32,
+        /// Required cluster axis size.
+        cluster: u32,
+    },
+    /// A launch dimension exceeded a live device limit.
+    DeviceDimensionExceeded {
+        /// Kernel being prepared.
+        kernel: &'static str,
+        /// Grid or block dimensions.
+        dimension: LaunchDimension,
+        /// Axis that exceeded its limit.
+        axis: LaunchAxis,
+        /// Requested size.
+        actual: u32,
+        /// Device maximum.
+        max: u32,
+    },
+    /// The block contained more threads than the device permits.
+    DeviceThreadsPerBlockExceeded {
+        /// Kernel being prepared.
+        kernel: &'static str,
+        /// Requested threads per block.
+        actual: u64,
+        /// Device maximum.
+        max: u32,
+    },
+    /// The block contained more threads than this function permits.
+    FunctionThreadsPerBlockExceeded {
+        /// Kernel being prepared.
+        kernel: &'static str,
+        /// Requested threads per block.
+        actual: u64,
+        /// Function maximum.
+        max: u32,
+    },
+    /// Static plus dynamic shared-memory arithmetic overflowed.
+    SharedMemoryTotalOverflow {
+        /// Kernel being prepared.
+        kernel: &'static str,
+        /// Function's static allocation.
+        static_bytes: u32,
+        /// Requested dynamic allocation.
+        dynamic_bytes: u32,
+    },
+    /// Static plus dynamic shared memory exceeded the device limit.
+    DeviceSharedMemoryExceeded {
+        /// Kernel being prepared.
+        kernel: &'static str,
+        /// Requested static plus dynamic bytes.
+        total: u64,
+        /// Device maximum.
+        max: u32,
+        /// Whether `max` is the device's opt-in limit.
+        opt_in: bool,
+    },
+    /// The device compute capability is below the contract minimum.
+    ComputeCapabilityTooLow {
+        /// Kernel being prepared.
+        kernel: &'static str,
+        /// Contract minimum.
+        required: (u32, u32),
+        /// Live device capability.
+        actual: (u32, u32),
+    },
+    /// The live device does not support cooperative launch.
+    CooperativeLaunchUnsupported {
+        /// Kernel being prepared.
+        kernel: &'static str,
+    },
+    /// The live device does not support thread-block clusters.
+    ClusterLaunchUnsupported {
+        /// Kernel being prepared.
+        kernel: &'static str,
+    },
+    /// The requested cluster contains more blocks than this function and
+    /// launch shape support on the live device.
+    ClusterSizeExceeded {
+        /// Kernel being prepared.
+        kernel: &'static str,
+        /// Requested blocks per cluster.
+        blocks: u64,
+        /// Maximum blocks per cluster reported by occupancy.
+        max: u32,
+    },
+    /// The contract disagrees with cluster dimensions compiled into the
+    /// function.
+    FunctionClusterShapeMismatch {
+        /// Kernel being prepared.
+        kernel: &'static str,
+        /// Cluster dimensions declared by the host contract.
+        declared: (u32, u32, u32),
+        /// Cluster dimensions required by the compiled function.
+        required: (u32, u32, u32),
+    },
+    /// The host contract declares a fixed cluster but the compiled function
+    /// does not contain matching required-cluster metadata.
+    RequiredClusterDimensionsMissing {
+        /// Kernel being prepared.
+        kernel: &'static str,
+        /// Cluster dimensions declared by the host contract.
+        declared: (u32, u32, u32),
+    },
+    /// CUDA rejected the concrete cluster shape for this function and launch
+    /// configuration.
+    ClusterShapeUnsupported {
+        /// Kernel being prepared.
+        kernel: &'static str,
+        /// Requested cluster dimensions.
+        cluster: (u32, u32, u32),
+    },
+    /// CUDA reported that no cluster of the requested shape can be resident.
+    ClusterHasNoResidency {
+        /// Kernel being prepared.
+        kernel: &'static str,
+        /// Requested cluster dimensions.
+        cluster: (u32, u32, u32),
+    },
+    /// A cooperative grid cannot be fully resident on the device.
+    CooperativeGridTooLarge {
+        /// Kernel being prepared.
+        kernel: &'static str,
+        /// Requested number of blocks.
+        blocks: u64,
+        /// Maximum resident blocks for this function and launch shape.
+        resident_capacity: u64,
+    },
+    /// A stream belongs to a different CUDA context from the prepared function.
+    ContextMismatch {
+        /// Kernel being launched.
+        kernel: &'static str,
+        /// Function device ordinal.
+        function_device: usize,
+        /// Stream device ordinal.
+        stream_device: usize,
+    },
+    /// A declared `requires` size requirement over the kernel's
+    /// parameters did not hold at launch time.
+    SizeRequirementViolated {
+        /// Kernel being launched.
+        kernel: &'static str,
+        /// Source text of the violated relation.
+        relation: &'static str,
+        /// Evaluated left-hand side of the comparison, widened to `u64`.
+        lhs: u64,
+        /// Evaluated right-hand side of the comparison, widened to `u64`.
+        rhs: u64,
+    },
+    /// Arithmetic inside a `requires` size requirement left the `u64`
+    /// range, so the relation could not be evaluated.
+    SizeRequirementOverflow {
+        /// Kernel being launched.
+        kernel: &'static str,
+        /// Source text of the relation whose arithmetic overflowed.
+        relation: &'static str,
+    },
+    /// A CUDA driver query or one-time function configuration failed.
+    Driver(DriverError),
+}
+
+impl Display for LaunchContractError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyKernelName => write!(f, "kernel launch contract has an empty name"),
+            Self::ZeroDimension {
+                kernel,
+                dimension,
+                axis,
+            } => write!(f, "{kernel}: {dimension:?}.{axis:?} must be nonzero"),
+            Self::DimensionProductOverflow { kernel, dimension } => {
+                write!(f, "{kernel}: {dimension:?} dimension product overflowed")
+            }
+            Self::CoordinateRangeExceedsU32 {
+                kernel,
+                axis,
+                grid,
+                block,
+                positions,
+            } => write!(
+                f,
+                "{kernel}: Grid.{axis:?} {grid} * Block.{axis:?} {block} requires {positions} coordinates, exceeding the u32 range"
+            ),
+            Self::InvalidSharedMemoryAlignment { kernel, alignment } => write!(
+                f,
+                "{kernel}: dynamic shared-memory alignment {alignment} is not a nonzero power of two"
+            ),
+            Self::InvalidSharedMemoryRange {
+                kernel,
+                min_bytes,
+                max_bytes,
+            } => write!(
+                f,
+                "{kernel}: dynamic shared-memory range {min_bytes}..={max_bytes} is invalid"
+            ),
+            Self::BlockShapeMismatch {
+                kernel,
+                required,
+                actual,
+            } => write!(
+                f,
+                "{kernel}: block {actual:?} does not match required block {required:?}"
+            ),
+            Self::BlockThreadsExceedContract {
+                kernel,
+                actual,
+                max,
+            } => write!(
+                f,
+                "{kernel}: block has {actual} threads; contract maximum is {max}"
+            ),
+            Self::DynamicSharedMemoryExactMismatch {
+                kernel,
+                required,
+                actual,
+            } => write!(
+                f,
+                "{kernel}: dynamic shared memory is {actual} bytes; contract requires {required}"
+            ),
+            Self::DynamicSharedMemoryOutsideRange {
+                kernel,
+                min,
+                max,
+                actual,
+            } => write!(
+                f,
+                "{kernel}: dynamic shared memory is {actual} bytes; contract permits {min}..={max}"
+            ),
+            Self::ClusterDoesNotDivideGrid {
+                kernel,
+                axis,
+                grid,
+                cluster,
+            } => write!(
+                f,
+                "{kernel}: cluster {axis:?} size {cluster} does not divide grid size {grid}"
+            ),
+            Self::DeviceDimensionExceeded {
+                kernel,
+                dimension,
+                axis,
+                actual,
+                max,
+            } => write!(
+                f,
+                "{kernel}: {dimension:?}.{axis:?} size {actual} exceeds device maximum {max}"
+            ),
+            Self::DeviceThreadsPerBlockExceeded {
+                kernel,
+                actual,
+                max,
+            } => write!(
+                f,
+                "{kernel}: block has {actual} threads; device maximum is {max}"
+            ),
+            Self::FunctionThreadsPerBlockExceeded {
+                kernel,
+                actual,
+                max,
+            } => write!(
+                f,
+                "{kernel}: block has {actual} threads; function maximum is {max}"
+            ),
+            Self::SharedMemoryTotalOverflow {
+                kernel,
+                static_bytes,
+                dynamic_bytes,
+            } => write!(
+                f,
+                "{kernel}: {static_bytes} static + {dynamic_bytes} dynamic shared-memory bytes overflowed"
+            ),
+            Self::DeviceSharedMemoryExceeded {
+                kernel,
+                total,
+                max,
+                opt_in,
+            } => write!(
+                f,
+                "{kernel}: {total} shared-memory bytes exceed the device {} limit {max}",
+                if *opt_in { "opt-in" } else { "portable" }
+            ),
+            Self::ComputeCapabilityTooLow {
+                kernel,
+                required,
+                actual,
+            } => write!(
+                f,
+                "{kernel}: compute capability {}.{} is below required {}.{}",
+                actual.0, actual.1, required.0, required.1
+            ),
+            Self::CooperativeLaunchUnsupported { kernel } => {
+                write!(f, "{kernel}: device does not support cooperative launch")
+            }
+            Self::ClusterLaunchUnsupported { kernel } => {
+                write!(f, "{kernel}: device does not support cluster launch")
+            }
+            Self::ClusterSizeExceeded {
+                kernel,
+                blocks,
+                max,
+            } => write!(
+                f,
+                "{kernel}: cluster has {blocks} blocks; live maximum is {max}"
+            ),
+            Self::FunctionClusterShapeMismatch {
+                kernel,
+                declared,
+                required,
+            } => write!(
+                f,
+                "{kernel}: declared cluster {declared:?} does not match function-required cluster {required:?}"
+            ),
+            Self::RequiredClusterDimensionsMissing { kernel, declared } => write!(
+                f,
+                "{kernel}: declared cluster {declared:?} is missing from the compiled function metadata"
+            ),
+            Self::ClusterShapeUnsupported { kernel, cluster } => write!(
+                f,
+                "{kernel}: cluster shape {cluster:?} is unsupported for this launch"
+            ),
+            Self::ClusterHasNoResidency { kernel, cluster } => write!(
+                f,
+                "{kernel}: no cluster with shape {cluster:?} can be resident"
+            ),
+            Self::CooperativeGridTooLarge {
+                kernel,
+                blocks,
+                resident_capacity,
+            } => write!(
+                f,
+                "{kernel}: cooperative grid has {blocks} blocks but only {resident_capacity} can be resident"
+            ),
+            Self::ContextMismatch {
+                kernel,
+                function_device,
+                stream_device,
+            } => write!(
+                f,
+                "{kernel}: function is on device {function_device}, stream is on device {stream_device}"
+            ),
+            Self::SizeRequirementViolated {
+                kernel,
+                relation,
+                lhs,
+                rhs,
+            } => write!(
+                f,
+                "{kernel}: size requirement `{relation}` violated: left-hand side is {lhs}, right-hand side is {rhs}"
+            ),
+            Self::SizeRequirementOverflow { kernel, relation } => write!(
+                f,
+                "{kernel}: arithmetic in size requirement `{relation}` overflowed the u64 range"
+            ),
+            Self::Driver(error) => Display::fmt(error, f),
+        }
+    }
+}
+
+impl Error for LaunchContractError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Driver(error) => Some(error),
+            _ => None,
+        }
+    }
+}
+
+impl From<DriverError> for LaunchContractError {
+    fn from(value: DriverError) -> Self {
+        Self::Driver(value)
+    }
+}
+
+/// A kernel function and launch configuration whose contract has been checked.
+///
+/// Preparation performs all device/function resource queries. Reusing this
+/// value performs no contract query; it only compares the stream's context
+/// handle before the normal launch path binds that context.
+pub struct PreparedLaunch<C: KernelLaunchContract> {
+    function: CudaFunction,
+    config: LaunchConfig,
+    _contract: PhantomData<fn(C) -> C>,
+}
+
+impl<C: KernelLaunchContract> Clone for PreparedLaunch<C> {
+    fn clone(&self) -> Self {
+        Self {
+            function: self.function.clone(),
+            config: self.config,
+            _contract: PhantomData,
+        }
+    }
+}
+
+impl<C: KernelLaunchContract> PreparedLaunch<C> {
+    /// Validates and prepares one generated kernel launch.
+    ///
+    /// This entry point is public only so `#[cuda_module]` expansions in
+    /// downstream crates can call it. Applications should use the generated
+    /// module constructor.
+    ///
+    /// # Safety
+    ///
+    /// `C::SPEC` must truthfully describe the compiled device function,
+    /// including its rank, fixed block assumptions, shared-memory layout, and
+    /// launch mode. cuda-oxide's macros generate that marker and uphold this
+    /// relationship.
+    #[doc(hidden)]
+    pub unsafe fn __prepare(
+        function: CudaFunction,
+        config: C::Config,
+    ) -> Result<Self, LaunchContractError> {
+        let raw = config.__raw();
+        validate_static(C::SPEC, raw)?;
+
+        let context = function.context();
+        let limits = context.launch_limits()?;
+        let function_max_threads = function.max_threads_per_block()?;
+        let static_shared = function.static_shared_memory_bytes()?;
+        let function_max_dynamic = function.max_dynamic_shared_memory_bytes()?;
+
+        validate_live_shape(C::SPEC, raw, limits, function_max_threads)?;
+
+        // Configure the immutable contract maximum, not this particular
+        // launch's chosen size. Concurrent preparations of two range values
+        // therefore write the same function attribute and cannot lower the
+        // maximum underneath an already prepared launch.
+        let contract_dynamic_max = dynamic_shared_memory_max(C::SPEC.dynamic_shared_memory);
+        let total_shared =
+            shared_memory_total(C::SPEC.kernel_name, static_shared, contract_dynamic_max)?;
+        if validate_shared_memory_limit(
+            C::SPEC.kernel_name,
+            total_shared,
+            limits.max_shared_memory_per_block,
+            false,
+        )
+        .is_err()
+        {
+            let opt_in_max = context.max_opt_in_shared_memory_per_block()?;
+            validate_shared_memory_limit(C::SPEC.kernel_name, total_shared, opt_in_max, true)?;
+        }
+
+        if let Some(required) = C::SPEC.min_compute_capability {
+            let (major, minor) = context.compute_capability()?;
+            let actual = (
+                u32::try_from(major).map_err(|_| {
+                    DriverError(cuda_bindings::cudaError_enum_CUDA_ERROR_INVALID_VALUE)
+                })?,
+                u32::try_from(minor).map_err(|_| {
+                    DriverError(cuda_bindings::cudaError_enum_CUDA_ERROR_INVALID_VALUE)
+                })?,
+            );
+            validate_compute_capability(C::SPEC.kernel_name, required, actual)?;
+        }
+
+        if let Some(cluster) = C::SPEC.cluster {
+            validate_cluster_support(C::SPEC.kernel_name, context.supports_cluster_launch()?)?;
+            validate_required_cluster(
+                C::SPEC.kernel_name,
+                cluster,
+                function.required_cluster_dimensions()?,
+            )?;
+        }
+
+        if C::SPEC.cooperative {
+            validate_cooperative_support(
+                C::SPEC.kernel_name,
+                context.supports_cooperative_launch()?,
+            )?;
+        }
+
+        // Perform the only persistent function mutation after all checks that
+        // do not themselves depend on the opted-in maximum. Cluster occupancy
+        // is checked next and may leave this monotonic increase in place when
+        // the concrete cluster shape is rejected.
+        if contract_dynamic_max > function_max_dynamic {
+            function.set_max_dynamic_shared_memory_bytes(contract_dynamic_max)?;
+        }
+
+        // Cluster occupancy is reused for cooperative residency when both
+        // modes are declared: a cooperative clustered grid must fit entirely
+        // in the concurrent cluster capacity reported by
+        // `cuOccupancyMaxActiveClusters`.
+        let mut clustered_resident_blocks: Option<u64> = None;
+
+        if let Some(cluster) = C::SPEC.cluster {
+            let max_cluster_size = function.max_potential_cluster_size(
+                raw.grid_dim,
+                raw.block_dim,
+                raw.shared_mem_bytes,
+            )?;
+            let cluster_blocks =
+                shape_product(C::SPEC.kernel_name, LaunchDimension::Cluster, cluster)?;
+            validate_cluster_size(C::SPEC.kernel_name, cluster_blocks, max_cluster_size)?;
+
+            let active_clusters = match function.max_active_clusters(
+                raw.grid_dim,
+                raw.block_dim,
+                raw.shared_mem_bytes,
+                cluster,
+            ) {
+                Ok(active_clusters) => active_clusters,
+                Err(error)
+                    if error.0 == cuda_bindings::cudaError_enum_CUDA_ERROR_INVALID_CLUSTER_SIZE =>
+                {
+                    return Err(LaunchContractError::ClusterShapeUnsupported {
+                        kernel: C::SPEC.kernel_name,
+                        cluster,
+                    });
+                }
+                Err(error) => return Err(error.into()),
+            };
+            validate_cluster_residency(C::SPEC.kernel_name, cluster, active_clusters)?;
+            // Deliberate error reuse: `active_clusters * cluster_blocks` is a
+            // device-capacity product over the cluster dimension, and
+            // `DimensionProductOverflow { Cluster }` is the closest existing
+            // diagnostic. The arm is unreachable in practice: both factors fit
+            // in u32 (`active_clusters` is driver-reported, `cluster_blocks`
+            // was validated against the u32 `max_cluster_size` above), so the
+            // product always fits in u64. `checked_mul` keeps the math honest.
+            clustered_resident_blocks = Some(
+                u64::from(active_clusters)
+                    .checked_mul(cluster_blocks)
+                    .ok_or(LaunchContractError::DimensionProductOverflow {
+                        kernel: C::SPEC.kernel_name,
+                        dimension: LaunchDimension::Cluster,
+                    })?,
+            );
+        }
+
+        if C::SPEC.cooperative {
+            let blocks = shape_product(C::SPEC.kernel_name, LaunchDimension::Grid, raw.grid_dim)?;
+            let resident_capacity = if let Some(capacity) = clustered_resident_blocks {
+                capacity
+            } else {
+                let block_threads =
+                    shape_product(C::SPEC.kernel_name, LaunchDimension::Block, raw.block_dim)?;
+                let active_per_sm = function.max_active_blocks_per_multiprocessor(
+                    block_threads as u32,
+                    raw.shared_mem_bytes,
+                )?;
+                let multiprocessors = context.multiprocessor_count()?;
+                u64::from(active_per_sm) * u64::from(multiprocessors)
+            };
+            validate_cooperative_residency(C::SPEC.kernel_name, blocks, resident_capacity)?;
+        }
+
+        Ok(Self {
+            function,
+            config: raw,
+            _contract: PhantomData,
+        })
+    }
+
+    /// Returns the prepared CUDA function.
+    pub fn function(&self) -> &CudaFunction {
+        &self.function
+    }
+
+    /// Returns a copy of the validated raw launch configuration.
+    ///
+    /// This is hidden because generated launch methods are its intended
+    /// consumer. Mutating the copy cannot change the prepared launch.
+    #[doc(hidden)]
+    pub fn __raw_config(&self) -> LaunchConfig {
+        self.config
+    }
+
+    /// Rejects a stream from a different context without making a driver call.
+    pub fn validate_stream(&self, stream: &CudaStream) -> Result<(), LaunchContractError> {
+        let function_context = self.function.context();
+        let stream_context = stream.context();
+        if function_context.cu_ctx() == stream_context.cu_ctx() {
+            Ok(())
+        } else {
+            Err(LaunchContractError::ContextMismatch {
+                kernel: C::SPEC.kernel_name,
+                function_device: function_context.ordinal(),
+                stream_device: stream_context.ordinal(),
+            })
+        }
+    }
+}
+
+fn validate_static(
+    spec: LaunchContractSpec,
+    config: LaunchConfig,
+) -> Result<(), LaunchContractError> {
+    if spec.kernel_name.trim().is_empty() {
+        return Err(LaunchContractError::EmptyKernelName);
+    }
+
+    validate_shape(spec.kernel_name, LaunchDimension::Grid, config.grid_dim)?;
+    validate_shape(spec.kernel_name, LaunchDimension::Block, config.block_dim)?;
+
+    if spec.coordinates == CoordinateRequirement::U32 {
+        validate_u32_coordinates(spec.kernel_name, config.grid_dim, config.block_dim)?;
+    }
+
+    match spec.block {
+        BlockRequirement::Exact(required) => {
+            validate_shape(spec.kernel_name, LaunchDimension::Block, required)?;
+            if config.block_dim != required {
+                return Err(LaunchContractError::BlockShapeMismatch {
+                    kernel: spec.kernel_name,
+                    required,
+                    actual: config.block_dim,
+                });
+            }
+        }
+        BlockRequirement::MaxThreads(max) => {
+            let actual = shape_product(spec.kernel_name, LaunchDimension::Block, config.block_dim)?;
+            if actual > u64::from(max) {
+                return Err(LaunchContractError::BlockThreadsExceedContract {
+                    kernel: spec.kernel_name,
+                    actual,
+                    max,
+                });
+            }
+        }
+    }
+
+    match spec.dynamic_shared_memory {
+        DynamicSharedMemoryRequirement::Exact {
+            bytes,
+            min_alignment,
+        } => {
+            validate_alignment(spec.kernel_name, min_alignment)?;
+            if config.shared_mem_bytes != bytes {
+                return Err(LaunchContractError::DynamicSharedMemoryExactMismatch {
+                    kernel: spec.kernel_name,
+                    required: bytes,
+                    actual: config.shared_mem_bytes,
+                });
+            }
+        }
+        DynamicSharedMemoryRequirement::Range {
+            min_bytes,
+            max_bytes,
+            min_alignment,
+        } => {
+            validate_alignment(spec.kernel_name, min_alignment)?;
+            if min_bytes > max_bytes {
+                return Err(LaunchContractError::InvalidSharedMemoryRange {
+                    kernel: spec.kernel_name,
+                    min_bytes,
+                    max_bytes,
+                });
+            }
+            if !(min_bytes..=max_bytes).contains(&config.shared_mem_bytes) {
+                return Err(LaunchContractError::DynamicSharedMemoryOutsideRange {
+                    kernel: spec.kernel_name,
+                    min: min_bytes,
+                    max: max_bytes,
+                    actual: config.shared_mem_bytes,
+                });
+            }
+        }
+    }
+
+    if let Some(cluster) = spec.cluster {
+        validate_shape(spec.kernel_name, LaunchDimension::Cluster, cluster)?;
+        for (axis, grid, cluster) in axes(config.grid_dim, cluster) {
+            if grid % cluster != 0 {
+                return Err(LaunchContractError::ClusterDoesNotDivideGrid {
+                    kernel: spec.kernel_name,
+                    axis,
+                    grid,
+                    cluster,
+                });
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_u32_coordinates(
+    kernel: &'static str,
+    grid: (u32, u32, u32),
+    block: (u32, u32, u32),
+) -> Result<(), LaunchContractError> {
+    const U32_COORDINATE_COUNT: u64 = u32::MAX as u64 + 1;
+
+    for (axis, grid, block) in axes(grid, block) {
+        let positions = u64::from(grid) * u64::from(block);
+        if positions > U32_COORDINATE_COUNT {
+            return Err(LaunchContractError::CoordinateRangeExceedsU32 {
+                kernel,
+                axis,
+                grid,
+                block,
+                positions,
+            });
+        }
+    }
+    Ok(())
+}
+
+fn validate_live_shape(
+    spec: LaunchContractSpec,
+    config: LaunchConfig,
+    limits: DeviceLaunchLimits,
+    function_max_threads: u32,
+) -> Result<(), LaunchContractError> {
+    validate_axes(config.grid_dim, limits.max_grid_dim, |axis, actual, max| {
+        LaunchContractError::DeviceDimensionExceeded {
+            kernel: spec.kernel_name,
+            dimension: LaunchDimension::Grid,
+            axis,
+            actual,
+            max,
+        }
+    })?;
+    validate_axes(
+        config.block_dim,
+        limits.max_block_dim,
+        |axis, actual, max| LaunchContractError::DeviceDimensionExceeded {
+            kernel: spec.kernel_name,
+            dimension: LaunchDimension::Block,
+            axis,
+            actual,
+            max,
+        },
+    )?;
+
+    let threads = shape_product(spec.kernel_name, LaunchDimension::Block, config.block_dim)?;
+    if threads > u64::from(limits.max_threads_per_block) {
+        return Err(LaunchContractError::DeviceThreadsPerBlockExceeded {
+            kernel: spec.kernel_name,
+            actual: threads,
+            max: limits.max_threads_per_block,
+        });
+    }
+    if threads > u64::from(function_max_threads) {
+        return Err(LaunchContractError::FunctionThreadsPerBlockExceeded {
+            kernel: spec.kernel_name,
+            actual: threads,
+            max: function_max_threads,
+        });
+    }
+
+    Ok(())
+}
+
+fn shared_memory_total(
+    kernel: &'static str,
+    static_bytes: u32,
+    dynamic_bytes: u32,
+) -> Result<u64, LaunchContractError> {
+    static_bytes
+        .checked_add(dynamic_bytes)
+        .map(u64::from)
+        .ok_or(LaunchContractError::SharedMemoryTotalOverflow {
+            kernel,
+            static_bytes,
+            dynamic_bytes,
+        })
+}
+
+const fn dynamic_shared_memory_max(requirement: DynamicSharedMemoryRequirement) -> u32 {
+    match requirement {
+        DynamicSharedMemoryRequirement::Exact { bytes, .. } => bytes,
+        DynamicSharedMemoryRequirement::Range { max_bytes, .. } => max_bytes,
+    }
+}
+
+fn validate_shared_memory_limit(
+    kernel: &'static str,
+    total: u64,
+    max: u32,
+    opt_in: bool,
+) -> Result<(), LaunchContractError> {
+    if total <= u64::from(max) {
+        Ok(())
+    } else {
+        Err(LaunchContractError::DeviceSharedMemoryExceeded {
+            kernel,
+            total,
+            max,
+            opt_in,
+        })
+    }
+}
+
+fn validate_compute_capability(
+    kernel: &'static str,
+    required: (u32, u32),
+    actual: (u32, u32),
+) -> Result<(), LaunchContractError> {
+    if actual >= required {
+        Ok(())
+    } else {
+        Err(LaunchContractError::ComputeCapabilityTooLow {
+            kernel,
+            required,
+            actual,
+        })
+    }
+}
+
+fn validate_cluster_support(
+    kernel: &'static str,
+    supported: bool,
+) -> Result<(), LaunchContractError> {
+    if supported {
+        Ok(())
+    } else {
+        Err(LaunchContractError::ClusterLaunchUnsupported { kernel })
+    }
+}
+
+fn validate_cluster_size(
+    kernel: &'static str,
+    blocks: u64,
+    max: u32,
+) -> Result<(), LaunchContractError> {
+    if blocks <= u64::from(max) {
+        Ok(())
+    } else {
+        Err(LaunchContractError::ClusterSizeExceeded {
+            kernel,
+            blocks,
+            max,
+        })
+    }
+}
+
+fn validate_required_cluster(
+    kernel: &'static str,
+    declared: (u32, u32, u32),
+    required: Option<(u32, u32, u32)>,
+) -> Result<(), LaunchContractError> {
+    match required {
+        Some(required) if declared == required => Ok(()),
+        Some(required) => Err(LaunchContractError::FunctionClusterShapeMismatch {
+            kernel,
+            declared,
+            required,
+        }),
+        None => Err(LaunchContractError::RequiredClusterDimensionsMissing { kernel, declared }),
+    }
+}
+
+fn validate_cluster_residency(
+    kernel: &'static str,
+    cluster: (u32, u32, u32),
+    active_clusters: u32,
+) -> Result<(), LaunchContractError> {
+    if active_clusters != 0 {
+        Ok(())
+    } else {
+        Err(LaunchContractError::ClusterHasNoResidency { kernel, cluster })
+    }
+}
+
+fn validate_cooperative_support(
+    kernel: &'static str,
+    supported: bool,
+) -> Result<(), LaunchContractError> {
+    if supported {
+        Ok(())
+    } else {
+        Err(LaunchContractError::CooperativeLaunchUnsupported { kernel })
+    }
+}
+
+fn validate_cooperative_residency(
+    kernel: &'static str,
+    blocks: u64,
+    resident_capacity: u64,
+) -> Result<(), LaunchContractError> {
+    if blocks <= resident_capacity {
+        Ok(())
+    } else {
+        Err(LaunchContractError::CooperativeGridTooLarge {
+            kernel,
+            blocks,
+            resident_capacity,
+        })
+    }
+}
+
+fn validate_alignment(kernel: &'static str, alignment: u32) -> Result<(), LaunchContractError> {
+    if alignment.is_power_of_two() {
+        Ok(())
+    } else {
+        Err(LaunchContractError::InvalidSharedMemoryAlignment { kernel, alignment })
+    }
+}
+
+fn validate_shape(
+    kernel: &'static str,
+    dimension: LaunchDimension,
+    shape: (u32, u32, u32),
+) -> Result<(), LaunchContractError> {
+    for (axis, value, _) in axes(shape, shape) {
+        if value == 0 {
+            return Err(LaunchContractError::ZeroDimension {
+                kernel,
+                dimension,
+                axis,
+            });
+        }
+    }
+    shape_product(kernel, dimension, shape)?;
+    Ok(())
+}
+
+fn shape_product(
+    kernel: &'static str,
+    dimension: LaunchDimension,
+    shape: (u32, u32, u32),
+) -> Result<u64, LaunchContractError> {
+    u64::from(shape.0)
+        .checked_mul(u64::from(shape.1))
+        .and_then(|xy| xy.checked_mul(u64::from(shape.2)))
+        .ok_or(LaunchContractError::DimensionProductOverflow { kernel, dimension })
+}
+
+fn axes(actual: (u32, u32, u32), limit: (u32, u32, u32)) -> [(LaunchAxis, u32, u32); 3] {
+    [
+        (LaunchAxis::X, actual.0, limit.0),
+        (LaunchAxis::Y, actual.1, limit.1),
+        (LaunchAxis::Z, actual.2, limit.2),
+    ]
+}
+
+fn validate_axes(
+    actual: (u32, u32, u32),
+    limit: (u32, u32, u32),
+    error: impl Fn(LaunchAxis, u32, u32) -> LaunchContractError,
+) -> Result<(), LaunchContractError> {
+    for (axis, actual, max) in axes(actual, limit) {
+        if actual > max {
+            return Err(error(axis, actual, max));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const KERNEL: &str = "test_kernel";
+
+    struct NonCloneContract;
+
+    impl KernelLaunchContract for NonCloneContract {
+        type Config = LaunchConfig1D;
+
+        const SPEC: LaunchContractSpec = LaunchContractSpec::new(
+            "non_clone",
+            BlockRequirement::Exact((1, 1, 1)),
+            DynamicSharedMemoryRequirement::Exact {
+                bytes: 0,
+                min_alignment: 1,
+            },
+        );
+    }
+
+    fn exact_spec(block: (u32, u32, u32)) -> LaunchContractSpec {
+        LaunchContractSpec::new(
+            KERNEL,
+            BlockRequirement::Exact(block),
+            DynamicSharedMemoryRequirement::Exact {
+                bytes: 0,
+                min_alignment: 1,
+            },
+        )
+    }
+
+    fn raw(
+        grid_dim: (u32, u32, u32),
+        block_dim: (u32, u32, u32),
+        shared_mem_bytes: u32,
+    ) -> LaunchConfig {
+        LaunchConfig {
+            grid_dim,
+            block_dim,
+            shared_mem_bytes,
+        }
+    }
+
+    fn generous_limits() -> DeviceLaunchLimits {
+        DeviceLaunchLimits {
+            max_threads_per_block: 1024,
+            max_block_dim: (1024, 1024, 64),
+            max_grid_dim: (u32::MAX, 65_535, 65_535),
+            max_shared_memory_per_block: 48 * 1024,
+        }
+    }
+
+    #[test]
+    fn typed_configs_fix_trailing_dimensions() {
+        let one = LaunchConfig1D::new(7, 64, 16).__raw();
+        assert_eq!(one.grid_dim, (7, 1, 1));
+        assert_eq!(one.block_dim, (64, 1, 1));
+        assert_eq!(one.shared_mem_bytes, 16);
+
+        let two = LaunchConfig2D::new((7, 5), (16, 8), 32).__raw();
+        assert_eq!(two.grid_dim, (7, 5, 1));
+        assert_eq!(two.block_dim, (16, 8, 1));
+
+        let three = LaunchConfig3D::new((7, 5, 3), (16, 8, 2), 64).__raw();
+        assert_eq!(three.grid_dim, (7, 5, 3));
+        assert_eq!(three.block_dim, (16, 8, 2));
+    }
+
+    #[test]
+    fn prepared_launch_clone_does_not_require_clone_brand() {
+        fn assert_clone<T: Clone>() {}
+        assert_clone::<PreparedLaunch<NonCloneContract>>();
+    }
+
+    #[test]
+    fn rejects_zero_and_overflowing_shapes() {
+        let zero = validate_static(exact_spec((32, 1, 1)), raw((0, 1, 1), (32, 1, 1), 0));
+        assert!(matches!(
+            zero,
+            Err(LaunchContractError::ZeroDimension {
+                dimension: LaunchDimension::Grid,
+                axis: LaunchAxis::X,
+                ..
+            })
+        ));
+
+        let overflow = validate_static(
+            exact_spec((1, 1, 1)),
+            raw((u32::MAX, u32::MAX, 2), (1, 1, 1), 0),
+        );
+        assert!(matches!(
+            overflow,
+            Err(LaunchContractError::DimensionProductOverflow {
+                dimension: LaunchDimension::Grid,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn exact_block_requires_the_whole_shape() {
+        let result = validate_static(exact_spec((32, 4, 1)), raw((1, 1, 1), (64, 2, 1), 0));
+        assert!(matches!(
+            result,
+            Err(LaunchContractError::BlockShapeMismatch {
+                required: (32, 4, 1),
+                actual: (64, 2, 1),
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn max_threads_applies_to_the_block_product_and_checks_overflow() {
+        let spec = LaunchContractSpec::new(
+            KERNEL,
+            BlockRequirement::MaxThreads(256),
+            DynamicSharedMemoryRequirement::Exact {
+                bytes: 0,
+                min_alignment: 1,
+            },
+        );
+        assert!(validate_static(spec, raw((1, 1, 1), (128, 1, 1), 0)).is_ok());
+        assert!(validate_static(spec, raw((1, 1, 1), (16, 16, 1), 0)).is_ok());
+        assert!(matches!(
+            validate_static(spec, raw((1, 1, 1), (17, 16, 1), 0)),
+            Err(LaunchContractError::BlockThreadsExceedContract {
+                actual: 272,
+                max: 256,
+                ..
+            })
+        ));
+
+        let overflowing_spec = LaunchContractSpec::new(
+            KERNEL,
+            BlockRequirement::MaxThreads(u32::MAX),
+            DynamicSharedMemoryRequirement::Exact {
+                bytes: 0,
+                min_alignment: 1,
+            },
+        );
+        assert!(matches!(
+            validate_static(overflowing_spec, raw((1, 1, 1), (u32::MAX, u32::MAX, 2), 0),),
+            Err(LaunchContractError::DimensionProductOverflow {
+                dimension: LaunchDimension::Block,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn u32_coordinate_contract_accepts_exact_range_and_rejects_larger_axis() {
+        let spec = exact_spec((2, 1, 1)).with_u32_coordinates();
+
+        // 2^31 blocks * 2 threads gives exactly 2^32 zero-based coordinates,
+        // whose largest value is u32::MAX.
+        assert!(validate_static(spec, raw((1 << 31, 1, 1), (2, 1, 1), 0)).is_ok());
+
+        assert!(matches!(
+            validate_static(spec, raw(((1 << 31) + 1, 1, 1), (2, 1, 1), 0)),
+            Err(LaunchContractError::CoordinateRangeExceedsU32 {
+                axis: LaunchAxis::X,
+                positions: 4_294_967_298,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn validates_dynamic_shared_memory_exact_range_and_alignment() {
+        let exact = LaunchContractSpec::new(
+            KERNEL,
+            BlockRequirement::Exact((32, 1, 1)),
+            DynamicSharedMemoryRequirement::Exact {
+                bytes: 1024,
+                min_alignment: 16,
+            },
+        );
+        assert!(validate_static(exact, raw((1, 1, 1), (32, 1, 1), 1024)).is_ok());
+        assert!(matches!(
+            validate_static(exact, raw((1, 1, 1), (32, 1, 1), 512)),
+            Err(LaunchContractError::DynamicSharedMemoryExactMismatch { .. })
+        ));
+
+        let range = LaunchContractSpec::new(
+            KERNEL,
+            BlockRequirement::Exact((32, 1, 1)),
+            DynamicSharedMemoryRequirement::Range {
+                min_bytes: 512,
+                max_bytes: 2048,
+                min_alignment: 32,
+            },
+        );
+        assert!(validate_static(range, raw((1, 1, 1), (32, 1, 1), 512)).is_ok());
+        assert!(validate_static(range, raw((1, 1, 1), (32, 1, 1), 2048)).is_ok());
+        assert!(matches!(
+            validate_static(range, raw((1, 1, 1), (32, 1, 1), 256)),
+            Err(LaunchContractError::DynamicSharedMemoryOutsideRange { .. })
+        ));
+
+        let reversed = LaunchContractSpec::new(
+            KERNEL,
+            BlockRequirement::Exact((32, 1, 1)),
+            DynamicSharedMemoryRequirement::Range {
+                min_bytes: 2,
+                max_bytes: 1,
+                min_alignment: 1,
+            },
+        );
+        assert!(matches!(
+            validate_static(reversed, raw((1, 1, 1), (32, 1, 1), 1)),
+            Err(LaunchContractError::InvalidSharedMemoryRange { .. })
+        ));
+
+        let bad_alignment = LaunchContractSpec::new(
+            KERNEL,
+            BlockRequirement::Exact((32, 1, 1)),
+            DynamicSharedMemoryRequirement::Exact {
+                bytes: 0,
+                min_alignment: 3,
+            },
+        );
+        assert!(matches!(
+            validate_static(bad_alignment, raw((1, 1, 1), (32, 1, 1), 0)),
+            Err(LaunchContractError::InvalidSharedMemoryAlignment { alignment: 3, .. })
+        ));
+    }
+
+    #[test]
+    fn cluster_dimensions_must_be_nonzero_and_divide_grid() {
+        let spec = exact_spec((32, 1, 1)).with_cluster((2, 2, 1));
+        assert!(validate_static(spec, raw((8, 4, 1), (32, 1, 1), 0)).is_ok());
+        assert!(matches!(
+            validate_static(spec, raw((7, 4, 1), (32, 1, 1), 0)),
+            Err(LaunchContractError::ClusterDoesNotDivideGrid {
+                axis: LaunchAxis::X,
+                grid: 7,
+                cluster: 2,
+                ..
+            })
+        ));
+
+        let zero = exact_spec((32, 1, 1)).with_cluster((2, 0, 1));
+        assert!(matches!(
+            validate_static(zero, raw((8, 4, 1), (32, 1, 1), 0)),
+            Err(LaunchContractError::ZeroDimension {
+                dimension: LaunchDimension::Cluster,
+                axis: LaunchAxis::Y,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn validates_device_and_function_block_limits() {
+        let spec = LaunchContractSpec::new(
+            KERNEL,
+            BlockRequirement::MaxThreads(2048),
+            DynamicSharedMemoryRequirement::Exact {
+                bytes: 0,
+                min_alignment: 1,
+            },
+        );
+        let limits = generous_limits();
+
+        assert!(matches!(
+            validate_live_shape(spec, raw((1, 1, 1), (1025, 1, 1), 0), limits, 1024),
+            Err(LaunchContractError::DeviceDimensionExceeded {
+                dimension: LaunchDimension::Block,
+                axis: LaunchAxis::X,
+                ..
+            })
+        ));
+        assert!(matches!(
+            validate_live_shape(spec, raw((1, 1, 1), (33, 33, 1), 0), limits, 2048),
+            Err(LaunchContractError::DeviceThreadsPerBlockExceeded { actual: 1089, .. })
+        ));
+        assert!(matches!(
+            validate_live_shape(spec, raw((1, 1, 1), (32, 16, 1), 0), limits, 256),
+            Err(LaunchContractError::FunctionThreadsPerBlockExceeded {
+                actual: 512,
+                max: 256,
+                ..
+            })
+        ));
+        assert!(matches!(
+            validate_live_shape(
+                spec,
+                raw((u32::MAX, 65_536, 1), (32, 1, 1), 0),
+                limits,
+                1024,
+            ),
+            Err(LaunchContractError::DeviceDimensionExceeded {
+                dimension: LaunchDimension::Grid,
+                axis: LaunchAxis::Y,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn validates_static_plus_dynamic_shared_resources() {
+        let total = shared_memory_total(KERNEL, 16 * 1024, 40 * 1024).unwrap();
+        assert!(matches!(
+            validate_shared_memory_limit(KERNEL, total, 48 * 1024, false),
+            Err(LaunchContractError::DeviceSharedMemoryExceeded {
+                total: 57_344,
+                max: 49_152,
+                opt_in: false,
+                ..
+            })
+        ));
+        assert!(validate_shared_memory_limit(KERNEL, total, 96 * 1024, true).is_ok());
+        assert!(matches!(
+            validate_shared_memory_limit(KERNEL, 100 * 1024, 96 * 1024, true),
+            Err(LaunchContractError::DeviceSharedMemoryExceeded { opt_in: true, .. })
+        ));
+        assert!(matches!(
+            shared_memory_total(KERNEL, u32::MAX, 1),
+            Err(LaunchContractError::SharedMemoryTotalOverflow { .. })
+        ));
+        assert_eq!(
+            dynamic_shared_memory_max(DynamicSharedMemoryRequirement::Range {
+                min_bytes: 1024,
+                max_bytes: 8192,
+                min_alignment: 16,
+            }),
+            8192
+        );
+    }
+
+    #[test]
+    fn shared_memory_range_requires_support_for_its_advertised_maximum() {
+        let requirement = DynamicSharedMemoryRequirement::Range {
+            min_bytes: 1024,
+            max_bytes: 96 * 1024,
+            min_alignment: 16,
+        };
+        let spec =
+            LaunchContractSpec::new(KERNEL, BlockRequirement::Exact((32, 1, 1)), requirement);
+
+        // The concrete 32 KiB choice belongs to the range.
+        assert!(validate_static(spec, raw((1, 1, 1), (32, 1, 1), 32 * 1024)).is_ok());
+
+        // Preparation nevertheless validates the immutable contract maximum,
+        // so every value advertised by the range is safe on this device.
+        let total = shared_memory_total(KERNEL, 0, dynamic_shared_memory_max(requirement)).unwrap();
+        assert!(matches!(
+            validate_shared_memory_limit(KERNEL, total, 64 * 1024, true),
+            Err(LaunchContractError::DeviceSharedMemoryExceeded {
+                total: 98_304,
+                max: 65_536,
+                opt_in: true,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn validates_architecture_and_optional_capabilities() {
+        assert!(validate_compute_capability(KERNEL, (9, 0), (10, 0)).is_ok());
+        assert!(matches!(
+            validate_compute_capability(KERNEL, (9, 0), (8, 9)),
+            Err(LaunchContractError::ComputeCapabilityTooLow { .. })
+        ));
+        assert!(matches!(
+            validate_cluster_support(KERNEL, false),
+            Err(LaunchContractError::ClusterLaunchUnsupported { .. })
+        ));
+        assert!(validate_cluster_size(KERNEL, 8, 8).is_ok());
+        assert!(matches!(
+            validate_cluster_size(KERNEL, 16, 8),
+            Err(LaunchContractError::ClusterSizeExceeded {
+                blocks: 16,
+                max: 8,
+                ..
+            })
+        ));
+        assert!(validate_required_cluster(KERNEL, (2, 1, 1), Some((2, 1, 1))).is_ok());
+        assert!(matches!(
+            validate_required_cluster(KERNEL, (2, 1, 1), Some((4, 1, 1))),
+            Err(LaunchContractError::FunctionClusterShapeMismatch { .. })
+        ));
+        assert!(matches!(
+            validate_required_cluster(KERNEL, (2, 1, 1), None),
+            Err(LaunchContractError::RequiredClusterDimensionsMissing { .. })
+        ));
+        assert!(validate_cluster_residency(KERNEL, (2, 1, 1), 1).is_ok());
+        assert!(matches!(
+            validate_cluster_residency(KERNEL, (2, 1, 1), 0),
+            Err(LaunchContractError::ClusterHasNoResidency { .. })
+        ));
+        assert!(matches!(
+            validate_cooperative_support(KERNEL, false),
+            Err(LaunchContractError::CooperativeLaunchUnsupported { .. })
+        ));
+    }
+
+    #[test]
+    fn validates_cooperative_residency_capacity() {
+        assert!(validate_cooperative_residency(KERNEL, 80, 80).is_ok());
+        assert!(matches!(
+            validate_cooperative_residency(KERNEL, 81, 80),
+            Err(LaunchContractError::CooperativeGridTooLarge {
+                blocks: 81,
+                resident_capacity: 80,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn clustered_cooperative_residency_uses_active_cluster_capacity() {
+        // A (2,1,1) cluster with 4 concurrent clusters can host 8 blocks.
+        // A fully-resident cooperative grid of 8 blocks therefore passes, while
+        // 10 blocks (5 clusters) must fail with CooperativeGridTooLarge.
+        let cluster_blocks = 2u64;
+        let active_clusters = 4u64;
+        let resident_capacity = active_clusters * cluster_blocks;
+
+        assert!(validate_cooperative_residency(KERNEL, 8, resident_capacity).is_ok());
+        assert!(matches!(
+            validate_cooperative_residency(KERNEL, 10, resident_capacity),
+            Err(LaunchContractError::CooperativeGridTooLarge {
+                blocks: 10,
+                resident_capacity: 8,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn combined_cluster_cooperative_spec_is_expressible() {
+        let spec = exact_spec((128, 1, 1))
+            .with_cluster((2, 1, 1))
+            .with_cooperative();
+        assert_eq!(spec.cluster(), Some((2, 1, 1)));
+        assert!(spec.cooperative());
+
+        // Static geometry still requires the grid to be an integer number of
+        // clusters even when cooperative residency is also required.
+        assert!(validate_static(spec, raw((4, 1, 1), (128, 1, 1), 0)).is_ok());
+        assert!(matches!(
+            validate_static(spec, raw((3, 1, 1), (128, 1, 1), 0)),
+            Err(LaunchContractError::ClusterDoesNotDivideGrid { .. })
+        ));
+    }
+
+    #[test]
+    fn spec_builders_preserve_diagnostic_metadata() {
+        let spec = exact_spec((32, 1, 1))
+            .with_cluster((2, 1, 1))
+            .with_cooperative()
+            .with_min_compute_capability(9, 0)
+            .with_u32_coordinates();
+        assert_eq!(spec.kernel_name(), KERNEL);
+        assert_eq!(spec.block(), BlockRequirement::Exact((32, 1, 1)));
+        assert_eq!(spec.cluster(), Some((2, 1, 1)));
+        assert!(spec.cooperative());
+        assert_eq!(spec.min_compute_capability(), Some((9, 0)));
+        assert_eq!(spec.coordinates(), CoordinateRequirement::U32);
+    }
+}

--- a/cuda-core/src/simt/memory.rs
+++ b/cuda-core/src/simt/memory.rs
@@ -1,0 +1,225 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! CUDA device memory allocation and transfer operations.
+//!
+//! Provides both **stream-ordered** (`*_async`) and **synchronous** (`*_sync`)
+//! variants. The async functions enqueue the operation on a stream and return
+//! immediately; the transfer completes in stream order. The sync variants block
+//! the calling thread until the operation finishes.
+//!
+//! All functions in this module are `unsafe` because they operate on raw device
+//! pointers whose validity cannot be checked at compile time.
+
+use crate::error::{DriverError, IntoResult};
+use cuda_bindings::CUdeviceptr;
+use std::ffi::c_void;
+use std::mem::MaybeUninit;
+
+/// Allocates `num_bytes` of device memory on `stream` using the stream-ordered
+/// allocator (`cuMemAllocAsync`).
+///
+/// The returned pointer is usable by any kernel or memcpy enqueued on `stream`
+/// after this call. Pair with [`free_async`] on a stream ordered after this
+/// allocation and every use of the pointer.
+///
+/// # Safety
+///
+/// - A CUDA context must be bound to the calling thread.
+/// - `stream` must be a valid `CUstream` from the current context.
+/// - `num_bytes` must not exceed the device memory pool limits.
+pub unsafe fn malloc_async(
+    stream: cuda_bindings::CUstream,
+    num_bytes: usize,
+) -> Result<CUdeviceptr, DriverError> {
+    let mut dev_ptr = MaybeUninit::uninit();
+    unsafe {
+        cuda_bindings::cuMemAllocAsync(dev_ptr.as_mut_ptr(), num_bytes, stream).result()?;
+        Ok(dev_ptr.assume_init())
+    }
+}
+
+/// Frees device memory previously allocated with [`malloc_async`] or
+/// [`malloc_sync`].
+///
+/// The free is enqueued on `stream` and completes in stream order. The pointer
+/// must not be accessed by any work enqueued after this call. If the pointer
+/// came from [`malloc_async`], `stream` must be ordered after its allocation
+/// stream. Every other stream using the pointer must also be ordered before
+/// `stream`.
+///
+/// # Safety
+///
+/// - `dptr` must have been returned by [`malloc_async`] or [`malloc_sync`] and
+///   not yet freed.
+/// - `stream` must be a valid `CUstream` from the same context as the
+///   allocation.
+/// - All allocation and use work on other streams must happen before the free
+///   on `stream`.
+pub unsafe fn free_async(
+    dptr: CUdeviceptr,
+    stream: cuda_bindings::CUstream,
+) -> Result<(), DriverError> {
+    unsafe { cuda_bindings::cuMemFreeAsync(dptr, stream) }.result()
+}
+
+/// Allocates `num_bytes` of device memory synchronously (`cuMemAlloc`).
+///
+/// Blocks the calling thread until the allocation completes. Pair with
+/// [`free_sync`].
+///
+/// # Safety
+///
+/// - A CUDA context must be bound to the calling thread.
+/// - `num_bytes` must not exceed available device memory.
+pub unsafe fn malloc_sync(num_bytes: usize) -> Result<CUdeviceptr, DriverError> {
+    let mut dev_ptr = MaybeUninit::uninit();
+    unsafe {
+        cuda_bindings::cuMemAlloc_v2(dev_ptr.as_mut_ptr(), num_bytes).result()?;
+        Ok(dev_ptr.assume_init())
+    }
+}
+
+/// Frees device memory previously allocated with [`malloc_sync`].
+///
+/// Blocks the calling thread. All pending GPU work referencing `dptr` must have
+/// completed before this call.
+///
+/// # Safety
+///
+/// - `dptr` must have been returned by [`malloc_sync`] and not yet freed.
+/// - No in-flight GPU operations may reference `dptr`.
+pub unsafe fn free_sync(dptr: CUdeviceptr) -> Result<(), DriverError> {
+    unsafe { cuda_bindings::cuMemFree_v2(dptr) }.result()
+}
+
+/// Copies `num_bytes` from host memory at `src` to device memory at `dst`,
+/// enqueued on `stream` (host-to-device, async).
+///
+/// The host buffer at `src` must remain valid and unmodified until the copy
+/// completes (i.e., until a synchronization point on `stream`). For
+/// guaranteed asynchronous behavior, `src` should point to page-locked
+/// (pinned) host memory.
+///
+/// # Safety
+///
+/// - `dst` must be a valid device pointer with at least `num_bytes` allocated.
+/// - `src` must point to at least `num_bytes` of readable host memory.
+/// - `stream` must be a valid `CUstream` from the current context.
+pub unsafe fn memcpy_htod_async<T>(
+    dst: CUdeviceptr,
+    src: *const T,
+    num_bytes: usize,
+    stream: cuda_bindings::CUstream,
+) -> Result<(), DriverError> {
+    unsafe { cuda_bindings::cuMemcpyHtoDAsync_v2(dst, src as *const _, num_bytes, stream) }.result()
+}
+
+/// Copies `num_bytes` from host memory at `src` to device memory at `dst`,
+/// synchronously (host-to-device).
+///
+/// Blocks the calling thread until the copy is complete.
+///
+/// # Safety
+///
+/// - `dst` must be a valid device pointer with at least `num_bytes` allocated.
+/// - `src` must point to at least `num_bytes` of readable host memory.
+/// - The active CUDA context must own `dst` (caller binds the context).
+pub unsafe fn memcpy_htod_sync<T>(
+    dst: CUdeviceptr,
+    src: *const T,
+    num_bytes: usize,
+) -> Result<(), DriverError> {
+    unsafe { cuda_bindings::cuMemcpyHtoD_v2(dst, src as *const _, num_bytes) }.result()
+}
+
+/// Copies `num_bytes` from device memory at `src` to host memory at `dst`,
+/// enqueued on `stream` (device-to-host, async).
+///
+/// The host buffer at `dst` must not be read until the copy completes.
+/// For guaranteed asynchronous behavior, `dst` should point to page-locked
+/// (pinned) host memory.
+///
+/// # Safety
+///
+/// - `src` must be a valid device pointer with at least `num_bytes` accessible.
+/// - `dst` must point to at least `num_bytes` of writable host memory.
+/// - `stream` must be a valid `CUstream` from the current context.
+pub unsafe fn memcpy_dtoh_async<T>(
+    dst: *mut T,
+    src: CUdeviceptr,
+    num_bytes: usize,
+    stream: cuda_bindings::CUstream,
+) -> Result<(), DriverError> {
+    unsafe { cuda_bindings::cuMemcpyDtoHAsync_v2(dst as *mut _, src, num_bytes, stream) }.result()
+}
+
+/// Copies `num_bytes` from device memory at `src` to device memory at `dst`,
+/// enqueued on `stream` (device-to-device, async).
+///
+/// `src` and `dst` may reside on different devices if peer access is enabled.
+///
+/// # Safety
+///
+/// - Both `dst` and `src` must be valid device pointers with at least
+///   `num_bytes` accessible.
+/// - `stream` must be a valid `CUstream` from the current context.
+/// - `dst` and `src` must not overlap unless they are identical.
+pub unsafe fn memcpy_dtod_async(
+    dst: CUdeviceptr,
+    src: CUdeviceptr,
+    num_bytes: usize,
+    stream: cuda_bindings::CUstream,
+) -> Result<(), DriverError> {
+    unsafe { cuda_bindings::cuMemcpyDtoDAsync_v2(dst, src, num_bytes, stream) }.result()
+}
+
+/// Sets `num_bytes` of device memory at `dptr` to `value`, enqueued on
+/// `stream`.
+///
+/// Each byte in the range `[dptr, dptr + num_bytes)` is set to `value`.
+///
+/// # Safety
+///
+/// - `dptr` must be a valid device pointer with at least `num_bytes` allocated.
+/// - `stream` must be a valid `CUstream` from the current context.
+pub unsafe fn memset_d8_async(
+    dptr: CUdeviceptr,
+    value: u8,
+    num_bytes: usize,
+    stream: cuda_bindings::CUstream,
+) -> Result<(), DriverError> {
+    unsafe { cuda_bindings::cuMemsetD8Async(dptr, value, num_bytes, stream) }.result()
+}
+
+/// Allocates `num_bytes` of page-locked host memory.
+///
+/// Pinned host memory can be used as a staging area for CUDA transfers that
+/// need higher bandwidth, and is required for host-device copies that are
+/// intended to overlap with GPU work. Pair with [`free_host`].
+///
+/// # Safety
+///
+/// - A CUDA context must be bound to the calling thread.
+/// - `num_bytes` must not exceed the host memory available for page-locked
+///   allocations. Passing zero bytes is not useful and the CUDA driver reports
+///   it as an error.
+pub unsafe fn malloc_host(num_bytes: usize) -> Result<*mut c_void, DriverError> {
+    let mut host_ptr = MaybeUninit::uninit();
+    unsafe {
+        cuda_bindings::cuMemAllocHost_v2(host_ptr.as_mut_ptr(), num_bytes).result()?;
+        Ok(host_ptr.assume_init())
+    }
+}
+
+/// Frees page-locked host memory previously allocated with [`malloc_host`].
+///
+/// # Safety
+///
+/// - `ptr` must have been returned by [`malloc_host`] and not yet freed.
+/// - No in-flight CUDA transfer or kernel may reference `ptr`.
+pub unsafe fn free_host(ptr: *mut c_void) -> Result<(), DriverError> {
+    unsafe { cuda_bindings::cuMemFreeHost(ptr) }.result()
+}

--- a/cuda-core/src/simt/mod.rs
+++ b/cuda-core/src/simt/mod.rs
@@ -1,0 +1,470 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! The cuda-oxide host surface.
+//!
+//! Everything under this module is the cuda-oxide host API, brought over
+//! as-is for the shared host-crate migration rather than reconciled:
+//! [`CudaContext`] lands next to this crate's own `Device`, and
+//! [`LaunchConfig`] next to this crate's own `LaunchConfig`. The two surfaces
+//! get reconciled after the repository migration, with both models in one
+//! tree, and this module is deletable as a unit once that happens.
+//!
+//! Naming: everything cuda-oxide exposed at its crate root is re-exported
+//! here, so `cuda_core::simt::X` is oxide's `cuda_core::X`. The crate root
+//! additionally re-exports every name that does not collide with the
+//! existing surface; the one collision is [`LaunchConfig`], which is
+//! reachable only through this module.
+//!
+//! Differences from the cuda-oxide original, recorded for the
+//! reconciliation:
+//!
+//! - `DeviceCopy` for the unstable `f16` primitive sits behind the
+//!   default-off `f16` cargo feature, since it is nightly-only; the
+//!   `half::f16` and `half::bf16` impls are always present.
+//! - `#[derive(DeviceCopy)]` comes from the sibling `cuda-core-derive`
+//!   crate, extracted from cuda-oxide's `cuda-macros` so it is publishable.
+//! - `vmm` and `peer` are copied like the rest; #202 remains the idiomatic
+//!   port of the VMM wrappers onto this crate's own runtime types.
+//! - `init` and `launch_kernel` are not copied: the crate root already
+//!   exposes identical ones, re-exported below.
+//! - `oxide-artifacts` comes from crates.io (cuda-oxide publishes it) and is
+//!   re-exported as [`artifacts`].
+
+pub mod context;
+pub mod device_buffer;
+pub mod embedded;
+pub mod event;
+pub mod launch;
+pub mod memory;
+pub mod module;
+pub mod peer;
+pub mod pinned_host_buffer;
+pub mod stream;
+pub mod vmm;
+
+pub use context::{ContextLimit, CudaContext, StreamPriorityRange, SyncPolicy};
+/// `#[derive(DeviceCopy)]`, re-exported next to the trait so
+/// `use cuda_core::DeviceCopy;` brings both into scope (serde pattern).
+pub use cuda_core_derive::DeviceCopy;
+pub use device_buffer::{DeviceBuffer, DeviceCopy};
+pub use embedded::{EmbeddedModule, EmbeddedModuleError};
+pub use event::CudaEvent;
+pub use launch::{
+    BlockRequirement, DeviceLaunchLimits, DynamicSharedMemoryRequirement, KernelLaunchConfig,
+    KernelLaunchContract, LaunchAxis, LaunchConfig, LaunchConfig1D, LaunchConfig2D, LaunchConfig3D,
+    LaunchContractError, LaunchContractSpec, LaunchDimension, PreparedLaunch,
+};
+pub use module::{ConstantHandle, CudaFunction, CudaModule};
+pub use pinned_host_buffer::PinnedHostBuffer;
+pub use stream::CudaStream;
+
+// The remaining items of oxide's crate root are identical on both surfaces;
+// they are re-exported so `cuda_core::simt` mirrors it completely.
+pub use crate::error::{DriverError, IntoResult};
+pub use crate::init;
+pub use crate::launch_kernel;
+pub use cuda_bindings as sys;
+/// Artifact-bundle metadata, from the published crate cuda-oxide releases.
+pub use oxide_artifacts as artifacts;
+
+/// Launches a CUDA kernel on a specific [`CudaStream`], binding its context first.
+///
+/// This is the usual host-side helper for `cuda_launch!` and async launches.
+/// It ensures the stream's owning context is current before calling the raw
+/// [`launch_kernel`] entry point, so callers do not need to manually call
+/// [`CudaContext::bind_to_thread`] before every launch.
+///
+/// Unlike [`launch_kernel`], this helper works with typed wrappers rather than
+/// raw driver handles. It is therefore the preferred API whenever you already
+/// have a [`CudaFunction`] and [`CudaStream`].
+///
+/// # Safety
+///
+/// - `func` must refer to a kernel loaded from the same CUDA context that owns
+///   `stream`.
+/// - Each element of `kernel_params` must point to a region of memory that
+///   matches the corresponding kernel parameter in size and alignment.
+/// - The pointed-to argument values must remain valid until this function
+///   returns.
+/// - The grid and block dimensions must not exceed device limits.
+/// - The grid, block, dynamic-shared-memory size, and launch mode must satisfy
+///   every semantic invariant assumed by the kernel body, including index-space
+///   uniqueness and synchronization requirements.
+///
+/// # Errors
+///
+/// Returns an error if binding `stream.context()` fails or if the underlying
+/// `cuLaunchKernel` call rejects the launch.
+#[inline]
+pub unsafe fn launch_kernel_on_stream(
+    func: &CudaFunction,
+    grid_dim: (u32, u32, u32),
+    block_dim: (u32, u32, u32),
+    shared_mem_bytes: u32,
+    stream: &CudaStream,
+    kernel_params: &mut [*mut std::ffi::c_void],
+) -> Result<(), DriverError> {
+    stream.context().bind_to_thread()?;
+    unsafe {
+        launch_kernel(
+            func.cu_function(),
+            grid_dim,
+            block_dim,
+            shared_mem_bytes,
+            stream.cu_stream(),
+            kernel_params,
+        )
+    }
+}
+
+/// Low-level wrapper around `cuLaunchKernelEx`.
+///
+/// This is the cluster-aware launch path. It builds a `CUlaunchConfig` with a
+/// `CU_LAUNCH_ATTRIBUTE_CLUSTER_DIMENSION` attribute set to `cluster_dim`.
+/// Required for thread-block cluster launches on sm_90+ (Hopper / Blackwell).
+///
+/// This helper performs **no context binding**. Prefer
+/// [`launch_kernel_ex_on_stream`] in normal host-side code so the correct
+/// stream context is made current automatically.
+///
+/// # Safety
+///
+/// Same preconditions as [`launch_kernel`], plus:
+/// - Each component of `cluster_dim` must divide the corresponding `grid_dim`
+///   component.
+/// - The total cluster size must not exceed the device maximum.
+/// - The device must support compute capability 9.0 or higher.
+///
+/// # Errors
+///
+/// Returns the CUDA driver error produced by `cuLaunchKernelEx` if launch
+/// submission fails.
+#[inline]
+pub unsafe fn launch_kernel_ex(
+    func: cuda_bindings::CUfunction,
+    grid_dim: (u32, u32, u32),
+    block_dim: (u32, u32, u32),
+    shared_mem_bytes: u32,
+    cluster_dim: (u32, u32, u32),
+    stream: cuda_bindings::CUstream,
+    kernel_params: &mut [*mut std::ffi::c_void],
+) -> Result<(), DriverError> {
+    // CUlaunchAttribute_st is opaque (see cuda-bindings/build.rs) for CUDA 13.2+
+    // compatibility. C layout: { id: u32 @ 0, pad: [u8;4] @ 4, value: union @ 8 }.
+    // clusterDim is three u32 fields (x, y, z) at offset 0 within the value union.
+    let mut cluster_attr: cuda_bindings::CUlaunchAttribute_st = unsafe { std::mem::zeroed() };
+    unsafe {
+        let base = &mut cluster_attr as *mut _ as *mut u8;
+        // id at offset 0
+        (base as *mut u32)
+            .write(cuda_bindings::CUlaunchAttributeID_enum_CU_LAUNCH_ATTRIBUTE_CLUSTER_DIMENSION);
+        // clusterDim.x/y/z at offsets 8, 12, 16
+        let dim_ptr = base.add(8) as *mut u32;
+        dim_ptr.write(cluster_dim.0);
+        dim_ptr.add(1).write(cluster_dim.1);
+        dim_ptr.add(2).write(cluster_dim.2);
+    }
+
+    let config = cuda_bindings::CUlaunchConfig_st {
+        gridDimX: grid_dim.0,
+        gridDimY: grid_dim.1,
+        gridDimZ: grid_dim.2,
+        blockDimX: block_dim.0,
+        blockDimY: block_dim.1,
+        blockDimZ: block_dim.2,
+        sharedMemBytes: shared_mem_bytes,
+        hStream: stream,
+        attrs: &mut cluster_attr,
+        numAttrs: 1,
+    };
+
+    unsafe {
+        cuda_bindings::cuLaunchKernelEx(
+            &config,
+            func,
+            kernel_params.as_mut_ptr(),
+            std::ptr::null_mut(),
+        )
+    }
+    .result()
+}
+
+/// Launches a CUDA kernel with extended configuration on a specific stream,
+/// binding the stream's owning context first.
+///
+/// This is the cluster-aware counterpart to [`launch_kernel_on_stream`]. It
+/// binds `stream.context()` to the calling thread, then forwards to the raw
+/// [`launch_kernel_ex`] helper.
+///
+/// # Safety
+///
+/// - `func` must refer to a kernel loaded from the same CUDA context that owns
+///   `stream`.
+/// - Each element of `kernel_params` must point to a region of memory that
+///   matches the corresponding kernel parameter in size and alignment.
+/// - The pointed-to argument values must remain valid until this function
+///   returns.
+/// - The grid, block, and cluster dimensions must satisfy the device limits and
+///   CUDA cluster-launch requirements.
+/// - The launch geometry, dynamic-shared-memory size, and cluster mode must
+///   satisfy every semantic invariant assumed by the kernel body.
+///
+/// # Errors
+///
+/// Returns an error if binding `stream.context()` fails or if the underlying
+/// `cuLaunchKernelEx` call rejects the launch.
+#[inline]
+pub unsafe fn launch_kernel_ex_on_stream(
+    func: &CudaFunction,
+    grid_dim: (u32, u32, u32),
+    block_dim: (u32, u32, u32),
+    shared_mem_bytes: u32,
+    cluster_dim: (u32, u32, u32),
+    stream: &CudaStream,
+    kernel_params: &mut [*mut std::ffi::c_void],
+) -> Result<(), DriverError> {
+    stream.context().bind_to_thread()?;
+    unsafe {
+        launch_kernel_ex(
+            func.cu_function(),
+            grid_dim,
+            block_dim,
+            shared_mem_bytes,
+            cluster_dim,
+            stream.cu_stream(),
+            kernel_params,
+        )
+    }
+}
+
+/// Low-level wrapper around `cuLaunchKernelEx` with the
+/// `CU_LAUNCH_ATTRIBUTE_COOPERATIVE` flag set.
+///
+/// A *cooperative* launch guarantees that every block in the grid is
+/// co-resident on the device, which is the precondition for grid-wide
+/// barriers like `cuda_device::grid::sync()`. The CUDA driver also
+/// populates PTX environment registers `%envreg1` / `%envreg2` with the
+/// pointer to the per-launch grid workspace; the device-side barrier
+/// implementation reads those registers to find the shared counter.
+///
+/// This helper performs **no context binding**. Prefer
+/// [`launch_kernel_cooperative_on_stream`] in normal host-side code so the
+/// correct stream context is made current automatically.
+///
+/// # Safety
+///
+/// Same preconditions as [`launch_kernel`], plus:
+/// - The device must support cooperative launch (`CU_DEVICE_ATTRIBUTE_COOPERATIVE_LAUNCH`).
+/// - The grid must fit in the maximum number of resident blocks for this
+///   kernel as reported by `cuOccupancyMaxActiveBlocksPerMultiprocessor`
+///   (otherwise `cuLaunchKernelEx` returns
+///   `CUDA_ERROR_COOPERATIVE_LAUNCH_TOO_LARGE`).
+///
+/// # Errors
+///
+/// Returns the CUDA driver error produced by `cuLaunchKernelEx` if launch
+/// submission fails.
+#[inline]
+pub unsafe fn launch_kernel_cooperative(
+    func: cuda_bindings::CUfunction,
+    grid_dim: (u32, u32, u32),
+    block_dim: (u32, u32, u32),
+    shared_mem_bytes: u32,
+    stream: cuda_bindings::CUstream,
+    kernel_params: &mut [*mut std::ffi::c_void],
+) -> Result<(), DriverError> {
+    // CUlaunchAttribute_st is opaque (see cuda-bindings/build.rs) for CUDA 13.2+
+    // compatibility. C layout: { id: u32 @ 0, pad: [u8;4] @ 4, value: union @ 8 }.
+    // For the COOPERATIVE attribute the value union holds a single `int cooperative`
+    // at offset 0 — set to 1 to enable, 0 to disable.
+    let mut coop_attr: cuda_bindings::CUlaunchAttribute_st = unsafe { std::mem::zeroed() };
+    unsafe {
+        let base = &mut coop_attr as *mut _ as *mut u8;
+        (base as *mut u32)
+            .write(cuda_bindings::CUlaunchAttributeID_enum_CU_LAUNCH_ATTRIBUTE_COOPERATIVE);
+        let val_ptr = base.add(8) as *mut i32;
+        val_ptr.write(1);
+    }
+
+    let config = cuda_bindings::CUlaunchConfig_st {
+        gridDimX: grid_dim.0,
+        gridDimY: grid_dim.1,
+        gridDimZ: grid_dim.2,
+        blockDimX: block_dim.0,
+        blockDimY: block_dim.1,
+        blockDimZ: block_dim.2,
+        sharedMemBytes: shared_mem_bytes,
+        hStream: stream,
+        attrs: &mut coop_attr,
+        numAttrs: 1,
+    };
+
+    unsafe {
+        cuda_bindings::cuLaunchKernelEx(
+            &config,
+            func,
+            kernel_params.as_mut_ptr(),
+            std::ptr::null_mut(),
+        )
+    }
+    .result()
+}
+
+/// Launches a cooperative CUDA kernel on a specific stream, binding the
+/// stream's owning context first.
+///
+/// This is the cooperative-launch counterpart to [`launch_kernel_on_stream`].
+/// It binds `stream.context()` to the calling thread, then forwards to the
+/// raw [`launch_kernel_cooperative`] helper.
+///
+/// # Safety
+///
+/// Same preconditions as [`launch_kernel_cooperative`].
+///
+/// # Errors
+///
+/// Returns an error if binding `stream.context()` fails or if the underlying
+/// `cuLaunchKernelEx` call rejects the launch.
+#[inline]
+pub unsafe fn launch_kernel_cooperative_on_stream(
+    func: &CudaFunction,
+    grid_dim: (u32, u32, u32),
+    block_dim: (u32, u32, u32),
+    shared_mem_bytes: u32,
+    stream: &CudaStream,
+    kernel_params: &mut [*mut std::ffi::c_void],
+) -> Result<(), DriverError> {
+    stream.context().bind_to_thread()?;
+    unsafe {
+        launch_kernel_cooperative(
+            func.cu_function(),
+            grid_dim,
+            block_dim,
+            shared_mem_bytes,
+            stream.cu_stream(),
+            kernel_params,
+        )
+    }
+}
+
+/// Low-level wrapper around `cuLaunchKernelEx` with **both** the
+/// `CU_LAUNCH_ATTRIBUTE_CLUSTER_DIMENSION` and
+/// `CU_LAUNCH_ATTRIBUTE_COOPERATIVE` attributes set.
+///
+/// `cuLaunchKernelEx` takes an array of launch attributes, so a single call
+/// can request thread-block clusters ([`launch_kernel_ex`]) and a
+/// cooperative launch ([`launch_kernel_cooperative`]) at the same time.
+/// This is the path used when a `#[cuda_module]` kernel carries both
+/// `#[cluster_launch(...)]` and `#[cooperative_launch]`.
+///
+/// This helper performs **no context binding**. Prefer
+/// [`launch_kernel_ex_cooperative_on_stream`] in normal host-side code so
+/// the correct stream context is made current automatically.
+///
+/// # Safety
+///
+/// The combined preconditions of [`launch_kernel_ex`] (cluster dimensions
+/// must divide the grid, sm_90+) and [`launch_kernel_cooperative`] (the
+/// device must support cooperative launch and the whole grid must be
+/// co-resident).
+///
+/// # Errors
+///
+/// Returns the CUDA driver error produced by `cuLaunchKernelEx` if launch
+/// submission fails.
+#[inline]
+pub unsafe fn launch_kernel_ex_cooperative(
+    func: cuda_bindings::CUfunction,
+    grid_dim: (u32, u32, u32),
+    block_dim: (u32, u32, u32),
+    shared_mem_bytes: u32,
+    cluster_dim: (u32, u32, u32),
+    stream: cuda_bindings::CUstream,
+    kernel_params: &mut [*mut std::ffi::c_void],
+) -> Result<(), DriverError> {
+    // CUlaunchAttribute_st is opaque (see cuda-bindings/build.rs) for CUDA 13.2+
+    // compatibility. C layout: { id: u32 @ 0, pad: [u8;4] @ 4, value: union @ 8 }.
+    // attrs[0]: clusterDim — three u32 fields (x, y, z) at offset 0 of the union.
+    // attrs[1]: cooperative — a single `int` at offset 0 of the union; 1 = enabled.
+    let mut attrs: [cuda_bindings::CUlaunchAttribute_st; 2] = unsafe { std::mem::zeroed() };
+    unsafe {
+        let base = &mut attrs[0] as *mut _ as *mut u8;
+        (base as *mut u32)
+            .write(cuda_bindings::CUlaunchAttributeID_enum_CU_LAUNCH_ATTRIBUTE_CLUSTER_DIMENSION);
+        let dim_ptr = base.add(8) as *mut u32;
+        dim_ptr.write(cluster_dim.0);
+        dim_ptr.add(1).write(cluster_dim.1);
+        dim_ptr.add(2).write(cluster_dim.2);
+
+        let base = &mut attrs[1] as *mut _ as *mut u8;
+        (base as *mut u32)
+            .write(cuda_bindings::CUlaunchAttributeID_enum_CU_LAUNCH_ATTRIBUTE_COOPERATIVE);
+        let val_ptr = base.add(8) as *mut i32;
+        val_ptr.write(1);
+    }
+
+    let config = cuda_bindings::CUlaunchConfig_st {
+        gridDimX: grid_dim.0,
+        gridDimY: grid_dim.1,
+        gridDimZ: grid_dim.2,
+        blockDimX: block_dim.0,
+        blockDimY: block_dim.1,
+        blockDimZ: block_dim.2,
+        sharedMemBytes: shared_mem_bytes,
+        hStream: stream,
+        attrs: attrs.as_mut_ptr(),
+        numAttrs: 2,
+    };
+
+    unsafe {
+        cuda_bindings::cuLaunchKernelEx(
+            &config,
+            func,
+            kernel_params.as_mut_ptr(),
+            std::ptr::null_mut(),
+        )
+    }
+    .result()
+}
+
+/// Launches a cooperative CUDA kernel with cluster dimensions on a specific
+/// stream, binding the stream's owning context first.
+///
+/// This is the cluster-plus-cooperative counterpart to
+/// [`launch_kernel_on_stream`]. It binds `stream.context()` to the calling
+/// thread, then forwards to the raw [`launch_kernel_ex_cooperative`] helper.
+///
+/// # Safety
+///
+/// Same preconditions as [`launch_kernel_ex_cooperative`].
+///
+/// # Errors
+///
+/// Returns an error if binding `stream.context()` fails or if the underlying
+/// `cuLaunchKernelEx` call rejects the launch.
+#[inline]
+pub unsafe fn launch_kernel_ex_cooperative_on_stream(
+    func: &CudaFunction,
+    grid_dim: (u32, u32, u32),
+    block_dim: (u32, u32, u32),
+    shared_mem_bytes: u32,
+    cluster_dim: (u32, u32, u32),
+    stream: &CudaStream,
+    kernel_params: &mut [*mut std::ffi::c_void],
+) -> Result<(), DriverError> {
+    stream.context().bind_to_thread()?;
+    unsafe {
+        launch_kernel_ex_cooperative(
+            func.cu_function(),
+            grid_dim,
+            block_dim,
+            shared_mem_bytes,
+            cluster_dim,
+            stream.cu_stream(),
+            kernel_params,
+        )
+    }
+}

--- a/cuda-core/src/simt/module.rs
+++ b/cuda-core/src/simt/module.rs
@@ -1,0 +1,700 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! CUDA module and function management (RAII, PTX/cubin loading).
+//!
+//! A [`CudaModule`] wraps a `CUmodule` loaded from PTX source or a cubin file.
+//! [`CudaFunction`] extracts a kernel entry point from a loaded module by
+//! symbol name. Both types are reference-counted and tie their lifetime to the
+//! parent [`CudaContext`] / [`CudaModule`] respectively.
+//!
+//! # Typical workflow
+//!
+//! ```ignore
+//! let ctx = CudaContext::new(0)?;
+//! let module = ctx.load_module_from_ptx_src(ptx)?;
+//! let kernel = module.load_function("my_kernel")?;
+//! ```
+//!
+//! # Raw CUDA interop
+//!
+//! Most users should load kernels with [`CudaModule::load_function`] and
+//! launch them through cuda-oxide's typed launch helpers. Some CUDA-adjacent
+//! libraries need the underlying driver handle to inspect or register
+//! module-scope device state before launch. For those cases,
+//! [`CudaModule::cu_module`] exposes a non-owning raw `CUmodule` handle under
+//! an explicit `unsafe` contract.
+
+use crate::error::{DriverError, IntoResult};
+use crate::simt::context::CudaContext;
+use std::borrow::Cow;
+use std::ffi::{c_void, CString};
+use std::mem::MaybeUninit;
+use std::sync::Arc;
+
+/// An RAII wrapper around a `CUmodule` handle.
+///
+/// Holds an `Arc<CudaContext>` to ensure the context outlives the module.
+/// Unloaded automatically via `cuModuleUnload` on [`Drop`].
+#[derive(Debug)]
+pub struct CudaModule {
+    /// Raw CUDA module handle.
+    pub(crate) cu_module: cuda_bindings::CUmodule,
+    /// Owning context. Kept alive for the lifetime of this module.
+    pub(crate) ctx: Arc<CudaContext>,
+}
+
+/// # Safety
+///
+/// `CUmodule` handles are not thread-local. The CUDA driver permits querying
+/// functions from a module on any thread, provided the owning context is bound.
+unsafe impl Send for CudaModule {}
+/// See [`Send`] impl.
+unsafe impl Sync for CudaModule {}
+
+/// Unloads the module on drop.
+///
+/// Binds the context to the current thread first (required by
+/// `cuModuleUnload`). Errors are recorded on the context rather than
+/// panicking.
+impl Drop for CudaModule {
+    fn drop(&mut self) {
+        self.ctx.record_err(self.ctx.bind_to_thread());
+        self.ctx
+            .record_err(unsafe { cuda_bindings::cuModuleUnload(self.cu_module).result() });
+    }
+}
+
+impl CudaContext {
+    /// JIT-compiles PTX source and loads the resulting module into this
+    /// context.
+    ///
+    /// `ptx_src` must be a valid, null-terminator-free PTX string. The driver
+    /// performs JIT compilation targeting the current device architecture.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `ptx_src` contains interior null bytes.
+    pub fn load_module_from_ptx_src(
+        self: &Arc<Self>,
+        ptx_src: &str,
+    ) -> Result<Arc<CudaModule>, DriverError> {
+        self.bind_to_thread()?;
+        let c_src = CString::new(ptx_src).unwrap();
+        let cu_module = unsafe {
+            let mut cu_module = MaybeUninit::uninit();
+            cuda_bindings::cuModuleLoadData(cu_module.as_mut_ptr(), c_src.as_ptr() as *const _)
+                .result()?;
+            cu_module.assume_init()
+        };
+        Ok(Arc::new(CudaModule {
+            cu_module,
+            ctx: self.clone(),
+        }))
+    }
+
+    /// Loads a CUDA module from an in-memory image.
+    ///
+    /// `image` may be PTX source bytes, a cubin, or a fatbin. PTX text is
+    /// null-terminated before it is passed to the CUDA driver; binary module
+    /// images tolerate the trailing byte because their own headers describe
+    /// their size.
+    pub fn load_module_from_image(
+        self: &Arc<Self>,
+        image: &[u8],
+    ) -> Result<Arc<CudaModule>, DriverError> {
+        self.bind_to_thread()?;
+        let image = null_terminated_image(image);
+        let cu_module = unsafe {
+            let mut cu_module = MaybeUninit::uninit();
+            cuda_bindings::cuModuleLoadData(cu_module.as_mut_ptr(), image.as_ptr() as *const _)
+                .result()?;
+            cu_module.assume_init()
+        };
+        Ok(Arc::new(CudaModule {
+            cu_module,
+            ctx: self.clone(),
+        }))
+    }
+
+    /// Loads a module from a cubin or PTX file on disk.
+    ///
+    /// `filename` is the filesystem path. The driver selects the loader based
+    /// on file contents (PTX text or cubin ELF).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `filename` contains interior null bytes.
+    pub fn load_module_from_file(
+        self: &Arc<Self>,
+        filename: &str,
+    ) -> Result<Arc<CudaModule>, DriverError> {
+        self.bind_to_thread()?;
+        let c_str = CString::new(filename).unwrap();
+        let mut cu_module = MaybeUninit::uninit();
+        let cu_module = unsafe {
+            cuda_bindings::cuModuleLoad(cu_module.as_mut_ptr(), c_str.as_ptr()).result()?;
+            cu_module.assume_init()
+        };
+        Ok(Arc::new(CudaModule {
+            cu_module,
+            ctx: self.clone(),
+        }))
+    }
+}
+
+fn null_terminated_image(image: &[u8]) -> Cow<'_, [u8]> {
+    if image.last() == Some(&0) {
+        Cow::Borrowed(image)
+    } else {
+        let mut owned = Vec::with_capacity(image.len() + 1);
+        owned.extend_from_slice(image);
+        owned.push(0);
+        Cow::Owned(owned)
+    }
+}
+
+/// A handle to a device kernel entry point within a loaded [`CudaModule`].
+///
+/// Holds an `Arc<CudaModule>` so the module (and transitively the context)
+/// remains loaded for the lifetime of this handle. Cloning is cheap (just an
+/// `Arc` bump).
+#[derive(Debug, Clone)]
+pub struct CudaFunction {
+    /// Raw CUDA function handle.
+    pub(crate) cu_function: cuda_bindings::CUfunction,
+    /// Owning module. Prevents unloading while this function handle exists.
+    #[allow(unused)]
+    pub(crate) module: Arc<CudaModule>,
+}
+
+/// # Safety
+///
+/// `CUfunction` handles are derived from a `CUmodule` and valid in any thread
+/// that has the owning context bound.
+unsafe impl Send for CudaFunction {}
+/// See [`Send`] impl.
+unsafe impl Sync for CudaFunction {}
+
+impl CudaModule {
+    /// Returns the parent [`CudaContext`].
+    ///
+    /// This is mainly useful when interoperating with raw CUDA driver APIs:
+    /// call [`CudaContext::bind_to_thread`] on this context before passing raw
+    /// module/function handles to APIs that require the owning context to be
+    /// current on the calling host thread.
+    pub fn context(&self) -> &Arc<CudaContext> {
+        &self.ctx
+    }
+
+    /// Returns the raw `CUmodule` handle owned by this wrapper.
+    ///
+    /// This is an escape hatch for CUDA driver interop libraries that need to
+    /// inspect or register a loaded module directly. For example, NVSHMEM uses
+    /// module-level state and may need the raw `CUmodule` before launching a
+    /// kernel that calls into NVSHMEM device code.
+    ///
+    /// The returned handle is copied by value, but it is non-owning.
+    /// cuda-oxide still owns the module and will unload it when the last
+    /// [`Arc`] owning this module is dropped.
+    ///
+    /// # Safety
+    ///
+    /// - The returned handle is valid only while this [`CudaModule`] remains
+    ///   alive. If the handle is stored outside the immediate call, the caller
+    ///   must keep an [`Arc`] to this module alive for at least as long.
+    /// - The caller must not unload the module through the raw handle, transfer
+    ///   ownership of it, or pass it to any API that may invalidate module,
+    ///   function, or global handles owned by cuda-oxide.
+    /// - Before passing the handle to CUDA driver APIs or interop libraries
+    ///   that make driver calls, the caller must ensure this module's owning
+    ///   context is current on the calling host thread, for example with
+    ///   [`CudaModule::context`] followed by
+    ///   [`CudaContext::bind_to_thread`].
+    /// - Any foreign library that retains this handle must obey the same
+    ///   lifetime and context-current requirements. cuda-oxide cannot enforce
+    ///   those requirements once the raw handle leaves Rust's type system.
+    pub unsafe fn cu_module(&self) -> cuda_bindings::CUmodule {
+        self.cu_module
+    }
+
+    /// Looks up a kernel entry point by `fn_name` in this module.
+    ///
+    /// The returned [`CudaFunction`] holds an `Arc` back to this module,
+    /// preventing unloading while the handle is live.
+    ///
+    /// This method first binds the module's owning context to the calling
+    /// thread, then performs `cuModuleGetFunction`. That makes it safe to look
+    /// up functions from any host thread, provided the module and its context
+    /// are still alive.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if binding the module's context fails or if
+    /// `cuModuleGetFunction` cannot resolve `fn_name` in this module.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `fn_name` contains interior null bytes.
+    pub fn load_function(self: &Arc<Self>, fn_name: &str) -> Result<CudaFunction, DriverError> {
+        self.ctx.bind_to_thread()?;
+        let c_name = CString::new(fn_name).unwrap();
+        let cu_function = unsafe {
+            let mut cu_function = MaybeUninit::uninit();
+            cuda_bindings::cuModuleGetFunction(
+                cu_function.as_mut_ptr(),
+                self.cu_module,
+                c_name.as_ptr(),
+            )
+            .result()?;
+            cu_function.assume_init()
+        };
+        Ok(CudaFunction {
+            cu_function,
+            module: self.clone(),
+        })
+    }
+}
+
+/// A resolved handle to a `#[constant]` device global. Macro-generated
+/// `set_<name>` methods resolve these lazily on first use and cache the
+/// handle on the `LoadedModule` struct. Callers pass `size_of::<T>()` on
+/// every write; correctness depends on the resolver asserting that the
+/// driver-reported size matches the host-side type.
+#[derive(Clone, Copy, Debug)]
+pub struct ConstantHandle {
+    pub(crate) dptr: cuda_bindings::CUdeviceptr,
+}
+
+impl ConstantHandle {
+    /// Construct from a raw device pointer. Used by macro-generated
+    /// `LoadedModule` initializers after [`CudaModule::get_global`] has
+    /// resolved the symbol and the size has been asserted against
+    /// `size_of::<T>()`.
+    ///
+    /// # Safety
+    ///
+    /// `dptr` must point to at least `size_of::<T>()` bytes of constant
+    /// memory in a still-loaded module.
+    pub unsafe fn from_raw(dptr: cuda_bindings::CUdeviceptr) -> Self {
+        Self { dptr }
+    }
+}
+
+impl ConstantHandle {
+    /// Stream-ordered `cuMemcpyHtoDAsync` from `src` (`num_bytes` of host
+    /// memory) into the device global.
+    ///
+    /// # Safety
+    ///
+    /// - `src` must point to at least `num_bytes` of readable host memory.
+    /// - The bytes must have a layout compatible with the device-side type.
+    pub unsafe fn write_async(
+        &self,
+        stream: &crate::CudaStream,
+        src: *const u8,
+        num_bytes: usize,
+    ) -> Result<(), DriverError> {
+        stream.context().bind_to_thread()?;
+        unsafe {
+            crate::simt::memory::memcpy_htod_async(self.dptr, src, num_bytes, stream.cu_stream())
+        }
+    }
+
+    /// Stream-ordered `cuMemcpyHtoDAsync` from owned host bytes into the
+    /// device global.
+    ///
+    /// The bytes are kept alive until the stream reaches a host callback
+    /// enqueued after the copy. This makes safe setters sound even when the
+    /// caller passes a temporary such as `&3.0`.
+    pub fn write_async_staged(
+        &self,
+        stream: &crate::CudaStream,
+        bytes: Box<[MaybeUninit<u8>]>,
+    ) -> Result<(), DriverError> {
+        stream.context().bind_to_thread()?;
+        let num_bytes = bytes.len();
+        if num_bytes == 0 {
+            return Ok(());
+        }
+
+        unsafe {
+            crate::simt::memory::memcpy_htod_async(
+                self.dptr,
+                bytes.as_ptr() as *const u8,
+                num_bytes,
+                stream.cu_stream(),
+            )?;
+        }
+
+        unsafe extern "C" fn drop_staged_bytes(callback: *mut c_void) {
+            drop(unsafe {
+                Box::<Box<[MaybeUninit<u8>]>>::from_raw(callback as *mut Box<[MaybeUninit<u8>]>)
+            });
+        }
+
+        let callback_data = Box::into_raw(Box::new(bytes)) as *mut c_void;
+        let callback_result = unsafe {
+            cuda_bindings::cuLaunchHostFunc(
+                stream.cu_stream(),
+                Some(drop_staged_bytes),
+                callback_data,
+            )
+        }
+        .result();
+
+        if let Err(err) = callback_result {
+            let staged = unsafe {
+                Box::<Box<[MaybeUninit<u8>]>>::from_raw(
+                    callback_data as *mut Box<[MaybeUninit<u8>]>,
+                )
+            };
+            if let Err(sync_err) = stream.synchronize() {
+                Box::leak(staged);
+                return Err(sync_err);
+            }
+            drop(staged);
+            return Err(err);
+        }
+
+        Ok(())
+    }
+
+    /// Synchronous `cuMemcpyHtoD` from `src` into the device global. Blocks
+    /// the calling thread.
+    ///
+    /// # Safety
+    ///
+    /// Same contract as [`write_async`](Self::write_async).
+    pub unsafe fn write_blocking(
+        &self,
+        module: &Arc<CudaModule>,
+        src: *const u8,
+        num_bytes: usize,
+    ) -> Result<(), DriverError> {
+        unsafe { module.copy_bytes_to_device_global_sync(self.dptr, src, num_bytes) }
+    }
+}
+
+impl CudaModule {
+    /// Resolves a device global by name and returns its device pointer and
+    /// size in bytes.
+    ///
+    /// Used to find `__constant__`-style globals (and other module-scope
+    /// device symbols) so the host can populate them via `cuMemcpyHtoD`.
+    /// The returned size is what the driver recorded for the symbol — host
+    /// code should assert it matches the expected element size before
+    /// copying.
+    ///
+    /// Binds the owning context to the calling thread first.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if binding fails or if `name` cannot be resolved
+    /// in this module.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `name` contains interior null bytes.
+    pub fn get_global(
+        self: &Arc<Self>,
+        name: &str,
+    ) -> Result<(cuda_bindings::CUdeviceptr, usize), DriverError> {
+        self.ctx.bind_to_thread()?;
+        let c_name = CString::new(name).unwrap();
+        let mut dptr = MaybeUninit::<cuda_bindings::CUdeviceptr>::uninit();
+        let mut size = MaybeUninit::<usize>::uninit();
+        unsafe {
+            cuda_bindings::cuModuleGetGlobal_v2(
+                dptr.as_mut_ptr(),
+                size.as_mut_ptr(),
+                self.cu_module,
+                c_name.as_ptr(),
+            )
+            .result()?;
+            Ok((dptr.assume_init(), size.assume_init()))
+        }
+    }
+
+    /// Synchronously copies `num_bytes` from host memory at `src` into the
+    /// device global at `dptr`.
+    ///
+    /// Intended for populating `#[constant]` statics from the macro-generated
+    /// `set_<name>_blocking` methods on `LoadedModule`. The caller is expected to have
+    /// already resolved `dptr` via [`get_global`](Self::get_global) and
+    /// verified that the driver-reported size matches the host type's size.
+    ///
+    /// # Safety
+    ///
+    /// - `dptr` must be a valid device pointer with at least `num_bytes` of
+    ///   accessible storage.
+    /// - `src` must point to at least `num_bytes` of readable host memory.
+    /// - The device-side type at `dptr` and the host bytes at `src` must
+    ///   have compatible layout.
+    pub unsafe fn copy_bytes_to_device_global_sync(
+        self: &Arc<Self>,
+        dptr: cuda_bindings::CUdeviceptr,
+        src: *const u8,
+        num_bytes: usize,
+    ) -> Result<(), DriverError> {
+        self.ctx.bind_to_thread()?;
+        unsafe { crate::simt::memory::memcpy_htod_sync(dptr, src, num_bytes) }
+    }
+}
+
+impl CudaFunction {
+    fn attribute(
+        &self,
+        attribute: cuda_bindings::CUfunction_attribute,
+    ) -> Result<u32, DriverError> {
+        self.context().bind_to_thread()?;
+        let mut value = MaybeUninit::uninit();
+        unsafe {
+            cuda_bindings::cuFuncGetAttribute(value.as_mut_ptr(), attribute, self.cu_function)
+                .result()?;
+            u32::try_from(value.assume_init())
+                .map_err(|_| DriverError(cuda_bindings::cudaError_enum_CUDA_ERROR_INVALID_VALUE))
+        }
+    }
+
+    /// Returns the context that owns this function.
+    pub fn context(&self) -> &Arc<CudaContext> {
+        self.module.context()
+    }
+
+    /// Queries the largest thread block accepted by this function.
+    pub fn max_threads_per_block(&self) -> Result<u32, DriverError> {
+        self.attribute(
+            cuda_bindings::CUfunction_attribute_enum_CU_FUNC_ATTRIBUTE_MAX_THREADS_PER_BLOCK,
+        )
+    }
+
+    /// Queries this function's statically allocated shared memory per block.
+    pub fn static_shared_memory_bytes(&self) -> Result<u32, DriverError> {
+        self.attribute(cuda_bindings::CUfunction_attribute_enum_CU_FUNC_ATTRIBUTE_SHARED_SIZE_BYTES)
+    }
+
+    /// Queries the currently configured dynamic shared-memory maximum.
+    pub fn max_dynamic_shared_memory_bytes(&self) -> Result<u32, DriverError> {
+        self.attribute(
+            cuda_bindings::CUfunction_attribute_enum_CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES,
+        )
+    }
+
+    /// Queries the number of registers each thread of this function uses.
+    ///
+    /// This is the `registers` figure `ptxas -v` prints at compile time, read
+    /// back from the loaded module instead. Register pressure is what caps
+    /// occupancy on most kernels, so this is the number to check first when a
+    /// launch runs at fewer blocks per SM than expected.
+    pub fn num_registers(&self) -> Result<u32, DriverError> {
+        self.attribute(cuda_bindings::CUfunction_attribute_enum_CU_FUNC_ATTRIBUTE_NUM_REGS)
+    }
+
+    /// Queries the per-thread local memory (frame) size of this function, in
+    /// bytes.
+    ///
+    /// This is the per-thread quantity that
+    /// [`CudaContext::set_stack_size`](crate::simt::context::CudaContext::set_stack_size)
+    /// budgets for: the driver reserves the stack limit for every resident
+    /// thread on the device, so a kernel with a large frame can reserve
+    /// device memory far in excess of anything it allocates explicitly.
+    pub fn local_size_bytes(&self) -> Result<u32, DriverError> {
+        self.attribute(cuda_bindings::CUfunction_attribute_enum_CU_FUNC_ATTRIBUTE_LOCAL_SIZE_BYTES)
+    }
+
+    /// Queries the user-declared constant memory this function requires, in
+    /// bytes.
+    ///
+    /// Covers only constant memory the kernel declares; it excludes the
+    /// driver's own kernel parameter and system constant banks.
+    pub fn const_size_bytes(&self) -> Result<u32, DriverError> {
+        self.attribute(cuda_bindings::CUfunction_attribute_enum_CU_FUNC_ATTRIBUTE_CONST_SIZE_BYTES)
+    }
+
+    /// Queries a cluster shape compiled into this function, if present.
+    ///
+    /// CUDA requires the three required-cluster attributes to be either all
+    /// zero or all positive. A partial tuple is treated as an invalid driver
+    /// response rather than silently normalizing it.
+    pub fn required_cluster_dimensions(&self) -> Result<Option<(u32, u32, u32)>, DriverError> {
+        let required = (
+            self.attribute(
+                cuda_bindings::CUfunction_attribute_enum_CU_FUNC_ATTRIBUTE_REQUIRED_CLUSTER_WIDTH,
+            )?,
+            self.attribute(
+                cuda_bindings::CUfunction_attribute_enum_CU_FUNC_ATTRIBUTE_REQUIRED_CLUSTER_HEIGHT,
+            )?,
+            self.attribute(
+                cuda_bindings::CUfunction_attribute_enum_CU_FUNC_ATTRIBUTE_REQUIRED_CLUSTER_DEPTH,
+            )?,
+        );
+        match required {
+            (0, 0, 0) => Ok(None),
+            (x, y, z) if x != 0 && y != 0 && z != 0 => Ok(Some(required)),
+            _ => Err(DriverError(
+                cuda_bindings::cudaError_enum_CUDA_ERROR_INVALID_VALUE,
+            )),
+        }
+    }
+
+    /// Opts this function into a larger dynamic shared-memory allocation.
+    ///
+    /// Typed launch preparation calls this at most once, and only after
+    /// checking static plus dynamic memory against the device opt-in limit.
+    pub(crate) fn set_max_dynamic_shared_memory_bytes(
+        &self,
+        bytes: u32,
+    ) -> Result<(), DriverError> {
+        self.context().bind_to_thread()?;
+        let bytes = i32::try_from(bytes)
+            .map_err(|_| DriverError(cuda_bindings::cudaError_enum_CUDA_ERROR_INVALID_VALUE))?;
+        unsafe {
+            cuda_bindings::cuFuncSetAttribute(
+                self.cu_function,
+                cuda_bindings::CUfunction_attribute_enum_CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES,
+                bytes,
+            )
+        }
+        .result()
+    }
+
+    /// Computes the maximum active blocks per streaming multiprocessor for a
+    /// concrete non-cluster launch shape.
+    pub fn max_active_blocks_per_multiprocessor(
+        &self,
+        block_threads: u32,
+        dynamic_shared_memory_bytes: u32,
+    ) -> Result<u32, DriverError> {
+        self.context().bind_to_thread()?;
+        let block_threads = i32::try_from(block_threads)
+            .map_err(|_| DriverError(cuda_bindings::cudaError_enum_CUDA_ERROR_INVALID_VALUE))?;
+        let mut blocks = MaybeUninit::uninit();
+        unsafe {
+            cuda_bindings::cuOccupancyMaxActiveBlocksPerMultiprocessor(
+                blocks.as_mut_ptr(),
+                self.cu_function,
+                block_threads,
+                dynamic_shared_memory_bytes as usize,
+            )
+            .result()?;
+            u32::try_from(blocks.assume_init())
+                .map_err(|_| DriverError(cuda_bindings::cudaError_enum_CUDA_ERROR_INVALID_VALUE))
+        }
+    }
+
+    /// Queries the maximum cluster size for this function and launch shape on
+    /// the current device.
+    ///
+    /// CUDA documents that `cuOccupancyMaxPotentialClusterSize` ignores any
+    /// cluster-dimension attribute in the supplied launch configuration, so
+    /// this query intentionally supplies only grid, block, and dynamic shared
+    /// memory. It respects compile-time cluster launch bounds and any function
+    /// opt-in to non-portable cluster sizes.
+    pub fn max_potential_cluster_size(
+        &self,
+        grid_dim: (u32, u32, u32),
+        block_dim: (u32, u32, u32),
+        dynamic_shared_memory_bytes: u32,
+    ) -> Result<u32, DriverError> {
+        self.context().bind_to_thread()?;
+        let config = cuda_bindings::CUlaunchConfig_st {
+            gridDimX: grid_dim.0,
+            gridDimY: grid_dim.1,
+            gridDimZ: grid_dim.2,
+            blockDimX: block_dim.0,
+            blockDimY: block_dim.1,
+            blockDimZ: block_dim.2,
+            sharedMemBytes: dynamic_shared_memory_bytes,
+            hStream: std::ptr::null_mut(),
+            attrs: std::ptr::null_mut(),
+            numAttrs: 0,
+        };
+        let mut cluster_size = MaybeUninit::uninit();
+        unsafe {
+            cuda_bindings::cuOccupancyMaxPotentialClusterSize(
+                cluster_size.as_mut_ptr(),
+                self.cu_function,
+                &config,
+            )
+            .result()?;
+            u32::try_from(cluster_size.assume_init())
+                .map_err(|_| DriverError(cuda_bindings::cudaError_enum_CUDA_ERROR_INVALID_VALUE))
+        }
+    }
+
+    /// Queries how many clusters with the exact requested shape can be active
+    /// on the target device.
+    ///
+    /// Unlike [`max_potential_cluster_size`](Self::max_potential_cluster_size),
+    /// this passes `cluster_dim` as a launch attribute. CUDA therefore checks
+    /// the concrete shape and any compiled required-cluster dimensions.
+    pub fn max_active_clusters(
+        &self,
+        grid_dim: (u32, u32, u32),
+        block_dim: (u32, u32, u32),
+        dynamic_shared_memory_bytes: u32,
+        cluster_dim: (u32, u32, u32),
+    ) -> Result<u32, DriverError> {
+        self.context().bind_to_thread()?;
+
+        // CUlaunchAttribute_st is opaque in the generated CUDA 13.2+
+        // bindings. Its C layout stores the id at offset 0 and the value union
+        // at offset 8; clusterDim.x/y/z occupy the first three u32 values in
+        // that union. This matches the launch helpers in cuda-core's root.
+        let mut cluster_attribute: cuda_bindings::CUlaunchAttribute_st =
+            unsafe { std::mem::zeroed() };
+        unsafe {
+            let base = &mut cluster_attribute as *mut _ as *mut u8;
+            (base as *mut u32).write(
+                cuda_bindings::CUlaunchAttributeID_enum_CU_LAUNCH_ATTRIBUTE_CLUSTER_DIMENSION,
+            );
+            let dimensions = base.add(8) as *mut u32;
+            dimensions.write(cluster_dim.0);
+            dimensions.add(1).write(cluster_dim.1);
+            dimensions.add(2).write(cluster_dim.2);
+        }
+
+        let config = cuda_bindings::CUlaunchConfig_st {
+            gridDimX: grid_dim.0,
+            gridDimY: grid_dim.1,
+            gridDimZ: grid_dim.2,
+            blockDimX: block_dim.0,
+            blockDimY: block_dim.1,
+            blockDimZ: block_dim.2,
+            sharedMemBytes: dynamic_shared_memory_bytes,
+            hStream: std::ptr::null_mut(),
+            attrs: &mut cluster_attribute,
+            numAttrs: 1,
+        };
+        let mut active_clusters = MaybeUninit::uninit();
+        unsafe {
+            cuda_bindings::cuOccupancyMaxActiveClusters(
+                active_clusters.as_mut_ptr(),
+                self.cu_function,
+                &config,
+            )
+            .result()?;
+            u32::try_from(active_clusters.assume_init())
+                .map_err(|_| DriverError(cuda_bindings::cudaError_enum_CUDA_ERROR_INVALID_VALUE))
+        }
+    }
+
+    /// Returns the raw `CUfunction` handle.
+    ///
+    /// # Safety
+    ///
+    /// The returned handle is copied by value, but it is non-owning. It is
+    /// invalidated if the parent [`CudaModule`] is dropped.
+    ///
+    /// Because [`CudaFunction`] holds an [`Arc`] to its parent module, the
+    /// module cannot be unloaded while `self` is alive. If the raw handle is
+    /// stored outside the immediate call, the caller must keep this
+    /// [`CudaFunction`] or another [`Arc`] owning the parent module alive for
+    /// at least as long as the raw handle is used.
+    pub unsafe fn cu_function(&self) -> cuda_bindings::CUfunction {
+        self.cu_function
+    }
+}

--- a/cuda-core/src/simt/peer.rs
+++ b/cuda-core/src/simt/peer.rs
@@ -1,0 +1,81 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! CUDA peer-to-peer (P2P) access management.
+//!
+//! Enables direct memory access between GPUs over NVLink or PCIe. Once enabled,
+//! kernels on one device can read/write memory allocated on the peer device, and
+//! `cuMemcpy` between devices avoids staging through host memory.
+//!
+//! P2P access depends on hardware topology. Use `can_access_peer` to query
+//! support before calling `enable_peer_access`.
+
+use crate::error::{DriverError, IntoResult};
+use crate::simt::context::CudaContext;
+use std::mem::MaybeUninit;
+use std::sync::Arc;
+
+/// Checks whether `from` can directly access memory on `to`.
+///
+/// Returns `true` if the two devices are connected via NVLink or PCIe with P2P
+/// support, and the system topology allows direct access. Returns `false` if
+/// P2P is not possible (e.g., different PCIe root complexes without a switch).
+///
+/// This is a query only -- it does not enable access. Call `enable_peer_access`
+/// to actually enable it.
+pub fn can_access_peer(from: &CudaContext, to: &CudaContext) -> Result<bool, DriverError> {
+    let mut can_access = MaybeUninit::uninit();
+    unsafe {
+        cuda_bindings::cuDeviceCanAccessPeer(
+            can_access.as_mut_ptr(),
+            from.cu_device(),
+            to.cu_device(),
+        )
+        .result()?;
+        Ok(can_access.assume_init() != 0)
+    }
+}
+
+/// Enables P2P access from `from`'s context to `to`'s device memory.
+///
+/// After this call, kernels running in `from`'s context can directly read/write
+/// memory allocated in `to`'s context, and memory copies between the two devices
+/// use the direct P2P path (NVLink or PCIe) instead of staging through host memory.
+///
+/// This is a one-directional operation. To enable bidirectional access, call this
+/// function twice with swapped arguments.
+///
+/// Returns `Ok(())` if access was enabled or was already enabled. Returns an error
+/// if the devices do not support P2P (check with `can_access_peer` first).
+pub fn enable_peer_access(
+    from: &Arc<CudaContext>,
+    to: &Arc<CudaContext>,
+) -> Result<(), DriverError> {
+    from.bind_to_thread()?;
+    let result = unsafe { cuda_bindings::cuCtxEnablePeerAccess(to.cu_ctx(), 0) };
+    match result {
+        cuda_bindings::cudaError_enum_CUDA_SUCCESS => Ok(()),
+        cuda_bindings::cudaError_enum_CUDA_ERROR_PEER_ACCESS_ALREADY_ENABLED => Ok(()),
+        _ => result.result(),
+    }
+}
+
+/// Disables P2P access from `from`'s context to `to`'s device memory.
+///
+/// After this call, direct memory access from `from` to `to` is no longer
+/// possible. Any in-flight operations accessing peer memory must have completed
+/// before calling this.
+pub fn disable_peer_access(
+    from: &Arc<CudaContext>,
+    to: &Arc<CudaContext>,
+) -> Result<(), DriverError> {
+    from.bind_to_thread()?;
+    let result = unsafe { cuda_bindings::cuCtxDisablePeerAccess(to.cu_ctx()) };
+    match result {
+        cuda_bindings::cudaError_enum_CUDA_SUCCESS => Ok(()),
+        cuda_bindings::cudaError_enum_CUDA_ERROR_PEER_ACCESS_NOT_ENABLED => Ok(()),
+        _ => result.result(),
+    }
+}

--- a/cuda-core/src/simt/pinned_host_buffer.rs
+++ b/cuda-core/src/simt/pinned_host_buffer.rs
@@ -1,0 +1,198 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Page-locked host memory for CUDA transfers.
+//!
+//! [`PinnedHostBuffer<T>`] owns CUDA page-locked host memory allocated with
+//! `cuMemAllocHost`. Pinned memory is useful as a staging area for host-device
+//! copies that need higher transfer bandwidth. Copies only overlap with GPU
+//! work when they are enqueued with non-blocking transfer APIs and synchronized
+//! later by the caller.
+
+use std::fmt;
+use std::marker::PhantomData;
+use std::ops::{Deref, DerefMut};
+use std::ptr::NonNull;
+use std::slice;
+use std::sync::Arc;
+
+use crate::error::DriverError;
+use crate::simt::context::CudaContext;
+use crate::simt::device_buffer::DeviceCopy;
+
+/// Owned page-locked host buffer.
+///
+/// The buffer is initialized and exposes normal Rust slices. The backing
+/// allocation is freed with `cuMemFreeHost` on drop.
+///
+/// Pinned transfer buffers require `T: DeviceCopy`, so host-owned values such
+/// as [`String`] are rejected.
+///
+/// ```compile_fail
+/// # use cuda_core::{CudaContext, PinnedHostBuffer};
+/// # fn rejects_non_device_copy(ctx: &std::sync::Arc<CudaContext>) {
+/// let _ = PinnedHostBuffer::<String>::zeroed(ctx, 1);
+/// # }
+/// ```
+pub struct PinnedHostBuffer<T: DeviceCopy> {
+    ptr: NonNull<T>,
+    len: usize,
+    num_bytes: usize,
+    ctx: Arc<CudaContext>,
+    _marker: PhantomData<T>,
+}
+
+// SAFETY: the allocation is host memory. Moving ownership to another thread is
+// safe when `T` is safe to send.
+unsafe impl<T: DeviceCopy + Send> Send for PinnedHostBuffer<T> {}
+// SAFETY: shared access only exposes `&[T]`.
+unsafe impl<T: DeviceCopy + Sync> Sync for PinnedHostBuffer<T> {}
+
+impl<T: DeviceCopy> PinnedHostBuffer<T> {
+    /// Allocates a pinned host buffer and fills it with zero bytes.
+    pub fn zeroed(ctx: &Arc<CudaContext>, len: usize) -> Result<Self, DriverError> {
+        let mut buffer = Self::allocate(ctx, len)?;
+        if buffer.num_bytes != 0 {
+            unsafe {
+                std::ptr::write_bytes(buffer.as_mut_ptr().cast::<u8>(), 0, buffer.num_bytes);
+            }
+        }
+
+        Ok(buffer)
+    }
+
+    /// Allocates a pinned host buffer and copies `data` into it.
+    pub fn from_slice(ctx: &Arc<CudaContext>, data: &[T]) -> Result<Self, DriverError> {
+        let buffer = Self::allocate(ctx, data.len())?;
+        if !data.is_empty() {
+            unsafe {
+                std::ptr::copy_nonoverlapping(data.as_ptr(), buffer.ptr.as_ptr(), data.len());
+            }
+        }
+        Ok(buffer)
+    }
+
+    /// Number of elements in the buffer.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Returns `true` if the buffer contains no elements.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Total size in bytes (`len * size_of::<T>()`).
+    #[inline]
+    pub fn num_bytes(&self) -> usize {
+        self.num_bytes
+    }
+
+    /// Returns the CUDA context used to allocate this buffer.
+    #[inline]
+    pub fn context(&self) -> &Arc<CudaContext> {
+        &self.ctx
+    }
+
+    /// Returns the host pointer.
+    #[inline]
+    pub fn as_ptr(&self) -> *const T {
+        self.ptr.as_ptr()
+    }
+
+    /// Returns the mutable host pointer.
+    #[inline]
+    pub fn as_mut_ptr(&mut self) -> *mut T {
+        self.ptr.as_ptr()
+    }
+
+    /// Returns the buffer as a host slice.
+    #[inline]
+    pub fn as_slice(&self) -> &[T] {
+        unsafe { slice::from_raw_parts(self.ptr.as_ptr(), self.len) }
+    }
+
+    /// Returns the buffer as a mutable host slice.
+    #[inline]
+    pub fn as_mut_slice(&mut self) -> &mut [T] {
+        unsafe { slice::from_raw_parts_mut(self.ptr.as_ptr(), self.len) }
+    }
+
+    fn allocate(ctx: &Arc<CudaContext>, len: usize) -> Result<Self, DriverError> {
+        let num_bytes = allocation_size::<T>(len)?;
+        let ptr = if num_bytes == 0 {
+            NonNull::dangling()
+        } else {
+            ctx.bind_to_thread()?;
+            let ptr = unsafe { crate::simt::memory::malloc_host(num_bytes)? };
+            NonNull::new(ptr.cast::<T>()).ok_or(DriverError(
+                cuda_bindings::cudaError_enum_CUDA_ERROR_INVALID_VALUE,
+            ))?
+        };
+
+        Ok(Self {
+            ptr,
+            len,
+            num_bytes,
+            ctx: ctx.clone(),
+            _marker: PhantomData,
+        })
+    }
+}
+
+impl<T: DeviceCopy> Drop for PinnedHostBuffer<T> {
+    fn drop(&mut self) {
+        if self.num_bytes != 0 {
+            self.ctx.record_err(self.ctx.bind_to_thread());
+            self.ctx
+                .record_err(unsafe { crate::simt::memory::free_host(self.ptr.as_ptr().cast()) });
+        }
+    }
+}
+
+impl<T: DeviceCopy> fmt::Debug for PinnedHostBuffer<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PinnedHostBuffer")
+            .field("ptr", &self.ptr)
+            .field("len", &self.len)
+            .field("num_bytes", &self.num_bytes)
+            .field("ctx", &self.ctx)
+            .finish()
+    }
+}
+
+impl<T: DeviceCopy> AsRef<[T]> for PinnedHostBuffer<T> {
+    fn as_ref(&self) -> &[T] {
+        self.as_slice()
+    }
+}
+
+impl<T: DeviceCopy> AsMut<[T]> for PinnedHostBuffer<T> {
+    fn as_mut(&mut self) -> &mut [T] {
+        self.as_mut_slice()
+    }
+}
+
+impl<T: DeviceCopy> Deref for PinnedHostBuffer<T> {
+    type Target = [T];
+
+    fn deref(&self) -> &Self::Target {
+        self.as_slice()
+    }
+}
+
+impl<T: DeviceCopy> DerefMut for PinnedHostBuffer<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.as_mut_slice()
+    }
+}
+
+fn allocation_size<T>(len: usize) -> Result<usize, DriverError> {
+    len.checked_mul(std::mem::size_of::<T>()).ok_or(DriverError(
+        cuda_bindings::cudaError_enum_CUDA_ERROR_INVALID_VALUE,
+    ))
+}

--- a/cuda-core/src/simt/stream.rs
+++ b/cuda-core/src/simt/stream.rs
@@ -1,0 +1,252 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! CUDA stream management (RAII, host callbacks, fork/join).
+//!
+//! A [`CudaStream`] wraps a `CUstream` handle and ties its lifetime to its
+//! parent [`CudaContext`]. Streams are created via
+//! [`CudaContext::new_stream`] or [`CudaStream::fork`] and destroyed
+//! automatically on [`Drop`].
+//!
+//! # Ordering model
+//!
+//! Operations enqueued on the same stream execute in FIFO order. Operations on
+//! different streams may overlap. Use [`fork`](CudaStream::fork) /
+//! [`join`](CudaStream::join) or explicit events ([`record_event`](CudaStream::record_event),
+//! [`wait`](CudaStream::wait)) to establish cross-stream ordering.
+//!
+//! # Host callbacks
+//!
+//! [`launch_host_function`](CudaStream::launch_host_function) enqueues a
+//! host-side closure that the driver invokes after all preceding stream work
+//! completes. This is the primary bridge between CUDA stream completion and
+//! Rust `async` futures.
+
+use crate::error::{DriverError, IntoResult};
+use crate::simt::context::CudaContext;
+use crate::simt::event::CudaEvent;
+use std::ffi::c_void;
+use std::mem::MaybeUninit;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+/// An RAII wrapper around a `CUstream` handle.
+///
+/// Holds an `Arc<CudaContext>` to ensure the context outlives the stream.
+/// A null `cu_stream` represents the per-context default stream (stream 0).
+#[derive(Debug, PartialEq, Eq)]
+pub struct CudaStream {
+    /// Raw CUDA stream handle. Null for the default stream.
+    pub(crate) cu_stream: cuda_bindings::CUstream,
+    /// Owning context. Kept alive for the lifetime of this stream.
+    pub(crate) ctx: Arc<CudaContext>,
+}
+
+/// # Safety
+///
+/// `CUstream` handles are not thread-local. The CUDA driver permits enqueuing
+/// work onto a stream from any thread, provided the owning context is bound
+/// (which [`bind_to_thread`](CudaContext::bind_to_thread) ensures).
+unsafe impl Send for CudaStream {}
+/// See [`Send`] impl.
+unsafe impl Sync for CudaStream {}
+
+/// Destroys the underlying `CUstream` on drop and decrements the context's
+/// live stream count.
+///
+/// The default stream (null handle) is never destroyed. Errors during
+/// teardown are recorded on the context rather than panicking.
+impl Drop for CudaStream {
+    fn drop(&mut self) {
+        self.ctx.record_err(self.ctx.bind_to_thread());
+        if !self.cu_stream.is_null() {
+            self.ctx.num_streams.fetch_sub(1, Ordering::Relaxed);
+            self.ctx
+                .record_err(unsafe { cuda_bindings::cuStreamDestroy_v2(self.cu_stream).result() });
+        }
+    }
+}
+
+impl CudaStream {
+    /// Returns the raw `CUstream` handle (null for the default stream).
+    pub fn cu_stream(&self) -> cuda_bindings::CUstream {
+        self.cu_stream
+    }
+
+    /// Returns the parent [`CudaContext`].
+    pub fn context(&self) -> &Arc<CudaContext> {
+        &self.ctx
+    }
+
+    /// Returns the priority this stream actually runs at.
+    ///
+    /// Wraps `cuStreamGetPriority`. This is the value to read after
+    /// [`CudaContext::new_stream_with_priority`](crate::simt::context::CudaContext::new_stream_with_priority),
+    /// which clamps an out-of-range request to the device's range without
+    /// reporting it. Lower numbers are higher priorities. The default stream
+    /// and any stream from [`CudaContext::new_stream`](crate::simt::context::CudaContext::new_stream)
+    /// report `0`.
+    pub fn priority(&self) -> Result<i32, DriverError> {
+        self.ctx.bind_to_thread()?;
+        let mut priority = MaybeUninit::uninit();
+        unsafe {
+            cuda_bindings::cuStreamGetPriority(self.cu_stream, priority.as_mut_ptr()).result()?;
+            Ok(priority.assume_init())
+        }
+    }
+
+    /// Blocks the calling thread until all work enqueued on this stream
+    /// completes.
+    pub fn synchronize(&self) -> Result<(), DriverError> {
+        self.ctx.bind_to_thread()?;
+        unsafe { cuda_bindings::cuStreamSynchronize(self.cu_stream) }.result()
+    }
+
+    /// Returns `true` when every operation enqueued on this stream has
+    /// completed, `false` while any is still in flight. Never blocks.
+    ///
+    /// Wraps `cuStreamQuery`, mapping `CUDA_SUCCESS` to `Ok(true)` and
+    /// `CUDA_ERROR_NOT_READY` to `Ok(false)`, as
+    /// [`CudaEvent::query`](crate::simt::event::CudaEvent::query) does for
+    /// `cuEventQuery`. Any other code is a real driver error.
+    ///
+    /// This is the completion half of the async bridge that
+    /// [`launch_host_function`](Self::launch_host_function) opens: a
+    /// `Future::poll` implementation needs to ask whether work has finished
+    /// without parking the executor's thread, which
+    /// [`synchronize`](Self::synchronize) cannot answer.
+    ///
+    /// A sticky error from earlier work on the stream surfaces here rather
+    /// than as `Ok(false)`, the same way it would from
+    /// [`synchronize`](Self::synchronize).
+    ///
+    /// On the default stream this reports the completion of every blocking
+    /// stream in the context, since the default stream orders against them
+    /// all.
+    pub fn query(&self) -> Result<bool, DriverError> {
+        self.ctx.bind_to_thread()?;
+        match unsafe { cuda_bindings::cuStreamQuery(self.cu_stream) } {
+            cuda_bindings::cudaError_enum_CUDA_SUCCESS => Ok(true),
+            cuda_bindings::cudaError_enum_CUDA_ERROR_NOT_READY => Ok(false),
+            err => Err(DriverError(err)),
+        }
+    }
+
+    /// Creates a new non-blocking stream that waits on all prior work in
+    /// `self` before executing its own.
+    ///
+    /// Semantically equivalent to creating a new stream and calling
+    /// [`join`](Self::join) on it with `self`, establishing a fork point
+    /// in the stream DAG.
+    pub fn fork(&self) -> Result<Arc<Self>, DriverError> {
+        self.ctx.bind_to_thread()?;
+        self.ctx.num_streams.fetch_add(1, Ordering::Relaxed);
+        let mut cu_stream = MaybeUninit::uninit();
+        let cu_stream = unsafe {
+            cuda_bindings::cuStreamCreate(
+                cu_stream.as_mut_ptr(),
+                cuda_bindings::CUstream_flags_enum_CU_STREAM_NON_BLOCKING,
+            )
+            .result()?;
+            cu_stream.assume_init()
+        };
+        let stream = Arc::new(CudaStream {
+            cu_stream,
+            ctx: self.ctx.clone(),
+        });
+        stream.join(self)?;
+        Ok(stream)
+    }
+
+    /// Makes `self` wait on all prior work in `other`.
+    ///
+    /// Records an event on `other` and enqueues a wait on `self`. This is the
+    /// join side of the fork/join pattern: after this call, work enqueued on
+    /// `self` is guaranteed to observe all side effects of prior work on
+    /// `other`.
+    pub fn join(&self, other: &CudaStream) -> Result<(), DriverError> {
+        self.wait(&other.record_event(None)?)
+    }
+
+    /// Records an event on this stream and returns it.
+    ///
+    /// `flags` defaults to `CU_EVENT_DISABLE_TIMING` when `None`, which is
+    /// cheaper than a timing-enabled event. Pass
+    /// `Some(CU_EVENT_DEFAULT)` if you need [`CudaEvent::elapsed_ms`].
+    pub fn record_event(
+        &self,
+        flags: Option<cuda_bindings::CUevent_flags>,
+    ) -> Result<CudaEvent, DriverError> {
+        let event = self.ctx.new_event(flags)?;
+        event.record(self)?;
+        Ok(event)
+    }
+
+    /// Enqueues a wait on `event` into this stream.
+    ///
+    /// All work enqueued on `self` after this call will not begin until
+    /// `event` has been recorded (i.e., all prior work on the stream that
+    /// recorded `event` has completed).
+    pub fn wait(&self, event: &CudaEvent) -> Result<(), DriverError> {
+        self.ctx.bind_to_thread()?;
+        unsafe {
+            cuda_bindings::cuStreamWaitEvent(
+                self.cu_stream,
+                event.cu_event(),
+                cuda_bindings::CUevent_wait_flags_enum_CU_EVENT_WAIT_DEFAULT,
+            )
+            .result()
+        }
+    }
+
+    /// Enqueues a host-side callback that the driver invokes after all prior
+    /// work on this stream completes.
+    ///
+    /// This is the bridge between CUDA stream ordering and Rust async: wrap a
+    /// `oneshot::Sender::send` or `Waker::wake` in `host_func` to unblock a
+    /// future when GPU work finishes.
+    ///
+    /// `host_func` is boxed, leaked into a raw pointer, and passed as user
+    /// data to `cuLaunchHostFunc`. The driver calls
+    /// `callback_wrapper` on a driver-internal
+    /// thread, which reclaims the box and invokes the closure.
+    ///
+    /// Panics inside the closure are caught and discarded to prevent unwinding
+    /// across the FFI boundary.
+    pub fn launch_host_function<F: FnOnce() + Send>(
+        &self,
+        host_func: F,
+    ) -> Result<(), DriverError> {
+        let boxed = Box::new(host_func);
+        unsafe {
+            cuda_bindings::cuLaunchHostFunc(
+                self.cu_stream,
+                Some(Self::callback_wrapper::<F>),
+                Box::into_raw(boxed) as *mut c_void,
+            )
+            .result()
+        }
+    }
+
+    /// `extern "C"` trampoline invoked by the CUDA driver on a driver-internal
+    /// thread when a host function callback fires.
+    ///
+    /// Reconstructs the `Box<F>` from the raw pointer and calls the closure.
+    /// Panics are caught with `catch_unwind` to prevent unwinding across the
+    /// C ABI boundary.
+    ///
+    /// # Safety
+    ///
+    /// - `callback` must be a pointer produced by `Box::into_raw(Box::new(f))`
+    ///   where `f: F`.
+    /// - Must be called exactly once per enqueued callback (double-free
+    ///   otherwise).
+    unsafe extern "C" fn callback_wrapper<F: FnOnce() + Send>(callback: *mut c_void) {
+        let _ = std::panic::catch_unwind(|| {
+            let callback: Box<F> = unsafe { Box::from_raw(callback as *mut F) };
+            callback();
+        });
+    }
+}

--- a/cuda-core/src/simt/vmm.rs
+++ b/cuda-core/src/simt/vmm.rs
@@ -1,0 +1,519 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! CUDA Virtual Memory Management (VMM) API wrappers.
+//!
+//! The VMM APIs provide fine-grained control over physical memory allocation,
+//! virtual address reservation, and mapping. Unlike `cuMemAlloc`, which bundles
+//! all three steps, VMM separates them so that physical memory from one device
+//! can be mapped into another device's virtual address space -- the foundation
+//! for P2P symmetric heaps.
+//!
+//! All handle types are RAII: `PhysicalAllocation` releases via `cuMemRelease`,
+//! `VirtualReservation` frees via `cuMemAddressFree`, and `Mapping` unmaps
+//! via `cuMemUnmap`. Drop order matters -- mappings must be dropped before the
+//! physical allocation or virtual reservation they reference.
+//!
+//! The module also wraps CUDA's multicast objects (`cuMulticast*`, CUDA
+//! 12.1+): `MulticastObject` (compiled out on pre-12.1 toolkits, see the
+//! build script probe) builds an NVLink SHARP (NVLS) team whose
+//! mapped VA ranges respond to device-side `multimem.*` instructions with
+//! switch-side reduction and broadcast across every bound GPU. See
+//! `tests/vmm_multicast.rs` and the `nvls_all_reduce` example.
+
+use crate::error::{DriverError, IntoResult};
+use cuda_bindings::CUdeviceptr;
+use std::mem::MaybeUninit;
+
+/// Sets the device ordinal on a `CUmemLocation_st`.
+///
+/// CUDA 13.2 wraps `id` in an anonymous union (`__bindgen_anon_1.id`), while
+/// older versions expose it directly. The memory layout is identical -- `id` is
+/// always at offset 4 (after the `type_` enum). Writing via pointer works across
+/// both layouts.
+unsafe fn set_mem_location_device(
+    loc: &mut cuda_bindings::CUmemLocation_st,
+    device: cuda_bindings::CUdevice,
+) {
+    loc.type_ = cuda_bindings::CUmemLocationType_enum_CU_MEM_LOCATION_TYPE_DEVICE;
+    unsafe {
+        let base = loc as *mut _ as *mut u8;
+        (base.add(4) as *mut i32).write(device);
+    }
+}
+
+/// A physical memory allocation created by `cuMemCreate`.
+///
+/// Owns the underlying `CUmemGenericAllocationHandle`. The allocation lives on
+/// a specific device and can be mapped into any device's VA space that has been
+/// granted access.
+///
+/// Dropping this releases the physical memory. All `Mapping`s referencing this
+/// allocation must be dropped first.
+pub struct PhysicalAllocation {
+    handle: cuda_bindings::CUmemGenericAllocationHandle,
+    size: usize,
+    device: cuda_bindings::CUdevice,
+}
+
+impl PhysicalAllocation {
+    /// Allocates `size` bytes of physical memory on `device`.
+    ///
+    /// `size` must be a multiple of the allocation granularity for the device
+    /// (query via [`allocation_granularity`]).
+    pub fn new(device: cuda_bindings::CUdevice, size: usize) -> Result<Self, DriverError> {
+        let mut prop: cuda_bindings::CUmemAllocationProp_st = unsafe { std::mem::zeroed() };
+        prop.type_ = cuda_bindings::CUmemAllocationType_enum_CU_MEM_ALLOCATION_TYPE_PINNED;
+        unsafe { set_mem_location_device(&mut prop.location, device) };
+
+        let mut handle = MaybeUninit::uninit();
+        unsafe {
+            cuda_bindings::cuMemCreate(handle.as_mut_ptr(), size, &prop, 0).result()?;
+            Ok(Self {
+                handle: handle.assume_init(),
+                size,
+                device,
+            })
+        }
+    }
+
+    /// Returns the raw `CUmemGenericAllocationHandle`.
+    pub fn handle(&self) -> cuda_bindings::CUmemGenericAllocationHandle {
+        self.handle
+    }
+
+    /// Returns the allocation size in bytes.
+    pub fn size(&self) -> usize {
+        self.size
+    }
+
+    /// Returns the device this allocation lives on.
+    pub fn device(&self) -> cuda_bindings::CUdevice {
+        self.device
+    }
+}
+
+impl Drop for PhysicalAllocation {
+    fn drop(&mut self) {
+        unsafe {
+            let _ = cuda_bindings::cuMemRelease(self.handle).result();
+        }
+    }
+}
+
+/// A reserved virtual address range created by `cuMemAddressReserve`.
+///
+/// Owns a contiguous VA range `[base, base + size)`. Physical memory can be
+/// mapped into this range via [`Mapping::new`]. The range is freed on drop.
+///
+/// All `Mapping`s within this range must be dropped before the reservation.
+pub struct VirtualReservation {
+    base: CUdeviceptr,
+    size: usize,
+}
+
+impl VirtualReservation {
+    /// Reserves `size` bytes of virtual address space.
+    ///
+    /// The driver chooses the base address. `size` must be a multiple of the
+    /// allocation granularity. `alignment` can be 0 to let the driver choose.
+    pub fn new(size: usize, alignment: usize) -> Result<Self, DriverError> {
+        let mut base = MaybeUninit::uninit();
+        unsafe {
+            cuda_bindings::cuMemAddressReserve(base.as_mut_ptr(), size, alignment, 0, 0)
+                .result()?;
+            Ok(Self {
+                base: base.assume_init(),
+                size,
+            })
+        }
+    }
+
+    /// Returns the base device pointer of the reserved range.
+    pub fn base(&self) -> CUdeviceptr {
+        self.base
+    }
+
+    /// Returns the reserved size in bytes.
+    pub fn size(&self) -> usize {
+        self.size
+    }
+}
+
+impl Drop for VirtualReservation {
+    fn drop(&mut self) {
+        unsafe {
+            let _ = cuda_bindings::cuMemAddressFree(self.base, self.size).result();
+        }
+    }
+}
+
+/// A mapping of physical memory into a virtual address range.
+///
+/// Created by [`Mapping::new`], which calls `cuMemMap` to bind a
+/// `PhysicalAllocation` (or a portion of it) to a region within a
+/// `VirtualReservation`. Dropped via `cuMemUnmap`.
+pub struct Mapping {
+    va: CUdeviceptr,
+    size: usize,
+}
+
+impl Mapping {
+    /// Maps `size` bytes of `phys` at `offset` into virtual address `va`.
+    ///
+    /// `va` must lie within a `VirtualReservation`. `offset` is the byte
+    /// offset into the physical allocation (typically 0 for full mappings).
+    /// `size` must be a multiple of the allocation granularity.
+    pub fn new(
+        va: CUdeviceptr,
+        size: usize,
+        phys: &PhysicalAllocation,
+        offset: usize,
+    ) -> Result<Self, DriverError> {
+        unsafe {
+            cuda_bindings::cuMemMap(va, size, offset, phys.handle(), 0).result()?;
+        }
+        Ok(Self { va, size })
+    }
+
+    /// Maps `size` bytes of a multicast object at `offset` into virtual
+    /// address `va`.
+    ///
+    /// The resulting VA is a *multicast* view: `multimem.*` PTX instructions
+    /// issued against it operate on every copy bound to the object (see
+    /// [`MulticastObject`]). Like [`Mapping::new`], the mapping is not
+    /// accessible until [`set_access`] grants the accessing device permission.
+    ///
+    /// All devices must have been added to the multicast object (via
+    /// [`MulticastObject::add_device`]) before mapping it.
+    #[cfg(cuda_has_multicast)]
+    pub fn new_multicast(
+        va: CUdeviceptr,
+        size: usize,
+        multicast: &MulticastObject,
+        offset: usize,
+    ) -> Result<Self, DriverError> {
+        unsafe {
+            cuda_bindings::cuMemMap(va, size, offset, multicast.handle(), 0).result()?;
+        }
+        Ok(Self { va, size })
+    }
+
+    /// Returns the virtual address this mapping occupies.
+    pub fn va(&self) -> CUdeviceptr {
+        self.va
+    }
+
+    /// Returns the mapped size in bytes.
+    pub fn size(&self) -> usize {
+        self.size
+    }
+}
+
+impl Drop for Mapping {
+    fn drop(&mut self) {
+        unsafe {
+            let _ = cuda_bindings::cuMemUnmap(self.va, self.size).result();
+        }
+    }
+}
+
+/// Sets read/write access on a virtual address range for one or more devices.
+///
+/// After calling `cuMemMap`, the mapping is not yet accessible. This function
+/// grants the specified `devices` read/write permission on the range
+/// `[va, va + size)`.
+///
+/// Typically called once after all mappings within a reservation are established.
+pub fn set_access(
+    va: CUdeviceptr,
+    size: usize,
+    devices: &[cuda_bindings::CUdevice],
+) -> Result<(), DriverError> {
+    let descs: Vec<cuda_bindings::CUmemAccessDesc_st> = devices
+        .iter()
+        .map(|&dev| {
+            let mut desc: cuda_bindings::CUmemAccessDesc_st = unsafe { std::mem::zeroed() };
+            unsafe { set_mem_location_device(&mut desc.location, dev) };
+            desc.flags = cuda_bindings::CUmemAccess_flags_enum_CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
+            desc
+        })
+        .collect();
+
+    unsafe { cuda_bindings::cuMemSetAccess(va, size, descs.as_ptr(), descs.len()) }.result()
+}
+
+/// Queries the minimum allocation granularity for VMM operations on `device`.
+///
+/// All sizes passed to [`PhysicalAllocation::new`], [`VirtualReservation::new`],
+/// and [`Mapping::new`] must be multiples of this value.
+pub fn allocation_granularity(device: cuda_bindings::CUdevice) -> Result<usize, DriverError> {
+    let mut prop: cuda_bindings::CUmemAllocationProp_st = unsafe { std::mem::zeroed() };
+    prop.type_ = cuda_bindings::CUmemAllocationType_enum_CU_MEM_ALLOCATION_TYPE_PINNED;
+    unsafe { set_mem_location_device(&mut prop.location, device) };
+
+    let mut granularity = MaybeUninit::uninit();
+    unsafe {
+        cuda_bindings::cuMemGetAllocationGranularity(
+            granularity.as_mut_ptr(),
+            &prop,
+            cuda_bindings::CUmemAllocationGranularity_flags_enum_CU_MEM_ALLOC_GRANULARITY_MINIMUM,
+        )
+        .result()?;
+        Ok(granularity.assume_init())
+    }
+}
+
+/// Rounds `size` up to the nearest multiple of `granularity`.
+pub fn align_size(size: usize, granularity: usize) -> usize {
+    (size + granularity - 1) & !(granularity - 1)
+}
+
+/// Granularity flavor for [`multicast_granularity`].
+#[cfg(cuda_has_multicast)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MulticastGranularity {
+    /// Minimum required granularity for multicast sizes and offsets.
+    Minimum,
+    /// Recommended granularity for best performance.
+    Recommended,
+}
+
+#[cfg(cuda_has_multicast)]
+impl MulticastGranularity {
+    fn to_flag(self) -> cuda_bindings::CUmulticastGranularity_flags {
+        match self {
+            MulticastGranularity::Minimum => {
+                cuda_bindings::CUmulticastGranularity_flags_enum_CU_MULTICAST_GRANULARITY_MINIMUM
+            }
+            MulticastGranularity::Recommended => {
+                cuda_bindings::CUmulticastGranularity_flags_enum_CU_MULTICAST_GRANULARITY_RECOMMENDED
+            }
+        }
+    }
+}
+
+/// Fills a `CUmulticastObjectProp_st` for a single-process team of
+/// `num_devices` GPUs binding up to `size` bytes each.
+///
+/// `handleTypes` is left at 0: the object cannot be exported to other
+/// processes. Multi-process teams (exporting the handle over a POSIX file
+/// descriptor or fabric handle) are out of scope for these wrappers.
+#[cfg(cuda_has_multicast)]
+fn multicast_prop(num_devices: u32, size: usize) -> cuda_bindings::CUmulticastObjectProp_st {
+    let mut prop: cuda_bindings::CUmulticastObjectProp_st = unsafe { std::mem::zeroed() };
+    prop.numDevices = num_devices;
+    prop.size = size;
+    prop
+}
+
+/// Returns whether `device` supports switch multicast and reduction
+/// operations (`CU_DEVICE_ATTRIBUTE_MULTICAST_SUPPORTED`).
+///
+/// Multicast requires an NVLink-switch-connected system (e.g. HGX/DGX
+/// H100 or B200) and CUDA 12.1+.
+#[cfg(cuda_has_multicast)]
+pub fn multicast_supported(device: cuda_bindings::CUdevice) -> Result<bool, DriverError> {
+    let mut value = MaybeUninit::uninit();
+    let status = unsafe {
+        cuda_bindings::cuDeviceGetAttribute(
+            value.as_mut_ptr(),
+            cuda_bindings::CUdevice_attribute_enum_CU_DEVICE_ATTRIBUTE_MULTICAST_SUPPORTED,
+            device,
+        )
+    };
+    // Drivers older than CUDA 12.1 do not know this attribute and answer
+    // CUDA_ERROR_INVALID_VALUE. That means "no multicast on this system",
+    // not a failure, so callers can probe-and-skip uniformly.
+    if status == cuda_bindings::cudaError_enum_CUDA_ERROR_INVALID_VALUE {
+        return Ok(false);
+    }
+    status.result()?;
+    Ok(unsafe { value.assume_init() } != 0)
+}
+
+/// Built against a pre-12.1 CUDA toolkit whose headers lack the multicast
+/// API: no device can be used for multicast through these wrappers.
+#[cfg(not(cuda_has_multicast))]
+pub fn multicast_supported(_device: cuda_bindings::CUdevice) -> Result<bool, DriverError> {
+    Ok(false)
+}
+
+/// Queries the multicast size/offset granularity for a team of
+/// `num_devices` GPUs binding `size` bytes each.
+///
+/// All sizes and offsets passed to [`MulticastObject::new`] and
+/// [`MulticastObject::bind_mem`] must be multiples of the
+/// [`MulticastGranularity::Minimum`] value; use
+/// [`MulticastGranularity::Recommended`] for best performance.
+#[cfg(cuda_has_multicast)]
+pub fn multicast_granularity(
+    num_devices: u32,
+    size: usize,
+    granularity: MulticastGranularity,
+) -> Result<usize, DriverError> {
+    let prop = multicast_prop(num_devices, size);
+    let mut value = MaybeUninit::uninit();
+    unsafe {
+        cuda_bindings::cuMulticastGetGranularity(value.as_mut_ptr(), &prop, granularity.to_flag())
+            .result()?;
+        Ok(value.assume_init())
+    }
+}
+
+/// A multicast object created by `cuMulticastCreate`: one virtual "team"
+/// handle backed by up to one physical allocation per participating GPU.
+///
+/// Once every team device is added ([`add_device`](Self::add_device)) and has
+/// bound physical memory ([`bind_mem`](Self::bind_mem)), the object can be
+/// mapped into each device's VA space with [`Mapping::new_multicast`].
+/// Device-side `multimem.ld_reduce` / `multimem.st` / `multimem.red`
+/// instructions issued against that mapping operate on *all* bound copies at
+/// once -- the NVSwitch performs the reduction/broadcast in the fabric
+/// (NVLink SHARP, the mechanism behind NCCL's NVLS algorithm).
+///
+/// Lifecycle rules, in order:
+/// 1. [`MulticastObject::new`] with the final team size.
+/// 2. [`add_device`](Self::add_device) exactly `num_devices` times.
+/// 3. [`bind_mem`](Self::bind_mem) per device (after ALL devices are added).
+/// 4. [`Mapping::new_multicast`] + [`set_access`] per device.
+///
+/// Teardown reverses it: mappings first, then bindings ([`MulticastBinding`]),
+/// then this object, then the physical allocations.
+///
+/// Dropping releases the handle via `cuMemRelease` (the documented release
+/// path for multicast objects).
+#[cfg(cuda_has_multicast)]
+pub struct MulticastObject {
+    handle: cuda_bindings::CUmemGenericAllocationHandle,
+    size: usize,
+    num_devices: u32,
+}
+
+#[cfg(cuda_has_multicast)]
+impl MulticastObject {
+    /// Creates a multicast object for a team of `num_devices` GPUs binding
+    /// up to `size` bytes each.
+    ///
+    /// `size` must be a multiple of the minimum multicast granularity
+    /// (query via [`multicast_granularity`]). The object is single-process
+    /// only (no exportable handle types).
+    pub fn new(num_devices: u32, size: usize) -> Result<Self, DriverError> {
+        let prop = multicast_prop(num_devices, size);
+        let mut handle = MaybeUninit::uninit();
+        unsafe {
+            cuda_bindings::cuMulticastCreate(handle.as_mut_ptr(), &prop).result()?;
+            Ok(Self {
+                handle: handle.assume_init(),
+                size,
+                num_devices,
+            })
+        }
+    }
+
+    /// Adds `device` to the multicast team.
+    ///
+    /// Must be called exactly [`num_devices`](Self::num_devices) times, once
+    /// per device, before any memory is bound.
+    pub fn add_device(&self, device: cuda_bindings::CUdevice) -> Result<(), DriverError> {
+        unsafe { cuda_bindings::cuMulticastAddDevice(self.handle, device).result() }
+    }
+
+    /// Binds `size` bytes of `phys` (starting at `mem_offset`) to this
+    /// multicast object at `mc_offset`.
+    ///
+    /// The bound device is taken from the physical allocation. All offsets
+    /// and `size` must be multiples of the minimum multicast granularity,
+    /// and every team device must already have been added. A CUDA context
+    /// for the bound device must be current.
+    ///
+    /// The returned [`MulticastBinding`] unbinds on drop; it must be dropped
+    /// before this object and before `phys`.
+    pub fn bind_mem(
+        &self,
+        mc_offset: usize,
+        phys: &PhysicalAllocation,
+        mem_offset: usize,
+        size: usize,
+    ) -> Result<MulticastBinding, DriverError> {
+        unsafe {
+            cuda_bindings::cuMulticastBindMem(
+                self.handle,
+                mc_offset,
+                phys.handle(),
+                mem_offset,
+                size,
+                0,
+            )
+            .result()?;
+        }
+        Ok(MulticastBinding {
+            mc_handle: self.handle,
+            device: phys.device(),
+            mc_offset,
+            size,
+        })
+    }
+
+    /// Returns the raw multicast `CUmemGenericAllocationHandle`.
+    pub fn handle(&self) -> cuda_bindings::CUmemGenericAllocationHandle {
+        self.handle
+    }
+
+    /// Returns the per-device bind capacity in bytes.
+    pub fn size(&self) -> usize {
+        self.size
+    }
+
+    /// Returns the team size this object was created for.
+    pub fn num_devices(&self) -> u32 {
+        self.num_devices
+    }
+}
+
+#[cfg(cuda_has_multicast)]
+impl Drop for MulticastObject {
+    fn drop(&mut self) {
+        unsafe {
+            let _ = cuda_bindings::cuMemRelease(self.handle).result();
+        }
+    }
+}
+
+/// One device's physical memory bound into a [`MulticastObject`].
+///
+/// Created by [`MulticastObject::bind_mem`]; unbinds via `cuMulticastUnbind`
+/// on drop. Must be dropped before the multicast object and before the
+/// physical allocation it binds.
+#[cfg(cuda_has_multicast)]
+pub struct MulticastBinding {
+    mc_handle: cuda_bindings::CUmemGenericAllocationHandle,
+    device: cuda_bindings::CUdevice,
+    mc_offset: usize,
+    size: usize,
+}
+
+#[cfg(cuda_has_multicast)]
+impl MulticastBinding {
+    /// Returns the device whose memory is bound.
+    pub fn device(&self) -> cuda_bindings::CUdevice {
+        self.device
+    }
+}
+
+#[cfg(cuda_has_multicast)]
+impl Drop for MulticastBinding {
+    fn drop(&mut self) {
+        unsafe {
+            let _ = cuda_bindings::cuMulticastUnbind(
+                self.mc_handle,
+                self.device,
+                self.mc_offset,
+                self.size,
+            )
+            .result();
+        }
+    }
+}

--- a/cuda-core/tests/derive_device_copy/fail_enum.rs
+++ b/cuda-core/tests/derive_device_copy/fail_enum.rs
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use cuda_core::DeviceCopy;
+
+// Enums are rejected: a zeroed or device-written buffer could materialize an
+// out-of-range discriminant, which is undefined behavior. Even an enum with a
+// zero-valid first variant is refused, because per-field checking cannot prove
+// every device-produced byte pattern is a valid variant.
+#[derive(Copy, Clone, DeviceCopy)]
+#[repr(u8)]
+enum Tag {
+    A = 1,
+    B = 2,
+}
+
+fn main() {
+    let _ = Tag::A;
+}

--- a/cuda-core/tests/derive_device_copy/fail_enum.stderr
+++ b/cuda-core/tests/derive_device_copy/fail_enum.stderr
@@ -1,0 +1,5 @@
+error: `#[derive(DeviceCopy)]` cannot be applied to enums: `DeviceCopy` requires every bit pattern (including the all-zero pattern written by `DeviceBuffer::zeroed`) to be a valid value, but an enum's discriminant leaves most byte patterns invalid, so a zeroed or device-written buffer could materialize an out-of-range discriminant (undefined behavior). If you can guarantee every device-produced byte pattern is a valid variant, write `unsafe impl DeviceCopy for ... {}` by hand.
+  --> tests/derive_device_copy/fail_enum.rs:12:6
+   |
+12 | enum Tag {
+   |      ^^^

--- a/cuda-core/tests/derive_device_copy/fail_non_device_copy_field.rs
+++ b/cuda-core/tests/derive_device_copy/fail_non_device_copy_field.rs
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use cuda_core::DeviceCopy;
+
+#[derive(Copy, Clone, DeviceCopy)]
+struct HostReference {
+    value: &'static u32,
+}
+
+fn main() {}

--- a/cuda-core/tests/derive_device_copy/fail_non_device_copy_field.stderr
+++ b/cuda-core/tests/derive_device_copy/fail_non_device_copy_field.stderr
@@ -1,0 +1,17 @@
+error[E0277]: the trait bound `&'static u32: DeviceCopy` is not satisfied
+ --> tests/derive_device_copy/fail_non_device_copy_field.rs:8:12
+  |
+8 |     value: &'static u32,
+  |            ^^^^^^^^^^^^ the trait `DeviceCopy` is not implemented for `&'static u32`
+  |
+note: required by a bound in `assert_impl`
+ --> tests/derive_device_copy/fail_non_device_copy_field.rs:6:23
+  |
+6 | #[derive(Copy, Clone, DeviceCopy)]
+  |                       ^^^^^^^^^^ required by this bound in `assert_impl`
+  = note: this error originates in the derive macro `DeviceCopy` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider removing the leading `&`-reference
+  |
+8 -     value: &'static u32,
+8 +     value: u32,
+  |

--- a/cuda-core/tests/derive_device_copy/pass_structs.rs
+++ b/cuda-core/tests/derive_device_copy/pass_structs.rs
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use cuda_core::DeviceCopy;
+
+#[derive(Copy, Clone, DeviceCopy)]
+struct Named {
+    id: u32,
+    values: [f32; 2],
+}
+
+#[derive(Copy, Clone, DeviceCopy)]
+struct Tuple(u16, Named);
+
+#[derive(Copy, Clone, DeviceCopy)]
+struct Generic<T> {
+    value: T,
+}
+
+fn assert_device_copy<T: DeviceCopy>() {}
+
+fn main() {
+    assert_device_copy::<Named>();
+    assert_device_copy::<Tuple>();
+    assert_device_copy::<Generic<Named>>();
+}

--- a/cuda-core/tests/derive_device_copy/pass_union.rs
+++ b/cuda-core/tests/derive_device_copy/pass_union.rs
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use cuda_core::DeviceCopy;
+
+// Unions are untagged, so any bit pattern (including all-zero) is valid as
+// long as every field is itself `DeviceCopy`. The derive accepts them.
+#[derive(Copy, Clone, DeviceCopy)]
+union Word {
+    bits: u32,
+    scalar: f32,
+}
+
+fn assert_device_copy<T: DeviceCopy>() {}
+
+fn main() {
+    assert_device_copy::<Word>();
+}

--- a/cuda-core/tests/launch_contract/fail_private_construction.rs
+++ b/cuda-core/tests/launch_contract/fail_private_construction.rs
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use cuda_core::LaunchConfig1D;
+
+fn main() {
+    let _forged = LaunchConfig1D {
+        grid_x: 1,
+        block_x: 32,
+        shared_mem_bytes: 0,
+    };
+}

--- a/cuda-core/tests/launch_contract/fail_private_construction.stderr
+++ b/cuda-core/tests/launch_contract/fail_private_construction.stderr
@@ -1,0 +1,11 @@
+error[E0451]: fields `grid_x`, `block_x` and `shared_mem_bytes` of struct `LaunchConfig1D` are private
+  --> tests/launch_contract/fail_private_construction.rs:8:9
+   |
+ 7 |     let _forged = LaunchConfig1D {
+   |                   -------------- in this type
+ 8 |         grid_x: 1,
+   |         ^^^^^^ private field
+ 9 |         block_x: 32,
+   |         ^^^^^^^ private field
+10 |         shared_mem_bytes: 0,
+   |         ^^^^^^^^^^^^^^^^ private field

--- a/cuda-core/tests/launch_contract/fail_private_mutation.rs
+++ b/cuda-core/tests/launch_contract/fail_private_mutation.rs
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use cuda_core::LaunchConfig1D;
+
+fn main() {
+    let mut valid = LaunchConfig1D::new(1, 32, 0);
+    valid.block_x = 64;
+}

--- a/cuda-core/tests/launch_contract/fail_private_mutation.stderr
+++ b/cuda-core/tests/launch_contract/fail_private_mutation.stderr
@@ -1,0 +1,5 @@
+error[E0616]: field `block_x` of struct `LaunchConfig1D` is private
+ --> tests/launch_contract/fail_private_mutation.rs:8:11
+  |
+8 |     valid.block_x = 64;
+  |           ^^^^^^^ private field

--- a/cuda-core/tests/launch_contract/fail_wrong_brand.rs
+++ b/cuda-core/tests/launch_contract/fail_wrong_brand.rs
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use cuda_core::{
+    BlockRequirement, DynamicSharedMemoryRequirement, KernelLaunchContract, LaunchConfig1D,
+    LaunchContractSpec, PreparedLaunch,
+};
+
+struct KernelA;
+struct KernelB;
+
+macro_rules! contract {
+    ($kernel:ty, $name:literal) => {
+        impl KernelLaunchContract for $kernel {
+            type Config = LaunchConfig1D;
+
+            const SPEC: LaunchContractSpec = LaunchContractSpec::new(
+                $name,
+                BlockRequirement::Exact((32, 1, 1)),
+                DynamicSharedMemoryRequirement::Exact {
+                    bytes: 0,
+                    min_alignment: 1,
+                },
+            );
+        }
+    };
+}
+
+contract!(KernelA, "kernel_a");
+contract!(KernelB, "kernel_b");
+
+fn launch_b(_: &PreparedLaunch<KernelB>) {}
+
+fn launch_a_as_b(prepared: &PreparedLaunch<KernelA>) {
+    launch_b(prepared);
+}
+
+fn main() {}

--- a/cuda-core/tests/launch_contract/fail_wrong_brand.stderr
+++ b/cuda-core/tests/launch_contract/fail_wrong_brand.stderr
@@ -1,0 +1,15 @@
+error[E0308]: mismatched types
+  --> tests/launch_contract/fail_wrong_brand.rs:35:14
+   |
+35 |     launch_b(prepared);
+   |     -------- ^^^^^^^^ expected `&PreparedLaunch<KernelB>`, found `&PreparedLaunch<KernelA>`
+   |     |
+   |     arguments to this function are incorrect
+   |
+   = note: expected reference `&PreparedLaunch<KernelB>`
+              found reference `&PreparedLaunch<KernelA>`
+note: function defined here
+  --> tests/launch_contract/fail_wrong_brand.rs:32:4
+   |
+32 | fn launch_b(_: &PreparedLaunch<KernelB>) {}
+   |    ^^^^^^^^ ---------------------------

--- a/cuda-core/tests/launch_contract/fail_wrong_rank.rs
+++ b/cuda-core/tests/launch_contract/fail_wrong_rank.rs
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use cuda_core::{
+    BlockRequirement, DynamicSharedMemoryRequirement, KernelLaunchContract, LaunchConfig1D,
+    LaunchConfig2D, LaunchContractSpec,
+};
+
+struct OneDimensionalKernel;
+
+impl KernelLaunchContract for OneDimensionalKernel {
+    type Config = LaunchConfig1D;
+
+    const SPEC: LaunchContractSpec = LaunchContractSpec::new(
+        "one_dimensional",
+        BlockRequirement::Exact((32, 1, 1)),
+        DynamicSharedMemoryRequirement::Exact {
+            bytes: 0,
+            min_alignment: 1,
+        },
+    );
+}
+
+fn prepare(_: <OneDimensionalKernel as KernelLaunchContract>::Config) {}
+
+fn main() {
+    prepare(LaunchConfig2D::new((1, 1), (32, 1), 0));
+}

--- a/cuda-core/tests/launch_contract/fail_wrong_rank.stderr
+++ b/cuda-core/tests/launch_contract/fail_wrong_rank.stderr
@@ -1,0 +1,13 @@
+error[E0308]: mismatched types
+  --> tests/launch_contract/fail_wrong_rank.rs:27:13
+   |
+27 |     prepare(LaunchConfig2D::new((1, 1), (32, 1), 0));
+   |     ------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `LaunchConfig1D`, found `LaunchConfig2D`
+   |     |
+   |     arguments to this function are incorrect
+   |
+note: function defined here
+  --> tests/launch_contract/fail_wrong_rank.rs:24:4
+   |
+24 | fn prepare(_: <OneDimensionalKernel as KernelLaunchContract>::Config) {}
+   |    ^^^^^^^ ---------------------------------------------------------

--- a/cuda-core/tests/simt_context_limits.rs
+++ b/cuda-core/tests/simt_context_limits.rs
@@ -1,0 +1,100 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! `CudaContext::{limit, set_limit}` over every [`ContextLimit`] variant.
+//!
+//! Its own test binary, for the reason `context_sync_policy.rs` has one: a
+//! limit is state on the device's primary context, shared by every handle in
+//! the process, so a test that wrote one while another test in the same binary
+//! read it would race. One test function walking the variants in sequence
+//! keeps the whole check on one thread.
+//!
+//! `MallocHeapSize` and `PrintfFifoSize` are writable here only because this
+//! binary launches no kernel: the driver refuses both once a kernel using
+//! `malloc` or `printf` has run in the process.
+
+use cuda_core::{ContextLimit, CudaContext};
+
+/// Every variant, in declaration order.
+const ALL: [ContextLimit; 7] = [
+    ContextLimit::StackSize,
+    ContextLimit::PrintfFifoSize,
+    ContextLimit::MallocHeapSize,
+    ContextLimit::DevRuntimeSyncDepth,
+    ContextLimit::DevRuntimePendingLaunchCount,
+    ContextLimit::MaxL2FetchGranularity,
+    ContextLimit::PersistingL2CacheSize,
+];
+
+/// `CUDA_ERROR_UNSUPPORTED_LIMIT`, the documented answer for a limit this
+/// device does not implement (`DevRuntimeSyncDepth` above compute 9.0).
+const UNSUPPORTED: cuda_core::sys::CUresult =
+    cuda_core::sys::cudaError_enum_CUDA_ERROR_UNSUPPORTED_LIMIT;
+
+#[test]
+fn every_limit_reads_and_the_writable_ones_round_trip() {
+    let ctx = CudaContext::new(0).expect("failed to create CUDA context");
+
+    // Reading must either succeed or give the one documented refusal. Any
+    // other status means to_raw() handed the driver a value it did not
+    // recognise.
+    for limit in ALL {
+        match ctx.limit(limit) {
+            Ok(_) => {}
+            Err(e) if e.0 == UNSUPPORTED => {}
+            Err(e) => panic!("limit({limit:?}) failed with an unexpected status: {e:?}"),
+        }
+    }
+
+    // The stack size is the one limit with an exact, driver-honoured
+    // round trip, so it is what proves set_limit reaches the right CUlimit
+    // rather than silently writing a neighbouring one.
+    let original = ctx
+        .stack_size()
+        .expect("stack_size() must be readable on any device");
+    let raised = original + 4096;
+    ctx.set_limit(ContextLimit::StackSize, raised)
+        .expect("set_limit(StackSize) failed");
+    assert_eq!(
+        ctx.limit(ContextLimit::StackSize).unwrap(),
+        raised,
+        "set_limit(StackSize, {raised}) must be observable through limit(StackSize)"
+    );
+
+    // The inherent accessors are now thin wrappers; this pins them to the
+    // same value rather than to a second, drifting implementation.
+    assert_eq!(
+        ctx.stack_size().unwrap(),
+        ctx.limit(ContextLimit::StackSize).unwrap(),
+        "stack_size() must agree with limit(StackSize)"
+    );
+    ctx.set_stack_size(original)
+        .expect("set_stack_size failed to restore the original");
+    assert_eq!(
+        ctx.stack_size().unwrap(),
+        original,
+        "set_stack_size() must agree with set_limit(StackSize, ..)"
+    );
+
+    // Writing one limit must not disturb its neighbours: a to_raw() that
+    // mapped two variants onto one CUlimit would pass every check above.
+    let heap_before = ctx.limit(ContextLimit::MallocHeapSize).unwrap();
+    let fifo_before = ctx.limit(ContextLimit::PrintfFifoSize).unwrap();
+    let heap_target = heap_before + (1 << 20);
+    ctx.set_limit(ContextLimit::MallocHeapSize, heap_target)
+        .expect("set_limit(MallocHeapSize) failed before any kernel launch");
+    assert_eq!(
+        ctx.limit(ContextLimit::MallocHeapSize).unwrap(),
+        heap_target,
+        "the malloc heap must hold the size just written"
+    );
+    assert_eq!(
+        ctx.limit(ContextLimit::PrintfFifoSize).unwrap(),
+        fifo_before,
+        "writing MallocHeapSize must leave PrintfFifoSize untouched"
+    );
+    ctx.set_limit(ContextLimit::MallocHeapSize, heap_before)
+        .expect("failed to restore the malloc heap size");
+}

--- a/cuda-core/tests/simt_context_sync_policy.rs
+++ b/cuda-core/tests/simt_context_sync_policy.rs
@@ -1,0 +1,42 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! `CudaContext::{set_sync_policy, sync_policy}` round-trip.
+//!
+//! Its own test binary (not merged into `device_buffer.rs`'s): the context's
+//! scheduling flags are shared, process-wide state on the primary context
+//! (`cuDevicePrimaryCtxSetFlags_v2`), so setting them from a test that runs
+//! concurrently with others in the same binary would race. A single test
+//! function exercising every policy in sequence keeps the whole check inside
+//! one thread.
+
+use cuda_core::{CudaContext, SyncPolicy};
+
+#[test]
+fn sync_policy_round_trips_through_every_named_value() {
+    let ctx = CudaContext::new(0).expect("failed to create CUDA context");
+
+    for policy in [
+        SyncPolicy::BlockingSync,
+        SyncPolicy::Spin,
+        SyncPolicy::Yield,
+        SyncPolicy::Auto,
+        // Land on BlockingSync last: it is the one #705 asks for, and this
+        // proves the round trip through every other value first didn't
+        // leave some other bit set that corrupts it.
+        SyncPolicy::BlockingSync,
+    ] {
+        ctx.set_sync_policy(policy)
+            .unwrap_or_else(|e| panic!("set_sync_policy({policy:?}) failed: {e:?}"));
+        let got = ctx
+            .sync_policy()
+            .unwrap_or_else(|e| panic!("sync_policy() after set({policy:?}) failed: {e:?}"));
+        assert_eq!(
+            got,
+            Some(policy),
+            "sync_policy() must read back exactly what set_sync_policy({policy:?}) wrote"
+        );
+    }
+}

--- a/cuda-core/tests/simt_device_buffer.rs
+++ b/cuda-core/tests/simt_device_buffer.rs
@@ -1,0 +1,423 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use cuda_core::{CudaContext, CudaStream, DeviceBuffer, DriverError, PinnedHostBuffer};
+use std::sync::{mpsc, Mutex, MutexGuard};
+use std::thread::JoinHandle;
+use std::time::Duration;
+
+const BLOCKED_TIMEOUT: Duration = Duration::from_millis(100);
+const COMPLETION_TIMEOUT: Duration = Duration::from_secs(1);
+static GATED_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+fn lock_gated_test() -> MutexGuard<'static, ()> {
+    GATED_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+enum CompletionObservation<T> {
+    Blocked,
+    Completed(T),
+    Disconnected,
+}
+
+fn observe_completion<T>(rx: &mpsc::Receiver<T>) -> CompletionObservation<T> {
+    match rx.recv_timeout(BLOCKED_TIMEOUT) {
+        Ok(value) => CompletionObservation::Completed(value),
+        Err(mpsc::RecvTimeoutError::Timeout) => CompletionObservation::Blocked,
+        Err(mpsc::RecvTimeoutError::Disconnected) => CompletionObservation::Disconnected,
+    }
+}
+
+fn finish_gated_worker<T>(
+    label: &str,
+    release_gate: mpsc::Sender<()>,
+    started_rx: mpsc::Receiver<()>,
+    completion_rx: mpsc::Receiver<T>,
+    worker: JoinHandle<()>,
+) -> T {
+    let started_result = started_rx.recv_timeout(COMPLETION_TIMEOUT);
+    let observation = observe_completion(&completion_rx);
+
+    // Release the CUDA callback and collect the worker before asserting the
+    // observation. A failing regression must not leave driver work blocked.
+    let release_result = release_gate.send(());
+    let (was_blocked, disconnected, completion_result) = match observation {
+        CompletionObservation::Blocked => {
+            (true, false, completion_rx.recv_timeout(COMPLETION_TIMEOUT))
+        }
+        CompletionObservation::Completed(value) => (false, false, Ok(value)),
+        CompletionObservation::Disconnected => {
+            (false, true, Err(mpsc::RecvTimeoutError::Disconnected))
+        }
+    };
+    let worker_result = worker.join();
+
+    started_result.unwrap_or_else(|error| panic!("{label} worker did not start: {error}"));
+    release_result.unwrap_or_else(|error| panic!("failed to release {label} gate: {error}"));
+    worker_result.unwrap_or_else(|_| panic!("{label} worker panicked"));
+    assert!(!disconnected, "{label} worker disconnected");
+    assert!(
+        was_blocked,
+        "{label} completed before the gated stream was released"
+    );
+    completion_result
+        .unwrap_or_else(|error| panic!("{label} did not complete after releasing gate: {error}"))
+}
+
+fn gate_stream(stream: &CudaStream) -> mpsc::Sender<()> {
+    let (tx, rx) = mpsc::channel();
+    stream
+        .launch_host_function(move || {
+            let _ = rx.recv();
+        })
+        .expect("failed to enqueue stream gate");
+    tx
+}
+
+#[test]
+fn device_buffer_from_host_roundtrip() {
+    let ctx = CudaContext::new(0).expect("failed to create CUDA context");
+    let stream = ctx.new_stream().expect("failed to create CUDA stream");
+
+    let data = [1_u32, 2, 3, 4, 5];
+    let dev_buf =
+        DeviceBuffer::from_host(&stream, &data).expect("failed to allocate DeviceBuffer from host");
+
+    assert_eq!(dev_buf.len(), 5);
+    assert_eq!(dev_buf.num_bytes(), 20);
+    assert!(!dev_buf.is_empty());
+
+    let host_vec = dev_buf
+        .to_host_vec(&stream)
+        .expect("failed to copy back to host");
+    assert_eq!(host_vec, data);
+}
+
+#[test]
+fn device_buffer_zeroed_initializes_with_zeros() {
+    let ctx = CudaContext::new(0).expect("failed to create CUDA context");
+    let stream = ctx.new_stream().expect("failed to create CUDA stream");
+
+    let dev_buf =
+        DeviceBuffer::<f32>::zeroed(&stream, 4).expect("failed to allocate zeroed DeviceBuffer");
+
+    assert_eq!(dev_buf.len(), 4);
+    assert_eq!(dev_buf.num_bytes(), 16);
+
+    let host_vec = dev_buf
+        .to_host_vec(&stream)
+        .expect("failed to copy back to host");
+    assert_eq!(host_vec, &[0.0, 0.0, 0.0, 0.0]);
+}
+
+#[test]
+fn device_buffer_supports_empty_allocations() {
+    let ctx = CudaContext::new(0).expect("failed to create CUDA context");
+    let stream = ctx.new_stream().expect("failed to create CUDA stream");
+
+    let dev_buf =
+        DeviceBuffer::<u8>::zeroed(&stream, 0).expect("failed to allocate empty device buffer");
+    assert_eq!(dev_buf.len(), 0);
+    assert_eq!(dev_buf.num_bytes(), 0);
+    assert!(dev_buf.is_empty());
+
+    let dev_buf_host = DeviceBuffer::<u8>::from_host(&stream, &[])
+        .expect("failed to allocate empty device buffer from empty slice");
+    assert_eq!(dev_buf_host.len(), 0);
+    assert_eq!(dev_buf_host.num_bytes(), 0);
+    assert!(dev_buf_host.is_empty());
+}
+
+#[test]
+fn device_buffer_rejects_allocation_size_overflow() {
+    let ctx = CudaContext::new(0).expect("failed to create CUDA context");
+    let stream = ctx.new_stream().expect("failed to create CUDA stream");
+    let overflowing_len = usize::MAX / std::mem::size_of::<u64>() + 1;
+
+    assert!(DeviceBuffer::<u64>::zeroed(&stream, overflowing_len).is_err());
+    // SAFETY: the constructor returns an error before allocation, and this
+    // test never reads from the uninitialized buffer.
+    assert!(unsafe { DeviceBuffer::<u64>::uninitialized_async(&stream, overflowing_len) }.is_err());
+}
+
+#[test]
+fn device_buffer_async_compat_methods_roundtrip() {
+    let ctx = CudaContext::new(0).expect("failed to create CUDA context");
+    let stream = ctx.new_stream().expect("failed to create CUDA stream");
+
+    let data = [7_u32, 11, 13, 17];
+    let mut dev = unsafe { DeviceBuffer::<u32>::uninitialized_async(&stream, data.len()) }
+        .expect("failed to allocate uninitialized device buffer");
+    // SAFETY: `data` remains alive and unmodified until the later
+    // `to_host_vec` call synchronizes the stream.
+    unsafe { dev.copy_from_host_async_unchecked(&stream, &data) }
+        .expect("failed to copy host data into device buffer");
+
+    let mut clone = unsafe { DeviceBuffer::<u32>::uninitialized_async(&stream, data.len()) }
+        .expect("failed to allocate clone device buffer");
+    clone
+        .copy_from_device_async(&dev, &stream)
+        .expect("failed to copy device buffer");
+    assert_eq!(
+        clone
+            .to_host_vec(&stream)
+            .expect("failed to copy clone back to host"),
+        data
+    );
+
+    clone
+        .zero_async(&stream)
+        .expect("failed to zero device buffer");
+    assert_eq!(
+        clone
+            .to_host_vec(&stream)
+            .expect("failed to copy zeroed buffer back to host"),
+        [0, 0, 0, 0]
+    );
+
+    // SAFETY: all prior work on these buffers ran on `stream` itself.
+    unsafe { clone.drop_async(&stream) }.expect("failed to async free clone");
+    unsafe { dev.drop_async(&stream) }.expect("failed to async free source");
+
+    let empty = unsafe { DeviceBuffer::<u8>::uninitialized_async(&stream, 0) }
+        .expect("failed to allocate empty uninitialized device buffer");
+    // SAFETY: the empty buffer has no pending work on any stream.
+    unsafe { empty.drop_async(&stream) }.expect("failed to async free empty buffer");
+    stream.synchronize().expect("stream sync failed");
+}
+
+#[test]
+fn async_allocation_ordinary_drop_waits_for_cross_stream_work() {
+    let _gated_test_guard = lock_gated_test();
+    let ctx = CudaContext::new(0).expect("failed to create CUDA context");
+    let allocation_stream = ctx
+        .new_stream()
+        .expect("failed to create allocation stream");
+    let use_stream = ctx.new_stream().expect("failed to create use stream");
+
+    let mut dev = unsafe { DeviceBuffer::<u32>::uninitialized_async(&allocation_stream, 4) }
+        .expect("failed to allocate async device buffer");
+    use_stream
+        .join(&allocation_stream)
+        .expect("failed to order use stream after allocation stream");
+    let release_gate = gate_stream(&use_stream);
+    dev.zero_async(&use_stream)
+        .expect("failed to enqueue cross-stream use");
+
+    let (started_tx, started_rx) = mpsc::channel();
+    let (completion_tx, completion_rx) = mpsc::channel();
+    let drop_thread = std::thread::spawn(move || {
+        started_tx
+            .send(())
+            .expect("failed to send drop worker start");
+        drop(dev);
+        completion_tx
+            .send(())
+            .expect("failed to send drop completion");
+    });
+    finish_gated_worker(
+        "ordinary async buffer drop",
+        release_gate,
+        started_rx,
+        completion_rx,
+        drop_thread,
+    );
+    ctx.synchronize().expect("context cleanup failed");
+}
+
+#[test]
+fn async_allocation_drop_async_orders_free_after_allocation_stream() {
+    let _gated_test_guard = lock_gated_test();
+    let ctx = CudaContext::new(0).expect("failed to create CUDA context");
+    let allocation_stream = ctx
+        .new_stream()
+        .expect("failed to create allocation stream");
+    let free_stream = ctx.new_stream().expect("failed to create free stream");
+
+    let mut dev = unsafe { DeviceBuffer::<u32>::uninitialized_async(&allocation_stream, 4) }
+        .expect("failed to allocate async device buffer");
+    let release_gate = gate_stream(&allocation_stream);
+    dev.zero_async(&allocation_stream)
+        .expect("failed to enqueue allocation-stream work");
+
+    // SAFETY: the only pending work runs on the allocation stream, which
+    // drop_async orders `free_stream` after; that ordering is what this
+    // test observes.
+    unsafe { dev.drop_async(&free_stream) }
+        .expect("drop_async should order free after allocation stream");
+    let (started_tx, started_rx) = mpsc::channel();
+    let (completion_tx, completion_rx) = mpsc::channel();
+    let free_stream_for_thread = free_stream.clone();
+    let sync_thread = std::thread::spawn(move || {
+        started_tx
+            .send(())
+            .expect("failed to send free-stream sync worker start");
+        completion_tx
+            .send(free_stream_for_thread.synchronize())
+            .expect("failed to send free-stream sync result");
+    });
+    finish_gated_worker(
+        "cross-stream async free",
+        release_gate,
+        started_rx,
+        completion_rx,
+        sync_thread,
+    )
+    .expect("cross-stream async free failed");
+}
+
+#[test]
+fn sync_allocation_allows_async_drop_after_queued_work() {
+    let _gated_test_guard = lock_gated_test();
+    let ctx = CudaContext::new(0).expect("failed to create CUDA context");
+    let stream = ctx.new_stream().expect("failed to create CUDA stream");
+
+    let mut dev = DeviceBuffer::<u32>::zeroed(&stream, 4)
+        .expect("failed to allocate synchronous device buffer");
+    let release_gate = gate_stream(&stream);
+    dev.zero_async(&stream)
+        .expect("failed to enqueue work before async free");
+    // SAFETY: all prior work on this buffer was enqueued on `stream` itself.
+    unsafe { dev.drop_async(&stream) }
+        .expect("synchronous allocation should support stream-ordered free");
+
+    let (started_tx, started_rx) = mpsc::channel();
+    let (completion_tx, completion_rx) = mpsc::channel();
+    let stream_for_thread = stream.clone();
+    let sync_thread = std::thread::spawn(move || {
+        started_tx
+            .send(())
+            .expect("failed to send stream sync worker start");
+        completion_tx
+            .send(stream_for_thread.synchronize())
+            .expect("failed to send stream sync result");
+    });
+    finish_gated_worker(
+        "synchronous allocation async free",
+        release_gate,
+        started_rx,
+        completion_rx,
+        sync_thread,
+    )
+    .expect("synchronous allocation async free failed");
+}
+
+#[test]
+fn drop_async_bind_error_preserves_ordinary_cleanup() {
+    let ctx = CudaContext::new(0).expect("failed to create CUDA context");
+    let stream = ctx.new_stream().expect("failed to create CUDA stream");
+    let dev = DeviceBuffer::<u8>::zeroed(&stream, 4096).expect("failed to allocate device buffer");
+    let ptr = dev.cu_deviceptr();
+
+    let mut base = 0;
+    let mut size = 0;
+    assert_eq!(
+        unsafe { cuda_bindings::cuMemGetAddressRange_v2(&mut base, &mut size, ptr) },
+        cuda_bindings::cudaError_enum_CUDA_SUCCESS,
+        "allocation must be live before drop_async"
+    );
+
+    let injected = DriverError(cuda_bindings::cudaError_enum_CUDA_ERROR_INVALID_VALUE);
+    ctx.record_err::<()>(Err(injected));
+    assert_eq!(
+        // SAFETY: no pending work on any stream touches this buffer.
+        unsafe { dev.drop_async(&stream) },
+        Err(injected),
+        "drop_async must propagate the pre-disarm bind error"
+    );
+
+    ctx.bind_to_thread()
+        .expect("ordinary drop should leave the context usable");
+    assert_eq!(
+        unsafe { cuda_bindings::cuMemGetAddressRange_v2(&mut base, &mut size, ptr) },
+        cuda_bindings::cudaError_enum_CUDA_ERROR_NOT_FOUND,
+        "ordinary drop must reclaim the still-armed allocation"
+    );
+}
+
+#[test]
+fn from_host_with_pinned_source_allows_source_drop_after_return() {
+    let ctx = CudaContext::new(0).expect("failed to create CUDA context");
+    let stream = ctx.new_stream().expect("failed to create CUDA stream");
+
+    let expected = vec![21_u32, 34, 55, 89];
+    let input =
+        PinnedHostBuffer::from_slice(&ctx, &expected).expect("failed to allocate pinned input");
+    let dev = DeviceBuffer::from_host(&stream, input.as_slice())
+        .expect("failed to copy pinned input to device");
+    drop(input);
+
+    assert_eq!(
+        dev.to_host_vec(&stream)
+            .expect("failed to copy device buffer back to host"),
+        expected
+    );
+}
+
+#[test]
+fn copy_from_host_with_pinned_source_allows_source_reuse_after_return() {
+    let ctx = CudaContext::new(0).expect("failed to create CUDA context");
+    let stream = ctx.new_stream().expect("failed to create CUDA stream");
+
+    let expected = vec![3_u32, 5, 8, 13];
+    let mut input =
+        PinnedHostBuffer::from_slice(&ctx, &expected).expect("failed to allocate pinned input");
+    let mut dev =
+        DeviceBuffer::<u32>::zeroed(&stream, input.len()).expect("failed to allocate device");
+
+    dev.copy_from_host(&stream, input.as_slice())
+        .expect("failed to copy pinned input to device");
+    input.as_mut_slice().fill(0);
+
+    assert_eq!(
+        dev.to_host_vec(&stream)
+            .expect("failed to copy device buffer back to host"),
+        expected
+    );
+}
+
+// Dangerous-path regression: a stream-ordered (`cuMemAllocAsync`) buffer that
+// is dropped *implicitly* while a copy is still in flight, with no explicit
+// synchronization by the caller. Ordinary `Drop` synchronizes the context
+// before enqueueing the free, so the in-flight copy cannot race deallocation.
+// Run under `compute-sanitizer --tool memcheck` to catch a regression.
+#[test]
+fn uninitialized_async_implicit_drop_waits_for_pending_work() {
+    let ctx = CudaContext::new(0).expect("failed to create CUDA context");
+    let stream = ctx.new_stream().expect("failed to create CUDA stream");
+
+    let n = 1 << 20; // 4 MiB of u32
+    let src = DeviceBuffer::<u32>::zeroed(&stream, n).expect("failed to allocate source buffer");
+    for _ in 0..64 {
+        let mut dst = unsafe { DeviceBuffer::<u32>::uninitialized_async(&stream, n) }
+            .expect("failed to allocate uninitialized device buffer");
+        // Enqueue a large async device-to-device copy, then let `dst` drop
+        // immediately with no `stream.synchronize()` in between.
+        dst.copy_from_device_async(&src, &stream)
+            .expect("failed to enqueue device-to-device copy");
+        drop(dst);
+    }
+    stream.synchronize().expect("stream sync failed");
+}
+
+#[test]
+fn uninitialized_async_cast_elem_implicit_drop_is_stream_ordered() {
+    let ctx = CudaContext::new(0).expect("failed to create CUDA context");
+    let stream = ctx.new_stream().expect("failed to create CUDA stream");
+
+    let n = 1 << 20; // 4 MiB of u32
+    let src = DeviceBuffer::<u32>::zeroed(&stream, n).expect("failed to allocate source buffer");
+    for _ in 0..64 {
+        let mut dst = unsafe { DeviceBuffer::<u32>::uninitialized_async(&stream, n) }
+            .expect("failed to allocate uninitialized device buffer");
+        dst.copy_from_device_async(&src, &stream)
+            .expect("failed to enqueue device-to-device copy");
+        let dst = dst.cast_elem::<std::num::Wrapping<u32>>();
+        drop(dst);
+    }
+    stream.synchronize().expect("stream sync failed");
+}

--- a/cuda-core/tests/simt_device_buffer_leaks.rs
+++ b/cuda-core/tests/simt_device_buffer_leaks.rs
@@ -1,0 +1,137 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Leak regression probes for `DeviceBuffer` construction (require a GPU).
+//!
+//! `DeviceBuffer::from_host` and `DeviceBuffer::zeroed` allocate device
+//! memory synchronously and then enqueue a fallible async operation. Two
+//! resources must be accounted for across that window and the buffer's
+//! whole lifecycle:
+//!
+//! - the device allocation itself (a leaked `CUdeviceptr` bleeds VRAM), and
+//! - the `Arc<CudaContext>` strong count (a leaked count means
+//!   `CudaContext::drop` / `cuCtxDestroy` never runs).
+//!
+//! These tests pin both to their baselines after construct/drop cycles, and
+//! pin the zero-length construction path, which must not call the driver
+//! allocator at all (`cuMemAlloc` rejects zero-byte requests).
+
+use std::sync::Arc;
+
+use cuda_core::{CudaContext, DeviceBuffer};
+
+/// A live buffer must hold exactly one extra context strong count, and the
+/// count must return to baseline once the buffer drops. A construction
+/// helper that `mem::forget`s a context clone (as an arm/disarm pointer
+/// guard would) fails the live-count assertion by one per construction.
+#[test]
+fn ctx_strong_count_returns_to_baseline_after_buffer_lifecycle() {
+    let ctx = CudaContext::new(0).expect("failed to create CUDA context");
+    let stream = ctx.new_stream().expect("failed to create CUDA stream");
+
+    let baseline = Arc::strong_count(&ctx);
+
+    {
+        let buf = DeviceBuffer::from_host(&stream, &[1u32, 2, 3, 4])
+            .expect("from_host failed on happy path");
+        assert_eq!(
+            Arc::strong_count(&ctx),
+            baseline + 1,
+            "live DeviceBuffer must add exactly one ctx strong count"
+        );
+        drop(buf);
+    }
+
+    assert_eq!(
+        Arc::strong_count(&ctx),
+        baseline,
+        "ctx strong count must return to baseline after from_host buffer drop"
+    );
+
+    {
+        let buf = DeviceBuffer::<f32>::zeroed(&stream, 16).expect("zeroed failed on happy path");
+        drop(buf);
+    }
+
+    assert_eq!(
+        Arc::strong_count(&ctx),
+        baseline,
+        "ctx strong count must return to baseline after zeroed buffer drop"
+    );
+}
+
+/// Repeated construct/drop cycles must not bleed device memory.
+///
+/// This cannot deterministically force the async-enqueue failure that
+/// triggered the original leak (no public API constructs an invalid
+/// `CudaStream`), but it pins the happy-path accounting with
+/// `cuMemGetInfo` before and after the cycles.
+#[test]
+fn vram_returns_to_baseline_after_buffer_cycles() {
+    let ctx = CudaContext::new(0).expect("failed to create CUDA context");
+    let stream = ctx.new_stream().expect("failed to create CUDA stream");
+
+    fn free_mem() -> usize {
+        let mut free = 0usize;
+        let mut total = 0usize;
+        let rc = unsafe { cuda_bindings::cuMemGetInfo_v2(&mut free, &mut total) };
+        assert_eq!(rc, 0, "cuMemGetInfo failed: {rc}");
+        free
+    }
+
+    // Warm up driver allocator caches so the measured window is stable.
+    for _ in 0..4 {
+        let b = DeviceBuffer::<u8>::zeroed(&stream, 1 << 20).expect("warmup alloc failed");
+        drop(b);
+    }
+    ctx.synchronize().expect("sync failed");
+
+    let before = free_mem();
+    for _ in 0..64 {
+        let b = DeviceBuffer::<u8>::zeroed(&stream, 1 << 20).expect("cycle alloc failed");
+        drop(b);
+    }
+    ctx.synchronize().expect("sync failed");
+    let after = free_mem();
+
+    // Allow small driver-side jitter; 64 leaked 1 MiB buffers would show
+    // up loudly.
+    assert!(
+        before.abs_diff(after) < (8 << 20),
+        "device free memory drifted by {} bytes across 64 construct/drop cycles",
+        before.abs_diff(after)
+    );
+}
+
+/// Zero-length construction must succeed for both constructors and must
+/// not leak anything on drop. `cuMemAlloc` rejects zero-byte requests with
+/// CUDA_ERROR_INVALID_VALUE, so empty buffers are represented without a
+/// driver allocation.
+#[test]
+fn zero_length_construction_succeeds_for_both_constructors() {
+    let ctx = CudaContext::new(0).expect("failed to create CUDA context");
+    let stream = ctx.new_stream().expect("failed to create CUDA stream");
+
+    let baseline = Arc::strong_count(&ctx);
+
+    let zeroed = DeviceBuffer::<u8>::zeroed(&stream, 0).expect("zeroed(len=0) must succeed");
+    assert_eq!(zeroed.len(), 0);
+    assert_eq!(zeroed.num_bytes(), 0);
+    assert!(zeroed.is_empty());
+
+    let from_host =
+        DeviceBuffer::<u32>::from_host(&stream, &[]).expect("from_host(empty) must succeed");
+    assert_eq!(from_host.len(), 0);
+    assert_eq!(from_host.num_bytes(), 0);
+    assert!(from_host.is_empty());
+
+    drop(zeroed);
+    drop(from_host);
+    assert_eq!(
+        Arc::strong_count(&ctx),
+        baseline,
+        "empty buffers must not leak a ctx strong count"
+    );
+}

--- a/cuda-core/tests/simt_device_copy_derive.rs
+++ b/cuda-core/tests/simt_device_copy_derive.rs
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test]
+fn device_copy_derive_compile_pass() {
+    let t = trybuild::TestCases::new();
+    t.pass("tests/derive_device_copy/pass_structs.rs");
+    t.pass("tests/derive_device_copy/pass_union.rs");
+    t.compile_fail("tests/derive_device_copy/fail_non_device_copy_field.rs");
+    t.compile_fail("tests/derive_device_copy/fail_enum.rs");
+}

--- a/cuda-core/tests/simt_device_copy_impls.rs
+++ b/cuda-core/tests/simt_device_copy_impls.rs
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::marker::PhantomData;
+use std::mem::MaybeUninit;
+use std::num::Wrapping;
+
+use cuda_core::DeviceCopy;
+
+fn assert_device_copy<T: DeviceCopy>() {}
+
+#[test]
+fn device_copy_covers_core_parity_types() {
+    // `bool` and `char` are intentionally NOT `DeviceCopy`: they have validity
+    // holes (only 0/1 for `bool`, only valid Unicode scalars for `char`), so a
+    // device-written byte outside that set would be UB on readback. Only the
+    // representation-preserving wrappers below are sound parity additions.
+    assert_device_copy::<PhantomData<String>>();
+    assert_device_copy::<MaybeUninit<u32>>();
+    assert_device_copy::<Wrapping<u64>>();
+}

--- a/cuda-core/tests/simt_launch_contract_types.rs
+++ b/cuda-core/tests/simt_launch_contract_types.rs
@@ -1,0 +1,13 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#[test]
+fn launch_contract_types_fail_closed() {
+    let tests = trybuild::TestCases::new();
+    tests.compile_fail("tests/launch_contract/fail_wrong_rank.rs");
+    tests.compile_fail("tests/launch_contract/fail_wrong_brand.rs");
+    tests.compile_fail("tests/launch_contract/fail_private_construction.rs");
+    tests.compile_fail("tests/launch_contract/fail_private_mutation.rs");
+}

--- a/cuda-core/tests/simt_pinned_host_buffer.rs
+++ b/cuda-core/tests/simt_pinned_host_buffer.rs
@@ -1,0 +1,127 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use cuda_core::{CudaContext, DeviceBuffer, PinnedHostBuffer};
+
+#[test]
+fn pinned_host_buffer_exposes_initialized_slice() {
+    let ctx = CudaContext::new(0).expect("failed to create CUDA context");
+    let mut host =
+        PinnedHostBuffer::<u32>::zeroed(&ctx, 4).expect("failed to allocate pinned host");
+
+    assert_eq!(host.len(), 4);
+    assert_eq!(host.num_bytes(), 16);
+    assert!(!host.is_empty());
+    assert_eq!(host.as_slice(), &[0, 0, 0, 0]);
+    assert!(format!("{host:?}").contains("PinnedHostBuffer"));
+
+    host.as_mut_slice().copy_from_slice(&[1, 2, 3, 4]);
+    assert_eq!(&host[..], &[1, 2, 3, 4]);
+}
+
+#[test]
+fn pinned_host_buffer_supports_empty_allocations() {
+    let ctx = CudaContext::new(0).expect("failed to create CUDA context");
+    let host =
+        PinnedHostBuffer::<u32>::zeroed(&ctx, 0).expect("failed to create empty pinned host");
+
+    assert_eq!(host.len(), 0);
+    assert_eq!(host.num_bytes(), 0);
+    assert!(host.is_empty());
+    assert_eq!(host.as_slice(), &[]);
+}
+
+#[test]
+fn pinned_host_buffer_from_slice_supports_empty_input() {
+    let ctx = CudaContext::new(0).expect("failed to create CUDA context");
+    let host = PinnedHostBuffer::<u32>::from_slice(&ctx, &[])
+        .expect("failed to create empty pinned host from slice");
+
+    assert_eq!(host.len(), 0);
+    assert_eq!(host.num_bytes(), 0);
+    assert_eq!(host.as_slice(), &[]);
+}
+
+#[test]
+fn pinned_host_buffer_supports_zero_sized_types() {
+    let ctx = CudaContext::new(0).expect("failed to create CUDA context");
+    let host = PinnedHostBuffer::<()>::zeroed(&ctx, 8)
+        .expect("failed to create zero-sized pinned host buffer");
+
+    assert_eq!(host.len(), 8);
+    assert_eq!(host.num_bytes(), 0);
+    assert_eq!(host.as_slice(), &[(); 8]);
+}
+
+#[test]
+fn pinned_host_buffer_roundtrips_through_device_buffer() {
+    let ctx = CudaContext::new(0).expect("failed to create CUDA context");
+    let stream = ctx.new_stream().expect("failed to create CUDA stream");
+
+    let input = PinnedHostBuffer::from_slice(&ctx, &[1_u32, 2, 3, 4])
+        .expect("failed to allocate pinned input");
+    // SAFETY: `input` is kept alive for the entire roundtrip, and
+    // `copy_to_pinned_host` synchronizes before returning, so both pinned
+    // buffers outlive their in-flight copies.
+    let device = unsafe { DeviceBuffer::from_pinned_host(&stream, &input) }
+        .expect("failed to copy input to device");
+    let mut output = PinnedHostBuffer::<u32>::zeroed(&ctx, input.len())
+        .expect("failed to allocate pinned output");
+
+    device
+        .copy_to_pinned_host(&stream, &mut output)
+        .expect("failed to copy output to host");
+
+    assert_eq!(output.as_slice(), input.as_slice());
+}
+
+#[test]
+fn pinned_host_buffer_async_copy_can_be_synchronized_later() {
+    let ctx = CudaContext::new(0).expect("failed to create CUDA context");
+    let stream = ctx.new_stream().expect("failed to create CUDA stream");
+
+    let input = PinnedHostBuffer::from_slice(&ctx, &[5_u32, 6, 7, 8])
+        .expect("failed to allocate pinned input");
+    // SAFETY: both pinned buffers are kept alive past `stream.synchronize()`
+    // below, satisfying the contract of the async pinned helpers.
+    let device = unsafe { DeviceBuffer::from_pinned_host(&stream, &input) }
+        .expect("failed to copy input to device");
+    let mut output = PinnedHostBuffer::<u32>::zeroed(&ctx, input.len())
+        .expect("failed to allocate pinned output");
+
+    unsafe { device.copy_to_pinned_host_async(&stream, &mut output) }
+        .expect("failed to enqueue output copy");
+    stream.synchronize().expect("failed to synchronize stream");
+
+    assert_eq!(output.as_slice(), input.as_slice());
+}
+
+#[test]
+fn device_buffer_can_be_refilled_from_pinned_host_async() {
+    let ctx = CudaContext::new(0).expect("failed to create CUDA context");
+    let stream = ctx.new_stream().expect("failed to create CUDA stream");
+
+    let mut device =
+        DeviceBuffer::<u32>::zeroed(&stream, 4).expect("failed to allocate device buffer");
+    let mut output =
+        PinnedHostBuffer::<u32>::zeroed(&ctx, 4).expect("failed to allocate pinned output buffer");
+
+    for round in 0..3 {
+        let payload = [round * 10, round * 10 + 1, round * 10 + 2, round * 10 + 3];
+        let input =
+            PinnedHostBuffer::from_slice(&ctx, &payload).expect("failed to allocate pinned input");
+
+        // SAFETY: `input` lives until the end of this scope and the
+        // `stream.synchronize()` below completes the in-flight refill before
+        // `input` is dropped. `output` outlives the synchronize call too.
+        unsafe { device.copy_from_pinned_host_async(&stream, &input) }
+            .expect("failed to enqueue refill");
+        unsafe { device.copy_to_pinned_host_async(&stream, &mut output) }
+            .expect("failed to enqueue readback");
+        stream.synchronize().expect("failed to synchronize stream");
+
+        assert_eq!(output.as_slice(), &payload);
+    }
+}

--- a/cuda-core/tests/simt_stream_priority.rs
+++ b/cuda-core/tests/simt_stream_priority.rs
@@ -1,0 +1,102 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! `CudaContext::{stream_priority_range, new_stream_with_priority}` and
+//! `CudaStream::priority`.
+//!
+//! Stream priority is per-stream state rather than the process-wide context
+//! state `context_sync_policy.rs` has to serialise, so these run in one
+//! binary without a race. What they do share is the device's range, which is
+//! read-only.
+
+use cuda_core::CudaContext;
+
+#[test]
+fn range_is_ordered_the_way_cuda_orders_it() {
+    let ctx = CudaContext::new(0).expect("failed to create CUDA context");
+    let range = ctx
+        .stream_priority_range()
+        .expect("stream_priority_range() failed");
+
+    assert!(
+        range.greatest() <= range.least(),
+        "the greatest priority is the numerically smaller value, got greatest={} least={}",
+        range.greatest(),
+        range.least()
+    );
+    assert!(
+        range.contains(range.least()) && range.contains(range.greatest()),
+        "both ends must lie inside the range they define"
+    );
+    assert_eq!(
+        range.is_supported(),
+        range.least() != range.greatest(),
+        "is_supported() must read the both-ends-zero answer the driver gives \
+         on a device without priority support"
+    );
+}
+
+#[test]
+fn a_stream_reports_the_priority_it_was_given() {
+    let ctx = CudaContext::new(0).expect("failed to create CUDA context");
+    let range = ctx
+        .stream_priority_range()
+        .expect("stream_priority_range() failed");
+
+    for requested in [range.least(), range.greatest()] {
+        let stream = ctx
+            .new_stream_with_priority(requested)
+            .unwrap_or_else(|e| panic!("new_stream_with_priority({requested}) failed: {e:?}"));
+        assert_eq!(
+            stream.priority().unwrap(),
+            requested,
+            "a priority inside the device's range must survive stream creation"
+        );
+    }
+}
+
+#[test]
+fn an_out_of_range_priority_is_clamped_rather_than_refused() {
+    let ctx = CudaContext::new(0).expect("failed to create CUDA context");
+    let range = ctx
+        .stream_priority_range()
+        .expect("stream_priority_range() failed");
+
+    // The driver clamps and reports nothing, so the check is that creation
+    // succeeds AND that the stream lands on the end of the range clamp()
+    // predicts. Asserting only that creation succeeds would pass against a
+    // clamp() that returned any value at all.
+    for requested in [i32::MIN, i32::MAX] {
+        let expected = range.clamp(requested);
+        assert!(
+            range.contains(expected),
+            "clamp({requested}) must land inside the range"
+        );
+        let stream = ctx
+            .new_stream_with_priority(requested)
+            .unwrap_or_else(|e| panic!("new_stream_with_priority({requested}) failed: {e:?}"));
+        assert_eq!(
+            stream.priority().unwrap(),
+            expected,
+            "an out-of-range request must land where clamp({requested}) says it will"
+        );
+    }
+}
+
+#[test]
+fn an_ordinary_stream_reports_the_default_priority() {
+    let ctx = CudaContext::new(0).expect("failed to create CUDA context");
+
+    assert_eq!(
+        ctx.new_stream().unwrap().priority().unwrap(),
+        0,
+        "new_stream() must keep the driver's default priority"
+    );
+    assert_eq!(
+        ctx.default_stream().priority().unwrap(),
+        0,
+        "the default stream must report the default priority"
+    );
+}

--- a/cuda-core/tests/simt_stream_query.rs
+++ b/cuda-core/tests/simt_stream_query.rs
@@ -1,0 +1,77 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! `CudaStream::query` reports completion without blocking.
+//!
+//! Work is enqueued with `launch_host_function` rather than a kernel: the
+//! point under test is the driver's completion status for a stream, a host
+//! callback holds the stream busy for a known interval, and `cuda-core`'s own
+//! tests do not compile device code.
+
+use cuda_core::CudaContext;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+/// Long enough that the first query lands inside it on a loaded machine,
+/// short enough to keep the suite quick.
+const BUSY: Duration = Duration::from_millis(500);
+
+#[test]
+fn an_idle_stream_reports_complete() {
+    let ctx = CudaContext::new(0).expect("failed to create CUDA context");
+    let stream = ctx.new_stream().expect("failed to create stream");
+
+    assert!(
+        stream.query().expect("query() failed on an idle stream"),
+        "a stream with nothing enqueued must report complete"
+    );
+}
+
+#[test]
+fn query_reports_in_flight_work_and_never_blocks() {
+    let ctx = CudaContext::new(0).expect("failed to create CUDA context");
+    let stream = ctx.new_stream().expect("failed to create stream");
+    let finished = Arc::new(AtomicBool::new(false));
+
+    let callback_finished = finished.clone();
+    stream
+        .launch_host_function(move || {
+            std::thread::sleep(BUSY);
+            callback_finished.store(true, Ordering::SeqCst);
+        })
+        .expect("failed to enqueue the host callback");
+
+    // The call itself must return while the callback is still running. A
+    // query() that fell back to synchronize() would pass an "is it done"
+    // assertion later on, so the check is on both the answer and the time
+    // taken to give it.
+    let before = Instant::now();
+    let in_flight = stream.query().expect("query() failed on a busy stream");
+    let elapsed = before.elapsed();
+
+    assert!(
+        !in_flight,
+        "a stream whose host callback is still sleeping must report incomplete"
+    );
+    assert!(
+        elapsed < BUSY / 2,
+        "query() must return without waiting for the work, took {elapsed:?}"
+    );
+    assert!(
+        !finished.load(Ordering::SeqCst),
+        "the callback must still have been running when query() answered"
+    );
+
+    stream.synchronize().expect("synchronize() failed");
+    assert!(
+        stream.query().expect("query() failed after synchronize()"),
+        "a stream must report complete once its work has finished"
+    );
+    assert!(
+        finished.load(Ordering::SeqCst),
+        "synchronize() must have waited for the callback"
+    );
+}

--- a/cuda-core/tests/simt_vmm_multicast.rs
+++ b/cuda-core/tests/simt_vmm_multicast.rs
@@ -1,0 +1,150 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Integration test: VMM multicast objects (NVLink SHARP / NVLS).
+//!
+//! Builds a two-GPU multicast team and verifies the host-side plumbing:
+//! create the object, add both devices, bind per-GPU physical memory, map
+//! unicast and multicast views, roundtrip data through the bound memory,
+//! and tear down in the required order.
+//!
+//! The switch-side reduction semantics can only be exercised from device
+//! code (`multimem.ld_reduce` / `multimem.st`); that lives in the
+//! `nvls_all_reduce` example. Host code must not dereference the multicast
+//! mapping, so this test only establishes and tears it down.
+//!
+//! Requires an NVLink-switch system (e.g. HGX H100/B200); skips elsewhere.
+//! Compiled out entirely when the CUDA toolkit predates the multicast API
+//! (CUDA 12.1); see cuda-core's build script probe.
+#![cfg(cuda_has_multicast)]
+
+use cuda_core::simt::context::CudaContext;
+use cuda_core::simt::vmm;
+use cuda_core::IntoResult;
+use std::mem::MaybeUninit;
+
+fn gpu_count() -> Result<usize, cuda_core::DriverError> {
+    unsafe { cuda_core::init(0)? };
+    let mut count = MaybeUninit::uninit();
+    unsafe {
+        cuda_bindings::cuDeviceGetCount(count.as_mut_ptr()).result()?;
+        Ok(count.assume_init() as usize)
+    }
+}
+
+#[test]
+fn multicast_two_gpu_team_roundtrip() {
+    let count = gpu_count().expect("failed to get device count");
+    if count < 2 {
+        eprintln!("SKIPPED: multicast_two_gpu_team_roundtrip requires 2+ GPUs (found {count})");
+        return;
+    }
+
+    let ctx0 = CudaContext::new(0).expect("GPU 0 context");
+    let ctx1 = CudaContext::new(1).expect("GPU 1 context");
+    let devices = [ctx0.cu_device(), ctx1.cu_device()];
+
+    for (i, &dev) in devices.iter().enumerate() {
+        let supported = vmm::multicast_supported(dev).expect("multicast_supported query failed");
+        if !supported {
+            eprintln!("SKIPPED: GPU {i} does not support switch multicast (NVLS)");
+            return;
+        }
+    }
+
+    let min_bytes = 1 << 20;
+    let granularity = vmm::multicast_granularity(
+        devices.len() as u32,
+        min_bytes,
+        vmm::MulticastGranularity::Recommended,
+    )
+    .expect("cuMulticastGetGranularity failed");
+    assert!(granularity > 0, "granularity must be positive");
+    let size = vmm::align_size(min_bytes, granularity);
+
+    let team =
+        vmm::MulticastObject::new(devices.len() as u32, size).expect("cuMulticastCreate failed");
+    assert_eq!(team.size(), size);
+    assert_eq!(team.num_devices(), 2);
+    for &dev in &devices {
+        team.add_device(dev).expect("cuMulticastAddDevice failed");
+    }
+
+    // The physical size must satisfy the allocation granularity as well as
+    // the multicast granularity, so align to both.
+    let contexts = [&ctx0, &ctx1];
+    let mut physes = Vec::new();
+    let mut bindings = Vec::new();
+    for (i, ctx) in contexts.iter().enumerate() {
+        ctx.bind_to_thread().expect("bind context");
+        let alloc_gran =
+            vmm::allocation_granularity(devices[i]).expect("allocation granularity query");
+        let phys_size = vmm::align_size(size, alloc_gran);
+        let phys = vmm::PhysicalAllocation::new(devices[i], phys_size).expect("cuMemCreate failed");
+        assert_eq!(phys.device(), devices[i]);
+        let binding = team
+            .bind_mem(0, &phys, 0, size)
+            .expect("cuMulticastBindMem failed");
+        assert_eq!(binding.device(), devices[i]);
+        physes.push(phys);
+        bindings.push(binding);
+    }
+
+    // Per GPU: (uc_va, uc_map, mc_va, mc_map)
+    let mut mappings = Vec::new();
+    for (i, ctx) in contexts.iter().enumerate() {
+        ctx.bind_to_thread().expect("bind context");
+
+        let uc_va = vmm::VirtualReservation::new(size, 0).expect("unicast VA reserve");
+        let uc_map =
+            vmm::Mapping::new(uc_va.base(), size, &physes[i], 0).expect("unicast cuMemMap");
+        vmm::set_access(uc_va.base(), size, &[devices[i]]).expect("unicast set_access");
+
+        let mc_va = vmm::VirtualReservation::new(size, granularity).expect("multicast VA reserve");
+        let mc_map =
+            vmm::Mapping::new_multicast(mc_va.base(), size, &team, 0).expect("multicast cuMemMap");
+        vmm::set_access(mc_va.base(), size, &[devices[i]]).expect("multicast set_access");
+
+        mappings.push((uc_va, uc_map, mc_va, mc_map));
+    }
+
+    ctx0.bind_to_thread().expect("bind ctx0");
+    let pattern: Vec<u32> = (0..256).map(|i| i * 3 + 7).collect();
+    let byte_len = pattern.len() * std::mem::size_of::<u32>();
+    let stream0 = ctx0.default_stream();
+    unsafe {
+        cuda_core::simt::memory::memcpy_htod_async(
+            mappings[0].0.base(),
+            pattern.as_ptr(),
+            byte_len,
+            stream0.cu_stream(),
+        )
+        .expect("HtoD via unicast view");
+    }
+    ctx0.synchronize().expect("sync GPU 0");
+
+    let mut readback = vec![0u32; 256];
+    unsafe {
+        cuda_core::simt::memory::memcpy_dtoh_async(
+            readback.as_mut_ptr(),
+            mappings[0].0.base(),
+            byte_len,
+            stream0.cu_stream(),
+        )
+        .expect("DtoH via unicast view");
+    }
+    ctx0.synchronize().expect("sync GPU 0");
+    assert_eq!(
+        readback, pattern,
+        "unicast roundtrip through bound memory failed"
+    );
+
+    // Teardown order: mappings, then bindings, then team, then physical
+    // allocations.
+    drop(mappings);
+    drop(bindings);
+    drop(team);
+    drop(physes);
+}

--- a/cuda-core/tests/simt_vmm_p2p.rs
+++ b/cuda-core/tests/simt_vmm_p2p.rs
@@ -1,0 +1,184 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Integration test: VMM + P2P cross-GPU memory access.
+//!
+//! This test does the following:
+//! 1. Checks that the machine has at least 2 GPUs.
+//! 2. Creates one CUDA context for GPU 0 and one for GPU 1.
+//! 3. Asks CUDA whether those two GPUs support direct peer access.
+//! 4. Enables peer access in both directions.
+//! 5. Allocates physical memory only on GPU 0.
+//! 6. Reserves one VA range on GPU 0 and maps that GPU 0 physical memory there.
+//! 7. Reserves a separate VA range on GPU 1 and maps the same GPU 0 physical
+//!    memory there too.
+//! 8. Grants both GPUs access to both mappings with `cuMemSetAccess`.
+//! 9. Writes a known `u32` pattern through GPU 0's mapping.
+//! 10. Reads back through GPU 1's mapping.
+//! 11. Asserts the bytes match exactly.
+//! 12. Tears everything down in the required order: mappings first, then VA
+//!     reservations, then physical allocation, then peer access.
+//!
+//! Requires a system with at least 2 CUDA-capable GPUs with P2P support.
+
+use cuda_core::simt::context::CudaContext;
+use cuda_core::simt::peer;
+use cuda_core::simt::vmm;
+use cuda_core::IntoResult;
+use std::mem::MaybeUninit;
+
+fn gpu_count() -> Result<usize, cuda_core::DriverError> {
+    unsafe { cuda_core::init(0)? };
+    let mut count = MaybeUninit::uninit();
+    unsafe {
+        cuda_bindings::cuDeviceGetCount(count.as_mut_ptr()).result()?;
+        Ok(count.assume_init() as usize)
+    }
+}
+
+#[test]
+fn vmm_alloc_map_set_access_roundtrip() {
+    let ctx = CudaContext::new(0).expect("failed to create context for GPU 0");
+    let granularity =
+        vmm::allocation_granularity(ctx.cu_device()).expect("failed to query granularity");
+    assert!(granularity > 0, "granularity must be positive");
+
+    let alloc_size = vmm::align_size(4096, granularity);
+
+    let phys =
+        vmm::PhysicalAllocation::new(ctx.cu_device(), alloc_size).expect("cuMemCreate failed");
+    assert_eq!(phys.size(), alloc_size);
+
+    let va = vmm::VirtualReservation::new(alloc_size, 0).expect("cuMemAddressReserve failed");
+    assert_ne!(va.base(), 0);
+
+    let mapping = vmm::Mapping::new(va.base(), alloc_size, &phys, 0).expect("cuMemMap failed");
+    assert_eq!(mapping.va(), va.base());
+
+    vmm::set_access(va.base(), alloc_size, &[ctx.cu_device()]).expect("cuMemSetAccess failed");
+
+    let stream = ctx.default_stream();
+    let pattern: Vec<u8> = (0..64).map(|i| (i * 3 + 7) as u8).collect();
+    unsafe {
+        cuda_core::simt::memory::memcpy_htod_async(
+            va.base(),
+            pattern.as_ptr(),
+            pattern.len(),
+            stream.cu_stream(),
+        )
+        .expect("HtoD memcpy failed");
+    }
+    ctx.synchronize().expect("sync failed");
+
+    let mut readback = vec![0u8; 64];
+    unsafe {
+        cuda_core::simt::memory::memcpy_dtoh_async(
+            readback.as_mut_ptr(),
+            va.base(),
+            readback.len(),
+            stream.cu_stream(),
+        )
+        .expect("DtoH memcpy failed");
+    }
+    ctx.synchronize().expect("sync failed");
+
+    assert_eq!(readback, pattern, "single-GPU VMM roundtrip failed");
+
+    drop(mapping);
+    drop(va);
+    drop(phys);
+}
+
+#[test]
+fn p2p_vmm_cross_gpu_access() {
+    let count = gpu_count().expect("failed to get device count");
+    if count < 2 {
+        eprintln!("SKIPPED: p2p_vmm_cross_gpu_access requires 2+ GPUs (found {count})");
+        return;
+    }
+
+    let ctx0 = CudaContext::new(0).expect("GPU 0 context");
+    let ctx1 = CudaContext::new(1).expect("GPU 1 context");
+
+    let can_p2p = peer::can_access_peer(&ctx0, &ctx1).expect("can_access_peer query failed");
+    if !can_p2p {
+        eprintln!("SKIPPED: GPU 0 cannot access GPU 1 via P2P");
+        return;
+    }
+
+    peer::enable_peer_access(&ctx0, &ctx1).expect("enable P2P 0→1 failed");
+    peer::enable_peer_access(&ctx1, &ctx0).expect("enable P2P 1→0 failed");
+
+    // --- Allocate physical memory on GPU 0 ---
+    let granularity = vmm::allocation_granularity(ctx0.cu_device()).expect("granularity query");
+    let alloc_size = vmm::align_size(4096, granularity);
+    let phys = vmm::PhysicalAllocation::new(ctx0.cu_device(), alloc_size).expect("cuMemCreate");
+
+    // --- Reserve VA and map on GPU 0 ---
+    let va0 = vmm::VirtualReservation::new(alloc_size, 0).expect("VA reserve for GPU 0");
+    let map0 = vmm::Mapping::new(va0.base(), alloc_size, &phys, 0).expect("map on GPU 0");
+    vmm::set_access(
+        va0.base(),
+        alloc_size,
+        &[ctx0.cu_device(), ctx1.cu_device()],
+    )
+    .expect("set_access for GPU 0 mapping");
+
+    // --- Reserve VA and map the SAME physical memory on GPU 1 ---
+    let va1 = vmm::VirtualReservation::new(alloc_size, 0).expect("VA reserve for GPU 1");
+    let map1 = vmm::Mapping::new(va1.base(), alloc_size, &phys, 0).expect("map on GPU 1");
+    vmm::set_access(
+        va1.base(),
+        alloc_size,
+        &[ctx0.cu_device(), ctx1.cu_device()],
+    )
+    .expect("set_access for GPU 1 mapping");
+
+    // --- GPU 0 writes data through its VA ---
+    let pattern: Vec<u32> = (0..256).collect();
+    let byte_len = pattern.len() * std::mem::size_of::<u32>();
+    let stream0 = ctx0.default_stream();
+    ctx0.bind_to_thread().expect("bind ctx0");
+    unsafe {
+        cuda_core::simt::memory::memcpy_htod_async(
+            va0.base(),
+            pattern.as_ptr(),
+            byte_len,
+            stream0.cu_stream(),
+        )
+        .expect("HtoD via GPU 0 VA");
+    }
+    ctx0.synchronize().expect("sync GPU 0");
+
+    // --- GPU 1 reads the data through its VA (P2P read of GPU 0's physical memory) ---
+    let mut readback = vec![0u32; 256];
+    let stream1 = ctx1.default_stream();
+    ctx1.bind_to_thread().expect("bind ctx1");
+    unsafe {
+        cuda_core::simt::memory::memcpy_dtoh_async(
+            readback.as_mut_ptr(),
+            va1.base(),
+            byte_len,
+            stream1.cu_stream(),
+        )
+        .expect("DtoH via GPU 1 VA");
+    }
+    ctx1.synchronize().expect("sync GPU 1");
+
+    assert_eq!(
+        readback, pattern,
+        "P2P cross-GPU VMM read failed: GPU 1 did not see GPU 0's data"
+    );
+
+    // --- Cleanup in correct order: mappings before VA/phys ---
+    drop(map1);
+    drop(map0);
+    drop(va1);
+    drop(va0);
+    drop(phys);
+
+    peer::disable_peer_access(&ctx0, &ctx1).expect("disable P2P 0→1");
+    peer::disable_peer_access(&ctx1, &ctx0).expect("disable P2P 1→0");
+}

--- a/cutile-compiler/build.rs
+++ b/cutile-compiler/build.rs
@@ -1,0 +1,54 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Advisory Tile-floor warning at build time.
+//!
+//! The authoritative check runs at tool discovery in
+//! `cuda_tile_runtime_utils`, on the machine that executes the JIT. This
+//! warning covers the common case where the build box and the run box are
+//! the same, so a too-old toolkit is reported at compile time instead of
+//! first launch. It never fails the build: emitting bytecode and
+//! cross-building are legitimate on machines without a 13.2+ toolkit.
+
+use std::env;
+use std::fs;
+use std::path::Path;
+
+const TOOLKIT_ENV_VARS: &[&str] = &["CUDA_TOOLKIT_PATH", "CUDA_HOME"];
+const DEFAULT_TOOLKIT_DIR: &str = "/usr/local/cuda";
+const MIN_TILE_CUDA_VERSION: u32 = 13020;
+
+fn main() {
+    for var in TOOLKIT_ENV_VARS {
+        println!("cargo:rerun-if-env-changed={var}");
+    }
+    let toolkit = TOOLKIT_ENV_VARS
+        .iter()
+        .find_map(|var| env::var(var).ok())
+        .unwrap_or_else(|| DEFAULT_TOOLKIT_DIR.to_string());
+    let cuda_h = Path::new(&toolkit).join("include").join("cuda.h");
+    let Ok(header) = fs::read_to_string(&cuda_h) else {
+        return;
+    };
+    let version = header.lines().find_map(|line| {
+        let mut parts = line.split_whitespace();
+        match (parts.next(), parts.next(), parts.next()) {
+            (Some("#define"), Some("CUDA_VERSION"), Some(version)) => version.parse::<u32>().ok(),
+            _ => None,
+        }
+    });
+    if let Some(version) = version {
+        if version < MIN_TILE_CUDA_VERSION {
+            println!(
+                "cargo:warning=cutile-compiler: the toolkit at {} is CUDA {}.{}; \
+                 cuTile requires CUDA 13.2+ at run time (tileiras ships with it). \
+                 The shared CUDA host-side crates support 13.0+.",
+                toolkit,
+                version / 1000,
+                (version % 1000) / 10
+            );
+        }
+    }
+}

--- a/cutile-compiler/src/cuda_tile_runtime_utils.rs
+++ b/cutile-compiler/src/cuda_tile_runtime_utils.rs
@@ -17,6 +17,11 @@ use std::process::Command;
 use std::sync::{Arc, Mutex, OnceLock};
 use uuid::Uuid;
 
+/// The minimum CUDA toolkit the Tile compiler supports; `tileiras` ships
+/// with CUDA 13.2. The shared host-side crates support 13.0+ and enforce
+/// their own floor in `cuda-bindings`.
+const MIN_TILE_CUDA_VERSION: u32 = 13020;
+
 /// Environment variable used to override the `tileiras` executable.
 ///
 /// Set this to an absolute path such as `/opt/cuda-tile/bin/tileiras` to use
@@ -354,6 +359,22 @@ fn compute_bytecode_version(tileiras: &Path, toolkit_dir: Option<&Path>) -> Byte
     if let Some(dir) = toolkit_dir {
         let cuda_h = dir.join("include").join("cuda.h");
         if let Ok(cuda_version) = cuda_version_from_header(&cuda_h) {
+            // The Tile floor. The shared host-side crates support CUDA 13.0+,
+            // but the Tile compiler drives toolkit binaries (tileiras) that
+            // ship with CUDA 13.2+, so complain here, at tool discovery, with
+            // the context to say what was found. SIMT-only users never reach
+            // this path. An explicit TILEIRAS_PATH_ENV or bare-PATH resolution
+            // bypasses the check by design: the user picked their own binary.
+            if cuda_version < MIN_TILE_CUDA_VERSION {
+                panic!(
+                    "cuTile requires CUDA 13.2 or newer: the resolved toolkit at {} is CUDA {}.{}. \
+                     Set {CUDA_TOOLKIT_PATH_ENV} to a CUDA 13.2+ install \
+                     (the shared CUDA host-side crates themselves support 13.0+).",
+                    dir.display(),
+                    cuda_version / 1000,
+                    (cuda_version % 1000) / 10,
+                );
+            }
             let version = bytecode_version_from_cuda_version(cuda_version);
             emit_setup_diagnostic(format_args!(
                 "bytecode version {version} from {}",


### PR DESCRIPTION
cuda-oxide's cuda-host and cuda-macros consume DeviceBuffer, the launch contract types, the embedded module, and the async launch builders. This PR copies those surfaces in as simt modules in cuda-core and cuda-async, as-is rather than reconciled, so cuda-oxide can build against the shared crates before the repository migration.

One collision on each side: LaunchConfig stays reachable only as cuda_core::simt::LaunchConfig, and cuda-async re-exports nothing at the root since the two stacks fork the same ancestor and share most type names. DriverError, IntoResult, init, and launch_kernel were already identical and are unified rather than duplicated. cuda-bindings gains the one missing helper, cu_event_elapsed_time. The simt modules are deletable as a unit at reconciliation.

Departures from the cuda-oxide originals are recorded in the module docs: the nightly-only DeviceCopy impl for primitive f16 is dropped (half::f16 remains), the DeviceCopy derive stays with cuda-oxide's cuda-macros, vmm and peer are not copied (no shared consumer; VMM arrives via #202), and oxide-artifacts is vendored as simt::artifacts since it is not on crates.io.

Full workspace compiles, 508 tests pass including cuda-oxide's launch-contract trybuild fixtures, no new clippy or rustdoc warnings. Ships in 0.3.1, not 0.3.0. Companion PR: NVlabs/cuda-oxide#1102.