### PR TITLE
feat: expose graph capture modes and device attributes

### DIFF
--- a/cuda-async/src/cuda_graph.rs
+++ b/cuda-async/src/cuda_graph.rs
@@ -12,7 +12,31 @@ use std::future::IntoFuture;
 use std::mem::MaybeUninit;
 use std::sync::Arc;
 
-const CU_STREAM_CAPTURE_MODE_RELAXED: sys::CUstreamCaptureMode = 2;
+/// Controls which potentially unsafe CUDA API calls invalidate stream capture.
+///
+/// [`Relaxed`](Self::Relaxed) preserves the mode used by [`CudaGraph::capture`]
+/// and [`CudaGraph::scope`]. The stricter modes are useful when graph capture
+/// must detect interfering CUDA work from the current thread or process.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum CaptureMode {
+    /// Invalidates capture when any thread makes an unsafe CUDA call.
+    Global,
+    /// Invalidates capture when the capturing thread makes an unsafe CUDA call.
+    ThreadLocal,
+    /// Only invalidates capture for calls that conflict with the capture graph.
+    #[default]
+    Relaxed,
+}
+
+impl CaptureMode {
+    fn as_raw(self) -> sys::CUstreamCaptureMode {
+        match self {
+            Self::Global => sys::CUstreamCaptureMode_enum_CU_STREAM_CAPTURE_MODE_GLOBAL,
+            Self::ThreadLocal => sys::CUstreamCaptureMode_enum_CU_STREAM_CAPTURE_MODE_THREAD_LOCAL,
+            Self::Relaxed => sys::CUstreamCaptureMode_enum_CU_STREAM_CAPTURE_MODE_RELAXED,
+        }
+    }
+}
 
 /// A captured and instantiated CUDA graph, ready for replay.
 ///
@@ -62,12 +86,21 @@ impl<T: Send> CudaGraph<T> {
         stream: Arc<Stream>,
         op: impl DeviceOp<Output = T>,
     ) -> Result<Self, DeviceError> {
+        Self::capture_with_mode(stream, CaptureMode::Relaxed, op)
+    }
+
+    /// Capture a [`DeviceOp`] using an explicit stream capture mode.
+    pub fn capture_with_mode(
+        stream: Arc<Stream>,
+        mode: CaptureMode,
+        op: impl DeviceOp<Output = T>,
+    ) -> Result<Self, DeviceError> {
         let device = stream.device().clone();
         device.bind_to_thread()?;
 
         // Begin capture.
         unsafe {
-            stream.begin_capture(CU_STREAM_CAPTURE_MODE_RELAXED)?;
+            stream.begin_capture(mode.as_raw())?;
         }
 
         // Execute the operation on the capture stream.
@@ -401,10 +434,22 @@ impl CudaGraph<()> {
     where
         F: FnOnce(&Scope) -> Result<(), DeviceError>,
     {
+        Self::scope_with_mode(stream, CaptureMode::Relaxed, f)
+    }
+
+    /// Capture a scoped sequence using an explicit stream capture mode.
+    pub fn scope_with_mode<F>(
+        stream: &Arc<Stream>,
+        mode: CaptureMode,
+        f: F,
+    ) -> Result<Self, DeviceError>
+    where
+        F: FnOnce(&Scope) -> Result<(), DeviceError>,
+    {
         crate::device_operation::acquire_execution_lock()?;
 
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            Self::scope_inner(stream, f)
+            Self::scope_inner(stream, mode, f)
         }));
 
         crate::device_operation::release_execution_lock();
@@ -415,7 +460,7 @@ impl CudaGraph<()> {
         }
     }
 
