### PR TITLE
fix: version persisted tuning cache keys

### DIFF
--- a/cutile-book/guide/performance.md
+++ b/cutile-book/guide/performance.md
@@ -207,10 +207,10 @@ How it works:
 
 ### Committing winners
 
-A `tune::Record` persists winners so production loads them instead of re-searching. It is one JSON file per kernel, written by `save` and intended to be committed next to the code it tunes. The file holds a provenance header (kernel name, source hash, cutile version, `tileiras` fingerprint, target architecture, search-space hash) and one entry per shape-class bucket: the winning `Config`, its median, and optionally the winner's JIT cache key.
+A `tune::Record` persists winners so production loads them instead of re-searching. It is one JSON file per kernel, written by `save` and intended to be committed next to the code it tunes. The file holds a provenance header (kernel name, source hash, cutile version, `tileiras` fingerprint, target architecture, search-space hash) and one entry per shape-class bucket: the winning `Config`, its median, and optionally the winner's JIT cache key. A stored key carries the key encoding that produced it, because cutile can change that encoding without any change to the kernel or the toolchain.
 
 ```rust
-use cutile::tune::{Record, RecordEntry, Workspace};
+use cutile::tune::{L2Key, Record, RecordEntry, Workspace};
 
 // After tuning: store the winner for this bucket.
 let mut record = Record::new(&workspace);
@@ -219,7 +219,7 @@ record.insert(RecordEntry {
     config: best,
     median_ms,
     samples,
-    l2_key: Some(launcher.specialize()?.l2_cache_key()?),
+    l2_key: Some(L2Key::current(launcher.specialize()?.l2_cache_key()?)),
 });
 record.save(&path)?;
 
@@ -229,7 +229,7 @@ let (record, warnings) = Record::load_verified(&path, &workspace, |entry| {
 })?;
 ```
 
-`load_verified` refuses a record whose kernel, architecture, source hash, or search space does not match the running workspace, and refuses any entry whose stored JIT cache key no longer matches the recomputed one. That last check covers the kernel's dependencies and the toolchain, so a stale winner fails loudly instead of applying silently. Conditions that do not invalidate the configs themselves, such as a `tileiras` version drift that only shifts timings, come back as warnings. A record is never applied on a best-effort basis: it either verifies or it does not load.
+`load_verified` refuses a record whose kernel, architecture, source hash, or search space does not match the running workspace, and refuses any entry whose stored JIT cache key no longer matches the recomputed one. That last check covers the kernel's dependencies and the toolchain, so a stale winner fails loudly instead of applying silently. Conditions that do not invalidate the configs themselves come back as warnings: a `tileiras` version drift that only shifts timings, and a stored key from an older key encoding — in both cases a recomputed key cannot match the stored one, so the check is skipped rather than read as staleness. A record is never applied on a best-effort basis: it either verifies or it does not load.
 
 The `autotune` example runs a complete search over the block size of an RMS normalization kernel:
 

--- a/cutile-compiler/src/jit_cache.rs
+++ b/cutile-compiler/src/jit_cache.rs
@@ -1164,4 +1164,20 @@ mod tests {
         };
         assert_eq!(encode_entry(&p, b"cubin"), None);
     }
+    #[test]
+    fn l2_key_preimage_is_pinned_to_the_schema() {
+        // This digest is the point: it pins the key PREIMAGE, not just its
+        // properties. If this assertion fails, you changed the l2 key
+        // encoding (field set, field order, or field encoding). That is
+        // allowed — but you MUST bump L2_KEY_SCHEMA, update this digest,
+        // and extend the schema history in its doc comment. Persisted keys
+        // (cutile::tune records) rely on the schema to tell an encoding
+        // migration apart from a stale winner; changing the preimage
+        // without the bump silently re-creates the #236/#241 bug.
+        assert_eq!(
+            l2_key(b"bc", V, "sm_90", &opts(3), "fp"),
+            "45274c4d279d97c5e383d8a8b035225d5ec81c91bd9f27c3027f5f5593473533",
+            "l2 key preimage changed: bump L2_KEY_SCHEMA (see comment above)"
+        );
+    }
 }

