### PR TITLE
feat: add CUDA graph capture modes

### DIFF
--- a/cuda-async/src/cuda_graph.rs
+++ b/cuda-async/src/cuda_graph.rs
@@ -12,7 +12,31 @@ use std::future::IntoFuture;
 use std::mem::MaybeUninit;
 use std::sync::Arc;
 
-const CU_STREAM_CAPTURE_MODE_RELAXED: sys::CUstreamCaptureMode = 2;
+/// Controls which potentially unsafe CUDA API calls invalidate stream capture.
+///
+/// [`Relaxed`](Self::Relaxed) preserves the mode used by [`CudaGraph::capture`]
+/// and [`CudaGraph::scope`]. The stricter modes are useful when graph capture
+/// must detect interfering CUDA work from the current thread or process.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum CaptureMode {
+    /// Invalidates capture when any thread makes an unsafe CUDA call.
+    Global,
+    /// Invalidates capture when the capturing thread makes an unsafe CUDA call.
+    ThreadLocal,
+    /// Only invalidates capture for calls that conflict with the capture graph.
+    #[default]
+    Relaxed,
+}
+
+impl CaptureMode {
+    fn as_raw(self) -> sys::CUstreamCaptureMode {
+        match self {
+            Self::Global => sys::CUstreamCaptureMode_enum_CU_STREAM_CAPTURE_MODE_GLOBAL,
+            Self::ThreadLocal => sys::CUstreamCaptureMode_enum_CU_STREAM_CAPTURE_MODE_THREAD_LOCAL,
+            Self::Relaxed => sys::CUstreamCaptureMode_enum_CU_STREAM_CAPTURE_MODE_RELAXED,
+        }
+    }
+}
 
 /// A captured and instantiated CUDA graph, ready for replay.
 ///
@@ -62,12 +86,21 @@ impl<T: Send> CudaGraph<T> {
         stream: Arc<Stream>,
         op: impl DeviceOp<Output = T>,
     ) -> Result<Self, DeviceError> {
+        Self::capture_with_mode(stream, CaptureMode::Relaxed, op)
+    }
+
+    /// Capture a [`DeviceOp`] using an explicit stream capture mode.
+    pub fn capture_with_mode(
+        stream: Arc<Stream>,
+        mode: CaptureMode,
+        op: impl DeviceOp<Output = T>,
+    ) -> Result<Self, DeviceError> {
         let device = stream.device().clone();
         device.bind_to_thread()?;
 
         // Begin capture.
         unsafe {
-            stream.begin_capture(CU_STREAM_CAPTURE_MODE_RELAXED)?;
+            stream.begin_capture(mode.as_raw())?;
         }
 
         // Execute the operation on the capture stream.
@@ -401,10 +434,22 @@ impl CudaGraph<()> {
     where
         F: FnOnce(&Scope) -> Result<(), DeviceError>,
     {
+        Self::scope_with_mode(stream, CaptureMode::Relaxed, f)
+    }
+
+    /// Capture a scoped sequence using an explicit stream capture mode.
+    pub fn scope_with_mode<F>(
+        stream: &Arc<Stream>,
+        mode: CaptureMode,
+        f: F,
+    ) -> Result<Self, DeviceError>
+    where
+        F: FnOnce(&Scope) -> Result<(), DeviceError>,
+    {
         crate::device_operation::acquire_execution_lock()?;
 
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            Self::scope_inner(stream, f)
+            Self::scope_inner(stream, mode, f)
         }));
 
         crate::device_operation::release_execution_lock();
@@ -415,7 +460,7 @@ impl CudaGraph<()> {
         }
     }
 