-    fn scope_inner<F>(stream: &Arc<Stream>, f: F) -> Result<Self, DeviceError>
+    fn scope_inner<F>(stream: &Arc<Stream>, mode: CaptureMode, f: F) -> Result<Self, DeviceError>
     where
         F: FnOnce(&Scope) -> Result<(), DeviceError>,
     {
@@ -424,7 +469,7 @@ impl CudaGraph<()> {
 
         // Begin capture.
         unsafe {
-            stream.begin_capture(CU_STREAM_CAPTURE_MODE_RELAXED)?;
+            stream.begin_capture(mode.as_raw())?;
         }
 
         let scope = Scope {

--- a/cuda-async/src/device_operation.rs
+++ b/cuda-async/src/device_operation.rs
@@ -334,6 +334,14 @@ pub trait DeviceOp:
         let stream = with_default_device_policy(|policy| policy.next_stream())??;
         self.graph_on(stream)
     }
+    /// Capture this operation using `mode` and the default device's scheduling policy.
+    fn graph_with_mode(
+        self,
+        mode: crate::cuda_graph::CaptureMode,
+    ) -> Result<crate::cuda_graph::CudaGraph<<Self as DeviceOp>::Output>, DeviceError> {
+        let stream = with_default_device_policy(|policy| policy.next_stream())??;
+        self.graph_on_with_mode(stream, mode)
+    }
     /// Capture this operation into a replayable [`CudaGraph`](crate::cuda_graph::CudaGraph)
     /// on an **explicit stream**.
     ///
@@ -345,6 +353,14 @@ pub trait DeviceOp:
         stream: Arc<Stream>,
     ) -> Result<crate::cuda_graph::CudaGraph<<Self as DeviceOp>::Output>, DeviceError> {
         crate::cuda_graph::CudaGraph::capture(stream, self)
+    }
+    /// Capture this operation on an explicit stream using `mode`.
+    fn graph_on_with_mode(
+        self,
+        stream: Arc<Stream>,
+        mode: crate::cuda_graph::CaptureMode,
+    ) -> Result<crate::cuda_graph::CudaGraph<<Self as DeviceOp>::Output>, DeviceError> {
+        crate::cuda_graph::CudaGraph::capture_with_mode(stream, mode, self)
     }
     /// Execute synchronously using the default device's scheduling policy.
     ///

--- a/cuda-async/src/prelude.rs
+++ b/cuda-async/src/prelude.rs
@@ -40,7 +40,7 @@ pub use crate::device_operation::SharedDeviceOp;
 pub use crate::device_operation::Value;
 
 // CUDA graph capture
-pub use crate::cuda_graph::{CudaGraph, GraphLaunch, Scope};
+pub use crate::cuda_graph::{CaptureMode, CudaGraph, GraphLaunch, Scope};
 
 // Error type
 pub use crate::error::DeviceError;

--- a/cuda-async/tests/cuda_graph.rs
+++ b/cuda-async/tests/cuda_graph.rs
@@ -5,7 +5,7 @@
 
 //! Tests for `CudaGraph::scope` — scoped CUDA graph capture.
 
-use cuda_async::cuda_graph::CudaGraph;
+use cuda_async::cuda_graph::{CaptureMode, CudaGraph};
 use cuda_async::device_operation::{value, DeviceOp};
 use cuda_async::error::DeviceError;
 
@@ -30,6 +30,47 @@ fn scope_empty_closure() {
 
         let graph = CudaGraph::scope(&stream, |_s| Ok(())).unwrap();
         graph.launch().sync_on(&stream).unwrap();
+    });
+}
+
+#[test]
+fn scope_supports_all_capture_modes() {
+    if !has_gpu() {
+        return;
+    }
+    on_fresh_thread(|| {
+        let device = cuda_core::Device::new(0).unwrap();
+        let stream = device.new_stream().unwrap();
+
+        for mode in [
+            CaptureMode::Global,
+            CaptureMode::ThreadLocal,
+            CaptureMode::Relaxed,
+        ] {
+            let graph = CudaGraph::scope_with_mode(&stream, mode, |_s| Ok(())).unwrap();
+            graph.launch().sync_on(&stream).unwrap();
+        }
+    });
+}
+
+#[test]
+fn capture_supports_all_capture_modes() {
+    if !has_gpu() {
+        return;
+    }
+    on_fresh_thread(|| {
+        let device = cuda_core::Device::new(0).unwrap();
+        let stream = device.new_stream().unwrap();
+
+        for mode in [
+            CaptureMode::Global,
+            CaptureMode::ThreadLocal,
+            CaptureMode::Relaxed,
+        ] {
+            let mut graph = CudaGraph::capture_with_mode(stream.clone(), mode, value(42)).unwrap();
+            assert_eq!(graph.take_output(), Some(42));
+            graph.launch().sync_on(&stream).unwrap();
+        }
     });
 }
 

--- a/cuda-core/src/runtime.rs
+++ b/cuda-core/src/runtime.rs
@@ -27,6 +27,64 @@ pub struct LaunchConfig {
     pub shared_mem_bytes: u32,
 }
 
