### PR TITLE
core: load_like, the method-form spelling of load_tile_like

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- `x.load_like(z)`: method-form spelling of `load_tile_like(x, z)`, lowering
+  to identical Tile IR with identical bounds-check placement. Both spellings
+  remain supported; docs and examples now use the method form.
+
 ## [0.3.0] - 2026-08-20
 
 This release introduces compiler optimizations that improve safe kernel

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ mod kernel {
         x: &Tensor<f32, { [-1] }>,
         y: &Tensor<f32, { [-1] }>,
     ) {
-        let tx = load_tile_like(x, z);
-        let ty = load_tile_like(y, z);
+        let tx = x.load_like(z);
+        let ty = y.load_like(z);
         z.store(tx + ty);
     }
 }

--- a/cutile-book/guide/debugging-and-profiling.md
+++ b/cutile-book/guide/debugging-and-profiling.md
@@ -14,7 +14,7 @@ fn debug_kernel<const S: [i32; 2]>(
 ) {
     let pid0 = program_id(0);
     let pid1 = program_id(1);
-    let tile = load_tile_like(x, z);
+    let tile = x.load_like(z);
 
     cuda_tile_print!("Program ({}, {}): loaded tile\n", pid0, pid1);
     z.store(tile);
@@ -26,7 +26,7 @@ GPU printing is slow and serializes tile block execution. Use it for small grids
 `cuda_tile_assert!` checks conditions inside a kernel:
 
 ```rust
-let tile = load_tile_like(x, z);
+let tile = x.load_like(z);
 cuda_tile_assert!(tile[0] > 0.0, "expected positive input");
 ```
 

--- a/cutile-book/guide/host-vs-device.md
+++ b/cutile-book/guide/host-vs-device.md
@@ -27,7 +27,7 @@ mod kernels {
         x: &Tensor<f32, { [-1, -1] }>,
         alpha: f32,
     ) {
-        let tile_x = load_tile_like(x, z);
+        let tile_x = x.load_like(z);
         z.store(tile_x * alpha);
     }
 }

--- a/cutile-book/guide/interoperability.md
+++ b/cutile-book/guide/interoperability.md
@@ -274,7 +274,7 @@ let function = Arc::new(module.load_function("gemm_kernel")?);
 | cuTile Python | cuTile Rust |
 |---------------|-------------|
 | `@ct.kernel` | `#[cutile::entry()]` |
-| `ct.load()` | `load_tile_like()` |
+| `ct.load()` | `x.load_like(z)` |
 | `ct.store()` | `tensor.store()` |
 | `ct.bid(0)` | Implicit via partition |
 | `ct.launch()` | Async operation + `.await` |

--- a/cutile-book/guide/introduction.md
+++ b/cutile-book/guide/introduction.md
@@ -24,8 +24,8 @@ mod my_module {
         x: &Tensor<f32, { [-1, -1] }>,
         y: &Tensor<f32, { [-1, -1] }>,
     ) {
-        let tile_x = load_tile_like(x, z);
-        let tile_y = load_tile_like(y, z);
+        let tile_x = x.load_like(z);
+        let tile_y = y.load_like(z);
         z.store(tile_x + tile_y);
     }
 }

--- a/cutile-book/guide/jit-compilation.md
+++ b/cutile-book/guide/jit-compilation.md
@@ -66,7 +66,7 @@ fn add<const S: [i32; 2]>(
     z: &mut Tensor<f32, S>,
     x: &Tensor<f32, { [-1, -1] }>,
 ) {
-    z.store(load_tile_like(x, z));
+    z.store(x.load_like(z));
 }
 ```
 
@@ -86,7 +86,7 @@ fn normalize<const BM: i32, const BN: i32>(
     z: &mut Tensor<f32, { [BM, BN] }>,
     x: &Tensor<f32, { [-1, -1] }>,
 ) {
-    let tile = load_tile_like(x, z);
+    let tile = x.load_like(z);
     let row_max = reduce_max(tile, 1i32);
     z.store(tile - row_max.reshape(const_shape![BM, 1]).broadcast(z.shape()));
 }

--- a/cutile-book/guide/performance.md
+++ b/cutile-book/guide/performance.md
@@ -32,7 +32,7 @@ fn fused<const BM: i32, const BN: i32>(
     z: &mut Tensor<f32, { [BM, BN] }>,
     x: &Tensor<f32, { [-1, -1] }>,
 ) {
-    let tile = load_tile_like(x, z);
+    let tile = x.load_like(z);
     let centered = tile - reduce_max(tile, 1i32)
         .reshape(const_shape![BM, 1])
         .broadcast(const_shape![BM, BN]);

--- a/cutile-book/guide/tensors-and-tiles.md
+++ b/cutile-book/guide/tensors-and-tiles.md
@@ -18,8 +18,8 @@ fn add<const S: [i32; 2]>(
     x: &Tensor<f32, { [-1, -1] }>,
     y: &Tensor<f32, { [-1, -1] }>,
 ) {
-    let tile_x = load_tile_like(x, z);
-    let tile_y = load_tile_like(y, z);
+    let tile_x = x.load_like(z);
+    let tile_y = y.load_like(z);
     z.store(tile_x + tile_y);
 }
 ```