-    fn scope_inner<F>(stream: &Arc<Stream>, f: F) -> Result<Self, DeviceError>
+    fn scope_inner<F>(stream: &Arc<Stream>, mode: CaptureMode, f: F) -> Result<Self, DeviceError>
     where
         F: FnOnce(&Scope) -> Result<(), DeviceError>,
     {
@@ -424,7 +469,7 @@ impl CudaGraph<()> {
 
         // Begin capture.
         unsafe {
-            stream.begin_capture(CU_STREAM_CAPTURE_MODE_RELAXED)?;
+            stream.begin_capture(mode.as_raw())?;
         }
 
         let scope = Scope {

--- a/cuda-async/src/device_operation.rs
+++ b/cuda-async/src/device_operation.rs
@@ -334,6 +334,14 @@ pub trait DeviceOp:
         let stream = with_default_device_policy(|policy| policy.next_stream())??;
         self.graph_on(stream)
     }
+    /// Capture this operation using `mode` and the default device's scheduling policy.
+    fn graph_with_mode(
+        self,
+        mode: crate::cuda_graph::CaptureMode,
+    ) -> Result<crate::cuda_graph::CudaGraph<<Self as DeviceOp>::Output>, DeviceError> {
+        let stream = with_default_device_policy(|policy| policy.next_stream())??;
+        self.graph_on_with_mode(stream, mode)
+    }
     /// Capture this operation into a replayable [`CudaGraph`](crate::cuda_graph::CudaGraph)
     /// on an **explicit stream**.
     ///
@@ -345,6 +353,14 @@ pub trait DeviceOp:
         stream: Arc<Stream>,
     ) -> Result<crate::cuda_graph::CudaGraph<<Self as DeviceOp>::Output>, DeviceError> {
         crate::cuda_graph::CudaGraph::capture(stream, self)
+    }
+    /// Capture this operation on an explicit stream using `mode`.
+    fn graph_on_with_mode(
+        self,
+        stream: Arc<Stream>,
+        mode: crate::cuda_graph::CaptureMode,
+    ) -> Result<crate::cuda_graph::CudaGraph<<Self as DeviceOp>::Output>, DeviceError> {
+        crate::cuda_graph::CudaGraph::capture_with_mode(stream, mode, self)
     }
     /// Execute synchronously using the default device's scheduling policy.
     ///

--- a/cuda-async/src/prelude.rs
+++ b/cuda-async/src/prelude.rs
@@ -40,7 +40,7 @@ pub use crate::device_operation::SharedDeviceOp;
 pub use crate::device_operation::Value;
 
 // CUDA graph capture
-pub use crate::cuda_graph::{CudaGraph, GraphLaunch, Scope};
+pub use crate::cuda_graph::{CaptureMode, CudaGraph, GraphLaunch, Scope};
 
 // Error type
 pub use crate::error::DeviceError;

--- a/cuda-async/tests/cuda_graph.rs
+++ b/cuda-async/tests/cuda_graph.rs
@@ -5,7 +5,7 @@
 
 //! Tests for `CudaGraph::scope` — scoped CUDA graph capture.
 
-use cuda_async::cuda_graph::CudaGraph;
+use cuda_async::cuda_graph::{CaptureMode, CudaGraph};
 use cuda_async::device_operation::{value, DeviceOp};
 use cuda_async::error::DeviceError;
 
@@ -30,6 +30,47 @@ fn scope_empty_closure() {
 
         let graph = CudaGraph::scope(&stream, |_s| Ok(())).unwrap();
         graph.launch().sync_on(&stream).unwrap();
+    });
+}
+
+#[test]
+fn scope_supports_all_capture_modes() {
+    if !has_gpu() {
+        return;
+    }
+    on_fresh_thread(|| {
+        let device = cuda_core::Device::new(0).unwrap();
+        let stream = device.new_stream().unwrap();
+
+        for mode in [
+            CaptureMode::Global,
+            CaptureMode::ThreadLocal,
+            CaptureMode::Relaxed,
+        ] {
+            let graph = CudaGraph::scope_with_mode(&stream, mode, |_s| Ok(())).unwrap();
+            graph.launch().sync_on(&stream).unwrap();
+        }
+    });
+}
+
+#[test]
+fn capture_supports_all_capture_modes() {
+    if !has_gpu() {
+        return;
+    }
+    on_fresh_thread(|| {
+        let device = cuda_core::Device::new(0).unwrap();
+        let stream = device.new_stream().unwrap();
+
+        for mode in [
+            CaptureMode::Global,
+            CaptureMode::ThreadLocal,
+            CaptureMode::Relaxed,
+        ] {
+            let mut graph = CudaGraph::capture_with_mode(stream.clone(), mode, value(42)).unwrap();
+            assert_eq!(graph.take_output(), Some(42));
+            graph.launch().sync_on(&stream).unwrap();
+        }
     });
 }
 


### PR DESCRIPTION
## Why

`cuda-async` always begins stream capture in relaxed mode. Callers that need CUDA to detect interfering work from the current thread or process currently have to bypass the graph API.

## What changed

- Add `CaptureMode::{Global, ThreadLocal, Relaxed}`.
- Add explicit-mode variants for operation and scoped graph capture.
- Re-export `CaptureMode` from the prelude.
- Keep existing capture methods unchanged, with relaxed mode as their default.
- Exercise both capture paths with every mode in the GPU-gated graph tests.

This does not change graph instantiation, upload, replay, or ownership behavior.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p cuda-async --all-targets`
- `cargo test -p cuda-async --test cuda_graph --no-run`
- `cargo test -p cuda-async --doc`
- full workspace Clippy, compile-only, and CPU suites passed before splitting the independent changes