+/// Integer-valued properties reported by `cuDeviceGetAttribute`.
+///
+/// Values use the units documented on each variant. Unsupported attributes are
+/// reported as a [`DriverError`] by [`Device::attribute`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum DeviceAttribute {
+    /// Compute capability major version.
+    ComputeCapabilityMajor,
+    /// Compute capability minor version.
+    ComputeCapabilityMinor,
+    /// Number of streaming multiprocessors.
+    MultiprocessorCount,
+    /// Peak device-memory clock rate in kHz.
+    MemoryClockRate,
+    /// Global-memory bus width in bits.
+    GlobalMemoryBusWidth,
+    /// L2 cache capacity in bytes.
+    L2CacheSize,
+    /// Maximum L2 capacity that can be reserved for persisting accesses, in bytes.
+    MaxPersistingL2CacheSize,
+    /// Maximum access-policy window size in bytes.
+    MaxAccessPolicyWindowSize,
+    /// Number of 32-bit registers available per streaming multiprocessor.
+    MaxRegistersPerMultiprocessor,
+    /// Maximum resident threads per streaming multiprocessor.
+    MaxThreadsPerMultiprocessor,
+    /// Maximum resident thread blocks per streaming multiprocessor.
+    MaxBlocksPerMultiprocessor,
+    /// Maximum shared memory available per streaming multiprocessor, in bytes.
+    MaxSharedMemoryPerMultiprocessor,
+    /// Peak streaming-multiprocessor clock rate in kHz.
+    ClockRate,
+    /// Warp width in threads.
+    WarpSize,
+}
+
+impl DeviceAttribute {
+    fn as_raw(self) -> cuda_bindings::CUdevice_attribute {
+        match self {
+            Self::ComputeCapabilityMajor => cuda_bindings::CUdevice_attribute_enum_CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR,
+            Self::ComputeCapabilityMinor => cuda_bindings::CUdevice_attribute_enum_CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR,
+            Self::MultiprocessorCount => cuda_bindings::CUdevice_attribute_enum_CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT,
+            Self::MemoryClockRate => cuda_bindings::CUdevice_attribute_enum_CU_DEVICE_ATTRIBUTE_MEMORY_CLOCK_RATE,
+            Self::GlobalMemoryBusWidth => cuda_bindings::CUdevice_attribute_enum_CU_DEVICE_ATTRIBUTE_GLOBAL_MEMORY_BUS_WIDTH,
+            Self::L2CacheSize => cuda_bindings::CUdevice_attribute_enum_CU_DEVICE_ATTRIBUTE_L2_CACHE_SIZE,
+            Self::MaxPersistingL2CacheSize => cuda_bindings::CUdevice_attribute_enum_CU_DEVICE_ATTRIBUTE_MAX_PERSISTING_L2_CACHE_SIZE,
+            Self::MaxAccessPolicyWindowSize => cuda_bindings::CUdevice_attribute_enum_CU_DEVICE_ATTRIBUTE_MAX_ACCESS_POLICY_WINDOW_SIZE,
+            Self::MaxRegistersPerMultiprocessor => cuda_bindings::CUdevice_attribute_enum_CU_DEVICE_ATTRIBUTE_MAX_REGISTERS_PER_MULTIPROCESSOR,
+            Self::MaxThreadsPerMultiprocessor => cuda_bindings::CUdevice_attribute_enum_CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_MULTIPROCESSOR,
+            Self::MaxBlocksPerMultiprocessor => cuda_bindings::CUdevice_attribute_enum_CU_DEVICE_ATTRIBUTE_MAX_BLOCKS_PER_MULTIPROCESSOR,
+            Self::MaxSharedMemoryPerMultiprocessor => cuda_bindings::CUdevice_attribute_enum_CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_MULTIPROCESSOR,
+            Self::ClockRate => cuda_bindings::CUdevice_attribute_enum_CU_DEVICE_ATTRIBUTE_CLOCK_RATE,
+            Self::WarpSize => cuda_bindings::CUdevice_attribute_enum_CU_DEVICE_ATTRIBUTE_WARP_SIZE,
+        }
+    }
+}
+
 /// Anything that owns an external CUDA resource. A borrowed handle can hold an
 /// `Arc<dyn ForeignOwner>` as a *liveness token*: while the handle (and anything
 /// derived from it) is alive, the token's refcount is nonzero, so the external