@@ -35,7 +35,7 @@ The output tensor is mutable and already partitioned by the host launcher. The i
 `Tile<E, S>` is an immutable register-resident array fragment. Tile operations create new tiles instead of mutating the original value:
 
 ```rust
-let tile = load_tile_like(x, z);
+let tile = x.load_like(z);
 let shifted = tile + 1.0f32;
 let scaled = shifted * 2.0f32;
 z.store(scaled);
@@ -88,7 +88,7 @@ fn normalize<const S: [i32; 2]>(
     z: &mut Tensor<f32, S>,          // Static tile shape from partition.
     x: &Tensor<f32, { [-1, -1] }>,   // Runtime full tensor shape.
 ) {
-    let tile = load_tile_like(x, z);
+    let tile = x.load_like(z);
     z.store(tile);
 }
 ```
@@ -99,7 +99,7 @@ Const generic arrays such as `const S: [i32; 2]` and `const_shape![BM, BK]` carr
 
 ## Loading, Computing, Storing
 
-`load_tile_like(input, output)` loads a read-only tensor region matching the output tensor's tile shape and tile-block coordinates. For explicit device-side partitions, call `partition.load(index)`:
+`input.load_like(output)` loads a read-only tensor region matching the output tensor's tile shape and tile-block coordinates. For explicit device-side partitions, call `partition.load(index)`:
 
 ```rust
 let part_x = x.partition(const_shape![BM, BK]);
@@ -126,7 +126,7 @@ The DSL API reference has complete signatures. These are the operation families 
 
 | Category | Examples |
 |---|---|
-| Load and store | `load_tile_like`, `load_tile_mut`, `Partition::load`, `Tensor::store` |
+| Load and store | `load_like` (method form of `load_tile_like`), `load_tile_mut`, `Partition::load`, `Tensor::store` |
 | Arithmetic | `+`, `-`, `*`, `/`, `fma`, `true_div` |
 | Math | `exp`, `log`, `sqrt`, `rsqrt`, `sin`, `cos`, `tanh` |
 | Reduction and scan | `reduce_max`, `reduce_sum`, `reduce_min`, `scan` |
@@ -232,7 +232,7 @@ fn scale<E: ElementType, const S: [i32; 2]>(
     x: &Tensor<E, { [-1, -1] }>,
     alpha: E,
 ) {
-    let tile = load_tile_like(x, z);
+    let tile = x.load_like(z);
     z.store(tile * alpha);
 }
 ```

--- a/cutile-book/guide/useful-mental-models.md
+++ b/cutile-book/guide/useful-mental-models.md
@@ -24,8 +24,8 @@ fn add<const S: [i32; 2]>(
     a: &Tensor<f32, { [-1, -1] }>,
     b: &Tensor<f32, { [-1, -1] }>,
 ) {
-    let tile_a = load_tile_like(a, c);
-    let tile_b = load_tile_like(b, c);
+    let tile_a = a.load_like(c);
+    let tile_b = b.load_like(c);
     c.store(tile_a + tile_b);
 }
 ```
@@ -81,7 +81,7 @@ NVIDIA GPUs have several memory levels:
 In cuTile Rust, you load from tensors in HBM and compute on tiles in registers. The Tile IR compiler and runtime decide how to stage data through shared memory, caches, threads, warps, Tensor Cores, and Tensor Memory Accelerator (TMA) instructions when those mechanisms are useful.
 
 ```rust
