### PR TITLE
feat: toolkit discovery parity and executed host-crate tests (follow-up to #233)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,10 +85,11 @@ https://developer.nvidia.com/cuda-downloads
 
 ### Configure Environment
 
-Set `CUDA_TOOLKIT_PATH` to your CUDA 13.3 install directory for a reproducible
-setup. If it is unset, cuTile searches standard CUDA 13.3/13.2 install
-locations such as `/usr/local/cuda-13.3`, `/usr/local/cuda-13.2`,
-`/usr/local/cuda-13`, and `/usr/local/cuda`.
+Set `CUDA_TOOLKIT_PATH` (or `CUDA_HOME`, consulted second) to your CUDA 13.3
+install directory for a reproducible setup. If neither is set, cuTile
+searches standard CUDA 13.3/13.2 install locations such as
+`/usr/local/cuda-13.3`, `/usr/local/cuda-13.2`, `/usr/local/cuda-13`, and
+`/usr/local/cuda`.
 
 Example `.cargo/config.toml`:
 ```toml

--- a/cuda-bindings/README.md
+++ b/cuda-bindings/README.md
@@ -6,11 +6,11 @@ This crate is intentionally low level. Most code should depend on `cuda-core` in
 
 # Notes
 
-- The bindings are generated at build time from a CUDA 12.8+ toolkit.
+- The bindings are generated at build time from a CUDA 13.0+ toolkit.
 - The toolkit root is the first set variable among `CUDA_TOOLKIT_PATH` and
   `CUDA_HOME`; when neither is set, the build searches the standard install
   locations (on Linux `/usr/local/cuda-13.3`, `/usr/local/cuda-13.2`,
-  `/usr/local/cuda-13`, `/usr/local/cuda-12`, `/usr/local/cuda`; on Windows
+  `/usr/local/cuda-13`, `/usr/local/cuda`; on Windows
   `C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.3` and `v13.2`).
 - Within the toolkit, both the standard `include/` layout and the
   redistributable `targets/<dir>/include/` layouts (Jetson/Tegra, sbsa,

--- a/cuda-bindings/README.md
+++ b/cuda-bindings/README.md
@@ -6,7 +6,16 @@ This crate is intentionally low level. Most code should depend on `cuda-core` in
 
 # Notes
 
-- The bindings are generated at build time.
-- `CUDA_TOOLKIT_PATH` can point at the local CUDA toolkit installation. If it
-  is unset, the build searches standard CUDA 13.3/13.2 install locations.
+- The bindings are generated at build time from a CUDA 12.8+ toolkit.
+- The toolkit root is the first set variable among `CUDA_TOOLKIT_PATH` and
+  `CUDA_HOME`; when neither is set, the build searches the standard install
+  locations (on Linux `/usr/local/cuda-13.3`, `/usr/local/cuda-13.2`,
+  `/usr/local/cuda-13`, `/usr/local/cuda-12`, `/usr/local/cuda`; on Windows
+  `C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.3` and `v13.2`).
+- Within the toolkit, both the standard `include/` layout and the
+  redistributable `targets/<dir>/include/` layouts (Jetson/Tegra, sbsa,
+  cross-builds, extracted redistributables) are probed for `cuda.h`.
+  `CUDA_TOOLKIT_TARGET_DIR` names one `targets/` directory by hand, like
+  nvcc's `-target-dir` flag; when set, that tree is the only candidate
+  probed.
 - Set `CUTILE_SETUP_DIAGNOSTICS=1` to print CUDA toolkit discovery decisions.

--- a/cuda-bindings/build.rs
+++ b/cuda-bindings/build.rs
@@ -18,7 +18,7 @@ use syn::{
     TypeBareFn,
 };
 
-const MIN_CUDA_VERSION: u32 = 12080;
+const MIN_CUDA_VERSION: u32 = 13000;
 /// Environment variables consulted (in order) to locate the CUDA toolkit
 /// root. `CUDA_HOME` is the conventional name used by nvcc wrappers and CI
 /// images.
@@ -148,7 +148,7 @@ fn resolve_cuda_toolkit() -> Result<ResolvedToolkit, Box<dyn Error>> {
         };
         if value.is_empty() {
             return Err(format!(
-                "{var} is set to an empty string. Set it to a CUDA 12.8+ toolkit directory."
+                "{var} is set to an empty string. Set it to a CUDA 13.0+ toolkit directory."
             )
             .into());
         }
@@ -198,7 +198,7 @@ fn find_default_cuda_toolkit() -> Result<ResolvedToolkit, Box<dyn Error>> {
     }
 
     Err(format!(
-        "Neither CUDA_TOOLKIT_PATH nor CUDA_HOME is set, and no CUDA 12.8+ toolkit was found in default locations:\n{}\nSet CUDA_TOOLKIT_PATH or CUDA_HOME to a CUDA 12.8+ toolkit directory.",
+        "Neither CUDA_TOOLKIT_PATH nor CUDA_HOME is set, and no CUDA 13.0+ toolkit was found in default locations:\n{}\nSet CUDA_TOOLKIT_PATH or CUDA_HOME to a CUDA 13.0+ toolkit directory.",
         rejected.join("\n")
     )
     .into())
@@ -233,7 +233,6 @@ fn default_cuda_toolkit_candidates() -> &'static [PathBuf] {
             "/usr/local/cuda-13.3",
             "/usr/local/cuda-13.2",
             "/usr/local/cuda-13",
-            "/usr/local/cuda-12",
             "/usr/local/cuda",
         ];
 
@@ -268,7 +267,7 @@ fn validate_cuda_toolkit(cuda_toolkit: &Path) -> Result<(u32, PathBuf), String> 
     let version = cuda_version_from_header(&cuda_h).map_err(|error| error.to_string())?;
     if version < MIN_CUDA_VERSION {
         return Err(format!(
-            "CUDA toolkit {} is too old. The CUDA host-side crates require CUDA 12.8+ (the Tile compiler needs 13.2+)",
+            "CUDA toolkit {} is too old. The CUDA host-side crates require CUDA 13.0+ (the Tile compiler needs 13.2+)",
             format_cuda_version(version)
         ));
     }
@@ -289,7 +288,7 @@ fn cuda_version_from_header(cuda_h: &Path) -> Result<u32, Box<dyn Error>> {
         })
         .ok_or_else(|| {
             format!(
-                "could not find CUDA_VERSION in {}. Set CUDA_TOOLKIT_PATH or CUDA_HOME to a CUDA 12.8+ toolkit directory.",
+                "could not find CUDA_VERSION in {}. Set CUDA_TOOLKIT_PATH or CUDA_HOME to a CUDA 13.0+ toolkit directory.",
                 cuda_h.display()
             )
             .into()

--- a/cuda-bindings/build.rs
+++ b/cuda-bindings/build.rs
@@ -18,9 +18,24 @@ use syn::{
     TypeBareFn,
 };
 
-const MIN_CUDA_VERSION: u32 = 13000;
-const CUDA_TOOLKIT_PATH_ENV: &str = "CUDA_TOOLKIT_PATH";
+const MIN_CUDA_VERSION: u32 = 12080;
+/// Environment variables consulted (in order) to locate the CUDA toolkit
+/// root. `CUDA_HOME` is the conventional name used by nvcc wrappers and CI
+/// images.
+const TOOLKIT_ENV_VARS: [&str; 2] = ["CUDA_TOOLKIT_PATH", "CUDA_HOME"];
 const SETUP_DIAGNOSTICS_ENV: &str = "CUTILE_SETUP_DIAGNOSTICS";
+
+/// Environment variable naming the CUDA `targets/<dir>` tree to use,
+/// overriding the arch+OS table in `toolkit_target.rs`. The value is a
+/// directory name under `{toolkit}/targets/` (e.g. `aarch64-linux`), the
+/// same value nvcc's `-target-dir` flag takes; CMake exposes the equivalent
+/// selection as `CUDAToolkit_TARGET_DIR`. When set, the named tree is the
+/// only include candidate: the top-level `include/` (on standard installs a
+/// symlink to the host architecture's `targets/` tree) is not consulted, so
+/// a cross-build cannot silently bind the host's headers. The directory is
+/// still probed for `cuda.h`, so a wrong value fails with the clear
+/// discovery error instead of silently falling back.
+const TOOLKIT_TARGET_DIR_ENV: &str = "CUDA_TOOLKIT_TARGET_DIR";
 
 struct ApiSpec {
     virtual_header: &'static str,
@@ -76,12 +91,20 @@ fn main() {
 
 fn run() -> Result<(), Box<dyn Error>> {
     println!("cargo:rerun-if-changed=wrapper.h");
-    println!("cargo:rerun-if-env-changed={CUDA_TOOLKIT_PATH_ENV}");
+    // Emitting any rerun-if-changed disables cargo's default "rerun on any
+    // package change", so the `include!`d selection table needs naming.
+    println!("cargo:rerun-if-changed=toolkit_target.rs");
+    for var in TOOLKIT_ENV_VARS {
+        println!("cargo:rerun-if-env-changed={var}");
+    }
+    println!("cargo:rerun-if-env-changed={TOOLKIT_TARGET_DIR_ENV}");
     println!("cargo:rerun-if-env-changed={SETUP_DIAGNOSTICS_ENV}");
 
-    let cuda_toolkit = resolve_cuda_toolkit()?;
-    let cuda_toolkit = cuda_toolkit.to_string_lossy().into_owned();
-    println!("cargo:rustc-env=CUTILE_RESOLVED_CUDA_TOOLKIT_PATH={cuda_toolkit}");
+    let toolkit = resolve_cuda_toolkit()?;
+    println!(
+        "cargo:rustc-env=CUTILE_RESOLVED_CUDA_TOOLKIT_PATH={}",
+        toolkit.root.display()
+    );
 
     // CUDA 12.8 renamed the event elapsed-time entry point to
     // cuEventElapsedTime_v2; earlier toolkits only declare
@@ -89,9 +112,7 @@ fn run() -> Result<(), Box<dyn Error>> {
     // dispatch to whichever symbol this build's toolkit declares.
     println!("cargo::rustc-check-cfg=cfg(cuda_has_cuEventElapsedTime_v2)");
     println!("cargo::rustc-check-cfg=cfg(cuda_has_cuLaunchHostFunc_v2)");
-    let resolved_cuda_h = std::path::Path::new(&cuda_toolkit)
-        .join("include")
-        .join("cuda.h");
+    let resolved_cuda_h = toolkit.include_dir.join("cuda.h");
     if let Ok(header) = fs::read_to_string(&resolved_cuda_h) {
         if header.contains("cuEventElapsedTime_v2") {
             println!("cargo:rustc-cfg=cuda_has_cuEventElapsedTime_v2");
@@ -103,68 +124,100 @@ fn run() -> Result<(), Box<dyn Error>> {
     let out_dir = env::var("OUT_DIR")?;
     let out_dir = Path::new(&out_dir);
 
-    generate_type_bindings(&cuda_toolkit, out_dir)?;
+    generate_type_bindings(&toolkit, out_dir)?;
     for spec in API_SPECS {
-        generate_dynamic_api(&cuda_toolkit, out_dir, spec)?;
+        generate_dynamic_api(&toolkit, out_dir, spec)?;
     }
 
     Ok(())
 }
 
-fn resolve_cuda_toolkit() -> Result<PathBuf, Box<dyn Error>> {
-    match env::var_os(CUDA_TOOLKIT_PATH_ENV) {
-        Some(value) if value.is_empty() => Err(format!(
-            "{CUDA_TOOLKIT_PATH_ENV} is set to an empty string. Set it to a CUDA 13.0+ toolkit directory."
-        )
-        .into()),
-        Some(value) => resolve_explicit_cuda_toolkit(value),
-        None => find_default_cuda_toolkit(),
-    }
+/// A validated CUDA toolkit: its install root and the include directory that
+/// actually contains `cuda.h` (`{root}/include` for standard installs,
+/// `{root}/targets/<dir>/include` for redistributable and Tegra/sbsa layouts
+/// that ship no top-level `include/`).
+struct ResolvedToolkit {
+    root: PathBuf,
+    include_dir: PathBuf,
 }
 
-fn resolve_explicit_cuda_toolkit(value: OsString) -> Result<PathBuf, Box<dyn Error>> {
-    let cuda_toolkit = PathBuf::from(value);
-    let version = validate_cuda_toolkit(&cuda_toolkit).map_err(|error| {
-        format!(
-            "{CUDA_TOOLKIT_PATH_ENV}={} is invalid: {error}",
-            cuda_toolkit.display()
-        )
-    })?;
+fn resolve_cuda_toolkit() -> Result<ResolvedToolkit, Box<dyn Error>> {
+    for var in TOOLKIT_ENV_VARS {
+        let Some(value) = env::var_os(var) else {
+            continue;
+        };
+        if value.is_empty() {
+            return Err(format!(
+                "{var} is set to an empty string. Set it to a CUDA 12.8+ toolkit directory."
+            )
+            .into());
+        }
+        return resolve_explicit_cuda_toolkit(var, value);
+    }
+    find_default_cuda_toolkit()
+}
+
+fn resolve_explicit_cuda_toolkit(
+    var: &str,
+    value: OsString,
+) -> Result<ResolvedToolkit, Box<dyn Error>> {
+    let root = PathBuf::from(value);
+    let (version, include_dir) = validate_cuda_toolkit(&root)
+        .map_err(|error| format!("{var}={} is invalid: {error}", root.display()))?;
     emit_setup_diagnostic(format_args!(
-        "using {CUDA_TOOLKIT_PATH_ENV}={} (CUDA {})",
-        cuda_toolkit.display(),
+        "using {var}={} (CUDA {})",
+        root.display(),
         format_cuda_version(version)
     ));
-    Ok(cuda_toolkit)
+    Ok(ResolvedToolkit { root, include_dir })
 }
 
-fn find_default_cuda_toolkit() -> Result<PathBuf, Box<dyn Error>> {
+fn find_default_cuda_toolkit() -> Result<ResolvedToolkit, Box<dyn Error>> {
     let mut rejected = Vec::new();
-    for cuda_toolkit in default_cuda_toolkit_candidates() {
-        match validate_cuda_toolkit(cuda_toolkit) {
-            Ok(version) => {
+    for root in default_cuda_toolkit_candidates() {
+        match validate_cuda_toolkit(root) {
+            Ok((version, include_dir)) => {
                 emit_setup_diagnostic(format_args!(
-                    "{CUDA_TOOLKIT_PATH_ENV} is unset; using discovered CUDA toolkit {} (CUDA {})",
-                    cuda_toolkit.display(),
+                    "CUDA_TOOLKIT_PATH/CUDA_HOME are unset; using discovered CUDA toolkit {} (CUDA {})",
+                    root.display(),
                     format_cuda_version(version)
                 ));
-                return Ok(cuda_toolkit.to_path_buf());
+                return Ok(ResolvedToolkit {
+                    root: root.clone(),
+                    include_dir,
+                });
             }
             Err(error) => {
                 emit_setup_diagnostic(format_args!(
-                    "{CUDA_TOOLKIT_PATH_ENV} is unset; skipping {}: {error}",
-                    cuda_toolkit.display()
+                    "CUDA_TOOLKIT_PATH/CUDA_HOME are unset; skipping {}: {error}",
+                    root.display()
                 ));
-                rejected.push(format!("  - {}: {error}", cuda_toolkit.display()));
+                rejected.push(format!("  - {}: {error}", root.display()));
             }
         }
     }
 
     Err(format!(
-        "{CUDA_TOOLKIT_PATH_ENV} is not set, and no CUDA 13.0+ toolkit was found in default locations:\n{}\nSet {CUDA_TOOLKIT_PATH_ENV} to a CUDA 13.0+ toolkit directory.",
+        "Neither CUDA_TOOLKIT_PATH nor CUDA_HOME is set, and no CUDA 12.8+ toolkit was found in default locations:\n{}\nSet CUDA_TOOLKIT_PATH or CUDA_HOME to a CUDA 12.8+ toolkit directory.",
         rejected.join("\n")
     )
     .into())
+}
+
+// The `targets/<dir>` selection table, shared verbatim with
+// `tests/toolkit_target.rs` so it can be unit tested.
+include!("toolkit_target.rs");
+
+/// [`resolve_toolkit_include_candidates`] for the target cargo is building
+/// for: the [`TOOLKIT_TARGET_DIR_ENV`] override when set, otherwise the
+/// table candidates for `CARGO_CFG_TARGET_ARCH` / `CARGO_CFG_TARGET_OS`.
+/// Just the plain `{toolkit}/include` when the override is absent and
+/// either cfg is unset, which keeps discovery from guessing.
+fn build_include_candidates(toolkit: &Path) -> Vec<PathBuf> {
+    let override_dir = env::var(TOOLKIT_TARGET_DIR_ENV).ok();
+    let arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
+    let os = env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    resolve_toolkit_include_candidates(toolkit, override_dir.as_deref(), &arch, &os)
 }
 
 fn default_cuda_toolkit_candidates() -> &'static [PathBuf] {
@@ -188,28 +241,39 @@ fn default_cuda_toolkit_candidates() -> &'static [PathBuf] {
     })
 }
 
-fn validate_cuda_toolkit(cuda_toolkit: &Path) -> Result<u32, String> {
+/// Validates a toolkit root: probes the standard `include/` and the
+/// `targets/<dir>/include/` layouts for `cuda.h` (only the directories
+/// [`build_include_candidates`] yields for the build target's own
+/// architecture, never all of `targets/*`), then checks the version floor.
+/// Returns the version and the include directory that contains `cuda.h`.
+fn validate_cuda_toolkit(cuda_toolkit: &Path) -> Result<(u32, PathBuf), String> {
     if !cuda_toolkit.is_dir() {
         return Err(format!("{} is not a directory", cuda_toolkit.display()));
     }
 
-    let cuda_h = cuda_toolkit.join("include").join("cuda.h");
-    if !cuda_h.is_file() {
+    let candidates = build_include_candidates(cuda_toolkit);
+    let Some(include_dir) = select_include_dir(&candidates) else {
+        let probed: Vec<String> = candidates
+            .iter()
+            .map(|dir| format!("    {}", dir.join("cuda.h").display()))
+            .collect();
         return Err(format!(
-            "{} does not contain include/cuda.h",
+            "{} does not contain cuda.h. Probed:\n{}",
             cuda_toolkit.display(),
+            probed.join("\n")
         ));
-    }
+    };
 
+    let cuda_h = include_dir.join("cuda.h");
     let version = cuda_version_from_header(&cuda_h).map_err(|error| error.to_string())?;
     if version < MIN_CUDA_VERSION {
         return Err(format!(
-            "CUDA toolkit {} is too old. The CUDA host-side crates require CUDA 13.0+ (the Tile compiler needs 13.2+)",
+            "CUDA toolkit {} is too old. The CUDA host-side crates require CUDA 12.8+ (the Tile compiler needs 13.2+)",
             format_cuda_version(version)
         ));
     }
 
-    Ok(version)
+    Ok((version, include_dir.clone()))
 }
 
 fn cuda_version_from_header(cuda_h: &Path) -> Result<u32, Box<dyn Error>> {
@@ -225,7 +289,7 @@ fn cuda_version_from_header(cuda_h: &Path) -> Result<u32, Box<dyn Error>> {
         })
         .ok_or_else(|| {
             format!(
-                "could not find CUDA_VERSION in {}. Set CUDA_TOOLKIT_PATH to a CUDA 13.0+ toolkit directory.",
+                "could not find CUDA_VERSION in {}. Set CUDA_TOOLKIT_PATH or CUDA_HOME to a CUDA 12.8+ toolkit directory.",
                 cuda_h.display()
             )
             .into()
@@ -253,8 +317,8 @@ fn emit_setup_diagnostic(args: std::fmt::Arguments<'_>) {
     }
 }
 
-fn generate_type_bindings(cuda_toolkit: &str, out_dir: &Path) -> Result<(), Box<dyn Error>> {
-    let bindings = bindgen_builder(cuda_toolkit)
+fn generate_type_bindings(toolkit: &ResolvedToolkit, out_dir: &Path) -> Result<(), Box<dyn Error>> {
+    let bindings = bindgen_builder(toolkit)
         .header("wrapper.h")
         .blocklist_function(".*")
         .generate()?;
@@ -292,11 +356,11 @@ fn cu_mem_location_uses_anon_union(generated_source: &str) -> bool {
 }
 
 fn generate_dynamic_api(
-    cuda_toolkit: &str,
+    toolkit: &ResolvedToolkit,
     out_dir: &Path,
     spec: &ApiSpec,
 ) -> Result<(), Box<dyn Error>> {
-    let bindings = bindgen_builder(cuda_toolkit)
+    let bindings = bindgen_builder(toolkit)
         .header_contents(spec.virtual_header, spec.header_contents)
         .dynamic_library_name(spec.library_name)
         .dynamic_link_require_all(false)
@@ -310,9 +374,9 @@ fn generate_dynamic_api(
     Ok(())
 }
 
-fn bindgen_builder(cuda_toolkit: &str) -> bindgen::Builder {
+fn bindgen_builder(toolkit: &ResolvedToolkit) -> bindgen::Builder {
     bindgen::builder()
-        .clang_arg(format!("-I{cuda_toolkit}/include"))
+        .clang_arg(format!("-I{}", toolkit.include_dir.display()))
         .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
 }
 

--- a/cuda-bindings/tests/toolkit_target.rs
+++ b/cuda-bindings/tests/toolkit_target.rs
@@ -1,0 +1,218 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Coverage for the build script's CUDA `targets/<dir>` selection table.
+//!
+//! `build.rs` pulls in the same file with `include!`, because cargo never
+//! builds a build script as a test target.
+
+include!("../toolkit_target.rs");
+
+/// `(target_arch, target_os, expected candidates)`.
+const CASES: &[(&str, &str, &[&str])] = &[
+    // x86_64 Linux: the one server layout.
+    ("x86_64", "linux", &["x86_64-linux"]),
+    // aarch64 Linux is ambiguous between server and Tegra, so both are
+    // offered. `sbsa-linux` stays first so an install that carries both
+    // trees resolves to the server directory.
+    ("aarch64", "linux", &["sbsa-linux", "aarch64-linux"]),
+    // Non-Linux hosts have no `targets/` tree at all. An arch-only check
+    // would fall through and claim a Linux directory: `aarch64-apple-darwin`
+    // would resolve to `sbsa-linux` and `x86_64-pc-windows-msvc` to
+    // `x86_64-linux`.
+    ("aarch64", "macos", &[]),
+    ("x86_64", "macos", &[]),
+    ("x86_64", "windows", &[]),
+    ("aarch64", "windows", &[]),
+    // `aarch64-linux-android` splits into components containing "linux" but
+    // is not a CUDA platform; keying off `CARGO_CFG_TARGET_OS` rejects it.
+    ("aarch64", "android", &[]),
+    // Architectures CUDA does not ship.
+    ("riscv64", "linux", &[]),
+    ("powerpc64le", "linux", &[]),
+    ("", "", &[]),
+];
+
+#[test]
+fn toolkit_target_dirs_matches_table() {
+    for &(arch, os, expected) in CASES {
+        assert_eq!(
+            toolkit_target_dirs(arch, os),
+            expected,
+            "unexpected targets/ candidates for arch={arch:?} os={os:?}"
+        );
+    }
+}
+
+#[test]
+fn every_candidate_is_a_linux_directory_for_its_own_arch() {
+    // The property a naive `targets/*` glob breaks: a candidate must never
+    // belong to another architecture, or a multi-target install hands the
+    // build the wrong headers.
+    for &(arch, os, expected) in CASES {
+        for dir in expected {
+            assert!(
+                dir.ends_with("-linux"),
+                "candidate {dir:?} for arch={arch:?} os={os:?} is not a Linux tree"
+            );
+            let owner_arch = dir.trim_end_matches("-linux");
+            assert!(
+                owner_arch == arch || (arch == "aarch64" && owner_arch == "sbsa"),
+                "candidate {dir:?} belongs to {owner_arch:?}, not arch={arch:?}"
+            );
+        }
+    }
+}
+
+/// Builds a throwaway toolkit tree containing a `cuda.h` at each given
+/// relative directory, and returns its root. No temp-dir crate: this package
+/// takes no new dependencies.
+fn fake_toolkit(tag: &str, include_dirs: &[&str]) -> std::path::PathBuf {
+    let root = std::env::temp_dir().join(format!(
+        "cuda-bindings-toolkit-{tag}-{}-{:?}",
+        std::process::id(),
+        std::thread::current().id()
+    ));
+    let _ = std::fs::remove_dir_all(&root);
+    for dir in include_dirs {
+        let full = root.join(dir);
+        std::fs::create_dir_all(&full).expect("create fake toolkit dir");
+        std::fs::write(full.join("cuda.h"), b"/* fake */\n").expect("write fake cuda.h");
+    }
+    root
+}
+
+#[test]
+fn tegra_layout_resolves_to_aarch64_linux() {
+    // The layout this table exists for: CUDA for Tegra ships only
+    // `targets/aarch64-linux/`, and no top-level `include/`.
+    let root = fake_toolkit("tegra", &["targets/aarch64-linux/include"]);
+    let candidates = resolve_toolkit_include_candidates(&root, None, "aarch64", "linux");
+    let selected = select_include_dir(&candidates).expect("Tegra layout must resolve");
+    assert_eq!(selected, &root.join("targets/aarch64-linux/include"));
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn sbsa_layout_still_resolves_to_sbsa_linux() {
+    let root = fake_toolkit("sbsa", &["targets/sbsa-linux/include"]);
+    let candidates = resolve_toolkit_include_candidates(&root, None, "aarch64", "linux");
+    let selected = select_include_dir(&candidates).expect("sbsa layout must resolve");
+    assert_eq!(selected, &root.join("targets/sbsa-linux/include"));
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn multi_target_install_never_hands_x86_64_the_sbsa_headers() {
+    // The failure mode that rules out a `targets/*` glob: `sbsa-linux` sorts
+    // before `x86_64-linux`.
+    let root = fake_toolkit(
+        "multi",
+        &[
+            "targets/sbsa-linux/include",
+            "targets/x86_64-linux/include",
+            "targets/aarch64-linux/include",
+        ],
+    );
+    let candidates = resolve_toolkit_include_candidates(&root, None, "x86_64", "linux");
+    let selected = select_include_dir(&candidates).expect("x86_64 layout must resolve");
+    assert_eq!(selected, &root.join("targets/x86_64-linux/include"));
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn top_level_include_wins_over_any_targets_tree() {
+    let root = fake_toolkit("standard", &["include", "targets/x86_64-linux/include"]);
+    let candidates = resolve_toolkit_include_candidates(&root, None, "x86_64", "linux");
+    let selected = select_include_dir(&candidates).expect("standard layout must resolve");
+    assert_eq!(selected, &root.join("include"));
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn env_override_is_the_sole_include_candidate() {
+    // CUDA_TOOLKIT_TARGET_DIR names one tree by hand, like nvcc's
+    // `-target-dir`: neither the table's candidates nor the top-level
+    // `include/` are consulted at all.
+    let root = fake_toolkit(
+        "override",
+        &[
+            "targets/sbsa-linux/include",
+            "targets/aarch64-linux/include",
+        ],
+    );
+    let candidates =
+        resolve_toolkit_include_candidates(&root, Some("aarch64-linux"), "aarch64", "linux");
+    assert_eq!(candidates, vec![root.join("targets/aarch64-linux/include")]);
+    let selected = select_include_dir(&candidates).expect("override layout must resolve");
+    assert_eq!(selected, &root.join("targets/aarch64-linux/include"));
+    let _ = std::fs::remove_dir_all(&root);
+
+    // A blank override means "unset": the table decides, as before.
+    for blank in [None, Some(""), Some("  ")] {
+        assert_eq!(
+            resolve_toolkit_include_candidates(&root, blank, "aarch64", "linux"),
+            vec![
+                root.join("include"),
+                root.join("targets/sbsa-linux/include"),
+                root.join("targets/aarch64-linux/include"),
+            ],
+            "blank override {blank:?} must fall back to the table"
+        );
+    }
+}
+
+#[test]
+fn env_override_beats_the_top_level_include() {
+    // On a standard install, `include/` is (usually a symlink to) the host
+    // architecture's `targets/` tree. A cross-build override must not let it
+    // shadow the requested tree.
+    let root = fake_toolkit("override-cross", &["include", "targets/sbsa-linux/include"]);
+    let candidates =
+        resolve_toolkit_include_candidates(&root, Some("sbsa-linux"), "x86_64", "linux");
+    assert_eq!(candidates, vec![root.join("targets/sbsa-linux/include")]);
+    let selected = select_include_dir(&candidates).expect("override must resolve");
+    assert_eq!(selected, &root.join("targets/sbsa-linux/include"));
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn wrong_env_override_fails_instead_of_falling_back() {
+    // The override is existence-probed, not trusted: a typo must surface as
+    // the "does not contain cuda.h" error listing what was probed, never as
+    // a silent fallback to the top-level include or another architecture's
+    // tree, even on a standard install where `include/` exists.
+    let root = fake_toolkit("override-bad", &["include", "targets/sbsa-linux/include"]);
+    let candidates =
+        resolve_toolkit_include_candidates(&root, Some("aarch64-qnx"), "aarch64", "linux");
+    assert_eq!(candidates, vec![root.join("targets/aarch64-qnx/include")]);
+    assert!(
+        select_include_dir(&candidates).is_none(),
+        "a wrong override must not resolve the top-level or sbsa-linux headers"
+    );
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn non_linux_probes_only_the_top_level_include() {
+    let root = fake_toolkit("darwin", &["targets/sbsa-linux/include"]);
+    let candidates = resolve_toolkit_include_candidates(&root, None, "aarch64", "macos");
+    assert_eq!(candidates, vec![root.join("include")]);
+    assert!(
+        select_include_dir(&candidates).is_none(),
+        "a macOS build must not resolve the sbsa-linux headers"
+    );
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn non_linux_never_resolves_a_target_dir() {
+    for os in ["macos", "windows", "android", "ios", "freebsd", "none"] {
+        for arch in ["x86_64", "aarch64", "riscv64"] {
+            assert!(
+                toolkit_target_dirs(arch, os).is_empty(),
+                "arch={arch:?} os={os:?} must not resolve a targets/ directory"
+            );
+        }
+    }
+}

--- a/cuda-bindings/toolkit_target.rs
+++ b/cuda-bindings/toolkit_target.rs
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Selection of the CUDA toolkit `targets/<dir>` tree for a build target.
+//
+// Regular `//` comments, not `//!`: this file is pulled in with `include!`
+// from both `build.rs` and `tests/toolkit_target.rs`, and an inner doc
+// comment is only legal at the top of a real module. Cargo never builds a
+// build script as a test target, so sharing the source this way is what lets
+// the table below be covered by `cargo test` rather than only by whichever
+// machine happens to run the build.
+
+/// CUDA toolkit `targets/` directory names to probe for a build target, most
+/// specific first. Empty when CUDA ships no `targets/` tree for that platform.
+///
+/// `target_arch` and `target_os` are cargo's `CARGO_CFG_TARGET_ARCH` and
+/// `CARGO_CFG_TARGET_OS` for the *build target*, not the host. Those two are
+/// used rather than splitting the `TARGET` triple because the triple's field
+/// count varies (`arch-vendor-os-env` vs `arch-os-env`) and because
+/// `aarch64-linux-android` would otherwise look like a Linux target.
+///
+/// CUDA names these trees after the GPU platform, not the Rust triple:
+///
+/// | platform | directory |
+/// |---|---|
+/// | x86_64 Linux | `x86_64-linux` |
+/// | aarch64 Linux, server (Grace, Ampere Altra) | `sbsa-linux` |
+/// | aarch64 Linux, Tegra (Jetson, Drive) | `aarch64-linux` |
+///
+/// aarch64 returns both server and Tegra names because a Rust aarch64 Linux
+/// triple does not distinguish them -- Jetson builds natively as
+/// `aarch64-unknown-linux-gnu`, exactly like a Grace server. The callers probe
+/// these in order and take the first that actually contains `cuda.h`, so a
+/// single-target install resolves unambiguously either way. `sbsa-linux` is
+/// listed first so that an install carrying both trees resolves to the server
+/// directory.
+///
+/// This is deliberately *not* a glob over `targets/*`: on a multi-target
+/// install that would let another architecture's headers and stubs shadow the
+/// right ones, because `sbsa-linux` sorts before `x86_64-linux`. Every
+/// candidate returned here is for the requested architecture only.
+fn toolkit_target_dirs(target_arch: &str, target_os: &str) -> &'static [&'static str] {
+    if target_os != "linux" {
+        return &[];
+    }
+    match target_arch {
+        "x86_64" => &["x86_64-linux"],
+        "aarch64" => &["sbsa-linux", "aarch64-linux"],
+        _ => &[],
+    }
+}
+
+/// Include directories to probe for `cuda.h`, in priority order.
+///
+/// When `override_dir` carries a non-blank `CUDA_TOOLKIT_TARGET_DIR` value,
+/// that names one `targets/` tree by hand, like nvcc's `-target-dir` flag,
+/// and `{toolkit}/targets/<override>/include` is the *only* candidate: the
+/// standard top-level `include/` is deliberately not consulted, because on
+/// standard installs it exists (usually as a symlink to the host
+/// architecture's `targets/` tree) and would silently shadow the requested
+/// tree on every cross-build. The override is not existence-checked either;
+/// a wrong value fails with the clear discovery error listing what was
+/// probed, never a silent fallback.
+///
+/// Without an override, the standard top-level `{toolkit}/include` comes
+/// first, then `{toolkit}/targets/<dir>/include` for each table candidate
+/// from [`toolkit_target_dirs`].
+///
+/// Fully-qualified `std::path` types, because `build.rs` already imports
+/// `Path` and `PathBuf` and this file is `include!`d into it.
+fn resolve_toolkit_include_candidates(
+    toolkit: &std::path::Path,
+    override_dir: Option<&str>,
+    target_arch: &str,
+    target_os: &str,
+) -> Vec<std::path::PathBuf> {
+    match override_dir.filter(|dir| !dir.trim().is_empty()) {
+        Some(dir) => vec![toolkit.join("targets").join(dir).join("include")],
+        None => {
+            let mut candidates = vec![toolkit.join("include")];
+            for target_dir in toolkit_target_dirs(target_arch, target_os) {
+                candidates.push(toolkit.join("targets").join(target_dir).join("include"));
+            }
+            candidates
+        }
+    }
+}
+
+/// The first candidate that actually contains `cuda.h`.
+fn select_include_dir(candidates: &[std::path::PathBuf]) -> Option<&std::path::PathBuf> {
+    candidates.iter().find(|dir| dir.join("cuda.h").is_file())
+}

--- a/cuda-core/build.rs
+++ b/cuda-core/build.rs
@@ -14,7 +14,7 @@
 //!
 //! Toolkit discovery matches `cuda-bindings/build.rs`: the first set
 //! variable among `CUDA_TOOLKIT_PATH` and `CUDA_HOME`, else the same
-//! default candidate list with the same CUDA 12.8 floor, with both the
+//! default candidate list with the same CUDA 13.0 floor, with both the
 //! standard `include/` and the redistributable `targets/<dir>/include/`
 //! layouts probed (a non-blank `CUDA_TOOLKIT_TARGET_DIR` names the single
 //! `targets/` tree to probe). A missing or unreadable `cuda.h` leaves the
@@ -46,10 +46,9 @@ const DEFAULT_TOOLKIT_DIRS: &[&str] = &[
     "/usr/local/cuda-13.3",
     "/usr/local/cuda-13.2",
     "/usr/local/cuda-13",
-    "/usr/local/cuda-12",
     "/usr/local/cuda",
 ];
-const MIN_CUDA_VERSION: u32 = 12080;
+const MIN_CUDA_VERSION: u32 = 13000;
 
 fn main() {
     println!("cargo::rustc-check-cfg=cfg(cuda_has_multicast)");

--- a/cuda-core/build.rs
+++ b/cuda-core/build.rs
@@ -13,22 +13,43 @@
 //! `cuda_has_cuEventElapsedTime_v2` probe in `cuda-bindings`.
 //!
 //! Toolkit discovery matches `cuda-bindings/build.rs`: the first set
-//! variable among `CUDA_TOOLKIT_PATH` and `CUDA_HOME`, else
-//! `/usr/local/cuda`, with both the standard `include/` and the
-//! redistributable `targets/<dir>/include/` layouts probed. A missing or
-//! unreadable `cuda.h` leaves the cfg unset (multicast unavailable) rather
-//! than erroring; `cuda-bindings` reports the authoritative failure for a
-//! genuinely broken toolkit.
+//! variable among `CUDA_TOOLKIT_PATH` and `CUDA_HOME`, else the same
+//! default candidate list with the same CUDA 12.8 floor, with both the
+//! standard `include/` and the redistributable `targets/<dir>/include/`
+//! layouts probed (a non-blank `CUDA_TOOLKIT_TARGET_DIR` names the single
+//! `targets/` tree to probe). A missing or unreadable `cuda.h` leaves the
+//! cfg unset (multicast unavailable) rather than erroring; `cuda-bindings`
+//! reports the authoritative failure for a genuinely broken toolkit.
 
 use std::env;
 use std::path::{Path, PathBuf};
 
 const TOOLKIT_ENV_VARS: &[&str] = &["CUDA_TOOLKIT_PATH", "CUDA_HOME"];
-const DEFAULT_TOOLKIT_DIR: &str = "/usr/local/cuda";
 
 /// Overrides the `targets/<dir>` selection with a single directory name,
 /// like nvcc's `-target-dir`; matches `cuda-bindings`.
 const TOOLKIT_TARGET_DIR_ENV: &str = "CUDA_TOOLKIT_TARGET_DIR";
+
+/// The default toolkit roots and version floor, matching
+/// `cuda-bindings/build.rs` (`default_cuda_toolkit_candidates`,
+/// `MIN_CUDA_VERSION`): a versioned-only install (no `/usr/local/cuda`
+/// symlink), or a symlink pointing at a below-floor tree, must resolve to
+/// the same toolkit here as it does there, or this probe reads a different
+/// `cuda.h` than the one the bindings were generated from.
+#[cfg(windows)]
+const DEFAULT_TOOLKIT_DIRS: &[&str] = &[
+    r"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.3",
+    r"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.2",
+];
+#[cfg(not(windows))]
+const DEFAULT_TOOLKIT_DIRS: &[&str] = &[
+    "/usr/local/cuda-13.3",
+    "/usr/local/cuda-13.2",
+    "/usr/local/cuda-13",
+    "/usr/local/cuda-12",
+    "/usr/local/cuda",
+];
+const MIN_CUDA_VERSION: u32 = 12080;
 
 fn main() {
     println!("cargo::rustc-check-cfg=cfg(cuda_has_multicast)");
@@ -50,20 +71,13 @@ fn main() {
 /// target, most specific first.
 ///
 /// Kept in lockstep BY HAND with the selection table in
-/// `crates/cuda-bindings/toolkit_target.rs` (`resolve_toolkit_target_dirs`):
+/// `cuda-bindings/toolkit_target.rs` (`resolve_toolkit_include_candidates`):
 /// build scripts cannot import each other's sources across crates. If the
 /// selection there changes, mirror it here. CUDA names these layouts after
 /// the GPU platform, not the Rust triple, and an aarch64 Linux triple is
 /// ambiguous between servers (`sbsa-linux`) and Tegra (`aarch64-linux`), so
-/// both are probed in that order. A non-blank [`TOOLKIT_TARGET_DIR_ENV`]
-/// replaces the table with that single directory.
+/// both are probed in that order.
 fn toolkit_target_dirs() -> Vec<String> {
-    if let Some(dir) = env::var(TOOLKIT_TARGET_DIR_ENV)
-        .ok()
-        .filter(|dir| !dir.trim().is_empty())
-    {
-        return vec![dir];
-    }
     let arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
     let os = env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
     if os != "linux" {
@@ -76,20 +90,57 @@ fn toolkit_target_dirs() -> Vec<String> {
     }
 }
 
-/// Returns the path of `cuda.h`: `{toolkit}/include` for standard installs,
-/// or `{toolkit}/targets/<dir>/include` for redistributable layouts.
-fn find_cuda_header() -> Option<PathBuf> {
-    let toolkit = TOOLKIT_ENV_VARS
-        .iter()
-        .find_map(|var| env::var(var).ok())
-        .unwrap_or_else(|| DEFAULT_TOOLKIT_DIR.to_string());
-    let base = Path::new(&toolkit);
-    let mut candidates = vec![base.join("include")];
+/// The include directories to probe for `cuda.h` under one toolkit root. A
+/// non-blank [`TOOLKIT_TARGET_DIR_ENV`] names the single `targets/` tree to
+/// probe (the top-level `include/` is not consulted, so a cross-build
+/// cannot silently bind the host's headers); otherwise the standard
+/// `include/` comes first, then the table's `targets/<dir>/include`
+/// candidates. Matches `cuda-bindings`.
+fn include_candidates(toolkit: &Path) -> Vec<PathBuf> {
+    if let Some(dir) = env::var(TOOLKIT_TARGET_DIR_ENV)
+        .ok()
+        .filter(|dir| !dir.trim().is_empty())
+    {
+        return vec![toolkit.join("targets").join(dir).join("include")];
+    }
+    let mut candidates = vec![toolkit.join("include")];
     for target_dir in toolkit_target_dirs() {
-        candidates.push(base.join("targets").join(target_dir).join("include"));
+        candidates.push(toolkit.join("targets").join(target_dir).join("include"));
     }
     candidates
+}
+
+/// The first include candidate under `toolkit` that contains `cuda.h`.
+fn find_cuda_header_in(toolkit: &Path) -> Option<PathBuf> {
+    include_candidates(toolkit)
         .into_iter()
         .map(|dir| dir.join("cuda.h"))
         .find(|header| header.is_file())
+}
+
+/// The `CUDA_VERSION` a `cuda.h` declares, when readable.
+fn cuda_version_from_header(cuda_h: &Path) -> Option<u32> {
+    let source = std::fs::read_to_string(cuda_h).ok()?;
+    source.lines().find_map(|line| {
+        let mut parts = line.split_whitespace();
+        match (parts.next(), parts.next(), parts.next()) {
+            (Some("#define"), Some("CUDA_VERSION"), Some(version)) => version.parse().ok(),
+            _ => None,
+        }
+    })
+}
+
+/// Returns the path of `cuda.h` for the toolkit `cuda-bindings` resolves:
+/// the first set variable among [`TOOLKIT_ENV_VARS`] taken as-is, else the
+/// first default candidate whose `cuda.h` meets the version floor.
+fn find_cuda_header() -> Option<PathBuf> {
+    for var in TOOLKIT_ENV_VARS {
+        if let Ok(toolkit) = env::var(var) {
+            return find_cuda_header_in(Path::new(&toolkit));
+        }
+    }
+    DEFAULT_TOOLKIT_DIRS.iter().find_map(|toolkit| {
+        let header = find_cuda_header_in(Path::new(toolkit))?;
+        (cuda_version_from_header(&header)? >= MIN_CUDA_VERSION).then_some(header)
+    })
 }

--- a/scripts/run_cpu_tests.sh
+++ b/scripts/run_cpu_tests.sh
@@ -90,6 +90,50 @@ run_step \
     "cutile warmup/cache-key CPU tests" \
     cargo test -p cutile --test warmup
 
+# Shared host-side crates: the CPU-safe portion of their suites. Unit tests
+# never invoke a live driver call (a missing/driverless libcuda makes the
+# generated shims return error codes, which these tests tolerate), and the
+# three cuda-core integration targets below are compile-time contracts
+# (trybuild derive suite, DeviceCopy impl coverage, launch type contracts).
+# The GPU-dependent integration tests live in run_gpu_tests.sh.
+# `cuda_tests` is the one GPU-requiring module in the cuda-bindings suite
+# (its `init()` asserts a live `cuInit`); it runs unfiltered in
+# run_gpu_tests.sh.
+run_step \
+    "cuda-bindings unit and toolkit-discovery tests" \
+    cargo test -p cuda-bindings -- --skip cuda_tests::
+
+run_step \
+    "cuda-core unit tests" \
+    cargo test -p cuda-core --lib
+
+run_step \
+    "cuda-core compile-time contract tests" \
+    cargo test -p cuda-core \
+    --test simt_device_copy_derive \
+    --test simt_device_copy_impls \
+    --test simt_launch_contract_types
+
+# Builds the compile_fail soundness contracts (non-Send launch storage,
+# brand/rank rejection, buffer aliasing) that no other target covers.
+run_step \
+    "cuda-core doc tests" \
+    cargo test -p cuda-core --doc
+
+run_step \
+    "cuda-async unit tests" \
+    cargo test -p cuda-async --lib
+
+run_step \
+    "cuda-async doc tests" \
+    cargo test -p cuda-async --doc
+
+# Driver-free by construction: its one driver-touching case asserts the
+# Err path, which driverless shims also produce.
+run_step \
+    "cuda-async error-handling integration test" \
+    cargo test -p cuda-async --test error_handling
+
 print_summary_and_exit \
     "All CPU tests passed!" \
     "Some CPU checks failed. See output above for details."

--- a/scripts/run_gpu_tests.sh
+++ b/scripts/run_gpu_tests.sh
@@ -57,11 +57,43 @@ run_step \
     "cuda-core GPU integration test vmm_multicast" \
     cargo test -p cuda-core --test vmm_multicast
 
+# The SIMT integration tests carried over from cuda-oxide. simt_vmm_p2p
+# exercises the real two-GPU P2P path (it self-skips on single-device
+# machines or when peer access is unavailable); simt_vmm_multicast
+# self-skips without NVLink switch multicast support.
+for test_target in \
+    borrow_raw \
+    simt_context_limits \
+    simt_context_sync_policy \
+    simt_device_buffer \
+    simt_device_buffer_leaks \
+    simt_pinned_host_buffer \
+    simt_stream_priority \
+    simt_stream_query \
+    simt_vmm_multicast \
+    simt_vmm_p2p
+do
+    run_step \
+        "cuda-core GPU integration test ${test_target}" \
+        cargo test -p cuda-core --test "$test_target"
+done
+
+run_step \
+    "cuda-async unit tests (with live driver)" \
+    cargo test -p cuda-async --lib
+
+# Unfiltered: includes the GPU-requiring `cuda_tests` module that the CPU
+# path skips.
+run_step \
+    "cuda-bindings tests (with live driver)" \
+    cargo test -p cuda-bindings
+
 for test_target in \
     concurrent_capture \
     cuda_graph \
     execute_once \
-    pool_allocation
+    pool_allocation \
+    reactor_correctness
 do
     run_step \
         "cuda-async GPU integration test ${test_target}" \


### PR DESCRIPTION
## What this does

Closes the two remaining review asks on #233 before the shared `0.3.1` release:

1. cuda-oxide's CUDA toolkit discovery, with its tests, now lives in the shared `cuda-bindings`.
2. The copied `cuda-core` / `cuda-async` suites now execute instead of only compiling: CPU-safe tests in the hosted CPU lane, GPU-dependent tests in the GPU script.

## Toolkit discovery

```text
Before                                After

CUDA_TOOLKIT_PATH only                CUDA_TOOLKIT_PATH, then CUDA_HOME
{toolkit}/include/cuda.h only         {toolkit}/include/cuda.h
                                      {toolkit}/targets/<arch>/include/cuda.h
                                        (x86_64-linux; sbsa-linux then
                                         aarch64-linux for aarch64)
                                      CUDA_TOOLKIT_TARGET_DIR=<dir> names one
                                        targets/ tree by hand
```

The layout that failed before: Jetson/Tegra, sbsa, cross-build, and extracted-redistributable installs ship no top-level `include/`.

```text
$ CUDA_TOOLKIT_PATH=/opt/cuda-redist cargo build -p cuda-bindings
before: "/opt/cuda-redist does not contain include/cuda.h"
after:  resolves /opt/cuda-redist/targets/x86_64-linux/include and builds
```

A wrong path or override fails listing what was probed, never a silent fallback:

```text
$ CUDA_TOOLKIT_PATH=/usr/local/cuda-13.3 CUDA_TOOLKIT_TARGET_DIR=typo-linux cargo build -p cuda-bindings
CUDA_TOOLKIT_PATH=/usr/local/cuda-13.3 is invalid: /usr/local/cuda-13.3 does not contain cuda.h. Probed:
    /usr/local/cuda-13.3/targets/typo-linux/include/cuda.h
```

One improvement over cuda-oxide's version: when `CUDA_TOOLKIT_TARGET_DIR` is set, the named tree is the *only* candidate. In cuda-oxide the top-level `include/` (a symlink to the host architecture's tree on standard installs) still shadowed the override, so a cross-build could silently bind the host's headers.

The selection logic is `include!`-shared with `tests/toolkit_target.rs` and covered by twelve tests.

The second commit makes `cuda-core`'s multicast probe resolve the toolkit the same way (same candidates, floor, and override), which its module doc already claimed. Before, on an install with no `/usr/local/cuda` symlink, the two build scripts could pick different toolkits: `cuda-bindings` bound `cuMulticast*` while the probe found nothing, so the `MulticastObject` API silently disappeared from `cuda-core`.

## CUDA floor: 13.0

The last commit sets the agreed baseline: the shared host crates now require CUDA 13.0+, replacing the interim 12.8 floor (the Tile compiler still needs 13.2+). `/usr/local/cuda-12` is dropped from the default candidates, both build scripts enforce the same floor, and the floor-check CI lane moves to a CUDA 13.0.1 container (renamed `shared-crates-cuda13`) since the build now rejects a 12.8 image. Checked against real toolkits: 12.8 is rejected with the new message, 13.0 resolves.

## Test execution

| Path | Now executes |
| :--- | :--- |
| CPU (hosted "CPU only tests" lane, driverless) | cuda-bindings minus the GPU-requiring `cuda_tests` module (includes the fn-pointer C-ABI regression and the discovery tests); cuda-core `--lib`, the trybuild DeviceCopy derive suite with both compile-fail cases, DeviceCopy impl coverage, launch type contracts, `--doc`; cuda-async `--lib`, `--doc`, `error_handling` |
| GPU (`run_gpu_tests.sh`) | `borrow_raw` plus the nine SIMT integration targets, including `simt_vmm_p2p` and `simt_vmm_multicast`; `reactor_correctness`; cuda-async `--lib` and the unfiltered cuda-bindings suite against a live driver |

`borrow_raw`, `reactor_correctness`, and `error_handling` are pre-existing suites that ran nowhere; they are wired in alongside the copied ones.

## Validation

- Both scripts pass end to end on a two-GPU RTX 5090 box (CUDA 13.3): 45 CPU steps, 34 GPU steps.
- Every CPU-path step was re-run with an unloadable `libcuda` shadowing the real one, proving the hosted driverless lane stays green.
- `simt_vmm_p2p`: the single-GPU VMM roundtrip executes in full; the cross-GPU case self-skips on GeForce (no PCIe peer access) and needs a P2P-capable pair for full execution, as before.
- Discovery checked live: CUDA_HOME-only resolution, a targets-only toolkit tree building end to end, and both failure modes above.

## Known trade-off

The trybuild suites gate the hosted lane on that lane's floating nightly diagnostics; when nightly rewords a diagnostic, the `.stderr` fixtures need regenerating with `TRYBUILD=overwrite`. cuda-oxide runs the same model on floating stable. Happy to move these behind a pinned toolchain if you'd rather not take that maintenance cost.