@@ -213,6 +271,16 @@ impl Device {
     /// Get the name of this device.
     pub fn name(&self) -> Result<String, DriverError> {
         device::get_name(self.cu_device)
+    }
+
+    /// Queries an integer-valued property of this device.
+    pub fn attribute(&self, attribute: DeviceAttribute) -> Result<i32, DriverError> {
+        let mut value = 0;
+        unsafe {
+            cuda_bindings::cuDeviceGetAttribute(&mut value, attribute.as_raw(), self.cu_device)
+                .result()?;
+        }
+        Ok(value)
     }
 
     /// Returns the raw `CUdevice` handle.
@@ -595,17 +663,7 @@ impl Device {
 
     /// Returns the device's L2 cache size in bytes.
     pub fn l2_cache_size_bytes(&self) -> Result<usize, DriverError> {
-        let mut value: core::ffi::c_int = 0;
-        // Safety: out-pointer is valid; the device handle is valid by
-        // construction.
-        unsafe {
-            cuda_bindings::cuDeviceGetAttribute(
-                &mut value,
-                cuda_bindings::CUdevice_attribute_enum_CU_DEVICE_ATTRIBUTE_L2_CACHE_SIZE,
-                self.cu_device,
-            )
-            .result()?;
-        }
+        let value = self.attribute(DeviceAttribute::L2CacheSize)?;
         Ok(value.max(0) as usize)
     }
 }

--- a/cuda-core/tests/device_attributes.rs
+++ b/cuda-core/tests/device_attributes.rs
@@ -1,0 +1,60 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use cuda_core::{Device, DeviceAttribute};
+
+fn has_gpu() -> bool {
+    Device::device_count().map(|n| n > 0).unwrap_or(false)
+}
+
+#[test]
+fn queries_device_attributes() {
+    if !has_gpu() {
+        return;
+    }
+
+    let device = Device::new(0).unwrap();
+    let attributes = [
+        DeviceAttribute::ComputeCapabilityMajor,
+        DeviceAttribute::ComputeCapabilityMinor,
+        DeviceAttribute::MultiprocessorCount,
+        DeviceAttribute::MemoryClockRate,
+        DeviceAttribute::GlobalMemoryBusWidth,
+        DeviceAttribute::L2CacheSize,
+        DeviceAttribute::MaxPersistingL2CacheSize,
+        DeviceAttribute::MaxAccessPolicyWindowSize,
+        DeviceAttribute::MaxRegistersPerMultiprocessor,
+        DeviceAttribute::MaxThreadsPerMultiprocessor,
+        DeviceAttribute::MaxBlocksPerMultiprocessor,
+        DeviceAttribute::MaxSharedMemoryPerMultiprocessor,
+        DeviceAttribute::ClockRate,
+        DeviceAttribute::WarpSize,
+    ];
+
+    for attribute in attributes {
+        assert!(
+            device.attribute(attribute).unwrap() >= 0,
+            "{attribute:?} must not be negative"
+        );
+    }
+
+    assert!(
+        device
+            .attribute(DeviceAttribute::ComputeCapabilityMajor)
+            .unwrap()
+            > 0
+    );
+    assert!(
+        device
+            .attribute(DeviceAttribute::MultiprocessorCount)
+            .unwrap()
+            > 0
+    );
+    assert!(device.attribute(DeviceAttribute::WarpSize).unwrap() > 0);
+    assert_eq!(
+        device.l2_cache_size_bytes().unwrap(),
+        device.attribute(DeviceAttribute::L2CacheSize).unwrap() as usize
+    );
+}


### PR DESCRIPTION
## Why

`cuda-async` always starts stream capture in relaxed mode. Callers that need CUDA to detect interference from the current thread or process have to bypass the graph API.

Likewise, `Device` exposes its L2 size, but querying the related occupancy, bandwidth, and persisting-cache limits still requires raw driver calls.

## What changed

- Add `CaptureMode::{Global, ThreadLocal, Relaxed}`.
- Add explicit-mode variants for operation and scoped graph capture while keeping relaxed capture as the existing default.
- Add a non-exhaustive `DeviceAttribute` enum and safe `Device::attribute` query.
- Cover compute capability, clocks, memory bus and cache limits, and per-SM occupancy resources.
- Route `l2_cache_size_bytes` through the common query path.
- Add GPU-gated coverage for every capture mode and device attribute.

This does not change graph instantiation, upload, or ownership behavior.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-features`
- `cargo test --no-run`
- `./scripts/run_cpu_tests.sh`
- focused `cuda-core` and `cuda-async` test targets compile successfully