-let tile = load_tile_like(x, z); // HBM -> tile.
+let tile = x.load_like(z); // HBM -> tile.
 let y = tile * 2.0f32;           // Register-resident computation.
 z.store(y);                      // Tile -> HBM.
 ```

--- a/cutile-book/index.md
+++ b/cutile-book/index.md
@@ -25,8 +25,8 @@ mod kernel {
         x: &Tensor<f32, { [-1] }>,
         y: &Tensor<f32, { [-1] }>,
     ) {
-        let tx = load_tile_like(x, z);
-        let ty = load_tile_like(y, z);
+        let tx = x.load_like(z);
+        let ty = y.load_like(z);
         z.store(tx + ty);
     }
 }

--- a/cutile-book/reference/dsl-api.md
+++ b/cutile-book/reference/dsl-api.md
@@ -378,7 +378,7 @@ Examples:
 | `pack`, `unpack` | Rank-1 byte packing and unpacking ops such as `cuda_tile.pack` and `cuda_tile.unpack` |
 | `Tile<f4e2m1fn, ...>::pack`, `Tile<f4e2m1fnx2, ...>::unpack` | Rust helpers that flatten shaped FP4 tiles, call rank-1 `cuda_tile.pack`/`cuda_tile.unpack`, and reshape the result |
 | `load_ptr_tko`, `store_ptr_tko`, `atomic_rmw_tko`, `atomic_cas_tko`, `new_token_unordered`, `join_tokens` | Memory, atomic, and token ops such as `cuda_tile.load_ptr_tko`, `cuda_tile.store_ptr_tko`, `cuda_tile.atomic_rmw_tko`, `cuda_tile.atomic_cas_tko`, `cuda_tile.make_token`, `cuda_tile.join_tokens` |
-| `load_tile_like`, `tensor.load_tile`, `tensor.store`, partition and tensor view helpers | View ops such as `cuda_tile.load_view_tko`, `cuda_tile.store_view_tko`, `cuda_tile.make_tensor_view`, `cuda_tile.make_partition_view`, plus compiler-generated shape/stride plumbing |
+| `load_like`/`load_tile_like`, `tensor.load_tile`, `tensor.store`, partition and tensor view helpers | View ops such as `cuda_tile.load_view_tko`, `cuda_tile.store_view_tko`, `cuda_tile.make_tensor_view`, `cuda_tile.make_partition_view`, plus compiler-generated shape/stride plumbing |
 | `assume_div_by`, `assume_bounds_*`, `cuda_tile_print!`, `cuda_tile_assert!` | Compiler and debugging ops such as `cuda_tile.assume`, `cuda_tile.print_tko`, and `cuda_tile.assert` |
 
 Some Tile IR operations are intentionally compiler-owned rather than public DSL
@@ -401,7 +401,7 @@ operation.
 | `tensor.store(tile)` | `(&mut Tensor<E, S>, Tile<E, S>)` | Store a tile to the tensor |
 | `tensor.load_tile(shape, idx)` | `(&Tensor<E, S>, Shape<R>, [i32; N]) -> Tile<E, R>` | Load at a partition index |
 | `load_tile_mut(tensor)` | `(&mut Tensor<E, S>) -> Tile<E, S>` | Load output tile (convenience) |
-| `load_tile_like(src, dst)` | `(&Tensor, &Tensor) -> Tile` | Load from src at dst's tile-block position (rank 1-3) |
+| `src.load_like(dst)` | `(&Tensor, &Tensor) -> Tile` | Load from src at dst's tile-block position (rank 1-3); also the free function `load_tile_like(src, dst)`. src must match the shape of the whole tensor behind dst (not dst's per-program slab), and dst must be a partitioned mutable output |
 
 ```rust
 // Pattern 1: Direct load/store on mutable tensor
@@ -413,7 +413,7 @@ let pid = program_id(0);
 let tile: Tile<f32, { [128] }> = input.load_tile(const_shape![128], [pid]);
 
 // Pattern 3: Load-like (positional)
