### PR TITLE
fix: restore three merges reverted by stale squash merges (#240, #225, #185)

### DIFF
--- a/cutile-book/guide/debugging-and-profiling.md
+++ b/cutile-book/guide/debugging-and-profiling.md
@@ -12,10 +12,11 @@ fn debug_kernel<const S: [i32; 2]>(
     z: &mut Tensor<f32, S>,
     x: &Tensor<f32, { [-1, -1] }>,
 ) {
-    let pid: (i32, i32, i32) = get_tile_block_id();
+    let pid0 = program_id(0);
+    let pid1 = program_id(1);
     let tile = load_tile_like(x, z);
 
-    cuda_tile_print!("Block ({}, {}): loaded tile\n", pid.0, pid.1);
+    cuda_tile_print!("Program ({}, {}): loaded tile\n", pid0, pid1);
     z.store(tile);
 }
 ```

--- a/cutile-book/guide/performance.md
+++ b/cutile-book/guide/performance.md
@@ -67,8 +67,8 @@ Use `mma` and `mmaf_scaled` for matrix multiply paths. The compiler lowers suppo
 ```rust
 let mut acc = constant(0.0f32, const_shape![BM, BN]);
 for k_tile in 0i32..k_tiles {
-    let tile_x = part_x.load([pid.0, k_tile]);
-    let tile_y = part_y.load([k_tile, pid.1]);
+    let tile_x = part_x.load([pid_m, k_tile]);
+    let tile_y = part_y.load([k_tile, pid_n]);
     acc = mma(tile_x, tile_y, acc);
 }
 z.store(acc);

--- a/cutile-book/guide/tensors-and-tiles.md
+++ b/cutile-book/guide/tensors-and-tiles.md
@@ -63,9 +63,9 @@ The partition shape becomes the static shape seen by the kernel. A `[1024, 1024]
 Read-only inputs do not need host-side partitioning. Inside the kernel, partition them with the shape needed by the algorithm:
 
 ```rust
-let pid: (i32, i32, i32) = get_tile_block_id();
+let pid_m = program_id(0);
 let part_x = x.partition(const_shape![BM, BK]);
-let tile_x = part_x.load([pid.0, i]);
+let tile_x = part_x.load([pid_m, i]);
 ```
 
 The same read-only tensor can be partitioned multiple ways inside one kernel. This is common in matrix multiplication, where the left-hand side and right-hand side are loaded with different tile shapes.
@@ -103,7 +103,7 @@ Const generic arrays such as `const S: [i32; 2]` and `const_shape![BM, BK]` carr
 
 ```rust
 let part_x = x.partition(const_shape![BM, BK]);
-let tile_x = part_x.load([pid.0, k_tile]);
+let tile_x = part_x.load([pid_m, k_tile]);
 ```
 
 Writable tensors store tile results:
@@ -186,7 +186,8 @@ fn tiled_gemm<
     x: &Tensor<E, { [-1, -1] }>,
     y: &Tensor<E, { [-1, -1] }>,
 ) {
-    let pid: (i32, i32, i32) = get_tile_block_id();
+    let pid_m = program_id(0);
+    let pid_n = program_id(1);
     let k_tiles = x.shape()[1] / BK;
 
     let part_x = x.partition(const_shape![BM, BK]);
@@ -194,8 +195,8 @@ fn tiled_gemm<
 
     let mut acc = constant(0.0f32, const_shape![BM, BN]);
     for k_tile in 0i32..k_tiles {
-        let tile_x = part_x.load([pid.0, k_tile]);
-        let tile_y = part_y.load([k_tile, pid.1]);
+        let tile_x = part_x.load([pid_m, k_tile]);
+        let tile_y = part_y.load([k_tile, pid_n]);
         acc = mma(tile_x, tile_y, acc);
     }
 

--- a/cutile-book/guide/useful-mental-models.md
+++ b/cutile-book/guide/useful-mental-models.md
@@ -32,16 +32,16 @@ fn add<const S: [i32; 2]>(
 
 The kernel describes what happens to one tile-shaped region. The compiler and runtime map that work onto CUDA execution units.
 
-## Tile Blocks and Tile Threads
+## Tile Programs and Tile Blocks
 
-A tile block is the logical unit of concurrent execution. Each tile block runs the entry function once and processes one region of the output. It can query its coordinates and the total launch grid:
+A tile program is the logical unit of concurrent execution. Each tile program runs the entry function once and processes one region of the output. It can query its per-axis grid coordinates and extents:
 
 ```rust
-let pid: (i32, i32, i32) = get_tile_block_id();
-let grid: (i32, i32, i32) = get_num_tile_blocks();
+let pid0 = program_id(0);
+let n0 = num_programs(0);
 ```
 
-The terms tile block and tile thread refer to the same logical unit. The API uses `get_tile_block_id()` and `get_num_tile_blocks()`.
+The terms tile program, tile block, and tile thread refer to the same logical unit. The API uses `program_id(axis)` and `num_programs(axis)`; the tuple forms `get_tile_block_id()` and `get_num_tile_blocks()` return all three axes at once.
 
 Tile blocks that fit on available Streaming Multiprocessors run at the same time. The full set of tile blocks is concurrent: their relative order is unspecified, and kernels must not depend on one tile block running before another unless an explicit synchronization mechanism exists outside the kernel.
 
@@ -57,12 +57,12 @@ Grid:            (ceil(128 / 32), ceil(256 / 64), 1)
 
 Tensor dimension 0 maps to grid `x`, dimension 1 maps to grid `y`, and dimension 2 maps to grid `z`. For tensors of lower rank, trailing grid dimensions are 1.
 
-Inside a kernel, the tile block id selects the logical region:
+Inside a kernel, the program id selects the logical region:
 
 ```rust
-let pid: (i32, i32, i32) = get_tile_block_id();
+let pid_m = program_id(0);
 let part_x = x.partition(const_shape![BM, BK]);
-let tile_x = part_x.load([pid.0, k_tile]);
+let tile_x = part_x.load([pid_m, k_tile]);
 ```
 
 For mutable outputs, the selected sub-tensor is passed directly to the tile block.

--- a/cutile-book/reference/dsl-api.md
+++ b/cutile-book/reference/dsl-api.md
@@ -25,9 +25,9 @@ mod my_kernels {
         a: &Tensor<f32, { [-1] }>,         // immutable: read-only input
         b: &Tensor<f32, { [-1] }>,         // immutable: read-only input
     ) {
-        let pid: (i32, i32, i32) = get_tile_block_id();
-        let tile_a: Tile<f32, S> = a.load_tile(const_shape!(S), [pid.0]);
-        let tile_b: Tile<f32, S> = b.load_tile(const_shape!(S), [pid.0]);
+        let pid = program_id(0);
+        let tile_a: Tile<f32, S> = a.load_tile(const_shape!(S), [pid]);
+        let tile_b: Tile<f32, S> = b.load_tile(const_shape!(S), [pid]);
         output.store(tile_a + tile_b);
     }
 }
@@ -112,8 +112,8 @@ mod my_kernels {
         output: &mut Tensor<f32, S>,
         input: &Tensor<f32, { [-1] }>,
     ) {
-        let pid: (i32, i32, i32) = get_tile_block_id();
-        let tile: Tile<f32, S> = input.load_tile(const_shape!(S), [pid.0]);
+        let pid = program_id(0);
+        let tile: Tile<f32, S> = input.load_tile(const_shape!(S), [pid]);
         output.store(relu(tile));  // device function call, inlined
     }
 }
@@ -163,8 +163,8 @@ mod my_kernels {
         output: &mut Tensor<f32, S>,
         input: &Tensor<f32, { [-1] }>,
     ) {
-        let pid: (i32, i32, i32) = get_tile_block_id();
-        let tile: Tile<f32, S> = input.load_tile(const_shape!(S), [pid.0]);
+        let pid = program_id(0);
+        let tile: Tile<f32, S> = input.load_tile(const_shape!(S), [pid]);
         let activated: Tile<f32, S> = relu(tile);   // inlined from Module A
         output.store(square(activated));             // inlined from Module A
     }
@@ -237,13 +237,13 @@ fn kernel(
 
 ### Partition / PartitionMut
 
-`Partition<'a, E, const D: [i32; N]>` — A read-only partitioned view of a tensor, dividing it into tiles indexed by block ID.
+`Partition<'a, E, const D: [i32; N]>` — A read-only partitioned view of a tensor, dividing it into tiles indexed by program ID.
 
 `PartitionMut<'a, E, const D: [i32; N]>` — A mutable partitioned view.
 
 ```rust
 let part: Partition<f32, { [128, 128] }> = input.partition(const_shape![128, 128]);
-let tile: Tile<f32, { [128, 128] }> = part.load([pid.0, pid.1]);
+let tile: Tile<f32, { [128, 128] }> = part.load([pid_m, pid_n]);
 ```
 
 ### Shape / Array
@@ -408,26 +408,30 @@ operation.
 let tile: Tile<f32, { [128] }> = load_tile_mut(output);
 output.store(tile * scale_tile);
 
-// Pattern 2: Load at block position
-let pid: (i32, i32, i32) = get_tile_block_id();
-let tile: Tile<f32, { [128] }> = input.load_tile(const_shape![128], [pid.0]);
+// Pattern 2: Load at program position
+let pid = program_id(0);
+let tile: Tile<f32, { [128] }> = input.load_tile(const_shape![128], [pid]);
 
 // Pattern 3: Load-like (positional)
 let tile_x: Tile<f32, { [16, 16] }> = load_tile_like(x, output);
 ```
 
-### Grid and Block
+### Grid and Program IDs
 
 | Function | Signature | Description |
 |---|---|---|
-| `get_tile_block_id()` | `() -> (i32, i32, i32)` | Current thread block's (x, y, z) index in the grid |
-| `get_num_tile_blocks()` | `() -> (i32, i32, i32)` | Total (x, y, z) dimensions of the grid |
+| `program_id(axis)` | `(i32) -> i32` | This tile program's index along grid axis `axis` (0, 1, or 2) |
+| `num_programs(axis)` | `(i32) -> i32` | The launch grid extent along grid axis `axis` (0, 1, or 2) |
+| `get_tile_block_id()` | `() -> (i32, i32, i32)` | All three (x, y, z) program indices as a tuple |
+| `get_num_tile_blocks()` | `() -> (i32, i32, i32)` | All three (x, y, z) grid extents as a tuple |
+
+For each axis `k`, `0 <= program_id(k) < num_programs(k)`.
 
 ```rust
-let pid: (i32, i32, i32) = get_tile_block_id();
-let grid: (i32, i32, i32) = get_num_tile_blocks();
+let pid = program_id(0);
+let n = num_programs(0);
 // Grid-stride loop
-for i in (pid.0..total).step_by(grid.0 as usize) { ... }
+for i in (pid..total).step_by(n as usize) { ... }
 ```
 
 ### Arithmetic (Element-wise)
@@ -605,8 +609,8 @@ Maps to hardware tensor cores when available.
 ```rust
 let mut acc: Tile<f32, { [16, 16] }> = constant(0.0f32, const_shape![16, 16]);
 for k in 0i32..(K/BK) {
-    let a_tile: Tile<f32, { [16, 8] }> = a_part.load([pid.0, k]);
-    let b_tile: Tile<f32, { [8, 16] }> = b_part.load([k, pid.1]);
+    let a_tile: Tile<f32, { [16, 8] }> = a_part.load([pid_m, k]);
+    let b_tile: Tile<f32, { [8, 16] }> = b_part.load([k, pid_n]);
     acc = mma(a_tile, b_tile, acc);
 }
 ```
@@ -666,9 +670,9 @@ ordering, scope, latency, and TMA controls explicitly.
 | `unsafe store_view_tko_mut(view, tile, index, ordering, scope, latency, tma)` | `(&mut PartitionMut<E, S>, Tile<E, S>, [i32; N], O, Sc, Option<i32>, T) -> Token` | Store a tile into a mutable partition |
 
 ```rust
-let pid = get_tile_block_id();
+let pid = program_id(0);
 let tile: Tile<f32, S> =
-    load_view_tko(&part, [pid.0], ordering::Weak, scope::TileBlock, None, tma::Enabled);
+    load_view_tko(&part, [pid], ordering::Weak, scope::TileBlock, None, tma::Enabled);
 ```
 
 #### Pointer-based loads and stores
@@ -836,12 +840,15 @@ let stride: i32 = unsafe { assume_div_by::<_, 4>(stride) };
 | `cuda_tile_assert!(cond, msg)` | GPU assertion |
 
 ```rust
-let pid: (i32, i32, i32) = get_tile_block_id();
-cuda_tile_print!("Block ({}, {}, {})\n", pid.0, pid.1, pid.2);
+let pid0 = program_id(0);
+let pid1 = program_id(1);
+let pid2 = program_id(2);
+cuda_tile_print!("Program ({}, {}, {})\n", pid0, pid1, pid2);
 
 // Assert a condition — aborts the kernel if false
 cuda_tile_assert!(len > 0, "Length must be positive");
 
-// Print scalars for debugging (runs on every block, so output may interleave)
-cuda_tile_print!("offset = {}\n", pid.0 * 128);
+// Print scalars for debugging (runs on every program, so output may interleave)
+let offset = pid0 * 128;
+cuda_tile_print!("offset = {}\n", offset);
 ```

--- a/cutile-book/reference/glossary.md
+++ b/cutile-book/reference/glossary.md
@@ -30,13 +30,17 @@ The generated launcher code accepts `Partition<Tensor<T>>` for every `&mut Tenso
 
 **Launch grid inference.** At kernel launch time, the launcher calls `.grid()` on each mutable output argument's host-side wrapper and collects the resulting grids. For ordinary `&mut Tensor` parameters, this is the host-side `Partition` grid. For `MappedPartitionMut` parameters, this is the mapped physical tile-block grid. If no explicit grid is specified via `.grid()` or `.const_grid()`, the launch grid is **inferred** from these grids. When multiple mutable output parameters are present, all inferred grids must match or the launch will fail with an error. This is how partitioning a tensor on the host side determines how many tile blocks the kernel runs.
 
+## Tile Program
+
+The basic unit of concurrent execution on the GPU — one instance of the kernel function, running once as a single logical thread of execution and operating on one partition of the data. This is the entity you write: a tile program has no visible internal threads; it loads tiles, computes on them, and stores results. Each tile program is identified by its per-axis grid index, `program_id(axis)`, with grid extents from `num_programs(axis)` (following Triton's `tl.program_id` / `tl.num_programs`); the tuple forms `get_tile_block_id()` and `get_num_tile_blocks()` return all three axes at once. Also called a *tile block* (emphasizing its place in the launch grid and its mapping onto hardware) or a *tile thread* (emphasizing the single-threaded programming model).
+
 ## Tile Block
 
-A logical tile thread and the basic unit of concurrent execution on the GPU. Each tile block runs the kernel function once as a single logical thread of execution, operating on one partition of the data. A tile block is identified by its coordinates, obtained via `get_tile_block_id()`. The cuTile Rust compiler maps each tile block to one or more underlying CUDA execution units (thread blocks, clusters, or warps) depending on the target architecture — but from the programmer's perspective, a tile block is simply a single-threaded context that processes one tile of data.
+The same unit as a [Tile Program](#tile-program), viewed from the launch-grid and hardware side: the launch grid is a 3-dimensional arrangement of tile blocks, and the cuTile Rust compiler maps each one to one or more underlying CUDA execution units (thread blocks, clusters, or warps) depending on the target architecture. From the programmer's perspective, a tile block remains a single-threaded context that processes one tile of data.
 
 ## Tile Thread
 
-An alias for [Tile Block](#tile-block), used throughout this book to emphasize the single-threaded programming model. Each tile thread executes the kernel function once as a single logical thread of execution. The terms "tile thread" and "tile block" are interchangeable — the API uses `get_tile_block_id()` and `get_num_tile_blocks()`, while the guides often say "tile thread" for clarity.
+An alias for [Tile Program](#tile-program), emphasizing the single-threaded programming model: each tile thread executes the kernel function once as a single logical thread of execution.
 
 ## Concurrent Execution
 

--- a/cutile-book/tutorials/01-hello-world.md
+++ b/cutile-book/tutorials/01-hello-world.md
@@ -1,6 +1,6 @@
 # 1. Hello World
 
-Tile kernels are functions which run as `N` copies concurrently and in parallel when invoked. The primary difference between tile-based kernels and CUDA C++ kernels is the basic unit of execution: a *tile-block*, which expresses the computation performed by a single logical *tile thread* operating over a multi-dimensional *tile of data*.
+Tile kernels are functions which run as `N` copies concurrently and in parallel when invoked. The primary difference between tile-based kernels and CUDA C++ kernels is the basic unit of execution: a *tile program* (also called a *tile block*), which expresses the computation performed by a single logical thread operating over a multi-dimensional *tile of data*.
 
 > **Note**: The distinction between parallel execution and concurrent execution is intentional: The CUDA runtime executes tile kernels concurrently, many of which may execute in parallel. While some support for inter-tile communication is possible, in-depth knowledge of the CUDA runtime is required to achieve this.
 
@@ -20,12 +20,16 @@ mod hello_world_module {
 
     #[cutile::entry()]
     fn hello_world_kernel() {
-        let pids: (i32, i32, i32) = get_tile_block_id();
-        let npids: (i32, i32, i32) = get_num_tile_blocks();
+        let pid0 = program_id(0);
+        let pid1 = program_id(1);
+        let pid2 = program_id(2);
+        let n0 = num_programs(0);
+        let n1 = num_programs(1);
+        let n2 = num_programs(2);
         cuda_tile_print!(
-            "Hello from tile <{}, {}, {}> in a grid of <{}, {}, {}> tiles!\n",
-            pids.0, pids.1, pids.2,
-            npids.0, npids.1, npids.2
+            "Hello from program <{}, {}, {}> in a grid of <{}, {}, {}> programs!\n",
+            pid0, pid1, pid2,
+            n0, n1, n2
         );
     }
 }
@@ -44,13 +48,13 @@ fn main() -> Result<(), Error> {
 **Output:**
 
 ```text
-Hello from tile <0, 0, 0> in a grid of <2, 2, 1> tiles!
-Hello from tile <1, 0, 0> in a grid of <2, 2, 1> tiles!
-Hello from tile <0, 1, 0> in a grid of <2, 2, 1> tiles!
-Hello from tile <1, 1, 0> in a grid of <2, 2, 1> tiles!
+Hello from program <0, 0, 0> in a grid of <2, 2, 1> programs!
+Hello from program <1, 0, 0> in a grid of <2, 2, 1> programs!
+Hello from program <0, 1, 0> in a grid of <2, 2, 1> programs!
+Hello from program <1, 1, 0> in a grid of <2, 2, 1> programs!
 ```
 
-Four tile threads were executed by the CUDA runtime, each printing its own coordinates.
+Four tile programs were executed by the CUDA runtime, each printing its own coordinates.
 
 ---
 
@@ -85,7 +89,7 @@ fn main() -> Result<(), Error> {
     let device = Device::new(0)?;             // Connect to GPU
     let stream = device.new_stream()?;             // Create a work queue
     let launcher = hello_world_kernel();   // Get the kernel launcher
-    launcher.grid((2, 2, 1)).sync_on(&stream)?; // Launch 2×2×1 = 4 tiles
+    launcher.grid((2, 2, 1)).sync_on(&stream)?; // Launch 2×2×1 = 4 programs
     Ok(())
 }
 ```
@@ -94,18 +98,20 @@ Host-side code sets up the GPU, specifies the kernel launch grid, and launches t
 
 ---
 
-## Tile IDs
+## Program IDs
 
-Each tile is assigned an ID corresponding to a coordinate within the 3-dimensional launch grid:
+Each tile program is assigned an ID along each axis of the 3-dimensional launch grid, following Triton's `tl.program_id(axis)` / `tl.num_programs(axis)`:
 
 ```rust
-let pids: (i32, i32, i32) = get_tile_block_id();    // This thread's (x, y, z) coordinates
-let npids: (i32, i32, i32) = get_num_tile_blocks(); // The grid dimensions
+let pid0 = program_id(0);   // This program's index along grid axis 0
+let n0 = num_programs(0);   // The grid extent along axis 0
 ```
 
-![A grid of tiles showing (x,y) coordinates](../_static/images/hello-world-grid.svg)
+For each axis `k`, `0 <= program_id(k) < num_programs(k)`. The tuple forms `get_tile_block_id()` and `get_num_tile_blocks()` return all three coordinates at once.
 
-Each tile runs the same code but with different coordinates. This is how tiles divide up work — each tile handles a different piece of data based on its ID.
+![A grid of tile programs showing (x,y) coordinates](../_static/images/hello-world-grid.svg)
+
+Each program runs the same code but with different coordinates. This is how programs divide up work — each one handles a different piece of data based on its ID.
 
 ---
 
@@ -114,8 +120,8 @@ Each tile runs the same code but with different coordinates. This is how tiles d
 1. **At compile time:** `#[cutile::module]` captures your Rust code as an AST.
 2. **At first kernel launch:** The AST is compiled to Tile IR bytecode → cubin (GPU binary).
 3. **Cached:** The cubin is cached, so subsequent runs are instant.
-4. **Launch:** 4 tile threads are dispatched to the GPU.
-5. **Execution:** All 4 tile threads run concurrently, each printing its coordinates.
+4. **Launch:** 4 tile programs are dispatched to the GPU.
+5. **Execution:** All 4 tile programs run concurrently, each printing its coordinates.
 
 ![The cuTile Rust compilation pipeline from Rust source to GPU execution](../_static/images/compilation-pipeline.svg)
 
@@ -125,10 +131,10 @@ Each tile runs the same code but with different coordinates. This is how tiles d
 
 | Concept | What It Means |
 |---------|---------------|
-| **Tile threads run concurrently** | You launch N tile threads, they all execute concurrently |
-| **Tile threads are assigned an ID** | Each tile uses its ID to work on different data |
+| **Tile programs run concurrently** | You launch N tile programs, they all execute concurrently |
+| **Tile programs are assigned IDs** | Each program uses its per-axis IDs to work on different data |
 | **Host orchestrates** | CPU code decides grid shape and launches work |
-| **Same code, different data** | The kernel is written once and executed by many tile threads |
+| **Same code, different data** | The kernel is written once and executed by many tile programs |
 
 ---
 
@@ -141,7 +147,7 @@ launcher.grid((3, 3, 1)).sync_on(&stream)?;
 ```
 
 :::{dropdown} Answer
-You should see 9 messages (3 × 3 × 1 = 9 tile threads).
+You should see 9 messages (3 × 3 × 1 = 9 tile programs).
 :::
 
 ### Exercise 2: Use the Z Dimension
@@ -152,16 +158,16 @@ Try `(2, 2, 2)` for a 3D grid. What changes?
 You'll see 8 messages. The `z` coordinate will now vary from 0 to 1.
 :::
 
-### Exercise 3: Calculate Total Tiles
+### Exercise 3: Calculate Total Programs
 
-Modify the kernel to also print the total number of tile threads.
+Modify the kernel to also print the total number of tile programs.
 
 :::{dropdown} Answer
 ```rust
-let total = npids.0 * npids.1 * npids.2;
+let total = n0 * n1 * n2;
 cuda_tile_print!(
-    "Tile <{}, {}, {}> of {} total tiles\n",
-    pids.0, pids.1, pids.2, total
+    "Program <{}, {}, {}> of {} total programs\n",
+    pid0, pid1, pid2, total
 );
 ```
 :::

--- a/cutile-book/tutorials/02-vector-addition.md
+++ b/cutile-book/tutorials/02-vector-addition.md
@@ -1,6 +1,6 @@
 # 2. Vector Addition
 
-In cutile, tile threads run concurrently and each tile knows its coordinates via `get_tile_block_id()`. To make tiles process different pieces of data, we use **partitioning** — dividing the output tensor into sub-tensors so that each tile thread reads from and writes to a distinct region.
+In cutile, tile programs run concurrently and each program knows its grid coordinates via `program_id(axis)`. To make programs process different pieces of data, we use **partitioning** — dividing the output tensor into sub-tensors so that each tile program reads from and writes to a distinct region.
 
 ![Partitioning divides data among tile threads](../_static/images/vector-addition-partitioning.svg)
 

--- a/cutile-book/tutorials/04-matrix-multiplication.md
+++ b/cutile-book/tutorials/04-matrix-multiplication.md
@@ -79,13 +79,14 @@ mod my_module {
     ) {
         let part_x = x.partition(const_shape![BM, BK]);
         let part_y = y.partition(const_shape![BK, BN]);
-        let pid: (i32, i32, i32) = get_tile_block_id();
+        let pid_m = program_id(0);
+        let pid_n = program_id(1);
 
         let mut tile_z = load_tile_mut(z);
 
         for i in 0i32..(K / BK) {
-            let tile_x = part_x.load([pid.0, i]);
-            let tile_y = part_y.load([i, pid.1]);
+            let tile_x = part_x.load([pid_m, i]);
+            let tile_y = part_y.load([i, pid_n]);
             tile_z = mma(tile_x, tile_y, tile_z);  // C += A @ B
         }
         z.store(tile_z);
@@ -136,8 +137,8 @@ The K-loop iterates over pairs of tiles from A and B, accumulating partial produ
 
 ```rust
 for i in 0i32..(K / BK) {
-    let tile_x = part_x.load([pid.0, i]);  // Load A[row_group, i]
-    let tile_y = part_y.load([i, pid.1]);  // Load B[i, col_group]
+    let tile_x = part_x.load([pid_m, i]);  // Load A[row_group, i]
+    let tile_y = part_y.load([i, pid_n]);  // Load B[i, col_group]
     tile_z = mma(tile_x, tile_y, tile_z);  // Accumulate: C += A @ B
 }
 ```
@@ -336,11 +337,12 @@ unsafe fn gemm<T: ElementType, const BM: i32, const BN: i32, const BK: i32>(
 ) {
     let part_x = x.partition(const_shape![BM, BK]);
     let part_y = y.partition(const_shape![BK, BN]);
-    let pid: (i32, i32, i32) = get_tile_block_id();
+    let pid_m = program_id(0);
+    let pid_n = program_id(1);
     let mut tile_z: Tile<T, { [BM, BN] }> = z.load();
     for i in 0i32..(k / BK) {
-        let tile_x = part_x.load([pid.0, i]);
-        let tile_y = part_y.load([i, pid.1]);
+        let tile_x = part_x.load([pid_m, i]);
+        let tile_y = part_y.load([i, pid_n]);
         tile_z = mma(tile_x, tile_y, tile_z);
     }
     z.store(tile_z);
@@ -371,7 +373,7 @@ See [`cutile-benchmarks/benches/gemm.rs`](https://github.com/nvlabs/cutile-rs/tr
 
 The older safe performance path is to make **all** tensor dimensions static const
 generics. When the compiler knows every dimension and the launch grid at JIT
-time, it can prove direct `get_tile_block_id()` partition accesses are in bounds
+time, it can prove direct `program_id(axis)` partition accesses are in bounds
 and optimize the checks away entirely - no `unsafe` required:
 
 ```rust
@@ -388,10 +390,11 @@ fn gemm<
     let part_x = x.partition(const_shape![BM, BK]);
     let part_y = y.partition(const_shape![BK, BN]);
     let mut tile_z = load_tile_mut(z);
-    let pid: (i32, i32, i32) = get_tile_block_id();
+    let pid_m = program_id(0);
+    let pid_n = program_id(1);
     for i in 0i32..(K / BK) {
-        let tile_x = part_x.load([pid.0, i]);
-        let tile_y = part_y.load([i, pid.1]);
+        let tile_x = part_x.load([pid_m, i]);
+        let tile_y = part_y.load([i, pid_n]);
         tile_z = mma(tile_x, tile_y, tile_z);
     }
     z.store(tile_z);

--- a/cutile-book/tutorials/06-flash-attention.md
+++ b/cutile-book/tutorials/06-flash-attention.md
@@ -146,11 +146,11 @@ mod fmha_module {
         v: &Tensor<f32, { [-1, -1, -1, -1] }>,   // (B, H, N, D)
         qk_scale: f32,
     ) {
-        let pid: (i32, i32, i32) = get_tile_block_id();
+        let pid0 = program_id(0);
         let h = q.shape()[1];
-        let batch_idx = pid.0 / h;
-        let head_idx = pid.0 % h;
-        let q_m_idx = pid.1;
+        let batch_idx = pid0 / h;
+        let head_idx = pid0 % h;
+        let q_m_idx = program_id(1);
 
         // Convert to exp2-friendly scale (exp2 is faster than exp on GPU)
         let two: Tile<f32, { [] }> = constant(2.0f32, const_shape![]);

--- a/cutile-book/tutorials/08-data-parallel-mlp.md
+++ b/cutile-book/tutorials/08-data-parallel-mlp.md
@@ -31,11 +31,12 @@ mod data_parallel_module {
     ) {
         let part_x = x.partition(const_shape![BM, BK]);
         let part_y = y.partition(const_shape![BK, BN]);
-        let pid: (i32, i32, i32) = get_tile_block_id();
+        let pid_m = program_id(0);
+        let pid_n = program_id(1);
         let mut tile_z = load_tile_mut(z);
         for i in 0i32..(K / BK) {
-            let tile_x = part_x.load([pid.0, i]);
-            let tile_y = part_y.load([i, pid.1]);
+            let tile_x = part_x.load([pid_m, i]);
+            let tile_y = part_y.load([i, pid_n]);
             tile_z = mma(tile_x, tile_y, tile_z);
         }
         z.store(tile_z);
@@ -50,10 +51,10 @@ mod data_parallel_module {
     ) {
         let part_x = x.partition(const_shape![BM, BK]);
         let part_y = y.partition(const_shape![BK]);
-        let pid: (i32, i32, i32) = get_tile_block_id();
+        let pid = program_id(0);
         let mut tile_z = z.load().reshape(const_shape![BM, 1]);
         for i in 0i32..(K / BK) {
-            let tile_x = part_x.load([pid.0, i]);
+            let tile_x = part_x.load([pid, i]);
             let tile_y = part_y.load([i]).reshape(const_shape![BK, 1]);
             tile_z = mma(tile_x, tile_y, tile_z);
             continue;

--- a/cutile-book/tutorials/09-pointer-addition.md
+++ b/cutile-book/tutorials/09-pointer-addition.md
@@ -31,13 +31,13 @@ mod my_module {
         let mut z_tensor: Tensor<T, { [-1] }> = unsafe { get_tensor(z_ptr, len) };
         let x_tensor: Tensor<T, { [-1] }> = unsafe { get_tensor(x_ptr, len) };
         let y_tensor: Tensor<T, { [-1] }> = unsafe { get_tensor(y_ptr, len) };
-        let pid: (i32, i32, i32) = get_tile_block_id();
+        let pid = program_id(0);
         let tile_shape = const_shape![4i32];
-        let tile_x = x_tensor.partition(tile_shape).load([pid.0]);
-        let tile_y = y_tensor.partition(tile_shape).load([pid.0]);
+        let tile_x = x_tensor.partition(tile_shape).load([pid]);
+        let tile_y = y_tensor.partition(tile_shape).load([pid]);
         z_tensor
             .partition_mut(tile_shape)
-            .store(tile_x + tile_y, [pid.0]);
+            .store(tile_x + tile_y, [pid]);
     }
 }
 

--- a/cutile-book/tutorials/11-nvfp4-inference.md
+++ b/cutile-book/tutorials/11-nvfp4-inference.md
@@ -253,7 +253,8 @@ mod nvfp4_linear {
         y_scales: &Tensor<f8e4m3fn, { [-1, -1] }>,
         alpha: f32,
     ) {
-        let pid = get_tile_block_id();
+        let pid_m = program_id(0);
+        let pid_n = program_id(1);
         let k_tiles = Dim::new(x.shape()[1] / BK_PACKED);
 
         let part_x = x.partition(const_shape![BM, BK_PACKED]);
@@ -264,14 +265,14 @@ mod nvfp4_linear {
         let mut tile_z = constant(0.0f32, const_shape![BM, BN]);
 
         for k_tile in k_tiles {
-            let tile_x_packed = part_x.load([pid.0, k_tile]);
-            let tile_y_packed = part_y.load([pid.1, k_tile]);
+            let tile_x_packed = part_x.load([pid_m, k_tile]);
+            let tile_y_packed = part_y.load([pid_n, k_tile]);
 
             let tile_x = tile_x_packed.unpack(const_shape![BM, BK]);
             let tile_y = tile_y_packed.unpack(const_shape![BN, BK]).transpose();
 
-            let tile_x_scales = part_x_scales.load([pid.0, k_tile]);
-            let tile_y_scales = part_y_scales.load([pid.1, k_tile]).transpose();
+            let tile_x_scales = part_x_scales.load([pid_m, k_tile]);
+            let tile_y_scales = part_y_scales.load([pid_n, k_tile]).transpose();
 
             tile_z = mmaf_scaled(tile_x, tile_y, tile_z, tile_x_scales, tile_y_scales);
         }
@@ -392,10 +393,10 @@ Inside the kernel, load the FP8 tiles directly, load the E8M0 scale tiles, and
 call `mmaf_scaled`:
 
 ```rust
-let tile_x = part_x.load([pid.0, k_tile]);
-let tile_y = part_y.load([pid.1, k_tile]).transpose();
-let tile_x_scales = part_x_scales.load([pid.0, k_tile]);
-let tile_y_scales = part_y_scales.load([pid.1, k_tile]).transpose();
+let tile_x = part_x.load([pid_m, k_tile]);
+let tile_y = part_y.load([pid_n, k_tile]).transpose();
+let tile_x_scales = part_x_scales.load([pid_m, k_tile]);
+let tile_y_scales = part_y_scales.load([pid_n, k_tile]).transpose();
 
 tile_z = mmaf_scaled(tile_x, tile_y, tile_z, tile_x_scales, tile_y_scales);
 ```

--- a/cutile-compiler/src/compiler/compile_global.rs
+++ b/cutile-compiler/src/compiler/compile_global.rs
@@ -414,7 +414,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
         method_call: &ExprMethodCall,
         info: &GlobalInfo,
     ) -> Result<cutile_ir::ir::Value, JITError> {
-        let ptr_ty = TileRustType::from_scalar_ptr(&info.element_name).ok_or_else(|| {
+        let ptr_ty = TileRustType::from_scalar_ptr(&info.element_name, true).ok_or_else(|| {
             self.jit_error(
                 &method_call.receiver.span(),
                 &format!(

--- a/cutile-compiler/src/compiler/compile_intrinsic.rs
+++ b/cutile-compiler/src/compiler/compile_intrinsic.rs
@@ -1884,7 +1884,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                     );
                 }
                 let mut new_value = args[0].clone();
-                let old_type = new_value.ty.rust_ty;
+                let old_type = new_value.ty.rust_ty.clone();
                 match compiler_op_function.as_str() {
                     "scalar_to_tile" => {
                         let element_type = get_rust_element_type_primitive(&old_type);
@@ -1917,12 +1917,20 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                                 .unwrap();
                     }
                     "pointer_to_tile" => {
-                        let element_type = get_rust_element_type_primitive(&old_type);
-                        if let Some(t) = TileRustType::from_scalar_ptr(&element_type) {
+                        // Wrapping preserves the pointer's constness: a
+                        // `*const E` wraps into `PointerTile<*const E, {[]}>`.
+                        let old_ty_str = old_type.to_token_stream().to_string();
+                        let (is_mutable, element_type) =
+                            match crate::types::get_ptr_type(&old_ty_str) {
+                                Some((is_mutable, element)) => (is_mutable, element),
+                                None => (true, get_rust_element_type_primitive(&old_type)),
+                            };
+                        if let Some(t) = TileRustType::from_scalar_ptr(&element_type, is_mutable) {
                             new_value.ty = t;
                         } else {
                             new_value.ty.rust_ty = syn::parse_str::<syn::Type>(&format!(
-                                "PointerTile<* mut {element_type}, {{[]}}>"
+                                "PointerTile<{} {element_type}, {{[]}}>",
+                                crate::types::ptr_prefix(is_mutable)
                             ))
                             .unwrap();
                         }
@@ -1942,10 +1950,21 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                                 ),
                             );
                         };
+                        // Unwrapping preserves the tile's constness.
+                        let is_mutable =
+                            !old_type.to_token_stream().to_string().contains("* const");
                         new_value.ty.rust_ty = syn::parse2::<syn::Type>(
-                            format!("* mut {element_type}").parse().unwrap(),
+                            format!("{} {element_type}", crate::types::ptr_prefix(is_mutable))
+                                .parse()
+                                .unwrap(),
                         )
                         .unwrap();
+                    }
+                    "cast_const" | "cast_tile_const" => {
+                        new_value.ty.set_pointer_constness(false);
+                    }
+                    "cast_mut" | "cast_tile_mut" => {
+                        new_value.ty.set_pointer_constness(true);
                     }
                     _ => {
                         return self.jit_error_result(

--- a/cutile-compiler/src/compiler/compile_type.rs
+++ b/cutile-compiler/src/compiler/compile_type.rs
@@ -291,8 +291,10 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                 TypeInstance::ElementType(element_instance),
             )?));
         } else if let Some(TypeInstance::PtrType(ptr_instance)) = type_instance {
-            let Some(pointer_attrs) = self.modules.get_primitives_attrs("Pointer", "* mut E")
-            else {
+            let Some(pointer_attrs) = self.modules.get_primitives_attrs(
+                "Pointer",
+                crate::types::pointer_impl_key(ptr_instance.is_mutable),
+            ) else {
                 return self
                     .jit_error_result(&ty.span(), "misconfigured Pointer impl in core module");
             };

--- a/cutile-compiler/src/compiler/tile_rust_type.rs
+++ b/cutile-compiler/src/compiler/tile_rust_type.rs
@@ -36,7 +36,11 @@ fn synthetic_tile_instance(rust_ty: syn::Type, element_name: &str, shape: &[i32]
 }
 
 /// Build a `TypeInstance::StructuredType` for a synthetic pointer tile type.
-fn synthetic_ptr_instance(rust_ty: syn::Type, element_name: &str) -> TypeInstance {
+fn synthetic_ptr_instance(
+    rust_ty: syn::Type,
+    element_name: &str,
+    is_mutable: bool,
+) -> TypeInstance {
     TypeInstance::StructuredType(crate::generics::TypeInstanceStructuredType {
         generic_ty: rust_ty.clone(),
         instance_ty: rust_ty.clone(),
@@ -45,7 +49,7 @@ fn synthetic_ptr_instance(rust_ty: syn::Type, element_name: &str) -> TypeInstanc
                 generic_ty: rust_ty.clone(),
                 instance_ty: rust_ty,
                 rust_element_instance_ty: element_name.to_string(),
-                is_mutable: true,
+                is_mutable,
             },
         )),
         shape: vec![],
@@ -217,8 +221,11 @@ impl TileRustType {
         Self::from_tile(element_name, &[])
     }
 
-    /// Build a `TileRustType` for a scalar pointer tile `PointerTile<*mut element, {[]}>`.
-    pub(crate) fn from_scalar_ptr(element_name: &str) -> Option<TileRustType> {
+    /// Build a `TileRustType` for a scalar pointer tile
+    /// `PointerTile<*mut element, {[]}>` / `PointerTile<*const element, {[]}>`.
+    /// Constness is a Rust-facing property only: the Tile IR pointer type
+    /// carries no mutability, so both build the same IR type.
+    pub(crate) fn from_scalar_ptr(element_name: &str, is_mutable: bool) -> Option<TileRustType> {
         let scalar = super::_type::scalar_from_name(element_name)?;
         let tile_ir_ty = TileIrType::Tile(cutile_ir::ir::TileType {
             shape: vec![],
@@ -227,8 +234,9 @@ impl TileRustType {
             )),
         });
         let type_str = format!("!cuda_tile.tile<!cuda_tile.ptr<{element_name}>>");
+        let prefix = crate::types::ptr_prefix(is_mutable);
         let rust_ty =
-            syn::parse_str::<syn::Type>(&format!("PointerTile<* mut {element_name}, {{[]}}>"))
+            syn::parse_str::<syn::Type>(&format!("PointerTile<{prefix} {element_name}, {{[]}}>"))
                 .ok()?;
         Some(TileRustType {
             kind: Kind::PrimitiveType,
@@ -237,8 +245,58 @@ impl TileRustType {
             tile_ir_ty: Some(tile_ir_ty),
             params: vec![],
             rust_ty: rust_ty.clone(),
-            type_instance: synthetic_ptr_instance(rust_ty, element_name),
+            type_instance: synthetic_ptr_instance(rust_ty, element_name, is_mutable),
         })
+    }
+
+    /// Re-labels the Rust-facing constness of this type's raw-pointer
+    /// component — `*mut E` <-> `*const E`, scalar or inside a
+    /// `PointerTile`. The Tile IR type is deliberately untouched: IR
+    /// pointers carry no constness, which is exactly what makes
+    /// `cast_const`/`cast_mut` free.
+    pub(crate) fn set_pointer_constness(&mut self, is_mutable: bool) {
+        let (from, to) = if is_mutable {
+            ("* const", "* mut")
+        } else {
+            ("* mut", "* const")
+        };
+        let relabel = |ty: &syn::Type| -> Option<syn::Type> {
+            let s = quote::quote!(#ty).to_string();
+            if s.contains(from) {
+                syn::parse_str::<syn::Type>(&s.replace(from, to)).ok()
+            } else {
+                None
+            }
+        };
+        if let Some(new_ty) = relabel(&self.rust_ty) {
+            self.rust_ty = new_ty;
+        }
+        let relabel_ptr_instance = |inst: &mut crate::generics::TypeInstancePtrType| {
+            inst.is_mutable = is_mutable;
+            if let Some(new_ty) = relabel(&inst.instance_ty) {
+                inst.instance_ty = new_ty;
+            }
+            if let Some(new_ty) = relabel(&inst.generic_ty) {
+                inst.generic_ty = new_ty;
+            }
+        };
+        match &mut self.type_instance {
+            TypeInstance::PtrType(inst) => relabel_ptr_instance(inst),
+            TypeInstance::StructuredType(structured) => {
+                if let Some(new_ty) = relabel(&structured.instance_ty) {
+                    structured.instance_ty = new_ty;
+                }
+                if let Some(new_ty) = relabel(&structured.generic_ty) {
+                    structured.generic_ty = new_ty;
+                }
+                if let Some(crate::generics::TypInstancePrimitiveType::PtrType(inst)) =
+                    &mut structured.primitive_type
+                {
+                    relabel_ptr_instance(inst);
+                }
+            }
+            _ => {}
+        }
     }
 
     pub(crate) fn new_structure(

--- a/cutile-compiler/src/generics.rs
+++ b/cutile-compiler/src/generics.rs
@@ -1018,7 +1018,13 @@ impl Instantiable for TypeInstanceStructuredType {
                                 // Map-shape metadata beyond the tile shape does not affect
                                 // TileRustType's element or shape instantiation.
                             } else {
-                                panic!("Failed to get cuda tile type for ty={} \n generic_arg={generic_arg:#?} \n generic_args={generic_vars:#?}", maybe_generic_ty.to_token_stream().to_string());
+                                // Can't resolve this type here — e.g. an element
+                                // var left unbound when a `P: PointerTo<E>` generic
+                                // is composed two levels deep. Give up gracefully so
+                                // the caller tries other instantiation strategies and
+                                // ultimately reports a spanned error, instead of
+                                // panicking the whole compile.
+                                return None;
                             }
                         }
                         syn::Type::Ptr(_) => {
@@ -1343,7 +1349,53 @@ impl GenericArgInference {
             let fn_arg_types = &fn_arg_types[i];
             self.add_generic_args(fn_arg_types, call_arg_rust_ty)?;
         }
+        self.propagate_pointer_to_bounds();
         Ok(())
+    }
+
+    /// Mirrors rustc's trait-driven inference for pointer ops: a generic
+    /// param declared `P: PointerTo<E>` that positional binding resolved
+    /// to a concrete raw pointer also determines `E` — its pointee —
+    /// because the only `PointerTo` impls are `*mut E` and `*const E`.
+    /// Without this, an element var that appears only in bounds and the
+    /// return type (the shape of every generic pointer memory op) would
+    /// stay unbound on the JIT track while rustc accepts the same call.
+    fn propagate_pointer_to_bounds(&mut self) {
+        for param in self.sig.generics.params.clone() {
+            let syn::GenericParam::Type(type_param) = param else {
+                continue;
+            };
+            let pointee = match self.param2arg.get(&type_param.ident.to_string()) {
+                Some(Some((_, bound_arg))) => match crate::types::get_ptr_type(bound_arg) {
+                    Some((_, pointee)) => pointee,
+                    None => continue,
+                },
+                _ => continue,
+            };
+            for bound in &type_param.bounds {
+                let syn::TypeParamBound::Trait(trait_bound) = bound else {
+                    continue;
+                };
+                let Some(segment) = trait_bound.path.segments.last() else {
+                    continue;
+                };
+                if segment.ident != "PointerTo" {
+                    continue;
+                }
+                let syn::PathArguments::AngleBracketed(args) = &segment.arguments else {
+                    continue;
+                };
+                let Some(GenericArgument::Type(element_ty)) = args.args.first() else {
+                    continue;
+                };
+                let Some(element_ident) = get_type_ident(element_ty) else {
+                    continue;
+                };
+                if let Some(slot @ None) = self.param2arg.get_mut(&element_ident.to_string()) {
+                    *slot = Some((GenericArgType::Type, pointee.clone()));
+                }
+            }
+        }
     }
     /// Applies explicitly provided generic arguments from a function call expression.
     pub fn apply_provided_generics_fn_call(
@@ -2012,7 +2064,14 @@ impl GenericArgInference {
                         Some((GenericArgType::Type, arg_type_str.to_string())),
                     );
                     if let Some(Some((_generic_arg_type, arg))) = replaced_arg {
-                        assert_eq!(arg, arg_type_str.to_string());
+                        // A shared pointer-typed generic param can bind to both
+                        // `*const T` and `*mut T`: rustc coerces at the call site
+                        // and Tile IR erases constness, so tolerate a const/mut-only
+                        // difference — only a different pointee is a real mismatch.
+                        debug_assert_eq!(
+                            arg.replace("* const ", "* mut "),
+                            arg_type_str.replace("* const ", "* mut ")
+                        );
                     }
                 }
             }
@@ -2029,7 +2088,14 @@ impl GenericArgInference {
                         Some((GenericArgType::Type, arg_type_str.to_string())),
                     );
                     if let Some(Some((_generic_arg_type, arg))) = replaced_arg {
-                        assert_eq!(arg, arg_type_str.to_string());
+                        // A shared pointer-typed generic param can bind to both
+                        // `*const T` and `*mut T`: rustc coerces at the call site
+                        // and Tile IR erases constness, so tolerate a const/mut-only
+                        // difference — only a different pointee is a real mismatch.
+                        debug_assert_eq!(
+                            arg.replace("* const ", "* mut "),
+                            arg_type_str.replace("* const ", "* mut ")
+                        );
                     }
                 }
             }

--- a/cutile-compiler/src/types.rs
+++ b/cutile-compiler/src/types.rs
@@ -419,7 +419,9 @@ impl MLIRVariadicArg {
             }
             Some(TypInstancePrimitiveType::PtrType(primitive_type)) => {
                 let rust_element_instance_ty = &primitive_type.rust_element_instance_ty;
-                if let Some(ptr_attrs) = get_primitives_attrs("Pointer", "* mut E", primitives) {
+                if let Some(ptr_attrs) =
+                    get_pointer_primitives_attrs(primitive_type.is_mutable, primitives)
+                {
                     if let Some(cuda_tile_element_type) =
                         get_cuda_tile_element_type_from_rust_primitive_str(
                             rust_element_instance_ty,
@@ -479,6 +481,36 @@ pub fn get_primitives_attrs(
         Some(item_impl) => get_meta_list("cuda_tile :: ty", &item_impl.attrs),
         None => None,
     }
+}
+
+/// The `Pointer` impl registration key for a given constness. Every
+/// consumer of pointer attrs goes through this so the `*mut`/`*const`
+/// pair never leaks into ad-hoc string keys.
+pub fn pointer_impl_key(is_mutable: bool) -> &'static str {
+    if is_mutable {
+        "* mut E"
+    } else {
+        "* const E"
+    }
+}
+
+/// The Rust-source pointer prefix for a given constness. Tile IR has a
+/// single pointer type, so constness lives only in the Rust-facing type
+/// strings built from this.
+pub fn ptr_prefix(is_mutable: bool) -> &'static str {
+    if is_mutable {
+        "* mut"
+    } else {
+        "* const"
+    }
+}
+
+/// Looks up the `Pointer` impl attrs matching the pointer's constness.
+pub fn get_pointer_primitives_attrs(
+    is_mutable: bool,
+    primitives: &HashMap<(String, String), ItemImpl>,
+) -> Option<SingleMetaList> {
+    get_primitives_attrs("Pointer", pointer_impl_key(is_mutable), primitives)
 }
 
 /// Returns `true` if the Rust type string is a registered element type.

--- a/cutile-examples/examples/hello_world.rs
+++ b/cutile-examples/examples/hello_world.rs
@@ -16,16 +16,20 @@ mod hello_world_module {
 
     #[cutile::entry(print_ir = true)]
     fn hello_world_kernel() {
-        let pids: (i32, i32, i32) = get_tile_block_id();
-        let npids: (i32, i32, i32) = get_num_tile_blocks();
+        let pid0 = program_id(0);
+        let pid1 = program_id(1);
+        let pid2 = program_id(2);
+        let n0 = num_programs(0);
+        let n1 = num_programs(1);
+        let n2 = num_programs(2);
         cuda_tile_print!(
-            "Hello, I am tile <{}, {}, {}> in a kernel with <{}, {}, {}> tiles.\n",
-            pids.0,
-            pids.1,
-            pids.2,
-            npids.0,
-            npids.1,
-            npids.2
+            "Hello, I am program <{}, {}, {}> in a kernel with <{}, {}, {}> programs.\n",
+            pid0,
+            pid1,
+            pid2,
+            n0,
+            n1,
+            n2
         );
     }
 }

--- a/cutile-macro/src/kernel_launcher_generator.rs
+++ b/cutile-macro/src/kernel_launcher_generator.rs
@@ -588,12 +588,12 @@ pub fn generate_kernel_launcher(
                         .err("Pointers can only be used in unsafe kernel entry points.");
                 }
                 let ptr_str = ptr_type.to_token_stream().to_string();
-                let Some((is_mutable, type_name)) = get_ptr_type(&ptr_str) else {
+                let Some((_is_mutable, type_name)) = get_ptr_type(&ptr_str) else {
                     return ptr_type.err(&format!("Unexpected pointer type: {}", ptr_str));
                 };
-                if !is_mutable {
-                    return ptr_type.err("Pointers must be * mut.");
-                }
+                // `*const` and `*mut` params launch identically: the host
+                // passes a device address either way; constness is a
+                // device-side type discipline, not a launch property.
                 arg_types.push(
                     syn::parse2::<Type>(format!("DevicePointer<{}>", type_name).parse().unwrap())
                         .unwrap(),

--- a/cutile/src/_core.rs
+++ b/cutile/src/_core.rs
@@ -417,11 +417,28 @@ pub mod core {
 
     // ---- §5.2 POINTERS -----------------------------------------------------
 
-    /// Marker for GPU pointer types. Impl'd for `*mut E` where `E: ElementType`.
+    /// Marker for GPU pointer types. Impl'd for `*mut E` and `*const E`
+    /// where `E: ElementType`. `Pointer` is the read capability: every op
+    /// that only loads is bound by it, so `*mut` works anywhere `*const`
+    /// does — the same containment Rust's raw pointers have.
     pub trait Pointer {}
     #[cuda_tile::ty(name="!cuda_tile.tile", pointer_type="!cuda_tile.ptr", type_params=["!cuda_tile.ptr<E>"])]
     impl<E: ElementType> Pointer for *mut E {}
-    // impl<E: ElementType> Pointer for *const E {}
+    #[cuda_tile::ty(name="!cuda_tile.tile", pointer_type="!cuda_tile.ptr", type_params=["!cuda_tile.ptr<E>"])]
+    impl<E: ElementType> Pointer for *const E {}
+
+    /// The write capability: only `*mut E`. Ops that store are bound by
+    /// this, so a `*const E` can never reach a store without an explicit
+    /// [`cast_mut`].
+    pub trait PointerMut: Pointer {}
+    impl<E: ElementType> PointerMut for *mut E {}
+
+    /// Relates a pointer type to its pointee: `*mut E` and `*const E` are
+    /// both `PointerTo<E>`. Generic memory ops use this so the element type
+    /// is inferred from the pointer at the call site.
+    pub trait PointerTo<E: ElementType>: Pointer {}
+    impl<E: ElementType> PointerTo<E> for *mut E {}
+    impl<E: ElementType> PointerTo<E> for *const E {}
 
     /// Tile of pointers — enables gather/scatter and indirect access.
     #[cuda_tile::ty(name="!cuda_tile.tile", type_params=["{D}xP"])]
@@ -705,6 +722,16 @@ pub mod core {
         /// Returns the shape of this tensor.
         pub fn shape<'b>(&self) -> Shape<'b, S> {
             get_tensor_shape_meta(self)
+        }
+
+        /// The base device address of this tensor view.
+        ///
+        /// Safe, mirroring `<[T]>::as_ptr`: obtaining the address never
+        /// touches memory. Dereferencing it — a gather load, or building a
+        /// view over it — is `unsafe` and carries the safety conditions at
+        /// those sites, exactly like dereferencing a raw pointer in Rust.
+        pub fn as_ptr(&self) -> *const E {
+            cast_const(tile_to_pointer(get_tensor_base(self)))
         }
         pub fn load_tile<const R: [i32; N]>(&self, shape: Shape<R>, idx: [i32; N]) -> Tile<E, R> {
             load_tile(self, shape, idx)
@@ -1455,6 +1482,54 @@ pub mod core {
         unreachable!()
     }
 
+    /// The index of the current tile program along `axis` of the launch
+    /// grid, following Triton's `tl.program_id(axis)`.
+    ///
+    /// `axis` selects the grid dimension: 0, 1, or 2. The host derives a
+    /// launch grid from a partition shape with partition axis `k` mapping
+    /// to grid axis `k`, so the idiom
+    /// `tensor.partition(shape).load([program_id(0)])` loads exactly the
+    /// sub-tensor this tile program owns. Equivalent to the matching
+    /// component of [`get_tile_block_id`]; a constant `axis` folds to
+    /// that component at compile time. Axes above 2 fail a device
+    /// assertion.
+    // cuda_tile_assert! expands to unreachable!() for the host build.
+    #[allow(unreachable_code)]
+    pub fn program_id(axis: i32) -> i32 {
+        let pid: (i32, i32, i32) = get_tile_block_id();
+        if axis == 0 {
+            pid.0
+        } else if axis == 1 {
+            pid.1
+        } else {
+            cuda_tile_assert!(axis == 2, "program_id: axis must be 0, 1, or 2");
+            pid.2
+        }
+    }
+
+    /// The number of tile programs along `axis` of the launch grid,
+    /// following Triton's `tl.num_programs(axis)`.
+    ///
+    /// `axis` selects the grid dimension: 0, 1, or 2. Together with
+    /// [`program_id`] this bounds the grid:
+    /// `0 <= program_id(k) < num_programs(k)` for each axis `k`.
+    /// Equivalent to the matching component of [`get_num_tile_blocks`];
+    /// a constant `axis` folds to that component at compile time. Axes
+    /// above 2 fail a device assertion.
+    // cuda_tile_assert! expands to unreachable!() for the host build.
+    #[allow(unreachable_code)]
+    pub fn num_programs(axis: i32) -> i32 {
+        let nb: (i32, i32, i32) = get_num_tile_blocks();
+        if axis == 0 {
+            nb.0
+        } else if axis == 1 {
+            nb.1
+        } else {
+            cuda_tile_assert!(axis == 2, "num_programs: axis must be 0, 1, or 2");
+            nb.2
+        }
+    }
+
     /// Wrap a scalar in a 0-dim tile.
     #[cuda_tile::compiler_op(name = "cast")]
     pub fn scalar_to_tile<E: ElementType>(scalar: impl Scalar) -> Tile<E, { [] }> {
@@ -1491,6 +1566,41 @@ pub mod core {
     /// Unwrap a 0-dim `PointerTile` back into a raw pointer.
     #[cuda_tile::compiler_op(name = "cast")]
     pub fn tile_to_pointer<P: Pointer>(tile: PointerTile<P, { [] }>) -> P {
+        unreachable!()
+    }
+
+    /// Convert `*mut E` to `*const E`, mirroring `<*mut T>::cast_const`.
+    /// Safe in both Rust and the DSL: the cast never changes what the
+    /// pointer may do — capability is checked where memory is touched.
+    #[cuda_tile::compiler_op(name = "cast")]
+    pub fn cast_const<E: ElementType>(ptr: *mut E) -> *const E {
+        unreachable!()
+    }
+
+    /// Convert `*const E` to `*mut E`, mirroring `<*const T>::cast_mut`.
+    /// Safe like its Rust counterpart: obtaining the `*mut` is harmless;
+    /// storing through it is the gated act — store ops are `unsafe` and
+    /// require [`PointerMut`], carrying their own safety conditions.
+    #[cuda_tile::compiler_op(name = "cast")]
+    pub fn cast_mut<E: ElementType>(ptr: *const E) -> *mut E {
+        unreachable!()
+    }
+
+    /// Elementwise [`cast_const`] over a pointer tile.
+    #[cuda_tile::variadic_op(N = 6)]
+    #[cuda_tile::compiler_op(name = "cast")]
+    pub fn cast_tile_const<E: ElementType, const D: [i32; N]>(
+        tile: PointerTile<*mut E, D>,
+    ) -> PointerTile<*const E, D> {
+        unreachable!()
+    }
+
+    /// Elementwise [`cast_mut`] over a pointer tile.
+    #[cuda_tile::variadic_op(N = 6)]
+    #[cuda_tile::compiler_op(name = "cast")]
+    pub fn cast_tile_mut<E: ElementType, const D: [i32; N]>(
+        tile: PointerTile<*const E, D>,
+    ) -> PointerTile<*mut E, D> {
         unreachable!()
     }
 
@@ -1863,6 +1973,15 @@ pub mod core {
         unreachable!()
     }
 
+    /// Extract a `Tensor`'s base pointer from its type metadata.
+    #[cuda_tile::variadic_op(N = 6)]
+    #[cuda_tile::compiler_op(name = "return_type_meta_field", type_meta_field = "base")]
+    pub fn get_tensor_base<E: ElementType, const S: [i32; N]>(
+        tensor: &Tensor<E, S>,
+    ) -> PointerTile<*mut E, { [] }> {
+        unreachable!()
+    }
+
     /// Update a `Tensor`'s ordering token after a memory op.
     #[cuda_tile::variadic_op(N = 6)]
     #[cuda_tile::compiler_op(name = "set_type_meta_field", type_meta_field = "token")]
@@ -2045,7 +2164,7 @@ pub mod core {
 
     /// Element-wise integer divide. `Zero` rounding = truncation;
     /// `PositiveInf` = ceiling div; `NegativeInf` = floor div (signed only).
-    #[cuda_tile::op(name = "cuda_tile.divi", params = ["lhs", "rhs"], static_params = ["rounding={Zero: , NearestEven: rounding=#cuda_tile.rounding<nearest_even>, PositiveInf: rounding=#cuda_tile.rounding<positive_inf>, NegativeInf: rounding=#cuda_tile.rounding<negative_inf>, Approx: rounding=#cuda_tile.rounding<approx>, Full: rounding=#cuda_tile.rounding<full>}"])]
+    #[cuda_tile::op(name = "cuda_tile.divi", params = ["lhs", "rhs"], static_params = ["rounding={Zero: rounding=#cuda_tile.rounding<zero>, NearestEven: rounding=#cuda_tile.rounding<nearest_even>, PositiveInf: rounding=#cuda_tile.rounding<positive_inf>, NegativeInf: rounding=#cuda_tile.rounding<negative_inf>, Approx: rounding=#cuda_tile.rounding<approx>, Full: rounding=#cuda_tile.rounding<full>}"], named_attributes = ["signedness=inferred_signedness"])]
     #[cuda_tile::variadic_op(N = 6)]
     pub fn divi<E: ElementType, const S: [i32; N], R: rounding::Mode>(
         lhs: Tile<E, S>,
@@ -2056,7 +2175,7 @@ pub mod core {
     }
 
     /// Element-wise integer remainder. Result sign matches dividend.
-    #[cuda_tile::op(name = "cuda_tile.remi", params = ["lhs", "rhs"])]
+    #[cuda_tile::op(name = "cuda_tile.remi", params = ["lhs", "rhs"], named_attributes = ["signedness=inferred_signedness"])]
     #[cuda_tile::variadic_op(N = 6)]
     pub fn remi<E: ElementType, const S: [i32; N]>(lhs: Tile<E, S>, rhs: Tile<E, S>) -> Tile<E, S> {
         unreachable!()
@@ -2694,16 +2813,23 @@ pub mod core {
 
     /// Gather from a pointer tile. Returns `(loaded_values, token)`.
     /// `memory_ordering` ⊆ {Weak, Relaxed, Acquire}; `Weak` drops scope.
+    ///
+    /// # Safety
+    /// Dereferences raw device pointers. Like `core::ptr::read`, forming and
+    /// offsetting the pointer tile is safe, but the load is not: every lane's
+    /// address (masked lanes excepted) must point to a valid, correctly-aligned
+    /// `E` the kernel is allowed to read for the launch's lifetime.
     #[cuda_tile::op(name="cuda_tile.load_ptr_tko", params=["source"])]
     #[cuda_tile::variadic_op(N = 6)]
-    pub fn load_ptr_tko<
+    pub unsafe fn load_ptr_tko<
         E: ElementType,
+        P: PointerTo<E>,
         const S: [i32; N],
         O: ordering::LoadMode,
         Sc: scope::Mode,
         const CYCLES: u32,
     >(
-        source: PointerTile<*mut E, S>,
+        source: PointerTile<P, S>,
         memory_ordering: O,
         memory_scope: Option<Sc>,
         mask: Option<Tile<bool, S>>,
@@ -2716,16 +2842,24 @@ pub mod core {
 
     /// Scatter to a pointer tile. Returns the completion token.
     /// `memory_ordering` ⊆ {Weak, Relaxed, Release}; `Weak` drops scope.
+    ///
+    /// # Safety
+    /// Dereferences raw device pointers. Like `core::ptr::write`, forming and
+    /// offsetting the pointer tile is safe, but the store is not: every lane's
+    /// address (masked lanes excepted) must point to a valid, correctly-aligned
+    /// `E` the kernel is allowed to write, with no aliasing that would race
+    /// another access, for the launch's lifetime.
     #[cuda_tile::op(name="cuda_tile.store_ptr_tko", params=["destination", "value"])]
     #[cuda_tile::variadic_op(N = 6)]
-    pub fn store_ptr_tko<
+    pub unsafe fn store_ptr_tko<
         E: ElementType,
+        P: PointerTo<E> + PointerMut,
         const S: [i32; N],
         O: ordering::StoreMode,
         Sc: scope::Mode,
         const CYCLES: u32,
     >(
-        destination: PointerTile<*mut E, S>,
+        destination: PointerTile<P, S>,
         value: Tile<E, S>,
         memory_ordering: O,
         memory_scope: Option<Sc>,

--- a/cutile/tests/gpu.rs
+++ b/cutile/tests/gpu.rs
@@ -32,6 +32,12 @@ mod add_basic;
 #[path = "gpu/add_ptr.rs"]
 mod add_ptr;
 
+#[path = "gpu/const_pointers.rs"]
+mod const_pointers;
+
+#[path = "gpu/program_id.rs"]
+mod program_id;
+
 #[path = "gpu/add_refs.rs"]
 mod add_refs;
 

--- a/cutile/tests/gpu/book_snippets.rs
+++ b/cutile/tests/gpu/book_snippets.rs
@@ -26,16 +26,20 @@ mod hello_world_module {
 
     #[cutile::entry()]
     fn hello_world_kernel() {
-        let pids: (i32, i32, i32) = get_tile_block_id();
-        let npids: (i32, i32, i32) = get_num_tile_blocks();
+        let pid0 = program_id(0);
+        let pid1 = program_id(1);
+        let pid2 = program_id(2);
+        let n0 = num_programs(0);
+        let n1 = num_programs(1);
+        let n2 = num_programs(2);
         cuda_tile_print!(
-            "Hello from tile <{}, {}, {}> in a grid of <{}, {}, {}> tiles!\n",
-            pids.0,
-            pids.1,
-            pids.2,
-            npids.0,
-            npids.1,
-            npids.2
+            "Hello from program <{}, {}, {}> in a grid of <{}, {}, {}> programs!\n",
+            pid0,
+            pid1,
+            pid2,
+            n0,
+            n1,
+            n2
         );
     }
 }
@@ -151,11 +155,12 @@ mod gemm_module {
     ) {
         let part_x = x.partition(const_shape![BM, BK]);
         let part_y = y.partition(const_shape![BK, BN]);
-        let pid: (i32, i32, i32) = get_tile_block_id();
+        let pid_m = program_id(0);
+        let pid_n = program_id(1);
         let mut tile_z = load_tile_mut(z);
         for i in 0i32..(K / BK) {
-            let tile_x = part_x.load([pid.0, i]);
-            let tile_y = part_y.load([i, pid.1]);
+            let tile_x = part_x.load([pid_m, i]);
+            let tile_y = part_y.load([i, pid_n]);
             tile_z = mma(tile_x, tile_y, tile_z);
         }
         z.store(tile_z);
@@ -265,11 +270,11 @@ mod fmha_module {
         out: &mut Tensor<f32, { [1, BM, D] }>,
         qk_scale: f32,
     ) {
-        let pid: (i32, i32, i32) = get_tile_block_id();
+        let pid0 = program_id(0);
         let h = q.shape()[1];
-        let batch_idx = pid.0 / h;
-        let head_idx = pid.0 % h;
-        let q_m_idx = pid.1;
+        let batch_idx = pid0 / h;
+        let head_idx = pid0 % h;
+        let q_m_idx = program_id(1);
 
         let two: Tile<f32, { [] }> = constant(2.0f32, const_shape![]);
         let log2: f32 = tile_to_scalar(log(two));
@@ -417,11 +422,12 @@ mod mlp_module {
     ) {
         let part_x = x.partition(const_shape![BM, BK]);
         let part_y = y.partition(const_shape![BK, BN]);
-        let pid: (i32, i32, i32) = get_tile_block_id();
+        let pid_m = program_id(0);
+        let pid_n = program_id(1);
         let mut tile_z = load_tile_mut(z);
         for i in 0i32..(K / BK) {
-            let tile_x = part_x.load([pid.0, i]);
-            let tile_y = part_y.load([i, pid.1]);
+            let tile_x = part_x.load([pid_m, i]);
+            let tile_y = part_y.load([i, pid_n]);
             tile_z = mma(tile_x, tile_y, tile_z);
         }
         z.store(tile_z);
@@ -435,10 +441,10 @@ mod mlp_module {
     ) {
         let part_x = x.partition(const_shape![BM, BK]);
         let part_y = y.partition(const_shape![BK]);
-        let pid: (i32, i32, i32) = get_tile_block_id();
+        let pid = program_id(0);
         let mut tile_z = z.load().reshape(const_shape![BM, 1]);
         for i in 0i32..(K / BK) {
-            let tile_x = part_x.load([pid.0, i]);
+            let tile_x = part_x.load([pid, i]);
             let tile_y = part_y.load([i]).reshape(const_shape![BK, 1]);
             tile_z = mma(tile_x, tile_y, tile_z);
         }
@@ -524,13 +530,13 @@ mod pointer_add_module {
         let mut z_tensor: Tensor<T, { [-1] }> = get_tensor(z_ptr, len);
         let x_tensor: Tensor<T, { [-1] }> = get_tensor(x_ptr, len);
         let y_tensor: Tensor<T, { [-1] }> = get_tensor(y_ptr, len);
-        let pid: (i32, i32, i32) = get_tile_block_id();
+        let pid = program_id(0);
         let tile_shape = const_shape![4i32];
-        let tile_x = x_tensor.partition(tile_shape).load([pid.0]);
-        let tile_y = y_tensor.partition(tile_shape).load([pid.0]);
+        let tile_x = x_tensor.partition(tile_shape).load([pid]);
+        let tile_y = y_tensor.partition(tile_shape).load([pid]);
         z_tensor
             .partition_mut(tile_shape)
-            .store(tile_x + tile_y, [pid.0]);
+            .store(tile_x + tile_y, [pid]);
     }
 }
 

--- a/cutile/tests/gpu/const_pointers.rs
+++ b/cutile/tests/gpu/const_pointers.rs
@@ -1,0 +1,146 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! `*const T` in the device DSL, mirroring Rust's raw-pointer model:
+//! obtaining and casting pointers is safe, dereferencing/viewing is the
+//! gated act, and `*mut` works anywhere `*const` does. Covers
+//! `Tensor::as_ptr`, `cast_const`/`cast_mut` (scalar and tile),
+//! constness-preserving `pointer_to_tile`, `*const` entry params, and
+//! gather loads through `PointerTile<*const E, S>`.
+
+use cutile::prelude::*;
+
+use crate::common;
+
+#[cutile::module]
+mod const_ptr_module {
+
+    use cutile::core::*;
+
+    /// Rebuild a read-only view from a `*const` base. The `cast_mut` is
+    /// the explicit constness boundary (`make_tensor_view` takes `*mut`),
+    /// mirroring Rust where the cast is safe and the view construction
+    /// carries the safety contract.
+    unsafe fn view_from_const<T: ElementType>(ptr: *const T, len: i32) -> Tensor<T, { [-1] }> {
+        let shape: Shape<{ [-1] }> = Shape::<{ [-1] }> { dims: &[len] };
+        let strides: Array<{ [-1] }> = Array::<{ [-1] }> { dims: &[1i32] };
+        let ptr_tile: PointerTile<*mut T, { [] }> = pointer_to_tile(cast_mut(ptr));
+        make_tensor_view(ptr_tile, shape, strides, new_token_unordered())
+    }
+
+    /// `x.as_ptr()` round-trips through the raw-pointer world and back to
+    /// a view that loads the same data the safe path loads.
+    #[cutile::entry()]
+    fn as_ptr_roundtrip(z: &mut Tensor<f32, { [4] }>, x: &Tensor<f32, { [-1] }>, len: i32) {
+        let x_base: *const f32 = x.as_ptr();
+        // TODO (hme): document safety
+        let x_view: Tensor<f32, { [-1] }> = unsafe { view_from_const(x_base, len) };
+        let pid: (i32, i32, i32) = get_tile_block_id();
+        let direct = x.load_tile(const_shape![4], [pid.0]);
+        let via_ptr = x_view.partition(const_shape![4]).load([pid.0]);
+        z.store(direct + via_ptr);
+    }
+
+    /// A `*const f32` entry param is accepted and readable; the scalar
+    /// casts convert in both directions.
+    #[cutile::entry()]
+    unsafe fn read_through_const(z: &mut Tensor<f32, { [4] }>, x_ptr: *const f32, len: i32) {
+        // *const -> *mut -> *const: both directions, like Rust's
+        // cast_mut/cast_const.
+        let x_mut: *mut f32 = cast_mut(x_ptr);
+        let x_const: *const f32 = cast_const(x_mut);
+        let x_view: Tensor<f32, { [-1] }> = view_from_const(x_const, len);
+        let pid: (i32, i32, i32) = get_tile_block_id();
+        let tile = x_view.partition(const_shape![4]).load([pid.0]);
+        z.store(tile);
+    }
+
+    /// Gather through a `PointerTile<*const f32, S>`: the read op is
+    /// generic over the pointer's constness (`P: PointerTo<E>`), so the
+    /// same `load_ptr_tko` accepts what a `*mut` tile satisfies too.
+    #[cutile::entry()]
+    unsafe fn gather_through_const(z: &mut Tensor<f32, { [4] }>, x_ptr: *const f32) {
+        let base: PointerTile<*const f32, { [] }> = pointer_to_tile(x_ptr);
+        let base: PointerTile<*const f32, { [1] }> = base.reshape(const_shape![1]);
+        let base: PointerTile<*const f32, { [4] }> = base.broadcast(const_shape![4]);
+        // Gather indices 0..4 reversed: element i reads x[3 - i].
+        let three = broadcast_scalar(3i32, const_shape![4]);
+        let offsets: Tile<i32, { [4] }> = three - iota(const_shape![4]);
+        let addrs: PointerTile<*const f32, { [4] }> = addptr_tile(base, offsets);
+        // The tile-level casts convert both directions as well.
+        let addrs: PointerTile<*mut f32, { [4] }> = cast_tile_mut(addrs);
+        let addrs: PointerTile<*const f32, { [4] }> = cast_tile_const(addrs);
+        let (tile, _token): (Tile<f32, { [4] }>, Token) = load_ptr_tko(
+            addrs,
+            ordering::Relaxed,
+            Some(scope::Device),
+            None,
+            None,
+            None,
+            Latency::<0>,
+        );
+        z.store(tile);
+    }
+}
+
+use const_ptr_module::{as_ptr_roundtrip, gather_through_const, read_through_const};
+
+#[test]
+fn as_ptr_matches_the_safe_path() {
+    common::with_test_stack(|| {
+        let len = 32usize;
+        let x = api::arange::<f32>(len);
+        let z_host = as_ptr_roundtrip(api::zeros(&[len]).partition([4]), x, len as i32)
+            .grid(((len / 4) as u32, 1, 1))
+            .first()
+            .unpartition()
+            .to_host_vec()
+            .sync()
+            .expect("as_ptr_roundtrip kernel");
+        for (i, v) in z_host.iter().enumerate() {
+            assert_eq!(*v, 2.0 * i as f32, "index {i}");
+        }
+    });
+}
+
+#[test]
+fn const_entry_param_loads() {
+    common::with_test_stack(|| {
+        let len = 32usize;
+        let x = api::arange::<f32>(len).sync().expect("arange");
+        let z_host = unsafe {
+            read_through_const(
+                api::zeros(&[len]).partition([4]),
+                x.device_pointer(),
+                len as i32,
+            )
+        }
+        .grid(((len / 4) as u32, 1, 1))
+        .first()
+        .unpartition()
+        .to_host_vec()
+        .sync()
+        .expect("read_through_const kernel");
+        for (i, v) in z_host.iter().enumerate() {
+            assert_eq!(*v, i as f32, "index {i}");
+        }
+    });
+}
+
+#[test]
+fn gather_loads_through_a_const_pointer_tile() {
+    common::with_test_stack(|| {
+        let x = api::arange::<f32>(4).sync().expect("arange");
+        let z_host =
+            unsafe { gather_through_const(api::zeros(&[4]).partition([4]), x.device_pointer()) }
+                .grid((1, 1, 1))
+                .first()
+                .unpartition()
+                .to_host_vec()
+                .sync()
+                .expect("gather_through_const kernel");
+        assert_eq!(z_host, vec![3.0, 2.0, 1.0, 0.0]);
+    });
+}

--- a/cutile/tests/gpu/program_id.rs
+++ b/cutile/tests/gpu/program_id.rs
@@ -1,0 +1,91 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! `program_id(axis)` / `num_programs(axis)`: the per-axis tile-program
+//! index and grid extent, following Triton's `tl.program_id` /
+//! `tl.num_programs`. Pins both against `get_tile_block_id()` /
+//! `get_num_tile_blocks()` on a rank-3 grid, and the rank-1 idiom
+//! `tensor.partition(shape).load([program_id(0)])`.
+
+use cutile::prelude::*;
+
+use crate::common;
+
+#[cutile::module]
+mod program_id_module {
+    use cutile::core::*;
+
+    /// Each program encodes its three `program_id` axes and the three
+    /// `num_programs` extents into one i32 and stores it into its own
+    /// `[1, 1, 1]` slab, which sits at its block coordinates — so the
+    /// host can compare every axis against the block coordinates it
+    /// launched.
+    #[cutile::entry()]
+    fn write_program_axes(out: &mut Tensor<i32, { [1, 1, 1] }>) {
+        let encoded = program_id(0)
+            + 10 * program_id(1)
+            + 100 * program_id(2)
+            + 1_000 * num_programs(0)
+            + 10_000 * num_programs(1)
+            + 100_000 * num_programs(2);
+        let id: Tile<i32, { [] }> = scalar_to_tile(encoded);
+        out.store(id.reshape(const_shape![1, 1, 1]));
+    }
+
+    /// The rank-1 idiom: each program copies exactly the sub-tensor it
+    /// owns.
+    #[cutile::entry()]
+    fn copy_by_program_id(z: &mut Tensor<f32, { [4] }>, x: &Tensor<f32, { [-1] }>) {
+        let tile = x.partition(const_shape![4]).load([program_id(0)]);
+        z.store(tile);
+    }
+}
+
+use program_id_module::{copy_by_program_id, write_program_axes};
+
+#[test]
+fn program_id_and_num_programs_match_the_block_coordinates_per_axis() {
+    common::with_test_stack(|| {
+        let (nx, ny, nz) = (4usize, 3usize, 2usize);
+        let result = write_program_axes(api::zeros::<i32>(&[nx, ny, nz]).partition([1, 1, 1]))
+            .grid((nx as u32, ny as u32, nz as u32))
+            .sync()
+            .expect("write_program_axes kernel");
+        let host = result
+            .0
+            .unpartition()
+            .to_host_vec()
+            .sync()
+            .expect("to_host");
+        // Row-major host layout: out[x][y][z] at x*ny*nz + y*nz + z.
+        for x in 0..nx {
+            for y in 0..ny {
+                for z in 0..nz {
+                    let got = host[x * ny * nz + y * nz + z];
+                    let expected =
+                        (x + 10 * y + 100 * z + 1_000 * nx + 10_000 * ny + 100_000 * nz) as i32;
+                    assert_eq!(got, expected, "block ({x}, {y}, {z})");
+                }
+            }
+        }
+    });
+}
+
+#[test]
+fn rank1_partition_load_by_program_id_copies_the_owned_subtensor() {
+    common::with_test_stack(|| {
+        let len = 32usize;
+        let z_host = copy_by_program_id(api::zeros(&[len]).partition([4]), api::arange::<f32>(len))
+            .grid(((len / 4) as u32, 1, 1))
+            .first()
+            .unpartition()
+            .to_host_vec()
+            .sync()
+            .expect("copy_by_program_id kernel");
+        for (i, v) in z_host.iter().enumerate() {
+            assert_eq!(*v, i as f32, "index {i}");
+        }
+    });
+}

--- a/cutile/tests/integer_ops.rs
+++ b/cutile/tests/integer_ops.rs
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 use cutile;
+use cutile::compile_api::KernelCompiler;
 use cutile_compiler::compiler::utils::CompileOptions;
 
 mod common;
@@ -183,6 +184,24 @@ fn compile_named_integer_arithmetic() -> () {
             "Expected overflow attributes in named integer arithmetic"
         );
     });
+}
+
+#[test]
+fn named_integer_arithmetic_serializes_bytecode() {
+    let artifacts = KernelCompiler::new(
+        __module_ast_self,
+        "integer_ops_module",
+        "named_integer_arithmetic_kernel",
+    )
+    .target("sm_120")
+    .generics(vec!["128".to_owned()])
+    .strides(&[("output", &[1])])
+    .compile()
+    .expect("named integer arithmetic should compile");
+    let bytecode = artifacts
+        .bytecode()
+        .expect("divi/remi signedness must serialize to Tile IR bytecode");
+    assert!(!bytecode.is_empty());
 }
 
 #[test]

--- a/cutile/tests/memory_and_atomic_ops.rs
+++ b/cutile/tests/memory_and_atomic_ops.rs
@@ -56,29 +56,33 @@ mod memory_and_atomic_ops_module {
         let ptrs: PointerTile<*mut f32, S> = ptr_to_ptr(ptrs_i64);
 
         // Load from pointer tile with relaxed/device semantics, no optional params
-        let (loaded_values, _load_token): (Tile<f32, S>, Token) = load_ptr_tko(
-            ptrs,
-            ordering::Relaxed,
-            Some(scope::Device),
-            None,
-            None,
-            None,
-            Latency::<0>,
-        );
+        let (loaded_values, _load_token): (Tile<f32, S>, Token) = unsafe {
+            load_ptr_tko(
+                ptrs,
+                ordering::Relaxed,
+                Some(scope::Device),
+                None,
+                None,
+                None,
+                Latency::<0>,
+            )
+        };
 
         // Modify the values
         let modified: Tile<f32, S> = loaded_values + constant(1.0, output.shape());
 
         // Store back to pointer tile with relaxed/device semantics, no optional params
-        let _store_token: Token = store_ptr_tko(
-            ptrs,
-            modified,
-            ordering::Relaxed,
-            Some(scope::Device),
-            None,
-            None,
-            Latency::<0>,
-        );
+        let _store_token: Token = unsafe {
+            store_ptr_tko(
+                ptrs,
+                modified,
+                ordering::Relaxed,
+                Some(scope::Device),
+                None,
+                None,
+                Latency::<0>,
+            )
+        };
 
         // Store result using regular tensor API
         output.store(modified);
@@ -91,15 +95,17 @@ mod memory_and_atomic_ops_module {
         let ptrs_i64: PointerTile<*mut i64, S> = int_to_ptr(ptr_seed);
         let ptrs: PointerTile<*mut f32, S> = ptr_to_ptr(ptrs_i64);
 
-        let (loaded_values, _token): (Tile<f32, S>, Token) = load_ptr_tko(
-            ptrs,
-            ordering::Weak,
-            None::<scope::TileBlock>,
-            None,
-            None,
-            None,
-            Latency::<0>,
-        );
+        let (loaded_values, _token): (Tile<f32, S>, Token) = unsafe {
+            load_ptr_tko(
+                ptrs,
+                ordering::Weak,
+                None::<scope::TileBlock>,
+                None,
+                None,
+                None,
+                Latency::<0>,
+            )
+        };
 
         output.store(loaded_values);
     }
@@ -111,15 +117,17 @@ mod memory_and_atomic_ops_module {
         let ptrs_i64: PointerTile<*mut i64, S> = int_to_ptr(ptr_seed);
         let ptrs: PointerTile<*mut f32, S> = ptr_to_ptr(ptrs_i64);
 
-        let (loaded_values, _token): (Tile<f32, S>, Token) = load_ptr_tko(
-            ptrs,
-            ordering::Acquire,
-            Some(scope::System),
-            None,
-            None,
-            None,
-            Latency::<0>,
-        );
+        let (loaded_values, _token): (Tile<f32, S>, Token) = unsafe {
+            load_ptr_tko(
+                ptrs,
+                ordering::Acquire,
+                Some(scope::System),
+                None,
+                None,
+                None,
+                Latency::<0>,
+            )
+        };
 
         output.store(loaded_values);
     }
@@ -132,15 +140,17 @@ mod memory_and_atomic_ops_module {
         let ptrs: PointerTile<*mut f32, S> = ptr_to_ptr(ptrs_i64);
 
         let input_token = new_token_unordered();
-        let (loaded_values, _result_token): (Tile<f32, S>, Token) = load_ptr_tko(
-            ptrs,
-            ordering::Relaxed,
-            Some(scope::Device),
-            None,
-            None,
-            Some(input_token),
-            Latency::<0>,
-        );
+        let (loaded_values, _result_token): (Tile<f32, S>, Token) = unsafe {
+            load_ptr_tko(
+                ptrs,
+                ordering::Relaxed,
+                Some(scope::Device),
+                None,
+                None,
+                Some(input_token),
+                Latency::<0>,
+            )
+        };
 
         output.store(loaded_values);
     }
@@ -156,15 +166,17 @@ mod memory_and_atomic_ops_module {
         let mask: Tile<bool, S> = constant(true, output.shape());
         let padding = 0.0f32;
 
-        let (loaded_values, _token): (Tile<f32, S>, Token) = load_ptr_tko(
-            ptrs,
-            ordering::Relaxed,
-            Some(scope::Device),
-            Some(mask),
-            Some(padding),
-            None,
-            Latency::<0>,
-        );
+        let (loaded_values, _token): (Tile<f32, S>, Token) = unsafe {
+            load_ptr_tko(
+                ptrs,
+                ordering::Relaxed,
+                Some(scope::Device),
+                Some(mask),
+                Some(padding),
+                None,
+                Latency::<0>,
+            )
+        };
 
         output.store(loaded_values);
     }
@@ -180,15 +192,17 @@ mod memory_and_atomic_ops_module {
         let values: Tile<f32, S> = constant(42.0f32, output.shape());
 
         // Store with release semantics and sys scope
-        let _store_token: Token = store_ptr_tko(
-            ptrs,
-            values,
-            ordering::Release,
-            Some(scope::System),
-            None,
-            None,
-            Latency::<0>,
-        );
+        let _store_token: Token = unsafe {
+            store_ptr_tko(
+                ptrs,
+                values,
+                ordering::Release,
+                Some(scope::System),
+                None,
+                None,
+                Latency::<0>,
+            )
+        };
 
         output.store(values);
     }
@@ -207,15 +221,17 @@ mod memory_and_atomic_ops_module {
         let mask: Tile<bool, S> = constant(true, output.shape());
 
         // Store with mask, relaxed semantics, and device scope
-        let _store_token: Token = store_ptr_tko(
-            ptrs,
-            values,
-            ordering::Relaxed,
-            Some(scope::Device),
-            Some(mask),
-            None,
-            Latency::<0>,
-        );
+        let _store_token: Token = unsafe {
+            store_ptr_tko(
+                ptrs,
+                values,
+                ordering::Relaxed,
+                Some(scope::Device),
+                Some(mask),
+                None,
+                Latency::<0>,
+            )
+        };
 
         output.store(values);
     }

--- a/cutile/tests/optimization_hints.rs
+++ b/cutile/tests/optimization_hints.rs
@@ -21,15 +21,17 @@ mod opt_hints_module {
         let ptr_seed: Tile<i64, S> = constant(0i64, output.shape());
         let ptrs_i64: PointerTile<*mut i64, S> = int_to_ptr(ptr_seed);
         let ptrs: PointerTile<*mut f32, S> = ptr_to_ptr(ptrs_i64);
-        let (loaded, _tok): (Tile<f32, S>, Token) = load_ptr_tko(
-            ptrs,
-            ordering::Weak,
-            None::<scope::TileBlock>,
-            None,
-            None,
-            None,
-            Latency::<4>,
-        );
+        let (loaded, _tok): (Tile<f32, S>, Token) = unsafe {
+            load_ptr_tko(
+                ptrs,
+                ordering::Weak,
+                None::<scope::TileBlock>,
+                None,
+                None,
+                None,
+                Latency::<4>,
+            )
+        };
         output.store(loaded);
     }
 
@@ -39,15 +41,17 @@ mod opt_hints_module {
         let ptrs_i64: PointerTile<*mut i64, S> = int_to_ptr(ptr_seed);
         let ptrs: PointerTile<*mut f32, S> = ptr_to_ptr(ptrs_i64);
         let vals: Tile<f32, S> = constant(1.0f32, output.shape());
-        let _tok: Token = store_ptr_tko(
-            ptrs,
-            vals,
-            ordering::Weak,
-            None::<scope::TileBlock>,
-            None,
-            None,
-            Latency::<2>,
-        );
+        let _tok: Token = unsafe {
+            store_ptr_tko(
+                ptrs,
+                vals,
+                ordering::Weak,
+                None::<scope::TileBlock>,
+                None,
+                None,
+                Latency::<2>,
+            )
+        };
         output.store(vals);
     }
 
@@ -63,28 +67,32 @@ mod opt_hints_module {
         let mask_opt: Option<Tile<bool, S>> = None;
         let padding_opt: Option<f32> = None;
         let token_none: Option<Token> = None;
-        let (loaded, _tok): (Tile<f32, S>, Token) = load_ptr_tko(
-            ptrs,
-            ordering::Relaxed,
-            scope_opt,
-            mask_opt,
-            padding_opt,
-            token_none,
-            Latency::<0>,
-        );
+        let (loaded, _tok): (Tile<f32, S>, Token) = unsafe {
+            load_ptr_tko(
+                ptrs,
+                ordering::Relaxed,
+                scope_opt,
+                mask_opt,
+                padding_opt,
+                token_none,
+                Latency::<0>,
+            )
+        };
 
         let token: Token = new_token_unordered();
         let token_some: Option<Token> = Some(token);
         let scope_none: Option<scope::TileBlock> = None;
-        let _store_tok: Token = store_ptr_tko(
-            ptrs,
-            loaded,
-            ordering::Weak,
-            scope_none,
-            None,
-            token_some,
-            Latency::<0>,
-        );
+        let _store_tok: Token = unsafe {
+            store_ptr_tko(
+                ptrs,
+                loaded,
+                ordering::Weak,
+                scope_none,
+                None,
+                token_some,
+                Latency::<0>,
+            )
+        };
 
         output.store(loaded);
     }

--- a/flake.nix
+++ b/flake.nix
@@ -37,6 +37,14 @@
             url = "${cudaRedistBase}/${name}/${cudaRedistArch}/${name}-${cudaRedistArch}-${version}-archive.tar.xz";
             sha256 = sha256.${cudaRedistArch};
           };
+        # Hashes come from NVIDIA's manifest for this release:
+        # https://developer.download.nvidia.com/compute/cuda/redist/redistrib_13.3.0.json
+        # (per package: .<name>.<arch>.sha256). Update from there on version bumps.
+        #
+        # ORDER MATTERS: archives are extracted with --skip-old-files
+        # (first-wins), so components must come before other archives that
+        # may carry stale copies of their files — libnvvm before cuda_nvcc,
+        # since both can populate nvvm/.
         cudaRedistArchives = [
           (fetchCudaRedist {
             name = "cuda_crt";
@@ -47,19 +55,19 @@
             };
           })
           (fetchCudaRedist {
-            name = "cuda_nvcc";
-            version = "13.3.33";
-            sha256 = {
-              linux-x86_64 = "93b098bda4a562ebf3541523ce82adc43f106a81dcf28bcbf8f0d8e093d1c66f";
-              linux-sbsa = "b5dde44aadd52234af3944ae3b2e74e811ad8e71fb600bcc9dfe6d8540353499";
-            };
-          })
-          (fetchCudaRedist {
             name = "libnvvm";
             version = "13.3.33";
             sha256 = {
               linux-x86_64 = "fc9c1fd5844e44c0e5eeb051378c1b13cf0e3bb3fe4966d5103c38885424f802";
               linux-sbsa = "5f8ca5c9a10c3c9804b045960ee6192281efec4c7d83d5f3245ec2de8612118e";
+            };
+          })
+          (fetchCudaRedist {
+            name = "cuda_nvcc";
+            version = "13.3.33";
+            sha256 = {
+              linux-x86_64 = "93b098bda4a562ebf3541523ce82adc43f106a81dcf28bcbf8f0d8e093d1c66f";
+              linux-sbsa = "b5dde44aadd52234af3944ae3b2e74e811ad8e71fb600bcc9dfe6d8540353499";
             };
           })
           (fetchCudaRedist {
@@ -94,12 +102,25 @@
         # store path, where it doesn't exist, and fail with exit status 5.
         cudaToolkit = pkgs.runCommand "cuda-toolkit-13.3" { } ''
           mkdir -p $out
+          # --skip-old-files: cross-archive path collisions are first-wins
+          # (see order note above) and show up in the build log instead of
+          # silently taking whichever archive extracted last.
           ${pkgs.lib.concatMapStrings (src: ''
-            tar xf ${src} --strip-components=1 -C $out
+            tar xf ${src} --strip-components=1 -C $out --skip-old-files --warning=existing-file
           '') cudaRedistArchives}
           # cuda-bindings/build.rs also looks for libs in lib64/
           if [ -d "$out/lib" ] && [ ! -e "$out/lib64" ]; then
             ln -s lib "$out/lib64"
+          fi
+          # The exe-relative lookup above is the invariant that broke in
+          # issue #172 — fail the build loudly if assembly ever loses it.
+          if [ ! -x "$out/bin/tileiras" ]; then
+            echo "cuda-toolkit assembly error: bin/tileiras missing or not executable" >&2
+            exit 1
+          fi
+          if [ ! -f "$out/nvvm/lib64/libnvvm.so" ]; then
+            echo "cuda-toolkit assembly error: nvvm/lib64/libnvvm.so missing (tileiras resolves it relative to its own binary)" >&2
+            exit 1
           fi
         '';
 
@@ -157,7 +178,9 @@
               export LD_LIBRARY_PATH="/run/opengl-driver/lib:$LD_LIBRARY_PATH"
             else
               _nv_drv_dir=$(mktemp -d /tmp/nix-nvidia-driver.XXXXXX)
-              for d in /usr/lib/x86_64-linux-gnu /lib/x86_64-linux-gnu /usr/lib/aarch64-linux-gnu /lib/aarch64-linux-gnu /usr/lib /usr/lib64; do
+              # Search the host's own Debian multiarch dir (uname -m matches
+              # the triplet prefix on x86_64 and aarch64), then generic dirs.
+              for d in /usr/lib/$(uname -m)-linux-gnu /lib/$(uname -m)-linux-gnu /usr/lib /usr/lib64; do
                 if [ -e "$d/libcuda.so.1" ]; then
                   for lib in "$d"/libcuda.so* "$d"/libnvidia-ptxjitcompiler.so* "$d"/libnvidia-gpucomp.so*; do
                     [ -e "$lib" ] && ln -sf "$lib" "$_nv_drv_dir/"


### PR DESCRIPTION
Three squash merges landed from branches that had resolved a merge against main by keeping pre-merge copies of files, so each one quietly reverted an earlier, unrelated merge. This re-applies the reverted content verbatim as cherry-picks of the original squashes:

- #239 (84ee7b3) reverted #240 (9bbd752): the const raw-pointer surface (`as_ptr`, `program_id`/`num_programs`, the `cast_*` and `get_tensor_base` helpers, `unsafe` on `load_ptr_tko`/`store_ptr_tko`), the compiler's const-pointer typing, the `const_pointers` and `program_id` GPU tests, and the matching book and tutorial text.
- #247 (d3c4c5f) reverted #225 (dda1806): integer division and remainder serialization (`rounding<zero>` and inferred signedness on `divi`/`remi`) and its test.
- #187 (18b29a3) reverted #185 (dabcd61): the flake.nix toolkit-assembly hardening and host-arch driver directory derivation.

The only overlapping file, `cutile-book/guide/performance.md`, merges cleanly with #239's own edits. A per-file scan of the last 60 merges finds no other reversal still missing at HEAD: #249's removal of the About page was deliberate, and the two `setup-python` flips in `pages.yml` were re-applied by the later dependabot bump.

Verified locally on an RTX 5090 with CUDA 13.3: `cargo fmt --check`, `cargo build`, and the restored `const_pointers` and `program_id` GPU tests plus `integer_ops`, `memory_and_atomic_ops`, and `optimization_hints` all pass.