--- a/cutile-compiler/src/jit_cache.rs
+++ b/cutile-compiler/src/jit_cache.rs
@@ -721,6 +721,15 @@ pub fn jit_disk_hit_count() -> u64 {
 /// rule changes: every old entry then misses naturally, no manual cache wipe.
 const DOMAIN: &[u8] = b"cutile-jit-cubin-v1\0";
 
+/// Version of the [`l2_key`] preimage. A cache entry that misses under a new
+/// encoding just recompiles, but a key *persisted* outside the cache (a
+/// `cutile::tune` record) has no such recovery: its holder must be able to
+/// tell "the workspace drifted" from "this key was never comparable". Bump
+/// this whenever the preimage changes, encoding rules and field set alike.
+///
+/// 1: `opt_level` alone. 2: `opt_level` plus the stage-2 flags byte.
+pub const L2_KEY_SCHEMA: u32 = 2;
+
 /// Content-addressed cache key: SHA-256 over the complete `tileiras` input.
 ///
 /// The key deliberately contains no `module_name`, no generics, and no

--- a/cutile/src/tune.rs
+++ b/cutile/src/tune.rs
@@ -33,6 +33,7 @@
 use crate::bench::{do_bench, BenchOptions, Measurement};
 use crate::error::Error;
 use cuda_core::Stream;
+use cutile_compiler::jit_cache::L2_KEY_SCHEMA;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::io::Write;
@@ -801,6 +802,57 @@ pub struct Record {
     pub entries: Vec<RecordEntry>,
 }
 
+/// A stored L2 cache key and the key encoding that produced it.
+///
+/// The two travel as one value on purpose. A digest is comparable only
+/// against another digest from the same encoding: cutile can change the key
+/// preimage without touching the kernel or the toolchain, and a bare digest
+/// cannot tell that migration apart from a stale winner.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum L2Key {
+    Tagged {
+        /// [`L2_KEY_SCHEMA`] at the time the digest was computed.
+        schema: u32,
+        digest: String,
+    },
+    /// A key written before the encoding was recorded. It cannot claim an
+    /// encoding, so it is never comparable.
+    Untagged(String),
+}
+
+impl L2Key {
+    /// Tags `digest` with the encoding this build computes keys under.
+    pub fn current(digest: String) -> Self {
+        Self::Tagged {
+            schema: L2_KEY_SCHEMA,
+            digest,
+        }
+    }
+
+    /// The digest itself, discarding comparability. For display and tooling;
+    /// [`comparable`](Self::comparable) is what a staleness check wants.
+    pub fn digest(&self) -> &str {
+        match self {
+            Self::Tagged { digest, .. } | Self::Untagged(digest) => digest,
+        }
+    }
+
+    /// The digest when this build would derive keys the same way, or why a
+    /// comparison would be meaningless.
+    pub fn comparable(&self) -> Result<&str, String> {
+        match self {
+            Self::Tagged { schema, digest } if *schema == L2_KEY_SCHEMA => Ok(digest),
+            Self::Tagged { schema, .. } => Err(format!(
+                "was computed under l2 key encoding {schema}, workspace uses {L2_KEY_SCHEMA}"
+            )),
+            Self::Untagged(_) => Err(format!(
+                "predates l2 key encoding tags, workspace uses {L2_KEY_SCHEMA}"
+            )),
+        }
+    }
+}
+
 /// One bucket's winner.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RecordEntry {
@@ -814,7 +866,7 @@ pub struct RecordEntry {
     pub samples: usize,
     /// The winner's persistent-cache (L2) key at tune time, when the caller
     /// recorded one. Enables the strong staleness check at load.
-    pub l2_key: Option<String>,
+    pub l2_key: Option<L2Key>,
 }
 
 /// The provenance the loader checks a record against.
@@ -893,11 +945,12 @@ impl Record {
     /// `l2_key` that differs from the recomputed one (the strong,
     /// dependency-inclusive check).
     ///
-    /// WARNS (returned, never silent) on: toolchain-fingerprint drift (the
-    /// stored l2 keys embed the old fingerprint, so recomputation cannot
-    /// match and is skipped — configs remain valid, timings may not); gate
-    /// tag drift; entries without a stored key; and entries whose key the
-    /// verifier declined to recompute (`Ok(None)`).
+    /// WARNS (returned, never silent) on: toolchain-fingerprint drift and
+    /// stored keys from another l2 key encoding (both make a recomputed key
+    /// incomparable, so the check is skipped rather than read as staleness —
+    /// configs remain valid, timings may not); gate tag drift; entries
+    /// without a stored key; and entries whose key the verifier declined to
+    /// recompute (`Ok(None)`).
     ///
     /// `verify_l2` receives each keyed entry and returns the key the CURRENT
     /// workspace derives for its config — typically
@@ -970,29 +1023,34 @@ impl Record {
                     .to_string(),
             );
         }