-let tile_x: Tile<f32, { [16, 16] }> = load_tile_like(x, output);
+let tile_x: Tile<f32, { [16, 16] }> = x.load_like(output);
 ```
 
 ### Grid and Program IDs
@@ -628,7 +628,7 @@ for the full pattern.
 
 These APIs are close to the Tile IR memory/view operations. Prefer the
 high-level methods above (`tensor.load_tile`, `partition.load`,
-`partition_mut.store`, `load_tile_like`, `tensor.store`) unless you are building
+`partition_mut.store`, `x.load_like(z)`, `tensor.store`) unless you are building
 custom views, raw-pointer kernels, or compiler-facing helpers.
 
 #### View construction and queries

--- a/cutile-book/tutorials/02-vector-addition.md
+++ b/cutile-book/tutorials/02-vector-addition.md
@@ -26,8 +26,8 @@ mod my_module {
         x: &Tensor<f32, {[-1, -1]}>,     // Input: dynamic shape (full tensor)
         y: &Tensor<f32, {[-1, -1]}>      // Input: dynamic shape (full tensor)
     ) {
-        let tile_x = load_tile_like(x, z);  // Load a tile from x using z's partitioning
-        let tile_y = load_tile_like(y, z);  // Load a tile from y using z's partitioning
+        let tile_x = x.load_like(z);  // Load a tile from x using z's partitioning
+        let tile_y = y.load_like(z);  // Load a tile from y using z's partitioning
         z.store(tile_x + tile_y);              // Add and store result
     }
 }
@@ -98,7 +98,7 @@ let tile = part_x.load([i, j]);
 
 This is more flexible — the same `&Tensor` can be partitioned in different ways within the same kernel (e.g., in GEMM, `x` and `y` use different partition shapes).
 
-In this tutorial, we use `load_tile_like(x, z)` instead of explicit device-side partitioning. This convenience function partitions `x` using the same shape and coordinates as `z`, which is the common case for element-wise operations. Later tutorials (starting with [matrix multiplication](./04-matrix-multiplication.md)) use explicit device-side partitioning when inputs need different access patterns.
+In this tutorial, we use `x.load_like(z)` instead of explicit device-side partitioning. This convenience function partitions `x` using the same shape and coordinates as `z`, which is the common case for element-wise operations. Later tutorials (starting with [matrix multiplication](./04-matrix-multiplication.md)) use explicit device-side partitioning when inputs need different access patterns.
 
 ### Putting It Together
 
@@ -118,13 +118,13 @@ fn add<const S: [i32; 2]>(
     x: &Tensor<f32, {[-1, -1]}>,  // Full input tensor
     y: &Tensor<f32, {[-1, -1]}>   // Full input tensor
 ) {
-    let tile_x = load_tile_like(x, z);
-    let tile_y = load_tile_like(y, z);
+    let tile_x = x.load_like(z);
+    let tile_y = y.load_like(z);
     z.store(tile_x + tile_y);
 }
 ```
 
-`load_tile_like(x, z)` loads a tile from `x` using the same tile shape (`S`=4×4) and coordinates (tile thread id) as `z`.
+`x.load_like(z)` loads a tile from `x` using the same tile shape (`S`=4×4) and coordinates (tile thread id) as `z`.
 
 ![How load_tile_like calculates which region to load](../_static/images/vector-addition-load-tile.svg)
 
@@ -133,7 +133,7 @@ Compare to CUDA C++:
 | Task | CUDA C++ | cuTile Rust |
 |------|----------|-----------|
 | Calculate thread index | `int i = blockIdx.x * blockDim.x + threadIdx.x;` | Not needed |
-| Calculate global offset | Manual pointer arithmetic | `load_tile_like()` |
+| Calculate global offset | Manual pointer arithmetic | `x.load_like(z)` |
 | Bounds checking | `if (i < n) { ... }` | Built-in |
 | Coalesced memory access | Manual, error-prone | Automatic |
 
