### PR TITLE
release: v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,85 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-08-20
+
+This release introduces compiler optimizations that improve safe kernel
+performance, async launch performance improvements, persistent kernel
+tuning, and zero-copy interop with externally owned device memory. The
+compiler now proves each partition access at compile time or verifies it
+once at launch, and places the rare remaining check where it costs
+nothing.
+
+### Highlights
+
+- Bounds-check placement: every partition access walks one proof ladder
+  (axis provenance, static folding, declared preconditions, host-side launch
+  checks) and only then pays an in-kernel assert, hoisted to the outermost
+  provable loop preheader. Kernels indexed by loop iterands, mapped schedule
+  components, or tile-block ids typically compile with zero in-kernel checks
+  and no annotations. `PartitionMut::store` joins the checked-by-default
+  surface (`store_unchecked` is the explicit escape) at identical register
+  counts.
+- `deny_in_kernel_checks = true` on an entry turns any check that would remain
+  in the kernel into a compile error, so an assert-free kernel is a contract
+  the build enforces rather than a property to audit.
+- Partial-coverage launches: `partition_prefix` lets the launch grid cover a
+  per-axis prefix of an output partition's block grid. Exceeding the grid on
+  any axis remains a launch error, and the default `partition` keeps strict
+  equality.
+- Zero-copy interop: `Tensor::from_foreign` borrows device memory owned by an
+  external framework (cudarc, torch, VMM ranges), holding the owner alive by
+  refcount and verifying the addressable extent at construction;
+  `Tensor::borrow_raw_parts`, `Device::borrow_with_owner`, and
+  `Stream::borrow_with_owner` cover bare handles.
+- Autotuner core: declared configuration spaces, pluggable searchers,
+  resumable grid search, and provenance-checked tuning records.
+- `cutile::bench` for device-event kernel benchmarking, an opt-in persistent
+  on-disk cubin cache, a process-global single-flight kernel cache with a
+  `.compile()` warmup API, and async launch latency at parity with sync.
+- A new book chapter, Bounds-Check Placement, documents the placement rules
+  and a verification workflow: per-kernel placement counts from
+  `CUTILE_JIT_TIMING`, and diffing the emitted Tile IR against an unsafe twin
+  before running anything.
+
+### Performance results
+
+- The fully checked flash-attention prefill kernel matches its unsafe twin
+  on RTX 5090, within 2.5% of the checks-disabled floor.
+- Async launch latency is at parity with sync, and a differential harness
+  verifies that every check placement refines the outcome of checking at the
+  access site.
+- Grout, the Qwen3 inference engine from the 0.2.0 paper, now runs its
+  25-kernel default engine path with zero unchecked kernels and six one-line
+  unsafe view constructions in total, at safe-vs-unsafe parity on RTX 5090
+  and B200.
+
+### Changed
+
+- `with_bounds` and `Dim::new` are deprecated: bounds inference and declared
+  preconditions prove everything they proved, with the checks placed at
+  launch instead of in the kernel. Migration notes are on the deprecations.
+- Tile IR bytecode version selection reads the CUDA toolkit when
+  discoverable and otherwise probes `tileiras` with a representative module
+  (an entry with a `for` region and view chain), so an accepted version is
+  one real kernels compile at.
+- The `persistent_gemm` example is rewritten in the zero-annotation form and
+  compiles under `deny_in_kernel_checks = true`.
+
+### Fixed
+
+- An entry declared as bare `#[cutile::entry]`, without an argument list, was
+  silently treated as a plain function; both attribute forms are now
+  recognized.
+- Interval range facts no longer survive arithmetic that can wrap `i32`; a
+  wrapped intermediate could previously discharge a check the machine value
+  violated.
+- Bounds analysis guards division and remainder against zero divisors,
+  saturates interval arithmetic, and uses overlap analysis for `eq`/`ne`.
+- Device-op `Send` bounds, CUDA driver flag types, and aarch64 flake support.
+- Security bumps for crossbeam-epoch (RUSTSEC-2026-0204) and anyhow
+  (RUSTSEC-2026-0190).
+
 ## [0.2.0] - 2026-06-16
 
 This release collects the changes since `0.1.0` and focuses on low-precision

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,7 +414,7 @@ dependencies = [
 
 [[package]]
 name = "cuda-async"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "cuda-bindings",
@@ -429,7 +429,7 @@ dependencies = [
 
 [[package]]
 name = "cuda-bindings"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bindgen 0.69.5",
  "libloading",
@@ -441,7 +441,7 @@ dependencies = [
 
 [[package]]
 name = "cuda-core"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "cuda-bindings",
@@ -450,7 +450,7 @@ dependencies = [
 
 [[package]]
 name = "cuda-tile-rs"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bindgen 0.71.1",
  "cmake",
@@ -458,7 +458,7 @@ dependencies = [
 
 [[package]]
 name = "cutile"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "cuda-async",
@@ -482,7 +482,7 @@ dependencies = [
 
 [[package]]
 name = "cutile-benchmarks"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "criterion",
  "cuda-async",
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "cutile-compiler"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "cuda-async",
@@ -514,7 +514,7 @@ dependencies = [
 
 [[package]]
 name = "cutile-examples"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -529,7 +529,7 @@ dependencies = [
 
 [[package]]
 name = "cutile-ir"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "half",
  "indexmap",
@@ -538,7 +538,7 @@ dependencies = [
 
 [[package]]
 name = "cutile-kernels"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "cutile",
  "cutile-compiler",
@@ -546,7 +546,7 @@ dependencies = [
 
 [[package]]
 name = "cutile-macro"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "convert_case",
  "cutile-compiler",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 rust-version = "1.89"
 license = "Apache-2.0"
@@ -87,13 +87,13 @@ sha2 = "0.10"
 once_cell = "1.19"
 
 # ── Intra-workspace ──────────────────────────────────────────────────────────
-cuda-bindings = { path = "cuda-bindings", version = "0.2.0" }
-cuda-core = { path = "cuda-core", version = "0.2.0" }
-cuda-async = { path = "cuda-async", version = "0.2.0" }
-cutile-compiler = { path = "cutile-compiler", version = "0.2.0" }
-cutile-macro = { path = "cutile-macro", version = "0.2.0" }
-cutile = { path = "cutile", version = "0.2.0" }
-cutile-kernels = { path = "cutile-kernels", version = "0.2.0" }
-cutile-examples = { path = "cutile-examples", version = "0.2.0" }
-cutile-ir = { path = "cutile-ir", version = "0.2.0" }
-cutile-benchmarks = { path = "cutile-benchmarks", version = "0.2.0" }
+cuda-bindings = { path = "cuda-bindings", version = "0.3.0" }
+cuda-core = { path = "cuda-core", version = "0.3.0" }
+cuda-async = { path = "cuda-async", version = "0.3.0" }
+cutile-compiler = { path = "cutile-compiler", version = "0.3.0" }
+cutile-macro = { path = "cutile-macro", version = "0.3.0" }
+cutile = { path = "cutile", version = "0.3.0" }
+cutile-kernels = { path = "cutile-kernels", version = "0.3.0" }
+cutile-examples = { path = "cutile-examples", version = "0.3.0" }
+cutile-ir = { path = "cutile-ir", version = "0.3.0" }
+cutile-benchmarks = { path = "cutile-benchmarks", version = "0.3.0" }


### PR DESCRIPTION
Bump workspace version to 0.3.0 for v0.3.0, with the 0.3.0 changelog entry. Merge last: the tag is cut from main once Cargo.toml reads 0.3.0.