-        let fingerprint_matches = record.tileiras_fingerprint == ws.tileiras_fingerprint;
-        if !fingerprint_matches {
-            // The stored keys embed the old fingerprint: recomputing under
-            // the new toolchain CANNOT match, so the strong check is skipped
-            // rather than misread as staleness. Ordering matters here.
+        // The stored keys embed the record's fingerprint: under toolchain
+        // drift recomputation CANNOT match, so the strong check is skipped
+        // record-wide rather than misread as staleness. Ordering matters here.
+        if record.tileiras_fingerprint != ws.tileiras_fingerprint {
             warnings.push(format!(
                 "tuning record was produced by a different tileiras ({} vs {}); configs remain valid but timings may have shifted and per-entry key verification was skipped — consider re-tuning",
                 record.tileiras_fingerprint, ws.tileiras_fingerprint,
             ));
         } else {
             for entry in &record.entries {
-                match &entry.l2_key {
+                // Three outcomes, not two: a key can match, contradict, or
+                // never have been comparable in the first place.
+                match entry.l2_key.as_ref().map(L2Key::comparable) {
                     None => warnings.push(format!(
                         "bucket {:?} carries no l2 key; only source-level staleness checks applied",
                         entry.bucket
                     )),
-                    Some(stored) => match verify_l2(entry)? {
+                    Some(Err(why)) => warnings.push(format!(
+                        "bucket {:?}: stored l2 key {why}; the key check was skipped — configs remain valid, consider re-tuning",
+                        entry.bucket
+                    )),
+                    Some(Ok(stored)) => match verify_l2(entry)? {
                         None => warnings.push(format!(
                             "bucket {:?}: verifier declined to recompute the l2 key; stored key not checked",
                             entry.bucket
                         )),
                         Some(current) => {
-                            if &current != stored {
+                            if current != stored {
                                 return refuse(
                                     &format!("l2 key for bucket {:?}", entry.bucket),
                                     stored,
@@ -1171,12 +1229,14 @@ mod tests {
             config: cfg(64, 8),
             median_ms: 1.25,
             samples: 12,
-            l2_key: Some("f".repeat(64)),
+            l2_key: Some(L2Key::current("f".repeat(64))),
         });
         a.save(&path).unwrap();
 
-        let (loaded, warnings) =
-            Record::load_verified(&path, &ws(), |e| Ok(e.l2_key.clone())).unwrap();
+        let (loaded, warnings) = Record::load_verified(&path, &ws(), |e| {
+            Ok(e.l2_key.as_ref().map(|k| k.digest().to_string()))
+        })
+        .unwrap();
         assert!(warnings.is_empty());
         let entry = loaded.get("tg<=512").unwrap();
         assert_eq!(entry.config.int("BN"), Some(64));
@@ -1248,7 +1308,7 @@ mod tests {
             config: cfg(64, 8),
             median_ms: 1.0,
             samples: 5,
-            l2_key: Some("a".repeat(64)),
+            l2_key: Some(L2Key::current("a".repeat(64))),
         });
         a.save(&path).unwrap();
 
@@ -1263,6 +1323,84 @@ mod tests {
         let (_, warnings) = Record::load_verified(&path, &drifted, |_| Ok(None)).unwrap();
         assert_eq!(warnings.len(), 1);
         assert!(warnings[0].contains("different tileiras"));
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn key_encoding_drift_skips_l2_verification_instead_of_refusing() {
+        // A cutile upgrade can change the l2 key preimage without touching
+        // the kernel or the toolchain. Such a key is not stale, it is
+        // incomparable, and the strong check steps aside instead of refusing.
+        let path = record_path("keyencoding");
+        let mut a = Record::new(&ws());
+        a.insert(RecordEntry {
+            bucket: "older".into(),
+            config: cfg(64, 8),
+            median_ms: 1.0,
+            samples: 5,
+            l2_key: Some(L2Key::Tagged {
+                schema: L2_KEY_SCHEMA - 1,
+                digest: "a".repeat(64),
+            }),
+        });
+        // A key written before encodings were tagged: same treatment.
+        a.insert(RecordEntry {
+            bucket: "untagged".into(),
+            config: cfg(128, 8),
+            median_ms: 1.0,
+            samples: 5,
+            l2_key: Some(L2Key::Untagged("b".repeat(64))),
+        });
+        a.save(&path).unwrap();
+        // Wire compatibility: an untagged key is a bare string on disk, so a
+        // record written before this field existed still parses.
+        let json = std::fs::read_to_string(&path).unwrap();
+        assert!(json.contains(&format!("\"l2_key\": \"{}\"", "b".repeat(64))));
+
+        let mut called = false;
+        let (_, warnings) = Record::load_verified(&path, &ws(), |_| {
+            called = true;
+            Ok(Some("c".repeat(64))) // would refuse if it were consulted
+        })
+        .unwrap();
+        assert!(!called, "verifier must not run on an incomparable key");
+        assert!(warnings[0].contains("l2 key encoding"));
+        assert!(warnings[1].contains("predates l2 key encoding tags"));
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn per_entry_encoding_keeps_mixed_records_honest() {
+        // Entries are inserted independently, so one record can hold keys
+        // from two encodings — re-tuning a single bucket does exactly that.
+        // Tagging the record as a whole would mis-sentence one of them; the
+        // tag rides with each key, so each is judged on its own.
+        let path = record_path("mixed");
+        let mut a = Record::new(&ws());
+        a.insert(RecordEntry {
+            bucket: "retuned".into(),
+            config: cfg(64, 8),
+            median_ms: 1.0,
+            samples: 5,
+            l2_key: Some(L2Key::current("a".repeat(64))),
+        });
+        a.insert(RecordEntry {
+            bucket: "carried over".into(),
+            config: cfg(128, 8),
+            median_ms: 2.0,
+            samples: 5,
+            l2_key: Some(L2Key::Untagged("b".repeat(64))),
+        });
+        a.save(&path).unwrap();
+
+        let mut checked = Vec::new();
+        let err = Record::load_verified(&path, &ws(), |e| {
+            checked.push(e.bucket.clone());
+            Ok(Some("z".repeat(64)))
+        })
+        .unwrap_err();
+        assert_eq!(checked, ["retuned"], "only the comparable key is verified");
+        assert!(err.to_string().contains("l2 key for bucket \"retuned\""));
         let _ = std::fs::remove_file(&path);
     }
 
@@ -1332,7 +1470,7 @@ mod tests {
             config: cfg(64, 8),
             median_ms: 1.0,
             samples: 5,
-            l2_key: Some("a".repeat(64)),
+            l2_key: Some(L2Key::current("a".repeat(64))),
         });
         a.save(&path).unwrap();
         let mut drifted = ws();

--- a/cutile/tests/autotune.rs
+++ b/cutile/tests/autotune.rs
@@ -199,7 +199,7 @@ fn record_end_to_end_with_real_l2_verification() {
             .and_then(|t| t.median_ms())
             .unwrap(),
         samples: 3,
-        l2_key: Some(winner_key.clone()),
+        l2_key: Some(cutile::tune::L2Key::current(winner_key.clone())),
     });
     let path = std::env::temp_dir().join(format!("cutile_record_gpu_{}.json", std::process::id()));
     record.save(&path).expect("save");
@@ -215,7 +215,7 @@ fn record_end_to_end_with_real_l2_verification() {
 
     // Tampered stored key: refused.
     let mut tampered = loaded.clone();
-    tampered.entries[0].l2_key = Some("0".repeat(64));
+    tampered.entries[0].l2_key = Some(cutile::tune::L2Key::current("0".repeat(64)));
     tampered.save(&path).expect("save tampered");
     let err = Record::load_verified(&path, &ws, |entry| {
         let tile = entry.config.int("TILE").unwrap() as usize;


### PR DESCRIPTION
## How this was found

While addressing #237's review follow-ups, including preserving the cache-key bit layout, I found a second consequence of #236's L2-key change.

#236 changed `cutile-compiler/src/jit_cache.rs:749` from hashing `[opt_level]` to `[opts.opt_level, opts.flags_byte()]`. Since `put_field` length-prefixes each field, every key changes, including defaults. For one real kernel with the same target, `tileiras 13.3 V13.3.36`, and default options:

```text
before: 1483ae7fad3dbc613f5cdba7c55a816105ede32aa5c3003b81533166a9970b11
after:  bdb251ef25a9034cb6de88f6dadc0b52633df1e15a0ccf8aa826a186c1f8203b
```

#236 documented the disk-cache cost as a one-time recompile (`jit_cache.rs:802-804`). However, the same key is also persisted in `cutile::tune::Record` (#224, released in 0.3.0), where drift causes `load_verified` to refuse the record. Existing version checks cannot soften this: the `cutile_version` warning comes after key verification (`tune.rs:1007` vs. `:996`), both versions are `0.3.0`, and `RECORD_SCHEMA` remains 1.

## What this PR does

This PR stores the key encoding with each digest:

```rust
L2Key::Tagged { schema, digest } | L2Key::Untagged(String)
```

Verification now has three outcomes:

- same schema, same digest: accept;
- same schema, different digest: refuse as drift;
- different or absent schema: warn and skip an incomparable check.

The tag is per key so partially retuned records can safely contain mixed encodings. `#[serde(untagged)]` keeps wire compatibility: a bare-string key written by released 0.3.0 still parses as `Untagged`.

This keeps #236's necessary flags-aware cache identity and preserves strict verification for comparable keys, instead of reverting the key change or globally loosening the loader.

Validation in `cutile-ci:13.3` with an RTX 5080 (`--gpus all`):

- `cargo test -p cutile --features experimental-tune`: 39 test binaries, 0 failures, including both GPU tests;
- `cutile-compiler` library tests: 135 passed;
- `cargo fmt`: clean.

## Open question: `gate`

`Record::gate` says drift is warned (`tune.rs:797`), and `load_verified` lists it under **WARNS** (`tune.rs:951`), but `Workspace` has no gate field and the loader never compares it.

Should I file an issue or send a follow-up PR? The fix is either to implement the check by adding `gate` to `Workspace`, or to correct the docs—depending on whether `gate` was intended to be a verification gate.
