### PR TITLE
fix: compute pointer alignment on the full 64-bit address

### DIFF
--- a/cutile-compiler/src/specialization.rs
+++ b/cutile-compiler/src/specialization.rs
@@ -52,12 +52,18 @@ impl DivHint {
     /// The result is in **bytes**: a divisor of 16 means the pointer is
     /// aligned to a 16-byte boundary. This matches cutile-python's
     /// `base_addr_divisible_by` convention.
+    ///
+    /// The alignment is computed on the full 64-bit address. Narrowing it
+    /// to `i32` first made an address whose low 32 bits are exactly
+    /// `0x8000_0000` (2 GiB-aligned mod 4 GiB) compute a NEGATIVE divisor
+    /// (`i32::MIN`), which the entry generator's `div > 1` guard then
+    /// silently rejected — losing the alignment assumption on a perfectly
+    /// aligned pointer.
     pub fn from_ptr(ptr: u64) -> Self {
-        let raw: i32 = max_pow2_divisor_unclamped(ptr as i32);
-        Self {
-            divisor: raw.min(16),
-            max: 16,
-        }
+        // trailing_zeros(0) = 64; the min(4) clamp makes zero mean "maximally
+        // aligned" (divisor 16 = 2^4), same as from_value's zero case.
+        let divisor = 1i32 << ptr.trailing_zeros().min(4);
+        Self { divisor, max: 16 }
     }
 
     /// Override the maximum clamp. Returns a new `DivHint` with
@@ -104,6 +110,13 @@ pub struct SpecializationBits {
 fn max_pow2_divisor_unclamped(val: i32) -> i32 {
     if val == 0 {
         return 16;
+    }
+    if val == i32::MIN {
+        // The one value whose lowest set bit (2^31) does not fit in a
+        // positive i32: `val & -val` returns i32::MIN itself, and a
+        // negative "divisor" downstream reads as "no divisibility". The
+        // magnitude is divisible by any representable power of two.
+        return 1 << 30;
     }
     val & val.wrapping_neg()
 }

--- a/cutile-compiler/src/specialization_tests.rs
+++ b/cutile-compiler/src/specialization_tests.rs
@@ -285,4 +285,37 @@ mod tests {
             );
         }
     }
+    /// A device address whose low 32 bits are exactly 0x8000_0000 (2 GiB
+    /// mod 4 GiB) is 16-byte aligned by any reading — but the old i32
+    /// narrowing computed divisor = i32::MIN, and the entry generator's
+    /// `div > 1` guard then silently dropped the assume_div_by. The
+    /// alignment must be computed on the full 64-bit address.
+    #[test]
+    fn ptr_at_two_gib_boundary_keeps_its_alignment() {
+        for addr in [
+            0x8000_0000u64,      // exactly the failing bit pattern
+            0x1_8000_0000u64,    // same low bits, high bits set
+            0x7f00_8000_0000u64, // realistic device address shape
+        ] {
+            let hint = DivHint::from_ptr(addr);
+            assert_eq!(
+                hint.divisor, 16,
+                "addr {addr:#x}: 2 GiB-aligned pointer must keep max divisor"
+            );
+        }
+        // Unaffected neighbors stay exact.
+        assert_eq!(DivHint::from_ptr(0x8000_0004).divisor, 4);
+        assert_eq!(DivHint::from_ptr(0x8000_0001).divisor, 1);
+        assert_eq!(DivHint::from_ptr(0).divisor, 16, "zero = maximally aligned");
+    }
+
+    /// The sibling latent case: from_value(i32::MIN) went negative through
+    /// the same `val & -val` identity. Its magnitude is a power of two, so
+    /// it clamps to the max divisor like any highly divisible value.
+    #[test]
+    fn value_divisor_is_never_negative() {
+        assert_eq!(DivHint::from_value(i32::MIN).divisor, 16);
+        assert_eq!(DivHint::from_value(-4).divisor, 4);
+        assert_eq!(DivHint::from_value(-3).divisor, 1);
+    }
 }


### PR DESCRIPTION
`DivHint::from_ptr` narrowed the 64-bit device address to `i32` before computing its power-of-2 alignment. An address whose low 32 bits are exactly `0x8000_0000` (2 GiB mod 4 GiB) narrows to `i32::MIN`, the one value whose lowest set bit does not fit in a positive `i32` — the computed divisor came out negative, and the kernel entry generator's `div > 1` guard then silently skipped the `assume_div_by` emission for a pointer that is in fact 16-byte aligned.

Impact: a missed optimization (lost alignment assumption) plus a spurious extra cache specialization for affected addresses — never a soundness issue, since the guard fails conservative.

`from_ptr` now computes trailing zeros on the full `u64` (zero still means maximally aligned), and the sibling latent case in the `i32` helper (`val == i32::MIN`) is pinned to a positive power of two. Regression tests cover the exact failing bit pattern, high-bit variants, unaffected neighboring addresses, and the negative-value paths.

Reported externally; thank you to Yinuo Liu for the precise diagnosis.