@@ -167,7 +167,7 @@ fn my_kernel(...) {
 | **Device-side partitioning** | `.partition(const_shape![M, N])` inside the kernel — available for `&Tensor`, flexible access patterns |
 | **Static shape `S`** | The tile shape carried in the compiled variant |
 | **Dynamic shape `[-1, -1]`** | Dynamic tensor shape; does not create a new compiled variant when tensor shape changes |
-| **load_tile_like** | Convenience for element-wise ops: loads from input using the same partitioning and mapping as the output |
+| **load_like** | Convenience for element-wise ops: loads from the input using the same partitioning and mapping as the output (also available as the free function `load_tile_like`). The input must have the same shape as the whole output tensor — the tensor the host partitioned, not the per-program sub-tensor — and the output must be a partitioned mutable tensor |
 | **Load/Store pattern** | Load → Compute → Store is the GPU kernel idiom |
 
 ---
@@ -195,7 +195,7 @@ Modify the kernel to add three tensors: `z = x + y + w`.
 :::{dropdown} Hint
 Add a third input parameter and load three tiles:
 ```rust
-let tile_w = load_tile_like(w, z);
+let tile_w = w.load_like(z);
 z.store(tile_x + tile_y + tile_w);
 ```
 :::
@@ -210,4 +210,4 @@ Try `partition([4, 8])` — rectangular tiles. Does it still work?
 
 - [Tensors and Tiles](../guide/tensors-and-tiles.md) — partitioning, load/store, and tile arithmetic
 - [Useful Mental Models](../guide/useful-mental-models.md) — tile blocks and grid geometry
-- [DSL API](../reference/dsl-api.md) — full signatures for `load_tile_like`, `store`, and the arithmetic operators used here
+- [DSL API](../reference/dsl-api.md) — full signatures for `load_like`, `store`, and the arithmetic operators used here

--- a/cutile-book/tutorials/03-saxpy.md
+++ b/cutile-book/tutorials/03-saxpy.md
@@ -40,7 +40,7 @@ mod my_module {
         x: &Tensor<f32, { [-1, -1] }>     // Vector input
     ) {
         let tile_a = a.broadcast(y.shape());  // Scalar → Tile
-        let tile_x = load_tile_like(x, y);
+        let tile_x = x.load_like(y);
         let tile_y = y.load();                // Load current y values
         y.store(tile_a * tile_x + tile_y);    // y = a*x + y
     }
@@ -157,7 +157,7 @@ fn saxpy_extended<const S: [i32; 2]>(
 ) {
     let tile_a = a.broadcast(y.shape());
     let tile_b = b.broadcast(y.shape());
-    let tile_x = load_tile_like(x, y);
+    let tile_x = x.load_like(y);
     let tile_y = y.load();
     y.store(tile_a * tile_x + tile_b * tile_y);
 }

--- a/cutile-book/tutorials/05-fused-softmax.md
+++ b/cutile-book/tutorials/05-fused-softmax.md
@@ -60,7 +60,7 @@ mod my_module {
         y: &mut Tensor<f32, { [BM, BN] }>,
         x: &Tensor<f32, { [-1, -1] }>,
     ) {
-        let tile_x: Tile<f32, { [BM, BN] }> = load_tile_like(x, y);
+        let tile_x: Tile<f32, { [BM, BN] }> = x.load_like(y);
 
         // Find max per row (for numerical stability)
         let tile_x_max: Tile<f32, { [BM] }> = reduce_max(tile_x, 1i32);
@@ -146,7 +146,7 @@ Fused kernels load once, compute everything in registers, and store once:
 
 ```rust
 // 1. LOAD once
-let tile = load_tile_like(input, output);
+let tile = input.load_like(output);
 
 // 2. ALL COMPUTATION in registers
 let step1 = reduce_max(tile, axis);
@@ -194,7 +194,7 @@ fn softmax_with_temp<const BM: i32, const BN: i32>(
     x: &Tensor<f32, {[-1, -1]}>,
     temperature: f32,  // Higher = more uniform, Lower = more peaked
 ) {
-    let tile_x = load_tile_like(x, y);
+    let tile_x = x.load_like(y);
     let scaled = tile_x / temperature.broadcast(y.shape());
     // ... rest of softmax ...
 }

--- a/cutile-book/tutorials/07-intro-to-async.md
+++ b/cutile-book/tutorials/07-intro-to-async.md
@@ -76,8 +76,8 @@ mod async_add_module {
         x: &Tensor<f32, {[-1, -1]}>,
         y: &Tensor<f32, {[-1, -1]}>
     ) {
-        let tile_x = load_tile_like(x, z);
-        let tile_y = load_tile_like(y, z);
+        let tile_x = x.load_like(z);
+        let tile_y = y.load_like(z);
         z.store(tile_x + tile_y);
     }
 }

--- a/cutile-examples/examples/async_add.rs
+++ b/cutile-examples/examples/async_add.rs
@@ -16,8 +16,8 @@ mod my_module {
         x: &Tensor<f32, { [-1] }>,
         y: &Tensor<f32, { [-1] }>,
     ) {
-        let tile_x = load_tile_like(x, z);
-        let tile_y = load_tile_like(y, z);
+        let tile_x = x.load_like(z);
+        let tile_y = y.load_like(z);
         z.store(tile_x + tile_y);
     }
 }

--- a/cutile-examples/examples/async_and_then_example.rs
+++ b/cutile-examples/examples/async_and_then_example.rs
@@ -22,7 +22,7 @@ mod my_module {
     #[cutile::entry()]
     fn saxpy<const S: [i32; 2]>(y: &mut Tensor<f32, S>, a: f32, x: &Tensor<f32, { [-1, -1] }>) {
         let tile_a: Tile<f32, S> = a.broadcast(y.shape());
-        let tile_x: Tile<f32, S> = load_tile_like(x, y);
+        let tile_x: Tile<f32, S> = x.load_like(y);
         let tile_y: Tile<f32, S> = y.load();
         y.store(tile_a * tile_x + tile_y);
     }

--- a/cutile-examples/examples/async_saxpy.rs
+++ b/cutile-examples/examples/async_saxpy.rs
@@ -24,7 +24,7 @@ mod my_module {
         x: &Tensor<T, { [-1, -1] }>,
     ) {
         let tile_a = a.broadcast(y.shape());
-        let tile_x = load_tile_like(x, y);
+        let tile_x = x.load_like(y);
         let tile_y = y.load();
         y.store(tile_a * tile_x + tile_y);
     }

--- a/cutile-examples/examples/cuda_graphs.rs
+++ b/cutile-examples/examples/cuda_graphs.rs
@@ -89,8 +89,8 @@ mod kernels {
         a: &Tensor<f32, { [-1] }>,
         b: &Tensor<f32, { [-1] }>,
     ) {
-        let ta: Tile<f32, { [B] }> = load_tile_like(a, out);
-        let tb: Tile<f32, { [B] }> = load_tile_like(b, out);
+        let ta: Tile<f32, { [B] }> = a.load_like(out);
+        let tb: Tile<f32, { [B] }> = b.load_like(out);
         out.store(ta + tb);
     }
 }

--- a/cutile-examples/examples/cuda_graphs_deviceop.rs
+++ b/cutile-examples/examples/cuda_graphs_deviceop.rs
@@ -90,8 +90,8 @@ mod kernels {
         a: &Tensor<f32, { [-1] }>,
         b: &Tensor<f32, { [-1] }>,
     ) {
-        let ta: Tile<f32, { [B] }> = load_tile_like(a, out);
-        let tb: Tile<f32, { [B] }> = load_tile_like(b, out);
+        let ta: Tile<f32, { [B] }> = a.load_like(out);
+        let tb: Tile<f32, { [B] }> = b.load_like(out);
         out.store(ta + tb);
     }
 }

--- a/cutile-examples/examples/cudarc_interop.rs
+++ b/cutile-examples/examples/cudarc_interop.rs
@@ -82,8 +82,8 @@ mod tile_add {
         x: &Tensor<f32, { [-1] }>,
         y: &Tensor<f32, { [-1] }>,
     ) {
-        let tx = load_tile_like(x, z);
-        let ty = load_tile_like(y, z);
+        let tx = x.load_like(z);
+        let ty = y.load_like(z);
         z.store(tx + ty);
     }
 }

--- a/cutile-examples/examples/dropout.rs
+++ b/cutile-examples/examples/dropout.rs
@@ -23,7 +23,7 @@ mod my_module {
         let zeros: Tile<f32, S> = constant(0.0, out.shape());
         let ones: Tile<f32, S> = constant(1.0, out.shape());
         let p_tile = p.broadcast(out.shape());
-        let x_keep_tile = load_tile_like(x_keep, out);
+        let x_keep_tile = x_keep.load_like(out);
         // x_keep_tile is the probability of keeping (higher is more likely).
         // p_tile is the probability of dropout (lower keeps more values).
         let out_tile = select(gt_tile(x_keep_tile, p_tile), x_keep_tile, zeros);

--- a/cutile-examples/examples/interop.rs
+++ b/cutile-examples/examples/interop.rs
@@ -41,8 +41,8 @@ mod tile_add {
         x: &Tensor<f32, { [-1] }>,
         y: &Tensor<f32, { [-1] }>,
     ) {
-        let tile_x = load_tile_like(x, z);
-        let tile_y = load_tile_like(y, z);
+        let tile_x = x.load_like(z);
+        let tile_y = y.load_like(z);
         z.store(tile_x + tile_y);
     }
 }

--- a/cutile-examples/examples/jit_custom_store.rs
+++ b/cutile-examples/examples/jit_custom_store.rs
@@ -92,8 +92,8 @@ mod custom_store_example_module {
         x: &Tensor<f32, { [-1] }>,
         y: &Tensor<f32, { [-1] }>,
     ) {
-        let tile_x = load_tile_like(x, z);
-        let tile_y = load_tile_like(y, z);
+        let tile_x = x.load_like(z);
+        let tile_y = y.load_like(z);
         z.store(tile_x + tile_y);
     }
 }

--- a/cutile-examples/examples/jit_disk_cache.rs
+++ b/cutile-examples/examples/jit_disk_cache.rs
@@ -40,8 +40,8 @@ mod disk_cache_example_module {
         x: &Tensor<f32, { [-1] }>,
         y: &Tensor<f32, { [-1] }>,
     ) {
-        let tile_x = load_tile_like(x, z);
-        let tile_y = load_tile_like(y, z);
+        let tile_x = x.load_like(z);
+        let tile_y = y.load_like(z);
         z.store(tile_x + tile_y);
     }
 }

--- a/cutile-examples/examples/saxpy.rs
+++ b/cutile-examples/examples/saxpy.rs
@@ -11,7 +11,7 @@ mod my_module {
     #[cutile::entry()]
     fn saxpy<const S: [i32; 2]>(y: &mut Tensor<f32, S>, a: f32, x: &Tensor<f32, { [-1, -1] }>) {
         let tile_a = a.broadcast(y.shape());
-        let tile_x = load_tile_like(x, y);
+        let tile_x = x.load_like(y);
         let tile_y = y.load();
         y.store(tile_a * tile_x + tile_y);
     }

--- a/cutile-examples/examples/softmax.rs
+++ b/cutile-examples/examples/softmax.rs
@@ -13,7 +13,7 @@ mod my_module {
         y: &mut Tensor<f32, { [BM, BN] }>,
         x: &Tensor<f32, { [-1, -1] }>,
     ) {
-        let tile_x: Tile<f32, { [BM, BN] }> = load_tile_like(x, y);
+        let tile_x: Tile<f32, { [BM, BN] }> = x.load_like(y);
         let tile_x_max: Tile<f32, { [BM] }> = reduce_max(tile_x, 1i32);
         let tile_x_max: Tile<f32, { [BM, BN] }> =
             tile_x_max.reshape(const_shape![BM, 1]).broadcast(y.shape());

--- a/cutile/src/_core.rs
+++ b/cutile/src/_core.rs
@@ -3536,10 +3536,24 @@ pub mod core {
     }
 
     /// Type-level dispatch for `load_tile_like`.
+    /// Load from `self` the tile at the partition index this program owns
+    /// in `y`.
+    ///
+    /// Contract: `self` must have the same shape as the whole tensor behind
+    /// `y` — the full tensor the host partitioned, not `y`'s declared
+    /// per-program slab — and `y` must be a mutable output tensor the host
+    /// passed as a partition (`tensor.partition([..])` at the call site).
+    /// The launch validator relates `self`'s tile count to the grid derived
+    /// from `y`'s partition, so an input too small for the grid is rejected
+    /// at launch.
     pub trait LoadTileLike<Y> {
         type Out;
 
         fn load_tile_like(&self, y: &Y) -> Self::Out;
+
+        /// Method-form spelling of [`load_tile_like`]; same contract as the
+        /// trait.
+        fn load_like(&self, y: &Y) -> Self::Out;
     }
 
     impl<E1: ElementType, E2: ElementType, const X: [i32; 1], const S: [i32; 1]>
@@ -3568,6 +3582,10 @@ pub mod core {
                 tma::Enabled,
             );
             tile_x
+        }
+
+        fn load_like(&self, y: &Tensor<E2, S>) -> Tile<E1, S> {
+            self.load_tile_like(y)
         }
     }
 
@@ -3598,6 +3616,10 @@ pub mod core {
             );
             tile_x
         }
+
+        fn load_like(&self, y: &Tensor<E2, S>) -> Tile<E1, S> {
+            self.load_tile_like(y)
+        }
     }
 
     impl<E1: ElementType, E2: ElementType, const X: [i32; 3], const S: [i32; 3]>
@@ -3627,9 +3649,16 @@ pub mod core {
             );
             tile_x
         }
+
+        fn load_like(&self, y: &Tensor<E2, S>) -> Tile<E1, S> {
+            self.load_tile_like(y)
+        }
     }
 
-    /// Load a tile of `x` matching `y`'s shape, indexed by the current tile-block id.
+    /// Load a tile of `x` matching `y`'s shape, indexed by the current
+    /// tile-block id. `x` must have the same shape as the whole tensor
+    /// behind `y` (not `y`'s per-program slab), and `y` must be a mutable
+    /// output tensor the host passed as a partition — see [`LoadTileLike`].
     pub fn load_tile_like<X, Y>(x: &X, y: &Y) -> <X as LoadTileLike<Y>>::Out
     where
         X: LoadTileLike<Y>,

--- a/cutile/tests/gpu/book_snippets.rs
+++ b/cutile/tests/gpu/book_snippets.rs
@@ -68,8 +68,8 @@ mod vector_add_module {
         x: &Tensor<f32, { [-1, -1] }>,
         y: &Tensor<f32, { [-1, -1] }>,
     ) {
-        let tile_x = load_tile_like(x, z);
-        let tile_y = load_tile_like(y, z);
+        let tile_x = x.load_like(z);
+        let tile_y = y.load_like(z);
         z.store(tile_x + tile_y);
     }
 }
@@ -102,7 +102,7 @@ mod saxpy_module {
     #[cutile::entry()]
     fn saxpy<const S: [i32; 2]>(a: f32, x: &Tensor<f32, { [-1, -1] }>, y: &mut Tensor<f32, S>) {
         let tile_a = a.broadcast(y.shape());
-        let tile_x = load_tile_like(x, y);
+        let tile_x = x.load_like(y);
         let tile_y = y.load();
         y.store(tile_a * tile_x + tile_y);
     }
@@ -208,7 +208,7 @@ mod softmax_module {
         x: &Tensor<f32, { [-1, -1] }>,
         y: &mut Tensor<f32, { [BM, BN] }>,
     ) {
-        let tile_x: Tile<f32, { [BM, BN] }> = load_tile_like(x, y);
+        let tile_x: Tile<f32, { [BM, BN] }> = x.load_like(y);
         let tile_x_max: Tile<f32, { [BM] }> = reduce_max(tile_x, 1i32);
         let tile_x_max: Tile<f32, { [BM, BN] }> =
             tile_x_max.reshape(const_shape![BM, 1]).broadcast(y.shape());

--- a/cutile/tests/load_like.rs
+++ b/cutile/tests/load_like.rs
@@ -1,0 +1,129 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! `x.load_like(z)` is the method-form spelling of `load_tile_like(x, z)`.
+//! Pins that both spellings lower to identical Tile IR (same ops, same
+//! bounds-check obligations) and that the method form compiles and runs
+//! in a `#[cutile::entry]` kernel.
+
+use cutile::prelude::*;
+use cutile_compiler::compiler::utils::CompileOptions;
+
+mod common;
+
+#[cutile::module]
+mod load_like_module {
+    use cutile::core::*;
+
+    #[cutile::entry()]
+    fn add_free_fn<const S: [i32; 1]>(
+        z: &mut Tensor<f32, S>,
+        x: &Tensor<f32, { [-1] }>,
+        y: &Tensor<f32, { [-1] }>,
+    ) {
+        let tx = load_tile_like(x, z);
+        let ty = load_tile_like(y, z);
+        z.store(tx + ty);
+    }
+
+    #[cutile::entry()]
+    fn add_method<const S: [i32; 1]>(
+        z: &mut Tensor<f32, S>,
+        x: &Tensor<f32, { [-1] }>,
+        y: &Tensor<f32, { [-1] }>,
+    ) {
+        let tx = x.load_like(z);
+        let ty = y.load_like(z);
+        z.store(tx + ty);
+    }
+}
+
+use load_like_module::__module_ast_self as load_like_module_ast;
+use load_like_module::add_method;
+
+fn compile(name: &str) -> String {
+    common::compile_to_ir(
+        load_like_module_ast,
+        "load_like_module",
+        name,
+        &["4".to_string()],
+        &[("z", &[1]), ("x", &[1]), ("y", &[1])],
+        &[],
+        &[],
+        None,
+        &CompileOptions::default(),
+    )
+    .expect("Failed to compile.")
+}
+
+/// Normalize a module dump to its live-op sequence: SSA numbers stripped,
+/// dead `constant` lines dropped (the method form's extra inline hop
+/// materializes shape-metadata constants the free-fn form doesn't; both
+/// are DCE'd by tileiras). What remains — every view construction, load,
+/// store, assume, and assert, in order — is exactly the placement-relevant
+/// content.
+fn live_ops(module: &str) -> Vec<String> {
+    module
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .filter(|line| !line.contains("= constant "))
+        .map(|line| {
+            let mut out = String::new();
+            let mut chars = line.chars().peekable();
+            while let Some(c) = chars.next() {
+                if c == '%' {
+                    while chars.peek().is_some_and(|d| d.is_ascii_digit()) {
+                        chars.next();
+                    }
+                    out.push('%');
+                } else {
+                    out.push(c);
+                }
+            }
+            out
+        })
+        .collect()
+}
+
+#[test]
+fn both_spellings_lower_to_the_same_live_ops() {
+    common::with_test_stack(|| {
+        let free_fn = compile("add_free_fn").replace("add_free_fn", "K");
+        let method = compile("add_method").replace("add_method", "K");
+        assert_eq!(
+            live_ops(&free_fn),
+            live_ops(&method),
+            "load_like must lower to the same live ops as load_tile_like"
+        );
+        // Same check-placement outcomes, explicitly: neither spelling may
+        // change the number of device asserts.
+        assert_eq!(
+            free_fn.matches("assert").count(),
+            method.matches("assert").count()
+        );
+    });
+}
+
+#[test]
+fn method_form_runs_end_to_end() {
+    common::with_test_stack(|| {
+        let len = 32usize;
+        let z_host = add_method(
+            api::zeros(&[len]).partition([4]),
+            api::arange::<f32>(len),
+            api::ones(&[len]),
+        )
+        .grid(((len / 4) as u32, 1, 1))
+        .first()
+        .unpartition()
+        .to_host_vec()
+        .sync()
+        .expect("add_method kernel");
+        for (i, v) in z_host.iter().enumerate() {
+            assert_eq!(*v, i as f32 + 1.0, "index {i}");
+        }
+    });
+}


### PR DESCRIPTION
Adds `x.load_like(z)` as a method on the `LoadTileLike` trait, delegating to `load_tile_like` in each rank impl so both spellings lower to identical Tile IR with identical bounds-check placement (pinned by a live-op-sequence test, plus an end-to-end run of the method form). Docs, README, and examples canonicalize the method form; the free function remains supported. The docs also state the shape contract: the input matches the whole tensor behind the output, and the output is a host-partitioned mutable tensor.