### PR TITLE
chore: enforce clippy::all across the workspace

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -72,7 +72,8 @@ jobs:
       - name: Clippy
         run: |
           source "${HOME}/.cargo/env"
-          cargo clippy --all-features
+          # cuda-tile-rs is outside default-members (its build compiles LLVM); keep it out of clippy too.
+          cargo clippy --workspace --exclude cuda-tile-rs --all-targets --all-features
 
       - name: Test (compile only)
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,3 +99,20 @@ cutile-kernels = { path = "cutile-kernels", version = "0.3.1" }
 cutile-examples = { path = "cutile-examples", version = "0.3.1" }
 cutile-ir = { path = "cutile-ir", version = "0.3.1" }
 cutile-benchmarks = { path = "cutile-benchmarks", version = "0.3.1" }
+
+# Lint policy shared by every workspace crate (`[lints] workspace = true`).
+[workspace.lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(loom)'] }
+
+[workspace.lints.clippy]
+all = { level = "deny", priority = -1 }
+missing_safety_doc = "allow"
+type_complexity = "allow"
+too_many_arguments = "allow"
+# Rewriting indexed loops over several parallel arrays and boxing large enum variants
+# is invasive in the compiler; both stay allowed for now.
+needless_range_loop = "allow"
+large_enum_variant = "allow"
+# `Tensor::slice` and friends take one `Range` per axis; a single-element range array is the
+# rank-1 case, not a mistaken `vec![0..n]`.
+single_range_in_vec_init = "allow"

--- a/cuda-async/Cargo.toml
+++ b/cuda-async/Cargo.toml
@@ -25,5 +25,6 @@ once_cell = { workspace = true }
 [target.'cfg(loom)'.dev-dependencies]
 loom = "0.7"
 
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(loom)'] }
+
+[lints]
+workspace = true

--- a/cuda-async/src/device_future.rs
+++ b/cuda-async/src/device_future.rs
@@ -58,7 +58,7 @@ pub enum DeviceFutureState {
 }
 
 /// Shared state between a CUDA stream callback and the async waker.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct StreamCallbackState {
     pub(crate) waker: AtomicWaker,
     pub(crate) complete: AtomicBool,
@@ -67,10 +67,7 @@ pub struct StreamCallbackState {
 impl StreamCallbackState {
     /// Creates a new callback state with the completion flag unset.
     pub fn new() -> Self {
-        Self {
-            waker: AtomicWaker::new(),
-            complete: AtomicBool::new(false),
-        }
+        Self::default()
     }
     /// Marks the operation as complete and wakes the associated task.
     ///

--- a/cuda-async/tests/reactor_correctness.rs
+++ b/cuda-async/tests/reactor_correctness.rs
@@ -316,7 +316,7 @@ fn sequential_pingpong_park_unpark() {
             }
         }
         let host = read_device(dptr, 4096);
-        assert!(host.iter().all(|&b| b == (199 % 251) as u8));
+        assert!(host.iter().all(|&b| b == 199_u8));
     });
 }
 

--- a/cuda-bindings/Cargo.toml
+++ b/cuda-bindings/Cargo.toml
@@ -21,3 +21,6 @@ prettyplease = { workspace = true }
 proc-macro2 = { workspace = true }
 quote = { workspace = true }
 syn = { workspace = true }
+
+[lints]
+workspace = true

--- a/cuda-core-derive/Cargo.toml
+++ b/cuda-core-derive/Cargo.toml
@@ -15,3 +15,6 @@ proc-macro = true
 proc-macro2 = { workspace = true }
 quote = { workspace = true }
 syn = { workspace = true }
+
+[lints]
+workspace = true

--- a/cuda-core/Cargo.toml
+++ b/cuda-core/Cargo.toml
@@ -22,3 +22,6 @@ trybuild = "1"
 [features]
 # Nightly-only: DeviceCopy for the unstable f16 primitive.
 f16 = []
+
+[lints]
+workspace = true

--- a/cuda-core/src/cudarc_shim.rs
+++ b/cuda-core/src/cudarc_shim.rs
@@ -43,7 +43,6 @@ pub(crate) mod primary_ctx {
 }
 
 /// Low-level device query operations.
-
 #[allow(dead_code)]
 pub(crate) mod device {
 
@@ -194,7 +193,6 @@ pub(crate) mod ctx {
 }
 
 /// Low-level CUDA stream operations.
-
 #[allow(dead_code)]
 pub(crate) mod stream {
     use super::{DriverError, IntoResult};

--- a/cuda-core/src/dtype.rs
+++ b/cuda-core/src/dtype.rs
@@ -398,8 +398,8 @@ mod tests {
 
     #[test]
     fn dtype_zero_one() {
-        assert_eq!(bool::zero(), false);
-        assert_eq!(bool::one(), true);
+        assert!(!bool::zero());
+        assert!(bool::one());
         assert_eq!(u8::zero(), 0u8);
         assert_eq!(u8::one(), 1u8);
         assert_eq!(i32::zero(), 0i32);

--- a/cuda-tile-rs/Cargo.toml
+++ b/cuda-tile-rs/Cargo.toml
@@ -17,3 +17,6 @@ exclude = [
 [build-dependencies]
 cmake = "0.1"
 bindgen = "0.71"
+
+[lints]
+workspace = true

--- a/cutile-benchmarks/Cargo.toml
+++ b/cutile-benchmarks/Cargo.toml
@@ -53,3 +53,6 @@ cutile-compiler = { workspace = true }
 cuda-async = { workspace = true }
 cuda-core = { workspace = true }
 cutile = { workspace = true }
+
+[lints]
+workspace = true

--- a/cutile-compiler/Cargo.toml
+++ b/cutile-compiler/Cargo.toml
@@ -28,3 +28,6 @@ cuda-async = { workspace = true }
 cutile-ir = { workspace = true }
 linkme = { workspace = true }
 sha2 = { workspace = true }
+
+[lints]
+workspace = true

--- a/cutile-compiler/src/bounds.rs
+++ b/cutile-compiler/src/bounds.rs
@@ -144,7 +144,7 @@ impl Add for Bounds<i64> {
         // Saturating so overflow widens to the i64 range (a sound over-
         // approximation) rather than panicking (debug) or wrapping (release,
         // which would be an unsound bound).
-        let possible_bounds = vec![
+        let possible_bounds = [
             a.start.saturating_add(b.start),
             a.start.saturating_add(b.end),
             a.end.saturating_add(b.start),
@@ -168,7 +168,7 @@ impl Sub for Bounds<i64> {
         let a = self;
         let b = rhs;
         // Saturating: see `Add` — overflow widens to the i64 range soundly.
-        let possible_bounds = vec![
+        let possible_bounds = [
             a.start.saturating_sub(b.start),
             a.start.saturating_sub(b.end),
             a.end.saturating_sub(b.start),
@@ -193,7 +193,7 @@ impl Mul for Bounds<i64> {
         let b = rhs;
         // Saturating: see `Add` — products can overflow i64 for wide inputs;
         // widening to the i64 range keeps the bound sound.
-        let possible_bounds = vec![
+        let possible_bounds = [
             a.start.saturating_mul(b.start),
             a.start.saturating_mul(b.end),
             a.end.saturating_mul(b.start),
@@ -232,7 +232,7 @@ impl Div for Bounds<i64> {
                 // `i64::MIN / -1`; saturating it to `i64::MAX` keeps the bound
                 // sound instead of panicking. Divisors are non-zero here (the
                 // caller of `bounds_from_bop` rejects zero divisors).
-                let possible_bounds = vec![
+                let possible_bounds = [
                     a.start.saturating_div(b.start),
                     a.start.saturating_div(b.end),
                     a.end.saturating_div(b.start),
@@ -293,7 +293,7 @@ pub fn bop_bounds<F: Fn(i64, i64) -> i64>(a: &Bounds<i64>, b: &Bounds<i64>, f: F
     if a.is_exact() && b.is_exact() {
         return Bounds::exact(f(a.start, b.start));
     }
-    let possible_bounds = vec![
+    let possible_bounds = [
         f(a.start, b.start),
         f(a.start, b.end),
         f(a.end, b.start),

--- a/cutile-compiler/src/compiler/_function.rs
+++ b/cutile-compiler/src/compiler/_function.rs
@@ -536,7 +536,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
 
         // 7. Build stride_args HashMap.
         let stride_args: HashMap<String, Vec<i32>> = stride_args
-            .into_iter()
+            .iter()
             .map(|(k, v)| (k.to_string(), v.to_vec()))
             .collect::<HashMap<_, _>>();
 
@@ -573,12 +573,12 @@ impl<'m> CUDATileFunctionCompiler<'m> {
             .collect();
         let (entry, validator) = generate_entry_point(
             modules,
-            &function,
+            function,
             &generic_vars,
             &stride_args,
             &spec_args_map,
             &scalar_hints_map,
-            &modules.primitives(),
+            modules.primitives(),
             &optimization_hints,
         )?;
 
@@ -1115,14 +1115,14 @@ impl<'m> CUDATileFunctionCompiler<'m> {
         if std::env::var("CUTILE_DEBUG_COMPILER2").is_ok() {
             eprintln!(
                 "compiler2: lowered entry function body:\n{}",
-                quote::quote!(#lowered_fn_item).to_string()
+                quote::quote!(#lowered_fn_item)
             );
         }
 
         let return_value = self.compile_block(
             module,
             block_id,
-            &*lowered_fn_item.block,
+            &lowered_fn_item.block,
             generic_vars,
             &mut ctx,
             None,
@@ -1189,7 +1189,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                 None
             };
             let value = self
-                .compile_expression(module, block_id, &arg, generic_args, ctx, expected)?
+                .compile_expression(module, block_id, arg, generic_args, ctx, expected)?
                 .ok_or(self.jit_error(
                     &arg.span(),
                     &format!(
@@ -1213,7 +1213,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
         let rust_ty_str = type_name::<T>();
         let rust_ty = syn::parse2::<syn::Type>(rust_ty_str.parse()?).unwrap();
         let tr_ty = self
-            .compile_type(&rust_ty, &generic_vars, &HashMap::new())?
+            .compile_type(&rust_ty, generic_vars, &HashMap::new())?
             .ok_or(self.jit_error(&rust_ty.span(), "failed to compile constant"))?;
         self.compile_constant_from_exact_bounds(module, block_id, bounds, tr_ty)
     }
@@ -1259,7 +1259,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
         };
         let Some(const_ty_str) = get_cuda_tile_element_type_from_rust_primitive_str(
             &type_inst.rust_element_instance_ty,
-            &self.modules.primitives(),
+            self.modules.primitives(),
         ) else {
             return self
                 .jit_error_result(&tr_ty.rust_ty.span(), "failed to compile constant value");

--- a/cutile-compiler/src/compiler/_module.rs
+++ b/cutile-compiler/src/compiler/_module.rs
@@ -556,8 +556,10 @@ fn trait_impl_matches_call(
         return false;
     }
 
-    let mut ctx = TraitMatchCtx::default();
-    ctx.caller_array_params = generic_vars.inst_array.clone();
+    let mut ctx = TraitMatchCtx {
+        caller_array_params: generic_vars.inst_array.clone(),
+        ..Default::default()
+    };
     collect_generics_for_trait_match(&item_impl.generics, &mut ctx);
     collect_generics_for_trait_match(&impl_method.sig.generics, &mut ctx);
 

--- a/cutile-compiler/src/compiler/_type.rs
+++ b/cutile-compiler/src/compiler/_type.rs
@@ -139,6 +139,6 @@ fn rust_scalar_type(name: &str) -> Option<ScalarType> {
 fn extract_pointer_element_type(ty_str: &str) -> Option<String> {
     let after_mut = ty_str.split("mut").nth(1)?;
     let trimmed = after_mut.trim();
-    let end = trimmed.find(|c: char| c == ',' || c == '>' || c == ' ')?;
+    let end = trimmed.find([',', '>', ' '])?;
     Some(trimmed[..end].to_string())
 }

--- a/cutile-compiler/src/compiler/_value.rs
+++ b/cutile-compiler/src/compiler/_value.rs
@@ -434,9 +434,7 @@ impl TileRustValue {
     }
 
     pub fn take_type_meta_field(self, name: &str) -> Option<Self> {
-        let Some(mut type_meta) = self.type_meta else {
-            return None;
-        };
+        let mut type_meta = self.type_meta?;
         type_meta.fields.remove(name)
     }
 

--- a/cutile-compiler/src/compiler/checks/mod.rs
+++ b/cutile-compiler/src/compiler/checks/mod.rs
@@ -92,7 +92,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                 &call_expr.span(),
                 &format!(
                     "expected a structured or primitive type for first argument of `{}`, got {:?}",
-                    &call_expr.to_token_stream().to_string(),
+                    call_expr.to_token_stream(),
                     partition_value.kind
                 ),
             );
@@ -102,7 +102,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                 &call_expr.span(),
                 &format!(
                     "Unexpected kind for arg 1 in {}",
-                    &call_expr.to_token_stream().to_string()
+                    call_expr.to_token_stream()
                 ),
             );
         }

--- a/cutile-compiler/src/compiler/compile_assume.rs
+++ b/cutile-compiler/src/compiler/compile_assume.rs
@@ -56,7 +56,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                 "expected a simple function path for assume invocation",
             );
         };
-        let ident = get_ident_from_path_expr(&path_expr);
+        let ident = get_ident_from_path_expr(path_expr);
         let compiler_op_function = ident.to_string();
         let mut args =
             self.compile_call_args(module, block_id, &call_expr.args, generic_vars, ctx)?;
@@ -75,7 +75,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                 "the first argument to `assume` must produce a value",
             );
         };
-        Ok(self.compile_value_assumption(
+        self.compile_value_assumption(
             module,
             block_id,
             val_value,
@@ -83,7 +83,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
             &predicate_args,
             return_type,
             &call_expr.span(),
-        )?)
+        )
     }
 
     /// Generates tile-ir assume operation with appropriate predicate attribute.

--- a/cutile-compiler/src/compiler/compile_binary_op.rs
+++ b/cutile-compiler/src/compiler/compile_binary_op.rs
@@ -342,8 +342,8 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                 &format!(
                     "binary `{:?}` requires operands of the same type, but got `{}` and `{}`",
                     tile_rust_arithmetic_op,
-                    lhs.ty.rust_ty.to_token_stream().to_string(),
-                    rhs.ty.rust_ty.to_token_stream().to_string()
+                    lhs.ty.rust_ty.to_token_stream(),
+                    rhs.ty.rust_ty.to_token_stream()
                 ),
             );
         }
@@ -366,14 +366,14 @@ impl<'m> CUDATileFunctionCompiler<'m> {
         let operand_type = lhs.ty.clone();
         let operand_rust_ty = &operand_type.rust_ty;
         let Some(operand_rust_element_type) =
-            operand_type.get_instantiated_rust_element_type(&self.modules.primitives())
+            operand_type.get_instantiated_rust_element_type(self.modules.primitives())
         else {
             return self.jit_error_result(
                 span,
                 &format!(
                     "unable to determine element type for `{:?}` on `{}`",
                     tile_rust_arithmetic_op,
-                    operand_type.rust_ty.to_token_stream().to_string()
+                    operand_type.rust_ty.to_token_stream()
                 ),
             );
         };
@@ -382,7 +382,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                 span,
                 &format!(
                     "type `{}` cannot be used with binary `{:?}`",
-                    operand_type.rust_ty.to_token_stream().to_string(),
+                    operand_type.rust_ty.to_token_stream(),
                     tile_rust_arithmetic_op
                 ),
             );
@@ -392,7 +392,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
         let operand_result_ty = module.value_type(lhs_value).clone();
 
         let Some(operand_cuda_tile_element_type) =
-            operand_type.get_cuda_tile_element_type(&self.modules.primitives())?
+            operand_type.get_cuda_tile_element_type(self.modules.primitives())?
         else {
             return self.jit_error_result(
                 span,
@@ -623,7 +623,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                     span,
                     &format!(
                         "Binary operation is not implemented for {}",
-                        operand_rust_ty.to_token_stream().to_string()
+                        operand_rust_ty.to_token_stream()
                     ),
                 );
             }
@@ -635,7 +635,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                 // Try to infer from lhs/rhs.
                 if is_cmp {
                     let bool_ty = syn::parse2::<syn::Type>("bool".parse().unwrap()).unwrap();
-                    self.compile_type(&bool_ty, &generic_vars, &HashMap::new())?
+                    self.compile_type(&bool_ty, generic_vars, &HashMap::new())?
                         .unwrap()
                 } else {
                     operand_type
@@ -657,7 +657,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                 );
             }
             let result_domain = return_type
-                .get_instantiated_rust_element_type(&self.modules.primitives())
+                .get_instantiated_rust_element_type(self.modules.primitives())
                 .as_deref()
                 .and_then(value_facts::int_value_domain);
             value_facts::transfer(tile_rust_arithmetic_op, &lhs, &rhs, result_domain)
@@ -673,12 +673,12 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                 // The lower/upper bounds are equivalent — emit a constant
                 // instead. The op allocated above becomes dead (not appended
                 // to any block).
-                return Ok(self.compile_constant_from_exact_bounds(
+                return self.compile_constant_from_exact_bounds(
                     module,
                     block_id,
-                    bounds.clone(),
+                    *bounds,
                     return_type,
-                )?);
+                );
             }
         }
 

--- a/cutile-compiler/src/compiler/compile_block.rs
+++ b/cutile-compiler/src/compiler/compile_block.rs
@@ -102,7 +102,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                         ),
                     );
                 }
-                for (pat, value) in tuple.elems.iter().zip(elements.into_iter()) {
+                for (pat, value) in tuple.elems.iter().zip(elements) {
                     self.bind_pattern_value(pat, value, inherited_mutability, ctx)?;
                 }
                 Ok(())
@@ -157,7 +157,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                                 ),
                             );
                         }
-                        for (pat, value) in pats.into_iter().zip(elements.into_iter()) {
+                        for (pat, value) in pats.into_iter().zip(elements) {
                             self.bind_pattern_value(pat, value, inherited_mutability, ctx)?;
                         }
                     }
@@ -211,7 +211,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                         ),
                     );
                 }
-                for (pat, value) in tuple_struct.elems.iter().zip(elements.into_iter()) {
+                for (pat, value) in tuple_struct.elems.iter().zip(elements) {
                     self.bind_pattern_value(pat, value, inherited_mutability, ctx)?;
                 }
                 Ok(())
@@ -269,7 +269,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                         let Some(value) = self.compile_expression(
                             module,
                             block_id,
-                            &*init.expr,
+                            &init.expr,
                             generic_args,
                             ctx,
                             init_ty,
@@ -291,7 +291,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                                 let binding_name: Option<String> =
                                     Some(const_item.ident.to_string());
                                 let ct_ty: Option<TileRustType> = self.compile_type(
-                                    &*const_item.ty,
+                                    &const_item.ty,
                                     generic_args,
                                     &HashMap::new(),
                                 )?;
@@ -304,7 +304,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                                 match self.compile_expression(
                                     module,
                                     block_id,
-                                    &*const_item.expr,
+                                    &const_item.expr,
                                     generic_args,
                                     ctx,
                                     ct_ty,
@@ -318,7 +318,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                                             &const_item.expr.span(),
                                             &format!(
                                                 "failed to compile const initializer: `{}`",
-                                                const_item.expr.to_token_stream().to_string()
+                                                const_item.expr.to_token_stream()
                                             ),
                                         )
                                     }
@@ -398,7 +398,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                                 match self.compile_expression(
                                     module,
                                     block_id,
-                                    &*assign_expr.right,
+                                    &assign_expr.right,
                                     generic_args,
                                     ctx,
                                     rhs_ty,
@@ -435,7 +435,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                                     return_value = self.compile_expression(
                                         module,
                                         block_id,
-                                        &*expr,
+                                        expr,
                                         generic_args,
                                         ctx,
                                         return_type.clone(),
@@ -450,7 +450,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                                 return_value = self.compile_expression(
                                     module,
                                     block_id,
-                                    &*expr,
+                                    expr,
                                     generic_args,
                                     ctx,
                                     return_type.clone(),
@@ -459,7 +459,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                                 self.compile_expression(
                                     module,
                                     block_id,
-                                    &*expr,
+                                    expr,
                                     generic_args,
                                     ctx,
                                     None,
@@ -523,7 +523,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                     }
                     Some(BlockTerminator::Return) => {
                         self.resolve_span(&block_expr.span())
-                            .jit_assert(loop_carry_var_names.len() == 0, "unexpected state")?;
+                            .jit_assert(loop_carry_var_names.is_empty(), "unexpected state")?;
                         if return_value.is_some() {
                             return self.jit_error_result(
                                 &block_expr.span(),

--- a/cutile-compiler/src/compiler/compile_cuda_tile_op.rs
+++ b/cutile-compiler/src/compiler/compile_cuda_tile_op.rs
@@ -395,16 +395,16 @@ impl<'m> CUDATileFunctionCompiler<'m> {
 
         let cuda_tile_op_params = op_attrs
             .parse_string_arr("params")
-            .unwrap_or_else(|| vec![]);
+            .unwrap_or_else(std::vec::Vec::new);
         let cuda_tile_op_attribute_params = op_attrs
             .parse_string_arr("attribute_params")
-            .unwrap_or_else(|| vec![]);
+            .unwrap_or_else(std::vec::Vec::new);
         let cuda_tile_op_hint_params = op_attrs
             .parse_string_arr("hint_params")
-            .unwrap_or_else(|| vec![]);
+            .unwrap_or_else(std::vec::Vec::new);
         let cuda_tile_op_named_attributes = op_attrs
             .parse_string_arr("named_attributes")
-            .unwrap_or_else(|| vec![]);
+            .unwrap_or_else(std::vec::Vec::new);
         let cuda_tile_op_static_params = op_attrs
             .parse_string_arr("static_params")
             .unwrap_or_default();
@@ -694,7 +694,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
         };
         let element_type = tensor_value
             .ty
-            .get_instantiated_rust_element_type(&self.modules.primitives())
+            .get_instantiated_rust_element_type(self.modules.primitives())
             .ok_or_else(|| {
                 self.jit_error(
                     &call_expr.args[0].span(),
@@ -948,17 +948,10 @@ impl<'m> CUDATileFunctionCompiler<'m> {
 
         let (op_id, results) = op_builder.build(module);
         append_op(module, block_id, op_id);
-        let mut values = vec![];
-        values.push(TileRustValue::new_structured_type(
-            results[0],
-            tile_elem_ty,
-            None,
-        ));
-        values.push(TileRustValue::new_primitive(
-            results[1],
-            token_elem_ty,
-            None,
-        ));
+        let values = vec![
+            TileRustValue::new_structured_type(results[0], tile_elem_ty, None),
+            TileRustValue::new_primitive(results[1], token_elem_ty, None),
+        ];
         Ok(Some(TileRustValue::new_compound(values, return_type_outer)))
     }
 
@@ -1188,7 +1181,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
 
         let elem_ty_prefix = ptr_value
             .ty
-            .get_cuda_tile_element_type_prefix(&self.modules.primitives())?;
+            .get_cuda_tile_element_type_prefix(self.modules.primitives())?;
         let atomic_mode = AtomicMode::new(mode.as_str(), elem_ty_prefix)? as i64;
 
         let mut operands = vec![ptrs, arg];
@@ -1238,17 +1231,10 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                 )
                 .build(module);
         append_op(module, block_id, op_id);
-        let mut values = vec![];
-        values.push(TileRustValue::new_structured_type(
-            results[0],
-            tile_elem_ty,
-            None,
-        ));
-        values.push(TileRustValue::new_primitive(
-            results[1],
-            token_elem_ty,
-            None,
-        ));
+        let values = vec![
+            TileRustValue::new_structured_type(results[0], tile_elem_ty, None),
+            TileRustValue::new_primitive(results[1], token_elem_ty, None),
+        ];
         Ok(Some(TileRustValue::new_compound(values, return_type_outer)))
     }
 
@@ -1406,17 +1392,10 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                 )
                 .build(module);
         append_op(module, block_id, op_id);
-        let mut values = vec![];
-        values.push(TileRustValue::new_structured_type(
-            results[0],
-            tile_elem_ty,
-            None,
-        ));
-        values.push(TileRustValue::new_primitive(
-            results[1],
-            token_elem_ty,
-            None,
-        ));
+        let values = vec![
+            TileRustValue::new_structured_type(results[0], tile_elem_ty, None),
+            TileRustValue::new_primitive(results[1], token_elem_ty, None),
+        ];
         Ok(Some(TileRustValue::new_compound(values, return_type_outer)))
     }
 
@@ -1539,7 +1518,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
         };
         let elem_ty_prefix = view_value
             .ty
-            .get_cuda_tile_element_type_prefix(&self.modules.primitives())?;
+            .get_cuda_tile_element_type_prefix(self.modules.primitives())?;
         let atomic_mode = AtomicMode::new(mode.as_str(), elem_ty_prefix)? as i64;
 
         let mut all_operands = vec![cuda_tile_view_value];
@@ -1838,7 +1817,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                 .result(tile_result_ir_ty)
                 .result(token_result_ir_ty)
                 .operands(all_operands.iter().copied())
-                .attrs(opt_hint_attrs.into_iter())
+                .attrs(opt_hint_attrs)
                 .attr(
                     "memory_ordering_semantics",
                     Attribute::i32(memory_ordering_value),
@@ -1978,7 +1957,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
             OpBuilder::new(Opcode::StoreViewTko, self.ir_location(&call_expr.span()))
                 .result(token_result_ir_ty)
                 .operands(all_operands.iter().copied())
-                .attrs(opt_hint_attrs.into_iter())
+                .attrs(opt_hint_attrs)
                 .attr(
                     "memory_ordering_semantics",
                     Attribute::i32(memory_ordering_value),
@@ -2183,7 +2162,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
             .unwrap();
         let elem_ty_str = operand_value
             .ty
-            .get_cuda_tile_element_type(&self.modules.primitives())?
+            .get_cuda_tile_element_type(self.modules.primitives())?
             .unwrap();
         let elem_ir_ty = super::_type::make_scalar_tile_type(&elem_ty_str)
             .expect("failed to build scalar tile type for reduce element");
@@ -2265,7 +2244,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
             result_value.value.unwrap()
         } else {
             let is_float =
-                super::_type::scalar_from_name(&elem_ty_str).map_or(false, |s| s.is_float());
+                super::_type::scalar_from_name(&elem_ty_str).is_some_and(|s| s.is_float());
             let add_opcode = if is_float { Opcode::AddF } else { Opcode::AddI };
             let mut add_op_builder =
                 OpBuilder::new(add_opcode, self.ir_location(&call_expr.span()))
@@ -2343,7 +2322,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
             .expect("failed to convert scan result type");
         let elem_ty_str = operand_value
             .ty
-            .get_cuda_tile_element_type(&self.modules.primitives())?
+            .get_cuda_tile_element_type(self.modules.primitives())?
             .unwrap();
         let elem_ir_ty = super::_type::make_scalar_tile_type(&elem_ty_str)
             .expect("failed to build scalar tile type for scan element");
@@ -2412,7 +2391,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
             result_value.value.unwrap()
         } else {
             let is_float =
-                super::_type::scalar_from_name(&elem_ty_str).map_or(false, |s| s.is_float());
+                super::_type::scalar_from_name(&elem_ty_str).is_some_and(|s| s.is_float());
             let add_opcode = if is_float { Opcode::AddF } else { Opcode::AddI };
             let mut add_op_builder =
                 OpBuilder::new(add_opcode, self.ir_location(&call_expr.span()))
@@ -2507,17 +2486,11 @@ impl<'m> CUDATileFunctionCompiler<'m> {
         };
 
         let return_type = if return_type.is_none() {
-            match rust_function_name.as_str() {
-                "constant" => {
-                    return self.jit_error_result(
-                        &call_expr.span(),
-                        &format!(
-                            "Return type required for {}",
-                            call_expr.to_token_stream().to_string()
-                        ),
-                    )
-                }
-                _ => {}
+            if rust_function_name.as_str() == "constant" {
+                return self.jit_error_result(
+                    &call_expr.span(),
+                    &format!("Return type required for {}", call_expr.to_token_stream()),
+                );
             }
             self.derive_type(
                 module,
@@ -2601,22 +2574,21 @@ impl<'m> CUDATileFunctionCompiler<'m> {
             compiled_args.push(op_arg.clone());
             let op_param = &cuda_tile_op_params[i];
             let mut arg_values: Vec<Value> = vec![];
-            if op_arg.value.is_some() {
-                arg_values.push(op_arg.value.clone().unwrap());
-            } else if op_arg.fields.is_some() {
-                let fields = op_arg.fields.as_ref().unwrap();
+            if let Some(value) = op_arg.value {
+                arg_values.push(value);
+            } else if let Some(fields) = &op_arg.fields {
                 let op_path = op_param.split(".").collect::<Vec<&str>>();
                 if op_path.len() <= 1 {
                     return self.jit_error_result(&call_expr.args[i].span(), &format!("Field expression required for struct param {call_expr_arg_str}, got {op_param}"));
                 }
-                let field = *op_path.last().clone().unwrap();
+                let field = *op_path.last().unwrap();
                 match fields.get(field) {
                     Some(field_value) => {
-                        if field_value.value.is_some() {
-                            arg_values.push(field_value.value.clone().unwrap());
-                        } else if field_value.values.is_some() {
-                            for value in field_value.values.as_ref().unwrap().iter() {
-                                let Some(v) = value.value.clone() else {
+                        if let Some(value) = field_value.value {
+                            arg_values.push(value);
+                        } else if let Some(values) = &field_value.values {
+                            for value in values.iter() {
+                                let Some(v) = value.value else {
                                     return self.jit_error_result(&call_expr.args[i].span(), &format!("Unexpected nested array {op_param} for {call_expr_arg_str}"));
                                 };
                                 arg_values.push(v);
@@ -2642,9 +2614,9 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                         )
                     }
                 }
-            } else if op_arg.values.is_some() {
-                for value in op_arg.values.as_ref().unwrap().iter() {
-                    let Some(v) = value.value.clone() else {
+            } else if let Some(values) = &op_arg.values {
+                for value in values.iter() {
+                    let Some(v) = value.value else {
                         return self.jit_error_result(
                             &call_expr.args[i].span(),
                             &format!("Unexpected nested array {op_param} for {call_expr_arg_str}"),
@@ -2668,16 +2640,16 @@ impl<'m> CUDATileFunctionCompiler<'m> {
             let (attr_name, attr_value) = (name_attr_split[0], name_attr_split[1]);
             if attr_name.starts_with("signedness") && attr_value == "inferred_signedness" {
                 let elem_ty = compiled_args
-                    .get(0)
+                    .first()
                     .and_then(|arg| {
                         arg.ty
-                            .get_instantiated_rust_element_type(&self.modules.primitives())
+                            .get_instantiated_rust_element_type(self.modules.primitives())
                     })
                     .expect("Failed to get element type for signedness inference.");
                 for arg in &compiled_args {
                     let arg_elem_ty = arg
                         .ty
-                        .get_instantiated_rust_element_type(&self.modules.primitives())
+                        .get_instantiated_rust_element_type(self.modules.primitives())
                         .expect("Operand types are not all equivalent.");
                     if arg_elem_ty != elem_ty {
                         return self.jit_error_result(&call_expr.span(), &format!("Element type mismatch for signedness inference: expected {elem_ty}, got {arg_elem_ty}"));
@@ -2692,7 +2664,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
         // Resolve static_params: ZST marker types -> tile-ir attributes.
         let resolved_static_attrs =
             resolve_static_params(cuda_tile_op_static_params, call_expr, fn_item)
-                .map_err(|e| JITError::Generic(e))?;
+                .map_err(JITError::Generic)?;
         for attr_str in &resolved_static_attrs {
             if let Some((name, val_str)) = attr_str.split_once('=') {
                 let name = name.trim();
@@ -2792,9 +2764,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                                 };
                                 attrs.push((
                                     attr_id.to_string(),
-                                    Attribute::DenseI32Array(
-                                        cga.iter().map(|&x| x as i32).collect(),
-                                    ),
+                                    Attribute::DenseI32Array(cga.to_vec()),
                                 ));
                             }
                             _ => {
@@ -2904,7 +2874,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                     };
                     // Build a DenseElements attribute from the literal value.
                     let elem_ty_str = return_type
-                        .get_cuda_tile_element_type(&self.modules.primitives())?
+                        .get_cuda_tile_element_type(self.modules.primitives())?
                         .unwrap_or("i32".to_string());
                     let result_ir_ty = super::_type::scalar_from_name(&elem_ty_str)
                         .map(|sc| {
@@ -3006,7 +2976,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                     }
                     if let Some(bounds) = op_arg.bounds {
                         if bounds.is_exact() {
-                            attrs.push(int_attr(attr_id, bounds.start as i64));
+                            attrs.push(int_attr(attr_id, bounds.start));
                         } else {
                             return self.jit_error_result(&call_expr.args[i].span(), &format!("Integer attribute {attr_id} must be a constant value, got bounds: {bounds:?}"));
                         }
@@ -3040,7 +3010,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
 
         let mut op_builder = OpBuilder::new(opcode, self.ir_location(&call_expr.span()))
             .operands(op_operands.iter().copied())
-            .attrs(attrs.into_iter());
+            .attrs(attrs);
 
         if function_returns(fn_item) {
             match return_type.kind {
@@ -3070,7 +3040,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                     if let Type::Tuple(tuple_type) = &return_type.rust_ty {
                         let mut elem_types = vec![];
                         for elem in &tuple_type.elems {
-                            let elem_ty = self.compile_type(&elem, generic_args, &HashMap::new())?;
+                            let elem_ty = self.compile_type(elem, generic_args, &HashMap::new())?;
                             if elem_ty.is_none() { return self.jit_error_result(&call_expr.span(), "failed to compile type"); }
                             let elem_ty = elem_ty.unwrap();
                             if elem_ty.tile_ir_ty.is_none() { return self.jit_error_result(&call_expr.span(), "failed to compile tile type"); }
@@ -3121,7 +3091,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                             }
                         }
                         Ok(Some(TileRustValue::new_compound(values, return_type)))
-                    } else { self.jit_error_result(&call_expr.span(), &format!("operations that return multiple values must use a tuple return type, got `{}`", return_type.rust_ty.to_token_stream().to_string())) }
+                    } else { self.jit_error_result(&call_expr.span(), &format!("operations that return multiple values must use a tuple return type, got `{}`", return_type.rust_ty.to_token_stream())) }
                 }
                 Kind::Struct => self.jit_error_result(&call_expr.span(), "this operation cannot return a struct; only scalar and structured (tile) types are supported as return types"),
                 Kind::String => self.jit_error_result(&call_expr.span(), "this operation cannot return a string; only scalar and structured (tile) types are supported as return types"),
@@ -3163,7 +3133,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                             let Some(val) = self.compile_expression(
                                 module,
                                 block_id,
-                                &expr,
+                                expr,
                                 generic_vars,
                                 ctx,
                                 None,
@@ -3188,10 +3158,9 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                 }
                 let re_repl = Regex::new(r"\{\}").unwrap();
                 for (i, element_ty) in element_type_instance.into_iter().enumerate() {
-                    let rust_element_type_instance = element_ty.expect(
-                        format!("failed to determine element type for print argument {}", i)
-                            .as_str(),
-                    );
+                    let rust_element_type_instance = element_ty.unwrap_or_else(|| {
+                        panic!("failed to determine element type for print argument {}", i)
+                    });
                     if !re_repl.is_match(&str_literal) {
                         return self.jit_error_result(
                             &mac.span(),
@@ -3201,7 +3170,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                     let Some(tile_element_type_instance) =
                         get_cuda_tile_element_type_from_rust_primitive_str(
                             &rust_element_type_instance,
-                            &self.modules.primitives(),
+                            self.modules.primitives(),
                         )
                     else {
                         return self.jit_error_result(&mac.span(), &format!("unable to determine tile element type for `{rust_element_type_instance}`"));
@@ -3486,7 +3455,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
 
         let element_type = tensor_value
             .ty
-            .get_instantiated_rust_element_type(&self.modules.primitives())
+            .get_instantiated_rust_element_type(self.modules.primitives())
             .ok_or_else(|| {
                 self.jit_error(
                     &call_expr.args[0].span(),
@@ -3639,7 +3608,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
 
         let element_type = tensor_value
             .ty
-            .get_instantiated_rust_element_type(&self.modules.primitives())
+            .get_instantiated_rust_element_type(self.modules.primitives())
             .ok_or_else(|| {
                 self.jit_error(
                     &call_expr.args[0].span(),
@@ -3821,7 +3790,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                 true,
             )?;
 
-        let all_operands = vec![
+        let all_operands = [
             cuda_tile_view_value,
             cuda_tile_sparse_index,
             cuda_tile_dense_index,
@@ -3852,17 +3821,10 @@ impl<'m> CUDATileFunctionCompiler<'m> {
         }
         let (op_id, results) = op_builder.build(module);
         append_op(module, block_id, op_id);
-        let mut values = vec![];
-        values.push(TileRustValue::new_structured_type(
-            results[0],
-            tile_elem_ty,
-            None,
-        ));
-        values.push(TileRustValue::new_primitive(
-            results[1],
-            token_elem_ty,
-            None,
-        ));
+        let values = vec![
+            TileRustValue::new_structured_type(results[0], tile_elem_ty, None),
+            TileRustValue::new_primitive(results[1], token_elem_ty, None),
+        ];
         Ok(Some(TileRustValue::new_compound(values, return_type_outer)))
     }
 
@@ -3985,17 +3947,10 @@ impl<'m> CUDATileFunctionCompiler<'m> {
         }
         let (op_id, results) = op_builder.build(module);
         append_op(module, block_id, op_id);
-        let mut values = vec![];
-        values.push(TileRustValue::new_structured_type(
-            results[0],
-            tile_elem_ty,
-            None,
-        ));
-        values.push(TileRustValue::new_primitive(
-            results[1],
-            token_elem_ty,
-            None,
-        ));
+        let values = vec![
+            TileRustValue::new_structured_type(results[0], tile_elem_ty, None),
+            TileRustValue::new_primitive(results[1], token_elem_ty, None),
+        ];
         Ok(Some(TileRustValue::new_compound(values, return_type_outer)))
     }
 }

--- a/cutile-compiler/src/compiler/compile_expression.rs
+++ b/cutile-compiler/src/compiler/compile_expression.rs
@@ -612,7 +612,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                 .ok_or_else(|| self.jit_error(span, "failed to compile Dim type"))?,
         };
         let dim_origin = value.dim_origin.clone();
-        let bounds = value.bounds.clone();
+        let bounds = value.bounds;
         let mut fields = BTreeMap::new();
         fields.insert("size".to_string(), value);
         let mut dim = TileRustValue::new_struct(fields, dim_type);
@@ -2122,7 +2122,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
         let Some(dim_value) = ctx.vars.get(&dim_name).cloned() else {
             return Ok(false);
         };
-        if !get_type_ident(&dim_value.ty.rust_ty).is_some_and(|ident| ident == "Dim") {
+        if get_type_ident(&dim_value.ty.rust_ty).is_none_or(|ident| ident != "Dim") {
             return Ok(false);
         }
         let Some(dim_origin) = Self::value_dim_origin(&dim_value) else {
@@ -2185,12 +2185,12 @@ impl<'m> CUDATileFunctionCompiler<'m> {
             let i32_type = self
                 .compile_type(&parse_quote!(i32), generic_vars, &HashMap::new())?
                 .ok_or_else(|| self.jit_error(&for_expr.span(), "failed to compile i32 type"))?;
-            let upper_bounds = dim_value.bounds.clone().or_else(|| {
+            let upper_bounds = dim_value.bounds.or_else(|| {
                 dim_value
                     .fields
                     .as_ref()
                     .and_then(|fields| fields.get("size"))
-                    .and_then(|size| size.bounds.clone())
+                    .and_then(|size| size.bounds)
             });
             let mut iterand_val = if let Some(bounds) = upper_bounds {
                 let upper = bounds.end - 1;
@@ -2381,8 +2381,8 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                             "failed to compile range end expression",
                         );
                     };
-                    let iterand_lower_const = start_val.bounds.clone();
-                    let iterand_upper_const = end_val.bounds.clone();
+                    let iterand_lower_const = start_val.bounds;
+                    let iterand_upper_const = end_val.bounds;
                     let lower_bound = start_val.value.unwrap();
                     let upper_bound = end_val.value.unwrap();
                     let step_value = if let Some(step_expr) = maybe_step_expr {
@@ -2605,7 +2605,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                         module,
                         loop_block_id,
                         &for_expr.body,
-                        &generic_vars,
+                        generic_vars,
                         &mut for_variables,
                         return_type,
                     )?;
@@ -2669,7 +2669,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                     }) = self.compile_expression(
                         module,
                         loop_block_id,
-                        &*while_expr.cond,
+                        &while_expr.cond,
                         generic_vars,
                         &mut loop_variables,
                         return_type.clone(),
@@ -2813,7 +2813,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                     let Some(conditional_val) = self.compile_expression(
                         module,
                         block_id,
-                        &*if_expr.cond,
+                        &if_expr.cond,
                         generic_vars,
                         ctx,
                         None,
@@ -3049,7 +3049,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                         module,
                         block_id,
                         &block_expr.block,
-                        &generic_vars,
+                        generic_vars,
                         &mut inner_block_vars,
                         return_type,
                     )?;
@@ -3074,7 +3074,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                         module,
                         block_id,
                         &block_expr.block,
-                        &generic_vars,
+                        generic_vars,
                         &mut inner_block_vars,
                         return_type,
                     )?;
@@ -3146,14 +3146,14 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                         };
                         fields.insert(field_name, field_value);
                     }
-                    return Ok(Some(TileRustValue::new_struct(fields, return_type)));
+                    Ok(Some(TileRustValue::new_struct(fields, return_type)))
                 }
                 Expr::Reference(ref_expr) => {
                     // TODO (hme): Check whether all expr types can be supported.
                     let return_type = match return_type {
                         Some(ty) => {
                             if let syn::Type::Reference(ref_type) = ty.rust_ty {
-                                self.compile_type(&*ref_type.elem, generic_vars, &HashMap::new())?
+                                self.compile_type(&ref_type.elem, generic_vars, &HashMap::new())?
                             } else {
                                 None
                             }
@@ -3193,12 +3193,10 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                             ctx,
                             return_type,
                         )?),
-                        _ => {
-                            return self.jit_error_result(
-                                &ref_expr.span(),
-                                "this reference expression form is not supported",
-                            )
-                        }
+                        _ => self.jit_error_result(
+                            &ref_expr.span(),
+                            "this reference expression form is not supported",
+                        ),
                     }
                 }
                 Expr::Tuple(tuple_expr) => {
@@ -3234,7 +3232,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                         match self.compile_expression(
                             module,
                             block_id,
-                            &elem,
+                            elem,
                             generic_vars,
                             ctx,
                             elem_return_type,
@@ -3286,14 +3284,14 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                             Some(return_type) => {
                                 match &return_type.rust_ty {
                                     syn::Type::Array(array_type) => self.compile_type(
-                                        &*array_type.elem,
+                                        &array_type.elem,
                                         generic_vars,
                                         &HashMap::new(),
                                     )?,
                                     syn::Type::Slice(slice) => {
                                         // TODO (hme): Confirm this is right.
                                         self.compile_type(
-                                            &*slice.elem,
+                                            &slice.elem,
                                             generic_vars,
                                             &HashMap::new(),
                                         )?
@@ -3303,7 +3301,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                                             &elem.span(),
                                             &format!(
                                                 "unexpected element type `{}`",
-                                                return_type.rust_ty.to_token_stream().to_string()
+                                                return_type.rust_ty.to_token_stream()
                                             ),
                                         )
                                     }
@@ -3314,7 +3312,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                         match self.compile_expression(
                             module,
                             block_id,
-                            &elem,
+                            elem,
                             generic_vars,
                             ctx,
                             elem_ty,
@@ -3328,8 +3326,10 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                             }
                         };
                     }
-                    let return_type = if return_type.is_none() {
-                        if values.len() == 0 {
+                    let return_type = if let Some(return_type) = return_type {
+                        return_type
+                    } else {
+                        if values.is_empty() {
                             return self.jit_error_result(
                                 &array_expr.span(),
                                 "unable to infer type for empty array; add a type annotation",
@@ -3359,8 +3359,6 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                                 )
                             }
                         }
-                    } else {
-                        return_type.unwrap()
                     };
                     Ok(Some(TileRustValue::new_compound(values, return_type)))
                 }
@@ -3424,8 +3422,10 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                         );
                     };
                     let values: Vec<TileRustValue> = vec![value; len];
-                    let return_type = if return_type.is_none() {
-                        if values.len() == 0 {
+                    let return_type = if let Some(return_type) = return_type {
+                        return_type
+                    } else {
+                        if values.is_empty() {
                             return self.jit_error_result(
                                 &repeat_expr.span(),
                                 "unable to infer type for zero-length repeat expression; add a type annotation",
@@ -3455,8 +3455,6 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                                 )
                             }
                         }
-                    } else {
-                        return_type.unwrap()
                     };
                     Ok(Some(TileRustValue::new_compound(values, return_type)))
                 }
@@ -3553,18 +3551,18 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                     // 4. Single-segment, not a local, not in resolver — error.
                     let suggestion = self.modules.name_resolver.find_all_definitions(&var_name);
                     if suggestion.is_empty() {
-                        return self.jit_error_result(
+                        self.jit_error_result(
                             &path_expr.span(),
                             &format!("undefined variable `{var_name}`"),
-                        );
+                        )
                     } else {
-                        return self.jit_error_result(
+                        self.jit_error_result(
                             &path_expr.span(),
                             &format!(
                                 "undefined variable `{var_name}` (did you mean the function defined in {}?)",
                                 suggestion.join(", ")
                             ),
-                        );
+                        )
                     }
                 }
                 Expr::Call(call_expr) => {
@@ -3582,9 +3580,9 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                                     return_type,
                                 );
                             }
-                            let ident = get_ident_from_path_expr(&path_expr);
+                            let ident = get_ident_from_path_expr(path_expr);
                             // Handle Some(...) specially - it's a Rust Option constructor, not a function call
-                            if ident.to_string() == "Some" {
+                            if ident == "Some" {
                                 if call_expr.args.len() != 1 {
                                     return self.jit_error_result(
                                         &call_expr.span(),
@@ -3627,9 +3625,10 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                                     option_type,
                                 )));
                             }
-                            if let Some(_) = self
+                            if self
                                 .modules
                                 .get_cuda_tile_op_attrs(ident.to_string().as_str())
+                                .is_some()
                             {
                                 Ok(self.compile_cuda_tile_op_call(
                                     module,
@@ -3664,24 +3663,22 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                                         module_name,
                                         fn_item,
                                         call_expr,
-                                        &generic_vars,
+                                        generic_vars,
                                         ctx,
                                         return_type,
                                     )?)
                                 }
                             } else {
-                                return self.jit_error_result(
+                                self.jit_error_result(
                                     &call_expr.func.span(),
-                                    &format!("call to `{}` is not supported", &call_expr_func_str),
-                                );
+                                    &format!("call to `{}` is not supported", call_expr_func_str),
+                                )
                             }
                         }
-                        _ => {
-                            return self.jit_error_result(
-                                &call_expr.func.span(),
-                                &format!("Call to {} not supported.", &call_expr_func_str),
-                            )
-                        }
+                        _ => self.jit_error_result(
+                            &call_expr.func.span(),
+                            &format!("Call to {} not supported.", call_expr_func_str),
+                        ),
                     }
                 }
                 Expr::MethodCall(method_call_expr) => {
@@ -3708,8 +3705,8 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                     if let Some(value) = self.compile_global_method_call(
                         module,
                         block_id,
-                        &method_call_expr,
-                        &generic_vars,
+                        method_call_expr,
+                        generic_vars,
                         ctx,
                         return_type.clone(),
                     )? {
@@ -3718,8 +3715,8 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                     Ok(self.inline_method_call(
                         module,
                         block_id,
-                        &method_call_expr,
-                        &generic_vars,
+                        method_call_expr,
+                        generic_vars,
                         ctx,
                         return_type,
                     )?)
@@ -3757,7 +3754,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                             let Some(field_value) = fields.get(&field_name.to_string()) else {
                                 return self.jit_error_result(
                                     &field_name.span(),
-                                    &format!("{} is not a field.", field_name.to_string()),
+                                    &format!("{} is not a field.", field_name),
                                 );
                             };
                             Ok(Some(field_value.clone()))
@@ -3824,7 +3821,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                                     let str = format!("-{}", int_lit.base10_digits());
                                     let val = -int_lit
                                         .base10_parse::<i32>()
-                                        .expect(format!("Failed to parse literal {str}").as_str())
+                                        .unwrap_or_else(|_| panic!("Failed to parse literal {str}"))
                                         as i64;
                                     (str, Some(Bounds::exact(val)))
                                 }
@@ -3836,7 +3833,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                                 }
                             };
                             let Some(cuda_tile_ty) = return_type
-                                .get_cuda_tile_element_type(&self.modules.primitives())?
+                                .get_cuda_tile_element_type(self.modules.primitives())?
                             else {
                                 return self.jit_error_result(
                                     &lit_expr.span(),
@@ -3876,12 +3873,10 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                                 op_result, ct_type, bounds,
                             )))
                         }
-                        _ => {
-                            return self.jit_error_result(
-                                &unary_expr.span(),
-                                "Non-const unary expressions not supported.",
-                            )
-                        }
+                        _ => self.jit_error_result(
+                            &unary_expr.span(),
+                            "Non-const unary expressions not supported.",
+                        ),
                     }
                 }
                 Expr::Cast(cast_expr) => {
@@ -3889,7 +3884,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                         .compile_expression(
                             module,
                             block_id,
-                            &*cast_expr.expr,
+                            &cast_expr.expr,
                             generic_vars,
                             ctx,
                             None,
@@ -3897,7 +3892,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                         .unwrap();
                     let src_elem_ty: String = src_expr
                         .ty
-                        .get_instantiated_rust_element_type(&self.modules.primitives())
+                        .get_instantiated_rust_element_type(self.modules.primitives())
                         .unwrap();
                     let dst_elem_ty: String = get_rust_element_type_primitive(&cast_expr.ty);
                     match (src_elem_ty.as_str(), dst_elem_ty.as_str()) {
@@ -3950,7 +3945,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                             &lit_expr.span(),
                             &format!(
                                 "Failed to infer type for lit expr {}.",
-                                lit_expr.to_token_stream().to_string()
+                                lit_expr.to_token_stream()
                             ),
                         );
                     };
@@ -3966,7 +3961,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                             let str = int_lit.base10_digits().to_string();
                             let val = int_lit
                                 .base10_parse::<i32>()
-                                .expect(format!("Failed to parse literal {str}").as_str())
+                                .unwrap_or_else(|_| panic!("Failed to parse literal {str}"))
                                 as i64;
                             (str, Some(Bounds::exact(val)))
                         }
@@ -3982,7 +3977,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                         }
                     };
                     let Some(cuda_tile_ty) =
-                        return_type.get_cuda_tile_element_type(&self.modules.primitives())?
+                        return_type.get_cuda_tile_element_type(self.modules.primitives())?
                     else {
                         return self.jit_error_result(
                             &lit_expr.span(),
@@ -4026,7 +4021,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                     Ok(self.compile_binary_op(
                         module,
                         block_id,
-                        &bin_expr,
+                        bin_expr,
                         generic_vars,
                         ctx,
                         return_type.clone(),
@@ -4098,17 +4093,17 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                     // Closures cannot be used as standalone expressions in CUDA Tile.
                     // They are only supported as arguments to specific operations (e.g., reduce, scan)
                     // that compile them into tile-ir regions.
-                    return self.jit_error_result(
+                    self.jit_error_result(
                         &closure_expr.span(),
                         "closures are not supported as standalone values; \
                          they can only be used as arguments to operations like `reduce()` or `scan()`",
-                    );
+                    )
                 }
                 Expr::Index(index_expr) => {
                     let Some(expr_val) = self.compile_expression(
                         module,
                         block_id,
-                        &*index_expr.expr,
+                        &index_expr.expr,
                         generic_vars,
                         ctx,
                         return_type.clone(),
@@ -4125,7 +4120,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                     let Some(index_val) = self.compile_expression(
                         module,
                         block_id,
-                        &*index_expr.index,
+                        &index_expr.index,
                         generic_vars,
                         ctx,
                         i32_type,
@@ -4197,15 +4192,12 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                             return Ok(Some(values.remove(index)));
                         }
                     }
-                    return self.jit_error_result(
+                    self.jit_error_result(
                         &index_expr.expr.span(),
                         "indexing is only supported on tuple/compound values and shape-like descriptors",
-                    );
+                    )
                 }
-                _ => {
-                    return self
-                        .jit_error_result(&expr.span(), "this expression form is not supported")
-                }
+                _ => self.jit_error_result(&expr.span(), "this expression form is not supported"),
             }
         }) // stacker::maybe_grow
     }

--- a/cutile-compiler/src/compiler/compile_global.rs
+++ b/cutile-compiler/src/compiler/compile_global.rs
@@ -67,7 +67,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
             })?;
             let value_ty = TileIrType::Tile(TileType {
                 shape: vec![1],
-                element_type: TileElementType::Scalar(scalar.clone()),
+                element_type: TileElementType::Scalar(scalar),
             });
             let init_expr = self.global_static_initializer(item)?;
             let init_value = self.global_scalar_initializer_value(&init_expr, module_name)?;

--- a/cutile-compiler/src/compiler/compile_inline.rs
+++ b/cutile-compiler/src/compiler/compile_inline.rs
@@ -97,6 +97,7 @@ fn set_lit_span(lit: &mut syn::Lit, span: Span) {
 }
 
 impl<'m> CUDATileFunctionCompiler<'m> {
+    #[allow(clippy::ptr_arg)] // public signature stays as-is
     pub fn inline_function_call(
         &self,
         module: &mut Module,
@@ -198,7 +199,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                 generic_arg_inference.map_args_to_params(&call_arg_rust_tys, None, generic_vars)?;
                 // println!("inline_function_call {:#?}: generic_vars={generic_vars:#?} \nexpr_generic_args={expr_generic_args:#?} \ngeneric_arg_inference={generic_arg_inference:#?}", fn_item.sig.ident.to_string());
                 generic_arg_inference
-                    .get_generic_vars_instance(&generic_vars, &self.modules.primitives())
+                    .get_generic_vars_instance(generic_vars, self.modules.primitives())
             };
             // The callee's body compiles in its own module's scope: its
             // `const`s, and the consts named in its types, are its module's.

--- a/cutile-compiler/src/compiler/compile_intrinsic.rs
+++ b/cutile-compiler/src/compiler/compile_intrinsic.rs
@@ -242,8 +242,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
             let offset = if ratio == 1 {
                 pid
             } else {
-                let ratio_value =
-                    self.compile_constant(module, block_id, generic_vars, ratio as i32)?;
+                let ratio_value = self.compile_constant(module, block_id, generic_vars, ratio)?;
                 self.compile_binary_op_from_values(
                     module,
                     block_id,
@@ -455,7 +454,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                 )
             })?;
         let final_ty =
-            tile_ir_type_from_trt(&return_type, &self.modules.primitives()).ok_or_else(|| {
+            tile_ir_type_from_trt(&return_type, self.modules.primitives()).ok_or_else(|| {
                 self.jit_error(
                     &call_expr.span(),
                     "failed to convert FP4 pack/unpack return type to Tile IR",
@@ -516,7 +515,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
         return_type: Option<TileRustType>,
     ) -> Result<Option<TileRustValue>, JITError> {
         let call_expr_func_str = call_expr.func.to_token_stream().to_string();
-        let ident = get_ident_from_path_expr(&path_expr);
+        let ident = get_ident_from_path_expr(path_expr);
         let Some(compiler_op_name) = compiler_op_attrs.parse_string("name") else {
             return self.jit_error_result(
                 &call_expr.span(),
@@ -532,7 +531,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                 let out = operands.remove(0);
                 let out_type = out.ty.clone();
                 let Some(out_rust_element_type) =
-                    out_type.get_instantiated_rust_element_type(&self.modules.primitives())
+                    out_type.get_instantiated_rust_element_type(self.modules.primitives())
                 else {
                     return self.jit_error_result(
                         &call_expr.span(),
@@ -552,7 +551,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                     );
                 };
                 let Some(out_cuda_tile_element_type) =
-                    out_type.get_cuda_tile_element_type(&self.modules.primitives())?
+                    out_type.get_cuda_tile_element_type(self.modules.primitives())?
                 else {
                     return self.jit_error_result(
                         &call_expr.span(),
@@ -563,13 +562,13 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                     );
                 };
                 let out_is_float = super::_type::scalar_from_name(&out_cuda_tile_element_type)
-                    .map_or(false, |s| s.is_float());
+                    .is_some_and(|s| s.is_float());
                 let (opcode, attrs) = if out_is_float {
                     (Opcode::MmaF, vec![])
                 } else if !out_is_float {
                     let Some(lhs_elem_ty) = lhs
                         .ty
-                        .get_instantiated_rust_element_type(&self.modules.primitives())
+                        .get_instantiated_rust_element_type(self.modules.primitives())
                     else {
                         return self.jit_error_result(
                             &call_expr.span(),
@@ -578,7 +577,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                     };
                     let Some(rhs_elem_ty) = lhs
                         .ty
-                        .get_instantiated_rust_element_type(&self.modules.primitives())
+                        .get_instantiated_rust_element_type(self.modules.primitives())
                     else {
                         return self.jit_error_result(
                             &call_expr.span(),
@@ -771,7 +770,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                                     "expected a structured type for the dimension map argument",
                                 );
                             };
-                            let Some(dim_map) = type_inst.try_extract_cga(&generic_vars) else {
+                            let Some(dim_map) = type_inst.try_extract_cga(generic_vars) else {
                                 return self.jit_error_result(
                                     &call_expr.args[1].span(),
                                     "dimension map must be a const generic array type",
@@ -796,12 +795,10 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                         };
                         Ok(Some(dst_slice))
                     }
-                    _ => {
-                        return self.jit_error_result(
-                            &call_expr.span(),
-                            &format!("unrecognized shape operation `{}`", compiler_op_function),
-                        );
-                    }
+                    _ => self.jit_error_result(
+                        &call_expr.span(),
+                        &format!("unrecognized shape operation `{}`", compiler_op_function),
+                    ),
                 }
             }
             "dim_new" => {
@@ -910,7 +907,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                         })?,
                 };
                 let dim_origin = value.dim_origin.clone();
-                let bounds = value.bounds.clone();
+                let bounds = value.bounds;
                 let mut fields = BTreeMap::new();
                 fields.insert("size".to_string(), value);
                 let mut dim = TileRustValue::new_struct(fields, return_type);
@@ -1475,7 +1472,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                         -1
                     };
                     if let (Some(bounds), true) = (coord_value.bounds, static_shape_dim != -1) {
-                        let num_partitions = (static_shape_dim as i64 + static_tile_dim as i64 - 1)
+                        let num_partitions = (static_shape_dim + static_tile_dim as i64 - 1)
                             / static_tile_dim as i64;
                         if !(0 <= bounds.start && bounds.end < num_partitions) {
                             return self.jit_error_result(
@@ -1751,7 +1748,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                         ir_operand_type.clone(), // operand_i_prev_iter
                     ];
                     let (local_block_id, local_block_args) = build_block(module, local_var_types);
-                    let local_var_names = vec!["curr", "prev"];
+                    let local_var_names = ["curr", "prev"];
                     let mut local_vars = CompilerContext::empty();
                     for i in 0..local_block_args.len() {
                         let value: Value = local_block_args[i];
@@ -1860,12 +1857,10 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                             &call_expr.span(),
                         )?))
                     }
-                    _ => {
-                        return self.jit_error_result(
-                            &call_expr.span(),
-                            &format!("arithmetic ops with {num_operands} operands not supported"),
-                        );
-                    }
+                    _ => self.jit_error_result(
+                        &call_expr.span(),
+                        &format!("arithmetic ops with {num_operands} operands not supported"),
+                    ),
                 }
             }
             "cast" => {
@@ -1896,21 +1891,19 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                     }
                     "tile_to_scalar" => {
                         let Some(element_type) =
-                            get_element_type_structured(&old_type, &self.modules.primitives())
+                            get_element_type_structured(&old_type, self.modules.primitives())
                         else {
                             return self.jit_error_result(
                                 &call_expr.span(),
                                 &format!(
                                     "Failed to cast from {} to {}",
-                                    old_type.to_token_stream().to_string(),
-                                    get_sig_output_type(&fn_item.sig)
-                                        .to_token_stream()
-                                        .to_string()
+                                    old_type.to_token_stream(),
+                                    get_sig_output_type(&fn_item.sig).to_token_stream()
                                 ),
                             );
                         };
                         new_value.ty.rust_ty =
-                            syn::parse2::<syn::Type>(format!("{element_type}").parse().unwrap())
+                            syn::parse2::<syn::Type>(element_type.to_string().parse().unwrap())
                                 .unwrap();
                     }
                     "pointer_to_tile" => {
@@ -1934,16 +1927,14 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                     }
                     "tile_to_pointer" => {
                         let Some(element_type) =
-                            get_element_type_structured(&old_type, &self.modules.primitives())
+                            get_element_type_structured(&old_type, self.modules.primitives())
                         else {
                             return self.jit_error_result(
                                 &call_expr.span(),
                                 &format!(
                                     "Failed to cast from {} to {}",
-                                    old_type.to_token_stream().to_string(),
-                                    get_sig_output_type(&fn_item.sig)
-                                        .to_token_stream()
-                                        .to_string()
+                                    old_type.to_token_stream(),
+                                    get_sig_output_type(&fn_item.sig).to_token_stream()
                                 ),
                             );
                         };
@@ -1990,8 +1981,8 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                             );
                         }
                         let mut arg = args.pop().unwrap();
-                        let new_type_compiled = if return_type.is_some() {
-                            return_type.unwrap()
+                        let new_type_compiled = if let Some(return_type) = return_type {
+                            return_type
                         } else {
                             let PathArguments::AngleBracketed(generic_args) =
                                 &path_expr.path.segments.last().unwrap().arguments
@@ -2000,7 +1991,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                                     &path_expr.span(),
                                     &format!(
                                         "Failed to get type parameters for {}",
-                                        path_expr.to_token_stream().to_string()
+                                        path_expr.to_token_stream()
                                     ),
                                 );
                             };
@@ -2018,18 +2009,18 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                                     &path_expr.span(),
                                     &format!(
                                         "Failed to get type parameters for {}",
-                                        path_expr.to_token_stream().to_string()
+                                        path_expr.to_token_stream()
                                     ),
                                 );
                             };
                             let Some(new_type_compiled) =
-                                self.compile_type(&new_type, &generic_vars, &HashMap::new())?
+                                self.compile_type(new_type, generic_vars, &HashMap::new())?
                             else {
                                 return self.jit_error_result(
                                     &call_expr.span(),
                                     &format!(
                                         "{compiler_op_function} failed to compile new type: {}",
-                                        new_type.to_token_stream().to_string()
+                                        new_type.to_token_stream()
                                     ),
                                 );
                             };
@@ -2060,16 +2051,16 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                             return Ok(Some(arg));
                         }
                         let output_type =
-                            tile_ir_type_from_trt(&new_type_compiled, &self.modules.primitives())
+                            tile_ir_type_from_trt(&new_type_compiled, self.modules.primitives())
                                 .ok_or_else(|| {
-                                self.jit_error(
-                                    &call_expr.span(),
-                                    &format!(
-                                        "Failed to obtain tile-ir type for convert {}",
-                                        call_expr.to_token_stream().to_string()
-                                    ),
-                                )
-                            })?;
+                                    self.jit_error(
+                                        &call_expr.span(),
+                                        &format!(
+                                            "Failed to obtain tile-ir type for convert {}",
+                                            call_expr.to_token_stream()
+                                        ),
+                                    )
+                                })?;
                         // These aren't required for all ops.
                         let (op_id, results) = match (
                             old_element_type_str.as_str(),
@@ -2097,9 +2088,9 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                             // Integer → float: IToF with signedness from source type.
                             (from, to)
                                 if super::_type::scalar_from_name(from)
-                                    .map_or(false, |s| s.is_integer())
+                                    .is_some_and(|s| s.is_integer())
                                     && super::_type::scalar_from_name(to)
-                                        .map_or(false, |s| s.is_float()) =>
+                                        .is_some_and(|s| s.is_float()) =>
                             {
                                 let signedness = signedness_attr(
                                     "signedness",
@@ -2114,7 +2105,6 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                                             call_expr
                                                 .args
                                                 .to_token_stream()
-                                                .to_string()
                                         ),
                                     );
                                 };
@@ -2127,9 +2117,9 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                             // Float → integer: FToI with signedness from target type.
                             (from, to)
                                 if super::_type::scalar_from_name(from)
-                                    .map_or(false, |s| s.is_float())
+                                    .is_some_and(|s| s.is_float())
                                     && super::_type::scalar_from_name(to)
-                                        .map_or(false, |s| s.is_integer()) =>
+                                        .is_some_and(|s| s.is_integer()) =>
                             {
                                 let signedness = signedness_attr(
                                     "signedness",
@@ -2143,7 +2133,6 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                                             call_expr
                                                 .args
                                                 .to_token_stream()
-                                                .to_string()
                                         ),
                                     );
                                 };
@@ -2161,9 +2150,9 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                             // cutile-python's _get_type_conversion_encoder.
                             (from, to)
                                 if super::_type::scalar_from_name(from)
-                                    .map_or(false, |s| s.is_float())
+                                    .is_some_and(|s| s.is_float())
                                     && super::_type::scalar_from_name(to)
-                                        .map_or(false, |s| s.is_float()) =>
+                                        .is_some_and(|s| s.is_float()) =>
                             {
                                 let rounding = rounding_mode_attr("nearest_even");
                                 let Some(input_value) = arg.value else {
@@ -2174,7 +2163,6 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                                             call_expr
                                                 .args
                                                 .to_token_stream()
-                                                .to_string()
                                         ),
                                     );
                                 };
@@ -2200,12 +2188,10 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                             new_type_compiled,
                         )))
                     }
-                    _ => {
-                        return self.jit_error_result(
-                            &call_expr.span(),
-                            &format!("Unsupported convert compiler_op: {}", compiler_op_function),
-                        );
-                    }
+                    _ => self.jit_error_result(
+                        &call_expr.span(),
+                        &format!("Unsupported convert compiler_op: {}", compiler_op_function),
+                    ),
                 }
             }
             "return_type_meta_field" => {
@@ -2360,19 +2346,19 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                         &call_expr.args[0].span(),
                         &format!(
                             "first argument to `set_type_meta_field` must be a simple variable path, got `{}`",
-                            call_expr.to_token_stream().to_string()
+                            call_expr.to_token_stream()
                         ),
                     );
                 };
                 let var_name = get_ident_from_path_expr(var_arg)
                     .to_token_stream()
                     .to_string();
-                if ctx.vars.get(var_name.as_str()).is_none() {
+                if !ctx.vars.contains_key(var_name.as_str()) {
                     return self.jit_error_result(
                         &call_expr.args[0].span(),
                         &format!(
                             "first argument to `set_type_meta_field` must be a known variable, got `{}`",
-                            call_expr.to_token_stream().to_string()
+                            call_expr.to_token_stream()
                         ),
                     );
                 }
@@ -2410,7 +2396,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                     );
                 }
                 ctx.vars.insert(var_name.clone(), result_value);
-                return Ok(None);
+                Ok(None)
             }
             "check" => {
                 if self.entry_attrs.get_entry_arg_bool("unchecked_accesses") {
@@ -2430,12 +2416,10 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                             generic_vars,
                             ctx,
                         ),
-                    _ => {
-                        return self.jit_error_result(
-                            &call_expr.span(),
-                            &format!("Unexpected compiler_op call {}", &call_expr_func_str),
-                        );
-                    }
+                    _ => self.jit_error_result(
+                        &call_expr.span(),
+                        &format!("Unexpected compiler_op call {}", call_expr_func_str),
+                    ),
                 }
             }
             "assume" => {
@@ -2443,12 +2427,10 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                     self.compile_assumption_call(call_expr, module, block_id, generic_vars, ctx)?;
                 Ok(Some(tr_value))
             }
-            _ => {
-                return self.jit_error_result(
-                    &call_expr.span(),
-                    &format!("Unexpected compiler_op {compiler_op_attrs:#?}"),
-                );
-            }
+            _ => self.jit_error_result(
+                &call_expr.span(),
+                &format!("Unexpected compiler_op {compiler_op_attrs:#?}"),
+            ),
         }
     }
 

--- a/cutile-compiler/src/compiler/compile_type.rs
+++ b/cutile-compiler/src/compiler/compile_type.rs
@@ -41,13 +41,13 @@ impl<'m> CUDATileFunctionCompiler<'m> {
         match ty {
             // Array, Slice, and Tuple compile to the same compiler representation (compound values).
             syn::Type::Tuple(tuple) => {
-                if tuple.elems.len() == 0 {
+                if tuple.elems.is_empty() {
                     return Ok(None);
                 } else {
                     let unknown_type_instance = TypeInstanceUserType::instantiate(
-                        &ty,
+                        ty,
                         generic_vars,
-                        &self.modules.primitives(),
+                        self.modules.primitives(),
                     )
                     .unwrap();
                     let type_instance = TypeInstance::UserType(unknown_type_instance);
@@ -55,27 +55,21 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                 }
             }
             syn::Type::Array(_) => {
-                let unknown_type_instance = TypeInstanceUserType::instantiate(
-                    &ty,
-                    generic_vars,
-                    &self.modules.primitives(),
-                )
-                .unwrap();
+                let unknown_type_instance =
+                    TypeInstanceUserType::instantiate(ty, generic_vars, self.modules.primitives())
+                        .unwrap();
                 let type_instance = TypeInstance::UserType(unknown_type_instance);
                 return Ok(Some(TileRustType::new_compound(type_instance)));
             }
             syn::Type::Slice(_) => {
-                let unknown_type_instance = TypeInstanceUserType::instantiate(
-                    &ty,
-                    generic_vars,
-                    &self.modules.primitives(),
-                )
-                .unwrap();
+                let unknown_type_instance =
+                    TypeInstanceUserType::instantiate(ty, generic_vars, self.modules.primitives())
+                        .unwrap();
                 let type_instance = TypeInstance::UserType(unknown_type_instance);
                 return Ok(Some(TileRustType::new_compound(type_instance)));
             }
             syn::Type::Reference(ref_ty) => {
-                let mut res = self.compile_type(&*ref_ty.elem, generic_vars, type_params)?;
+                let mut res = self.compile_type(&ref_ty.elem, generic_vars, type_params)?;
                 match &mut res {
                     Some(cuda_tile_ty) => {
                         cuda_tile_ty.rust_ty = ty.clone();
@@ -89,9 +83,9 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                     let type_name = ident.to_string();
                     if type_name == "Option" {
                         let option_type_instance = TypeInstanceUserType::instantiate(
-                            &ty,
+                            ty,
                             generic_vars,
-                            &self.modules.primitives(),
+                            self.modules.primitives(),
                         )
                         .unwrap();
                         return Ok(Some(TileRustType::new_enum(TypeInstance::UserType(
@@ -102,9 +96,9 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                         ty_attrs = self.modules.get_cuda_tile_type_attrs(type_name.as_str());
                         if ty_attrs.is_none() {
                             let unknown_type_instance = TypeInstanceUserType::instantiate(
-                                &ty,
+                                ty,
                                 generic_vars,
-                                &self.modules.primitives(),
+                                self.modules.primitives(),
                             )
                             .unwrap();
                             let type_instance = TypeInstance::UserType(unknown_type_instance);
@@ -113,12 +107,12 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                                 type_instance,
                             )));
                         }
-                        structure = Some((type_name.clone(), &item_struct));
+                        structure = Some((type_name.clone(), item_struct));
                         type_instance =
-                            Some(generic_vars.instantiate_type(ty, &self.modules.primitives())?);
+                            Some(generic_vars.instantiate_type(ty, self.modules.primitives())?);
                     } else {
                         let local_type_instance =
-                            generic_vars.instantiate_type(ty, &self.modules.primitives())?;
+                            generic_vars.instantiate_type(ty, self.modules.primitives())?;
                         if let TypeInstance::StringType(_string_inst) = local_type_instance {
                             return Ok(Some(TileRustType::new_string(TypeInstance::StringType(
                                 _string_inst,
@@ -148,13 +142,13 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                 None => return self.jit_error_result(&ty.span(), "Failed to compile type"),
             },
             syn::Type::Ptr(_) => {
-                let type_name = get_type_ident(&ty);
+                let type_name = get_type_ident(ty);
                 if type_name.is_none() {
                     return self.jit_error_result(&ty.span(), "Failed to compile type");
                 }
                 let type_name = type_name.unwrap().to_string();
                 let local_type_instance =
-                    generic_vars.instantiate_type(ty, &self.modules.primitives())?;
+                    generic_vars.instantiate_type(ty, self.modules.primitives())?;
                 let Some(element_type_instance_str) =
                     local_type_instance.get_rust_element_instance_ty()
                 else {
@@ -196,7 +190,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                     &ty.span(),
                     &format!(
                         "Unable to compile compiling type {} using attrs {ty_attrs:#?}",
-                        ty.to_token_stream().to_string()
+                        ty.to_token_stream()
                     ),
                 );
             }
@@ -259,7 +253,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
             return Ok(Some(TileRustType::new_structured_type(
                 type_name,
                 generic_vars,
-                &self.modules.primitives(),
+                self.modules.primitives(),
                 args,
                 type_instance,
             )?));
@@ -276,7 +270,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                     &ty.span(),
                     &format!(
                         "Unable to compile type {} using attrs {scalar_attrs:#?}",
-                        element_instance.generic_ty.to_token_stream().to_string()
+                        element_instance.generic_ty.to_token_stream()
                     ),
                 );
             }
@@ -287,13 +281,13 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                 None,
                 Some(TypeInstance::ElementType(element_instance.clone())),
             )];
-            return Ok(Some(TileRustType::new_primitive_type(
+            Ok(Some(TileRustType::new_primitive_type(
                 type_name,
                 generic_vars,
-                &self.modules.primitives(),
+                self.modules.primitives(),
                 args,
                 TypeInstance::ElementType(element_instance),
-            )?));
+            )?))
         } else if let Some(TypeInstance::PtrType(ptr_instance)) = type_instance {
             let Some(pointer_attrs) = self.modules.get_primitives_attrs(
                 "Pointer",
@@ -308,7 +302,7 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                     &ty.span(),
                     &format!(
                         "Unable to compile compiling type {} using attrs {pointer_attrs:#?}",
-                        ty.to_token_stream().to_string()
+                        ty.to_token_stream()
                     ),
                 );
             }
@@ -319,18 +313,18 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                 None,
                 Some(TypeInstance::PtrType(ptr_instance.clone())),
             )];
-            return Ok(Some(TileRustType::new_primitive_type(
+            Ok(Some(TileRustType::new_primitive_type(
                 type_name,
                 generic_vars,
-                &self.modules.primitives(),
+                self.modules.primitives(),
                 args,
                 TypeInstance::PtrType(ptr_instance),
-            )?));
+            )?))
         } else {
-            return self.jit_error_result(
+            self.jit_error_result(
                 &ty.span(),
                 &format!("Unable to instantiate Scalar or Pointer impls: type_instance={type_instance:#?}"),
-            );
+            )
         }
     }
 }

--- a/cutile-compiler/src/compiler/shared_utils.rs
+++ b/cutile-compiler/src/compiler/shared_utils.rs
@@ -103,13 +103,13 @@ impl AtomicMode {
                 &format!("invalid atomic mode `{mode}`; valid modes are: And, Or, Xor, Add, AddF, Max, Min, Umax, Umin, Xchg"),
             ),
         };
-        if elem_ty_prefix == ElementTypePrefix::Float {
-            if ![AtomicMode::XChg, AtomicMode::AddF].contains(&result) {
-                return SourceLocation::unknown().jit_error_result(&format!(
-                    "float types only support `Xchg` and `AddF` atomic modes, got `{:?}`",
-                    result
-                ));
-            }
+        if elem_ty_prefix == ElementTypePrefix::Float
+            && ![AtomicMode::XChg, AtomicMode::AddF].contains(&result)
+        {
+            return SourceLocation::unknown().jit_error_result(&format!(
+                "float types only support `Xchg` and `AddF` atomic modes, got `{:?}`",
+                result
+            ));
         }
         Ok(result)
     }
@@ -345,7 +345,7 @@ pub fn extract_zst_type_name(expr: &syn::Expr, param_name: &str) -> Result<Strin
         Expr::Path(path) => Ok(path.path.segments.last().unwrap().ident.to_string()),
         _ => SourceLocation::unknown().jit_error_result(&format!(
             "`{param_name}` must be a unit-struct type-as-value path, got `{}`",
-            expr.to_token_stream().to_string()
+            expr.to_token_stream()
         )),
     }
 }
@@ -402,7 +402,7 @@ pub fn extract_string_literal(
         }
         _ => SourceLocation::unknown().jit_error_result(&format!(
             "`{param_name}` must be a string literal, got `{}`",
-            expr.to_token_stream().to_string()
+            expr.to_token_stream()
         )),
     }
 }
@@ -508,7 +508,7 @@ pub fn collect_mutated_variables_from_block(
 ) -> Result<BTreeSet<String>, JITError> {
     let mut local_vars: HashSet<String> = HashSet::new();
     let mut result: BTreeSet<String> = BTreeSet::new();
-    for (_i, statement) in block.stmts.iter().enumerate() {
+    for statement in block.stmts.iter() {
         match statement {
             Stmt::Local(local) => {
                 let mut var_names: Vec<String> = vec![];
@@ -841,7 +841,7 @@ pub fn dedup<T: Hash + Eq + Clone>(v: &mut Vec<T>) {
 pub fn parse_list_of_expr(tokens: TokenStream) -> Result<Vec<Expr>, JITError> {
     let mut args: Vec<Expr> = vec![];
     let mut arg_expr: Vec<TokenTree> = vec![];
-    for (_i, token) in tokens.clone().into_iter().enumerate() {
+    for token in tokens.clone().into_iter() {
         match &token {
             TokenTree::Literal(_lit) => {
                 arg_expr.push(token.clone());
@@ -851,7 +851,7 @@ pub fn parse_list_of_expr(tokens: TokenStream) -> Result<Vec<Expr>, JITError> {
             }
             TokenTree::Punct(punct) => {
                 if punct.as_char() == ',' {
-                    if arg_expr.len() > 0 {
+                    if !arg_expr.is_empty() {
                         let expr =
                             syn::parse2::<syn::Expr>(arg_expr.into_iter().collect()).unwrap();
                         args.push(expr);
@@ -862,14 +862,12 @@ pub fn parse_list_of_expr(tokens: TokenStream) -> Result<Vec<Expr>, JITError> {
                 }
             }
             _ => {
-                return SourceLocation::unknown().jit_error_result(&format!(
-                    "unexpected token `{}` in expression list",
-                    token.to_string()
-                ));
+                return SourceLocation::unknown()
+                    .jit_error_result(&format!("unexpected token `{}` in expression list", token));
             }
         }
     }
-    if arg_expr.len() > 0 {
+    if !arg_expr.is_empty() {
         let expr = syn::parse2::<syn::Expr>(arg_expr.into_iter().collect()).unwrap();
         args.push(expr);
     }
@@ -890,7 +888,7 @@ pub fn update_token(
     let Some(var_arg_ident) = get_ident_from_expr(var_arg) else {
         return SourceLocation::unknown().jit_error_result(&format!(
             "expected a variable name, got `{}`",
-            var_arg.to_token_stream().to_string()
+            var_arg.to_token_stream()
         ));
     };
     let var_name = var_arg_ident.to_string();
@@ -966,7 +964,7 @@ pub fn get_token_from_expr(
     let Some(var_arg_ident) = get_ident_from_expr(var_arg) else {
         return SourceLocation::unknown().jit_error_result(&format!(
             "expected a variable name, got `{}`",
-            var_arg.to_token_stream().to_string()
+            var_arg.to_token_stream()
         ));
     };
     let var_name = var_arg_ident.to_string();
@@ -998,7 +996,7 @@ pub fn update_outer_block_type_meta(
     inner_block_vars: &mut CompilerContext,
     outer_block_vars: &mut CompilerContext,
     field_name: String,
-) -> () {
+) {
     let mut var_map = std::collections::HashMap::new();
     for var_name in outer_block_vars.var_keys() {
         var_map.insert(var_name.clone(), var_name.clone());
@@ -1012,7 +1010,7 @@ pub fn update_type_meta(
     outer_block_vars: &mut CompilerContext,
     outer2inner_vars: &std::collections::HashMap<String, String>,
     _field_name: String,
-) -> () {
+) {
     use super::shared_types::Mutability;
     let outer_keys_ = outer_block_vars.var_keys();
     let outer_keys = outer_keys_

--- a/cutile-compiler/src/compiler/tile_rust_type.rs
+++ b/cutile-compiler/src/compiler/tile_rust_type.rs
@@ -111,12 +111,10 @@ impl TileRustType {
             .ok_or_else(|| {
                 JITError::generic_err(&format!(
                     "unable to determine element type for `{}`",
-                    self.rust_ty.to_token_stream().to_string()
+                    self.rust_ty.to_token_stream()
                 ))
             })?;
-        Ok(super::shared_utils::ElementTypePrefix::new(
-            &cuda_elem_ty_str,
-        )?)
+        super::shared_utils::ElementTypePrefix::new(&cuda_elem_ty_str)
     }
     pub(crate) fn get_cuda_tile_type_str(&self) -> Option<String> {
         self.cuda_tile_ty_str.clone()
@@ -136,7 +134,7 @@ impl TileRustType {
         let rust_ty = type_instance.get_source_type().clone();
         let type_param_str = params
             .iter_mut()
-            .map(|tp| tp.instantiate(generic_vars, &primitives))
+            .map(|tp| tp.instantiate(generic_vars, primitives))
             .collect::<Result<Vec<_>, _>>()?
             .join(",");
         let type_str = format!("{}<{}>", cuda_tile_name, type_param_str);
@@ -160,12 +158,12 @@ impl TileRustType {
         type_instance: TypeInstance,
     ) -> Result<TileRustType, JITError> {
         let rust_ty = type_instance.get_source_type().clone();
-        let type_str = if params.len() == 0 {
-            format!("{}", cuda_tile_name)
+        let type_str = if params.is_empty() {
+            cuda_tile_name.to_string()
         } else {
             let type_param_str = params
                 .iter_mut()
-                .map(|tp| tp.instantiate(generic_args, &primitives))
+                .map(|tp| tp.instantiate(generic_args, primitives))
                 .collect::<Result<Vec<_>, _>>()?
                 .join(",");
             format!("{}<{}>", cuda_tile_name, type_param_str)

--- a/cutile-compiler/src/cuda_tile_runtime_utils.rs
+++ b/cutile-compiler/src/cuda_tile_runtime_utils.rs
@@ -557,7 +557,7 @@ fn build_probe_module() -> cutile_ir::Module {
     let ub = const_i32(&mut module, 4);
     let step = const_i32(&mut module, 1);
     let (body_region, body_blk, body_args) =
-        build_single_block_region(&mut module, &[tile_i32.clone()]);
+        build_single_block_region(&mut module, std::slice::from_ref(&tile_i32));
     // The load sits INSIDE the region and references parent-scope values
     // (view, token) plus the block argument — the cross-region encoding a
     // real kernel exercises.
@@ -1533,7 +1533,7 @@ mod tests {
         let tileiras = create_fake_cuda_toolkit(&temp_dir, 13020, true);
 
         assert_eq!(
-            resolve_tileiras_binary_with_candidates(None, None, &[temp_dir.clone()]),
+            resolve_tileiras_binary_with_candidates(None, None, std::slice::from_ref(&temp_dir)),
             tileiras
         );
 

--- a/cutile-compiler/src/error.rs
+++ b/cutile-compiler/src/error.rs
@@ -61,11 +61,11 @@ impl error::Error for JITError {}
 impl JITError {
     /// Create a `Generic` error value (not wrapped in `Result`).
     pub fn generic_err(err_str: &str) -> JITError {
-        return JITError::Generic(err_str.to_string());
+        JITError::Generic(err_str.to_string())
     }
     /// Create a `Generic` error wrapped in `Err`.
     pub fn generic<R>(err_str: &str) -> Result<R, JITError> {
-        return Err(JITError::generic_err(err_str));
+        Err(JITError::generic_err(err_str))
     }
     /// Create a `Located` error that carries a real source location captured
     /// at proc macro expansion time.

--- a/cutile-compiler/src/generics.rs
+++ b/cutile-compiler/src/generics.rs
@@ -138,7 +138,7 @@ impl GenericVars {
         {
             Some(GenericVarType::ConstVariable)
         } else {
-            return None;
+            None
         }
     }
 
@@ -412,7 +412,7 @@ impl GenericVars {
                             let name = const_param.ident.to_string();
                             let from_generic_args = self;
                             if let Some(res) = try_get_const_generic_from_generic_argument(
-                                &generic_arg,
+                                generic_arg,
                                 from_generic_args,
                             ) {
                                 // This is something like
@@ -420,12 +420,12 @@ impl GenericVars {
                                 inst_i32.insert(name.clone(), res);
                             } else {
                                 let Some(res) =
-                                    get_cga_from_generic_argument(&generic_arg, from_generic_args)
+                                    get_cga_from_generic_argument(generic_arg, from_generic_args)
                                 else {
                                     return SourceLocation::unknown().jit_error_result(&format!(
                                         "unable to resolve generic argument `{}` for parameter `{}`",
-                                        generic_arg.to_token_stream().to_string(),
-                                        generic_param.to_token_stream().to_string()
+                                        generic_arg.to_token_stream(),
+                                        generic_param.to_token_stream()
                                     ));
                                 };
                                 // This is something like
@@ -445,8 +445,8 @@ impl GenericVars {
                         _ => {
                             return SourceLocation::unknown().jit_error_result(&format!(
                                 "unable to resolve generic argument `{}` for parameter `{}`",
-                                generic_arg.to_token_stream().to_string(),
-                                generic_param.to_token_stream().to_string()
+                                generic_arg.to_token_stream(),
+                                generic_param.to_token_stream()
                             ));
                         }
                     }
@@ -526,8 +526,8 @@ impl GenericVars {
                         _ => {
                             return SourceLocation::unknown().jit_error_result(&format!(
                                 "unable to resolve generic argument `{}` for parameter `{}`",
-                                generic_arg.to_token_stream().to_string(),
-                                generic_param.to_token_stream().to_string()
+                                generic_arg.to_token_stream(),
+                                generic_param.to_token_stream()
                             ));
                         }
                     }
@@ -571,12 +571,8 @@ impl GenericVars {
             return Some(*inst);
         }
         if let Some(arr_name) = self.len2array.get(name) {
-            if let Some(inst) = self.inst_array.get(arr_name) {
-                return Some(inst.len() as i32);
-            } else {
-                // Internal invariant: length var exists but corresponding array doesn't.
-                return None;
-            }
+            // Internal invariant: the length var exists but the array may not; `?` yields None.
+            return Some(self.inst_array.get(arr_name)?.len() as i32);
         }
         None
     }
@@ -644,12 +640,12 @@ impl GenericVars {
         if let Some(instance) =
             TypeInstanceStructuredType::instantiate(&maybe_generic_ty, self, primitives)
         {
-            return Ok(TypeInstance::StructuredType(instance));
+            Ok(TypeInstance::StructuredType(instance))
         } else {
-            return SourceLocation::unknown().jit_error_result(&format!(
+            SourceLocation::unknown().jit_error_result(&format!(
                 "unable to resolve generic type `{}`",
-                maybe_generic_ty.to_token_stream().to_string()
-            ));
+                maybe_generic_ty.to_token_stream()
+            ))
         }
     }
 }
@@ -901,7 +897,7 @@ impl Instantiable for TypeInstancePtrType {
                 .unwrap();
                 Some(Self {
                     generic_ty: maybe_generic_ty.clone(),
-                    instance_ty: instance_ty,
+                    instance_ty,
                     is_mutable,
                     rust_element_instance_ty: concrete_ptr_ty.to_string(),
                 })
@@ -953,7 +949,7 @@ impl Instantiable for TypeInstanceStructuredType {
                 .path
                 .segments
                 .last_mut()
-                .expect(format!("Unexpected structured type {maybe_generic_ty:#?}.").as_str());
+                .unwrap_or_else(|| panic!("Unexpected structured type {maybe_generic_ty:#?}."));
             let PathArguments::AngleBracketed(type_params) = &mut last_seg.arguments else {
                 panic!(
                     "Unexpected structured type generic arguments {:#?} for {maybe_generic_ty:#?}",
@@ -1052,7 +1048,7 @@ impl Instantiable for TypeInstanceStructuredType {
                         syn::Type::Ptr(_) => {
                             let Some(ptr_inst) = TypeInstancePtrType::instantiate(
                                 type_param,
-                                &generic_vars,
+                                generic_vars,
                                 primitives,
                             ) else {
                                 panic!("Unexpected primitives {primitives:#?}.")
@@ -1177,7 +1173,7 @@ impl Instantiable for TypeInstanceStructuredType {
                                             // This is something like Tensor<E, {[-1; N]}>
                                             let num_rep_var =
                                                 len_path.to_token_stream().to_string();
-                                            if !generic_vars.get_i32(&num_rep_var).is_some() {
+                                            if generic_vars.get_i32(&num_rep_var).is_none() {
                                                 panic!(
                                                     "Expected instance for generic argument {}",
                                                     num_rep_var
@@ -1364,6 +1360,7 @@ impl GenericArgInference {
     /// symbolic shape elements normalize before unification: argument types
     /// mix entry-substituted literals (`128`) with unsubstituted caller
     /// symbols (`D`) for the same dimension.
+    #[allow(clippy::ptr_arg)] // public signature stays as-is
     pub fn map_args_to_params(
         &mut self,
         call_arg_rust_tys: &Vec<syn::Type>,
@@ -1544,7 +1541,7 @@ impl GenericArgInference {
         let Some(method_params) = &self.method_params else {
             panic!(
                 "Method params undefined for {}",
-                method_call_expr.to_token_stream().to_string()
+                method_call_expr.to_token_stream()
             )
         };
         assert_eq!(expr_generic_args.args.len(), method_params.len());
@@ -1647,7 +1644,7 @@ impl GenericArgInference {
     /// Returns `true` if all generic parameters have been resolved.
     pub fn verify(&self) -> bool {
         // Check if computed and succeeded.
-        for (_key, val) in &self.param2arg {
+        for val in self.param2arg.values() {
             if val.is_none() {
                 return false;
             }
@@ -1958,7 +1955,7 @@ impl GenericArgInference {
                         }
                         (syn::Type::Ptr(arg_type_ptr), syn::Type::Ptr(param_type_ptr)) => {
                             // Something like (PointerTile<*mut f32, ...>, PointerTile<*mut E, ...>)
-                            let param_elem_ty = match get_type_ident(&*param_type_ptr.elem) {
+                            let param_elem_ty = match get_type_ident(&param_type_ptr.elem) {
                                 Some(ident) => ident.to_string(),
                                 None => panic!(
                                     "Unable to extract ident from pointer {param_type_ptr:#?}"
@@ -2178,7 +2175,7 @@ impl GenericArgInference {
             }
             (syn::Type::Ptr(arg_type_ptr), syn::Type::Ptr(param_type_ptr)) => {
                 // Something like (PointerTile<*mut f32, ...>, PointerTile<*mut E, ...>)
-                let param_elem_ty = match get_type_ident(&*param_type_ptr.elem) {
+                let param_elem_ty = match get_type_ident(&param_type_ptr.elem) {
                     Some(ident) => ident.to_string(),
                     None => panic!("Unable to extract ident from pointer {param_type_ptr:#?}"),
                 };
@@ -2216,7 +2213,7 @@ impl GenericArgInference {
     pub fn infer_type(&self, ty: &syn::Type, _generic_vars: &GenericVars) -> syn::Type {
         let arg_map = &self.param2arg;
         // println!("Infer generic args for {} using \n {arg_map:#?}", ty.to_token_stream().to_string());
-        let Some(mut result_args) = maybe_generic_args(&ty) else {
+        let Some(mut result_args) = maybe_generic_args(ty) else {
             // Is it a generic arg itself?
             // TODO (hme): *Really* need to make this recursive and just call with the following types.
             let mut result = ty.clone();
@@ -2399,36 +2396,30 @@ impl GenericArgInference {
                             else {
                                 panic!("Unexpected block expression.")
                             };
-                            match param_stmt_expr {
-                                Expr::Array(param_array_expr) => {
-                                    for i in 0..param_array_expr.elems.iter().len() {
-                                        let param_elem = &mut param_array_expr.elems[i];
-                                        let param_var = param_elem.to_token_stream().to_string();
-                                        match arg_map.get(param_var.as_str()) {
-                                            None => {
-                                                // This is not a generic parameter.
-                                            }
-                                            Some(None) => {
-                                                panic!(
-                                                    "Failed to infer generic parameter {param_var}"
-                                                )
-                                            }
-                                            Some(Some((
-                                                GenericArgType::GenericConstExpr,
-                                                target_expr,
-                                            ))) => {
-                                                *param_elem = syn::parse2::<Expr>(
-                                                    target_expr.parse().unwrap(),
-                                                )
-                                                .unwrap();
-                                            }
-                                            Some(Some((arg_type, _arg))) => {
-                                                panic!("Unexpected arg type {arg_type:#?}")
-                                            }
+                            if let Expr::Array(param_array_expr) = param_stmt_expr {
+                                for i in 0..param_array_expr.elems.iter().len() {
+                                    let param_elem = &mut param_array_expr.elems[i];
+                                    let param_var = param_elem.to_token_stream().to_string();
+                                    match arg_map.get(param_var.as_str()) {
+                                        None => {
+                                            // This is not a generic parameter.
+                                        }
+                                        Some(None) => {
+                                            panic!("Failed to infer generic parameter {param_var}")
+                                        }
+                                        Some(Some((
+                                            GenericArgType::GenericConstExpr,
+                                            target_expr,
+                                        ))) => {
+                                            *param_elem =
+                                                syn::parse2::<Expr>(target_expr.parse().unwrap())
+                                                    .unwrap();
+                                        }
+                                        Some(Some((arg_type, _arg))) => {
+                                            panic!("Unexpected arg type {arg_type:#?}")
                                         }
                                     }
                                 }
-                                _ => {}
                             }
                         }
                         Expr::Path(param_path) => {
@@ -2465,8 +2456,8 @@ pub fn get_cga_from_type(ty: &syn::Type, generic_args: &GenericVars) -> Option<V
     let mut shape: Option<Vec<i32>> = None;
     for type_generic_arg in &type_generic_args.args {
         let res = get_cga_from_generic_argument(type_generic_arg, generic_args);
-        if res.is_some() {
-            shape = Some(res.unwrap());
+        if let Some(value) = res {
+            shape = Some(value);
         }
     }
     shape
@@ -2479,33 +2470,23 @@ pub fn try_get_const_generic_from_generic_argument(
 ) -> Option<i32> {
     let mut result: Option<i32> = None;
     match generic_arg {
-        GenericArgument::Type(type_param) => {
-            match type_param {
-                syn::Type::Path(type_path) => {
-                    let last_ident = type_path.path.segments.last().unwrap().ident.to_string();
-                    // println!("get_variadic_type_args: Type::Path: {}", last_ident);
-                    if generic_args.inst_i32.contains_key(&last_ident) {
-                        // This is something like N for const generic N: i32.
-                        result = Some(generic_args.inst_i32.get(&last_ident).unwrap().clone());
-                    }
-                    // If it's anything else, then return None.
-                }
-                _ => {}
+        GenericArgument::Type(syn::Type::Path(type_path)) => {
+            let last_ident = type_path.path.segments.last().unwrap().ident.to_string();
+            // println!("get_variadic_type_args: Type::Path: {}", last_ident);
+            if generic_args.inst_i32.contains_key(&last_ident) {
+                // This is something like N for const generic N: i32.
+                result = Some(*generic_args.inst_i32.get(&last_ident).unwrap());
             }
+            // If it's anything else, then return None.
         }
-        GenericArgument::Const(const_param) => {
+        GenericArgument::Const(Expr::Lit(lit)) => {
             // println!("expand GenericArgument::Const? {const_param:#?}");
-            match const_param {
-                Expr::Lit(lit) => {
-                    let Lit::Int(int_lit) = &lit.lit else {
-                        panic!("Expected int literal, got {:#?}", lit)
-                    };
-                    // This is something like 32 in Tile<E, {[32]}>
-                    // TODO (hme): Add a test for this.
-                    result = Some(int_lit.base10_parse().unwrap());
-                }
-                _ => {}
-            }
+            let Lit::Int(int_lit) = &lit.lit else {
+                panic!("Expected int literal, got {:#?}", lit)
+            };
+            // This is something like 32 in Tile<E, {[32]}>
+            // TODO (hme): Add a test for this.
+            result = Some(int_lit.base10_parse().unwrap());
         }
         _ => {}
     }
@@ -2542,86 +2523,72 @@ pub fn get_cga_from_generic_argument(
     let mut shape: Option<Vec<i32>> = None;
     match generic_arg {
         GenericArgument::Type(type_param) => {
-            match type_param {
-                syn::Type::Path(type_path) => {
-                    // This must be a CGA, or it will fail.
-                    let last_ident = type_path.path.segments.last().unwrap().ident.to_string();
-                    // println!("get_variadic_type_args: Type::Path: {}", last_ident);
-                    if generic_args.inst_array.contains_key(&last_ident) {
-                        // This is something like Shape<D> for const generic array D: [i32; N].
-                        let array_instance = generic_args.inst_array.get(&last_ident).unwrap();
-                        if shape.is_some() {
-                            panic!("Unexpected array arg: {last_ident:#?}")
-                        }
-                        shape = Some(array_instance.clone());
-                    } else if generic_args.inst_i32.contains_key(&last_ident) {
-                        // This is something like N for const generic N: i32.
-                        // This should have been handled by
-                        // try_get_const_generic_from_generic_argument.
-                        unimplemented!(
-                            "Unexpected const arg {last_ident} for type {type_param:#?}"
-                        );
-                    } else {
-                        unimplemented!("Failed to get cga for {type_param:#?}");
+            if let syn::Type::Path(type_path) = type_param {
+                // This must be a CGA, or it will fail.
+                let last_ident = type_path.path.segments.last().unwrap().ident.to_string();
+                // println!("get_variadic_type_args: Type::Path: {}", last_ident);
+                if generic_args.inst_array.contains_key(&last_ident) {
+                    // This is something like Shape<D> for const generic array D: [i32; N].
+                    let array_instance = generic_args.inst_array.get(&last_ident).unwrap();
+                    if shape.is_some() {
+                        panic!("Unexpected array arg: {last_ident:#?}")
                     }
+                    shape = Some(array_instance.clone());
+                } else if generic_args.inst_i32.contains_key(&last_ident) {
+                    // This is something like N for const generic N: i32.
+                    // This should have been handled by
+                    // try_get_const_generic_from_generic_argument.
+                    unimplemented!("Unexpected const arg {last_ident} for type {type_param:#?}");
+                } else {
+                    unimplemented!("Failed to get cga for {type_param:#?}");
                 }
-                _ => {}
             }
         }
-        GenericArgument::Const(const_param) => {
+        GenericArgument::Const(Expr::Block(block_expr)) => {
             // println!("expand GenericArgument::Const? {const_param:#?}");
-            match const_param {
-                Expr::Block(block_expr) => {
-                    // This is something like Tensor<E, {[...]}>
-                    assert_eq!(block_expr.block.stmts.len(), 1);
-                    let statement = &block_expr.block.stmts[0];
-                    let Stmt::Expr(statement_expr, _) = statement else {
-                        panic!("Unexpected block expression.")
-                    };
-                    match statement_expr {
-                        Expr::Array(array_expr) => {
-                            // This is something like Tensor<E, {[1, 2, -1]}>
-                            let mut _shape: Vec<i32> = vec![];
-                            for elem in &array_expr.elems {
-                                _shape.push(parse_expr_as_i32(elem, generic_args));
+            // This is something like Tensor<E, {[...]}>
+            assert_eq!(block_expr.block.stmts.len(), 1);
+            let statement = &block_expr.block.stmts[0];
+            let Stmt::Expr(statement_expr, _) = statement else {
+                panic!("Unexpected block expression.")
+            };
+            match statement_expr {
+                Expr::Array(array_expr) => {
+                    // This is something like Tensor<E, {[1, 2, -1]}>
+                    let mut _shape: Vec<i32> = vec![];
+                    for elem in &array_expr.elems {
+                        _shape.push(parse_expr_as_i32(elem, generic_args));
+                    }
+                    shape = Some(_shape);
+                }
+                Expr::Repeat(repeat_expr) => {
+                    // println!("Expr::Repeat: {:?}", repeat_expr.expr);
+                    let thing_to_repeat = parse_expr_as_i32(&repeat_expr.expr, generic_args);
+                    match &*repeat_expr.len {
+                        Expr::Path(len_path) => {
+                            // This is something like Tensor<E, {[-1; N]}>
+                            let num_rep_var = len_path.to_token_stream().to_string();
+                            if generic_args.get_i32(&num_rep_var).is_none() {
+                                panic!("Expected instance for generic argument {}", num_rep_var);
                             }
-                            shape = Some(_shape);
+                            let num_rep = generic_args.get_i32(&num_rep_var).unwrap();
+                            shape = Some(vec![thing_to_repeat; num_rep as usize]);
                         }
-                        Expr::Repeat(repeat_expr) => {
-                            // println!("Expr::Repeat: {:?}", repeat_expr.expr);
-                            let thing_to_repeat =
-                                parse_expr_as_i32(&repeat_expr.expr, generic_args);
-                            match &*repeat_expr.len {
-                                Expr::Path(len_path) => {
-                                    // This is something like Tensor<E, {[-1; N]}>
-                                    let num_rep_var = len_path.to_token_stream().to_string();
-                                    if !generic_args.get_i32(&num_rep_var).is_some() {
-                                        panic!(
-                                            "Expected instance for generic argument {}",
-                                            num_rep_var
-                                        );
-                                    }
-                                    let num_rep = generic_args.get_i32(&num_rep_var).unwrap();
-                                    shape = Some(vec![thing_to_repeat; num_rep as usize]);
-                                }
-                                Expr::Lit(len_lit) => {
-                                    // This is something like Tensor<E, {[-1; 3]}>
-                                    let num_rep: u32 = len_lit
-                                        .to_token_stream()
-                                        .to_string()
-                                        .parse::<u32>()
-                                        .unwrap();
-                                    shape = Some(vec![thing_to_repeat; num_rep as usize]);
-                                }
-                                _ => {
-                                    unimplemented!("Unexpected repeat expression: {repeat_expr:#?}")
-                                }
-                            }
+                        Expr::Lit(len_lit) => {
+                            // This is something like Tensor<E, {[-1; 3]}>
+                            let num_rep: u32 = len_lit
+                                .to_token_stream()
+                                .to_string()
+                                .parse::<u32>()
+                                .unwrap();
+                            shape = Some(vec![thing_to_repeat; num_rep as usize]);
                         }
-                        _ => panic!("Unexpected block expression."),
+                        _ => {
+                            unimplemented!("Unexpected repeat expression: {repeat_expr:#?}")
+                        }
                     }
                 }
-                _ => {}
+                _ => panic!("Unexpected block expression."),
             }
         }
         _ => {}
@@ -2636,7 +2603,7 @@ pub fn parse_expr_as_i32(expr: &Expr, generic_args: &GenericVars) -> i32 {
         Expr::Path(path) => {
             let ident = get_ident_from_path_expr(path);
             match generic_args.inst_i32.get(ident.to_string().as_str()) {
-                Some(val) => return *val,
+                Some(val) => *val,
                 None => panic!("Undefined generic parameter {ident}"),
             }
         }

--- a/cutile-compiler/src/hints.rs
+++ b/cutile-compiler/src/hints.rs
@@ -206,50 +206,49 @@ impl OptimizationHints {
         result.target_gpu_name = Some(target_gpu_name);
         for sm_key_val in &opt_hints.elems {
             let (opt_key, opt_value) = Self::parse_key_value(sm_key_val)?;
-            match opt_key.as_str() {
-                _ => {
-                    if !opt_key.starts_with("sm_") {
-                        return SourceLocation::unknown().jit_error_result(&format!(
-                            "Unexpected optimization hint {}.",
-                            sm_key_val.to_token_stream().to_string()
-                        ));
-                    }
-                    let Expr::Tuple(hints_tuple) = opt_value else {
-                        return SourceLocation::unknown()
-                            .jit_error_result("expected a tuple expression for architecture-specific optimization hints");
-                    };
-                    let mut sm_hints_result = SMHints::new(opt_key.clone());
-                    for hint_key_val in hints_tuple.elems.iter() {
-                        let (key, hints) = Self::parse_key_value(hint_key_val)?;
-                        match key.as_str() {
-                            "num_cta_in_cga" => sm_hints_result.set_num_cta_in_cga(&hints)?,
-                            "occupancy" => sm_hints_result.set_occupancy(&hints)?,
-                            "max_divisibility" => sm_hints_result.set_max_divisibility(&hints)?,
-                            "num_worker_warps_per_cta" => {
-                                sm_hints_result.set_num_worker_warps_per_cta(&hints)?
-                            }
-                            "allow_tma" | "latency" => {
-                                return SourceLocation::unknown().jit_error_result(&format!(
+            {
+                if !opt_key.starts_with("sm_") {
+                    return SourceLocation::unknown().jit_error_result(&format!(
+                        "Unexpected optimization hint {}.",
+                        sm_key_val.to_token_stream()
+                    ));
+                }
+                let Expr::Tuple(hints_tuple) = opt_value else {
+                    return SourceLocation::unknown().jit_error_result(
+                        "expected a tuple expression for architecture-specific optimization hints",
+                    );
+                };
+                let mut sm_hints_result = SMHints::new(opt_key.clone());
+                for hint_key_val in hints_tuple.elems.iter() {
+                    let (key, hints) = Self::parse_key_value(hint_key_val)?;
+                    match key.as_str() {
+                        "num_cta_in_cga" => sm_hints_result.set_num_cta_in_cga(&hints)?,
+                        "occupancy" => sm_hints_result.set_occupancy(&hints)?,
+                        "max_divisibility" => sm_hints_result.set_max_divisibility(&hints)?,
+                        "num_worker_warps_per_cta" => {
+                            sm_hints_result.set_num_worker_warps_per_cta(&hints)?
+                        }
+                        "allow_tma" | "latency" => {
+                            return SourceLocation::unknown().jit_error_result(&format!(
                                     "'{key}' is a per-op hint and cannot be set at the entry level. \
                                      Use it as a parameter on individual load/store operations instead."
                                 ));
-                            }
-                            _ => {
-                                return SourceLocation::unknown().jit_error_result(&format!(
-                                    "Unexpected optimization hint key '{key}'."
-                                ));
-                            }
+                        }
+                        _ => {
+                            return SourceLocation::unknown().jit_error_result(&format!(
+                                "Unexpected optimization hint key '{key}'."
+                            ));
                         }
                     }
-                    if result
-                        .tile_as_hints
-                        .insert(opt_key.clone(), sm_hints_result)
-                        .is_some()
-                    {
-                        return SourceLocation::unknown().jit_error_result(&format!(
-                            "Duplicate optimization hint key '{opt_key}'."
-                        ));
-                    }
+                }
+                if result
+                    .tile_as_hints
+                    .insert(opt_key.clone(), sm_hints_result)
+                    .is_some()
+                {
+                    return SourceLocation::unknown().jit_error_result(&format!(
+                        "Duplicate optimization hint key '{opt_key}'."
+                    ));
                 }
             }
         }

--- a/cutile-compiler/src/jit_cache.rs
+++ b/cutile-compiler/src/jit_cache.rs
@@ -349,13 +349,10 @@ impl FileSystemJitStore {
             if total as f64 <= target {
                 break;
             }
-            match std::fs::remove_file(&path) {
-                Ok(()) => {
-                    total -= len;
-                    deleted += 1;
-                }
-                // In use (Windows) or already gone: skip, keep going.
-                Err(_) => {}
+            // A failed removal (in use on Windows, or already gone) is skipped.
+            if std::fs::remove_file(&path).is_ok() {
+                total -= len;
+                deleted += 1;
             }
         }
         cache_log(format_args!(

--- a/cutile-compiler/src/kernel_entry_generator.rs
+++ b/cutile-compiler/src/kernel_entry_generator.rs
@@ -200,6 +200,7 @@ impl TensorInput {
         fn_args
     }
 
+    #[allow(clippy::ptr_arg)] // public signature stays as-is
     fn get_dynamic_elements(
         &self,
         static_elements: &Vec<String>,
@@ -418,7 +419,7 @@ fn normalized_fn_arg_type(param: &FnArg, ty: syn::Type) -> Result<FnArg, JITErro
         return SourceLocation::unknown().jit_error_result("Unexpected receiver argument.");
     };
     let mut typed_param = typed_param.clone();
-    typed_param.ty = Box::new(ty);
+    *typed_param.ty = ty;
     Ok(FnArg::Typed(typed_param))
 }
 
@@ -511,7 +512,8 @@ pub fn generate_entry_point(
                                     if s == "- 1" {
                                         -1
                                     } else {
-                                        s.parse::<i32>().expect(format!("{s}").as_str())
+                                        s.parse::<i32>()
+                                            .unwrap_or_else(|_| panic!("{}", s.to_string()))
                                     }
                                 })
                                 .collect::<Vec<i32>>(),
@@ -548,7 +550,8 @@ pub fn generate_entry_point(
                                             if s == "- 1" {
                                                 -1
                                             } else {
-                                                s.parse::<i32>().expect(format!("{s}").as_str())
+                                                s.parse::<i32>()
+                                                    .unwrap_or_else(|_| panic!("{}", s.to_string()))
                                             }
                                         })
                                         .collect::<Vec<i32>>(),
@@ -691,104 +694,43 @@ pub fn get_tensor_shape(
     let mut shape: Option<InputTensorShape> = None;
     for generic_arg in &type_generic_args.args {
         match generic_arg {
-            GenericArgument::Type(type_param) => {
+            GenericArgument::Type(syn::Type::Path(type_path)) => {
                 // Currently, this is either shape or element_type
-                match type_param {
-                    syn::Type::Path(type_path) => {
-                        let last_ident = type_path.path.segments.last().unwrap().ident.to_string();
-                        // println!("get_variadic_type_args: Type::Path: {}", last_ident);
-                        if shape.is_none() && generic_vars.inst_array.contains_key(&last_ident) {
-                            // This is something like Shape<D> for const generic array D: [i32; N].
-                            let array_instance = generic_vars.inst_array.get(&last_ident).unwrap();
-                            shape = Some(InputTensorShape {
-                                generic_cga_var: Some(last_ident.clone()),
-                                shape_param: last_ident,
-                                shape: array_instance.iter().map(|elem| elem.to_string()).collect(),
-                            });
-                        }
-                    }
-                    _ => {}
+                let last_ident = type_path.path.segments.last().unwrap().ident.to_string();
+                // println!("get_variadic_type_args: Type::Path: {}", last_ident);
+                if shape.is_none() && generic_vars.inst_array.contains_key(&last_ident) {
+                    // This is something like Shape<D> for const generic array D: [i32; N].
+                    let array_instance = generic_vars.inst_array.get(&last_ident).unwrap();
+                    shape = Some(InputTensorShape {
+                        generic_cga_var: Some(last_ident.clone()),
+                        shape_param: last_ident,
+                        shape: array_instance.iter().map(|elem| elem.to_string()).collect(),
+                    });
                 }
             }
-            GenericArgument::Const(const_param) => {
+            GenericArgument::Const(Expr::Block(block_expr)) => {
                 // println!("expand GenericArgument::Const? {const_param:#?}");
-                match const_param {
-                    Expr::Block(block_expr) => {
-                        // This is something like Tensor<E, {[...]}>
-                        if block_expr.block.stmts.len() != 1 {
-                            return SourceLocation::unknown().jit_error_result(&format!(
-                                "Expected exactly 1 statement in block expression, got {}",
-                                block_expr.block.stmts.len()
-                            ));
-                        }
-                        let statement = &block_expr.block.stmts[0];
-                        let Stmt::Expr(statement_expr, _) = statement else {
-                            return SourceLocation::unknown()
-                                .jit_error_result("Unexpected block expression.");
-                        };
-                        match statement_expr {
-                            Expr::Array(array_expr) => {
-                                // This is something like Tensor<E, {[1, 2, -1]}>
-                                let mut _shape = vec![];
-                                for elem in &array_expr.elems {
-                                    match elem {
-                                        Expr::Lit(lit) => {
-                                            let val = match &lit.lit {
-                                                Lit::Int(int_lit) => int_lit.to_string(),
-                                                _ => return SourceLocation::unknown().jit_error_result(
-                                                    &format!("Unexpected array element {elem:#?} in {array_expr:#?}"),
-                                                ),
-                                            };
-                                            _shape.push(val);
-                                        }
-                                        Expr::Unary(unary_expr) => {
-                                            _shape.push(unary_expr.to_token_stream().to_string());
-                                        }
-                                        Expr::Path(path) => {
-                                            let ident = get_ident_from_path_expr(path);
-                                            match generic_vars
-                                                .inst_i32
-                                                .get(ident.to_string().as_str())
-                                            {
-                                                Some(val) => _shape.push(val.to_string()),
-                                                None => {
-                                                    return SourceLocation::unknown()
-                                                        .jit_error_result(&format!(
-                                                            "Undefined generic parameter {ident}"
-                                                        ));
-                                                }
-                                            }
-                                        }
-                                        Expr::Index(index) => {
-                                            let Expr::Path(path) = index.expr.as_ref() else {
-                                                return SourceLocation::unknown().jit_error_result(
-                                                    &format!(
-                                                    "Unexpected const generic array base {elem:#?}"
-                                                ),
-                                                );
-                                            };
-                                            let ident = get_ident_from_path_expr(path);
-                                            let Some(shape) = generic_vars
-                                                .inst_array
-                                                .get(ident.to_string().as_str())
-                                            else {
-                                                return SourceLocation::unknown()
-                                                    .jit_error_result(&format!(
-                                                        "Undefined const generic array parameter {ident}"
-                                                    ));
-                                            };
-                                            let i = crate::types::parse_signed_literal_as_i32(
-                                                &index.index,
-                                            );
-                                            let Some(dim) = shape.get(i as usize) else {
-                                                return SourceLocation::unknown()
-                                                    .jit_error_result(&format!(
-                                                        "Index {i} out of bounds for const generic array `{ident}` of length {}",
-                                                        shape.len()
-                                                    ));
-                                            };
-                                            _shape.push(dim.to_string());
-                                        }
+                // This is something like Tensor<E, {[...]}>
+                if block_expr.block.stmts.len() != 1 {
+                    return SourceLocation::unknown().jit_error_result(&format!(
+                        "Expected exactly 1 statement in block expression, got {}",
+                        block_expr.block.stmts.len()
+                    ));
+                }
+                let statement = &block_expr.block.stmts[0];
+                let Stmt::Expr(statement_expr, _) = statement else {
+                    return SourceLocation::unknown()
+                        .jit_error_result("Unexpected block expression.");
+                };
+                match statement_expr {
+                    Expr::Array(array_expr) => {
+                        // This is something like Tensor<E, {[1, 2, -1]}>
+                        let mut _shape = vec![];
+                        for elem in &array_expr.elems {
+                            match elem {
+                                Expr::Lit(lit) => {
+                                    let val = match &lit.lit {
+                                        Lit::Int(int_lit) => int_lit.to_string(),
                                         _ => {
                                             return SourceLocation::unknown().jit_error_result(
                                                 &format!(
@@ -796,78 +738,114 @@ pub fn get_tensor_shape(
                                         ),
                                             )
                                         }
+                                    };
+                                    _shape.push(val);
+                                }
+                                Expr::Unary(unary_expr) => {
+                                    _shape.push(unary_expr.to_token_stream().to_string());
+                                }
+                                Expr::Path(path) => {
+                                    let ident = get_ident_from_path_expr(path);
+                                    match generic_vars.inst_i32.get(ident.to_string().as_str()) {
+                                        Some(val) => _shape.push(val.to_string()),
+                                        None => {
+                                            return SourceLocation::unknown().jit_error_result(
+                                                &format!("Undefined generic parameter {ident}"),
+                                            );
+                                        }
                                     }
                                 }
+                                Expr::Index(index) => {
+                                    let Expr::Path(path) = index.expr.as_ref() else {
+                                        return SourceLocation::unknown().jit_error_result(
+                                            &format!(
+                                                "Unexpected const generic array base {elem:#?}"
+                                            ),
+                                        );
+                                    };
+                                    let ident = get_ident_from_path_expr(path);
+                                    let Some(shape) =
+                                        generic_vars.inst_array.get(ident.to_string().as_str())
+                                    else {
+                                        return SourceLocation::unknown().jit_error_result(
+                                            &format!(
+                                                "Undefined const generic array parameter {ident}"
+                                            ),
+                                        );
+                                    };
+                                    let i = crate::types::parse_signed_literal_as_i32(&index.index);
+                                    let Some(dim) = shape.get(i as usize) else {
+                                        return SourceLocation::unknown()
+                                                .jit_error_result(&format!(
+                                                    "Index {i} out of bounds for const generic array `{ident}` of length {}",
+                                                    shape.len()
+                                                ));
+                                    };
+                                    _shape.push(dim.to_string());
+                                }
+                                _ => {
+                                    return SourceLocation::unknown().jit_error_result(&format!(
+                                        "Unexpected array element {elem:#?} in {array_expr:#?}"
+                                    ))
+                                }
+                            }
+                        }
+                        if shape.is_none() {
+                            shape = Some(InputTensorShape {
+                                generic_cga_var: None,
+                                shape_param: block_expr.block.to_token_stream().to_string(),
+                                shape: _shape,
+                            });
+                        }
+                    }
+                    Expr::Repeat(repeat_expr) => {
+                        // println!("Expr::Repeat: {:?}", repeat_expr.expr);
+                        let thing_to_repeat = repeat_expr.expr.to_token_stream().to_string();
+                        match &*repeat_expr.len {
+                            Expr::Path(len_path) => {
+                                // This is something like Tensor<E, {[-1; N]}>
+                                let num_rep_var = len_path.to_token_stream().to_string();
+                                if generic_vars.get_i32(&num_rep_var).is_none() {
+                                    return SourceLocation::unknown().jit_error_result(&format!(
+                                        "Expected instance for generic argument {}",
+                                        num_rep_var
+                                    ));
+                                }
+                                let num_rep = generic_vars.get_i32(&num_rep_var).unwrap();
                                 if shape.is_none() {
                                     shape = Some(InputTensorShape {
                                         generic_cga_var: None,
                                         shape_param: block_expr.block.to_token_stream().to_string(),
-                                        shape: _shape,
+                                        shape: vec![thing_to_repeat; num_rep as usize],
                                     });
                                 }
                             }
-                            Expr::Repeat(repeat_expr) => {
-                                // println!("Expr::Repeat: {:?}", repeat_expr.expr);
-                                let thing_to_repeat =
-                                    repeat_expr.expr.to_token_stream().to_string();
-                                match &*repeat_expr.len {
-                                    Expr::Path(len_path) => {
-                                        // This is something like Tensor<E, {[-1; N]}>
-                                        let num_rep_var = len_path.to_token_stream().to_string();
-                                        if !generic_vars.get_i32(&num_rep_var).is_some() {
-                                            return SourceLocation::unknown().jit_error_result(
-                                                &format!(
-                                                    "Expected instance for generic argument {}",
-                                                    num_rep_var
-                                                ),
-                                            );
-                                        }
-                                        let num_rep = generic_vars.get_i32(&num_rep_var).unwrap();
-                                        if shape.is_none() {
-                                            shape = Some(InputTensorShape {
-                                                generic_cga_var: None,
-                                                shape_param: block_expr
-                                                    .block
-                                                    .to_token_stream()
-                                                    .to_string(),
-                                                shape: vec![thing_to_repeat; num_rep as usize],
-                                            });
-                                        }
-                                    }
-                                    Expr::Lit(len_lit) => {
-                                        // This is something like Tensor<E, {[-1; 3]}>
-                                        let num_rep: u32 = len_lit
-                                            .to_token_stream()
-                                            .to_string()
-                                            .parse::<u32>()
-                                            .unwrap();
-                                        if shape.is_none() {
-                                            shape = Some(InputTensorShape {
-                                                generic_cga_var: None,
-                                                shape_param: block_expr
-                                                    .block
-                                                    .to_token_stream()
-                                                    .to_string(),
-                                                shape: vec![thing_to_repeat; num_rep as usize],
-                                            });
-                                        }
-                                    }
-                                    _ => {
-                                        return SourceLocation::unknown().jit_error_result(
-                                            &format!(
-                                                "Unexpected repeat expression: {repeat_expr:#?}"
-                                            ),
-                                        )
-                                    }
+                            Expr::Lit(len_lit) => {
+                                // This is something like Tensor<E, {[-1; 3]}>
+                                let num_rep: u32 = len_lit
+                                    .to_token_stream()
+                                    .to_string()
+                                    .parse::<u32>()
+                                    .unwrap();
+                                if shape.is_none() {
+                                    shape = Some(InputTensorShape {
+                                        generic_cga_var: None,
+                                        shape_param: block_expr.block.to_token_stream().to_string(),
+                                        shape: vec![thing_to_repeat; num_rep as usize],
+                                    });
                                 }
                             }
                             _ => {
-                                return SourceLocation::unknown()
-                                    .jit_error_result("Unexpected block expression.")
+                                return SourceLocation::unknown().jit_error_result(&format!(
+                                    "Unexpected repeat expression: {repeat_expr:#?}"
+                                ))
                             }
                         }
                     }
-                    _ => {}
+                    _ => {
+                        return SourceLocation::unknown()
+                            .jit_error_result("Unexpected block expression.")
+                    }
                 }
             }
             _ => {}

--- a/cutile-compiler/src/passes/node_ids.rs
+++ b/cutile-compiler/src/passes/node_ids.rs
@@ -36,9 +36,7 @@ pub fn assign_block_expr_ids(block: &mut syn::Block) {
 }
 
 pub fn expr_id(expr: &Expr) -> Option<NodeId> {
-    expr_attrs(expr)?
-        .iter()
-        .find_map(|attr| node_id_from_attr(attr))
+    expr_attrs(expr)?.iter().find_map(node_id_from_attr)
 }
 
 pub fn set_expr_id(expr: &mut Expr, id: NodeId) {
@@ -83,7 +81,7 @@ impl VisitMut for NodeIdAssigner {
         match expr {
             Expr::Assign(assign) => {
                 // The destination is binding syntax, not a value expression.
-                self.visit_expr_mut(&mut *assign.right);
+                self.visit_expr_mut(&mut assign.right);
             }
             Expr::Call(call) => {
                 // The callee is name-resolution syntax in this DSL.

--- a/cutile-compiler/src/passes/type_inference.rs
+++ b/cutile-compiler/src/passes/type_inference.rs
@@ -2483,7 +2483,7 @@ impl<'a, 'm> TypeInferenceCx<'a, 'm> {
             if let Expr::Closure(closure) = arg {
                 if let Some(signature) = signature {
                     if let Some((param_types, return_type)) =
-                        self.instantiate_closure_signature(&signature, &generic_arg_inf)
+                        self.instantiate_closure_signature(signature, &generic_arg_inf)
                     {
                         self.infer_closure(closure, &param_types, return_type)?;
                     } else {
@@ -2830,7 +2830,7 @@ impl<'a, 'm> TypeInferenceCx<'a, 'm> {
             }
         }
 
-        for ((trait_name, self_name), _impls) in self.compiler.modules.trait_impls() {
+        for (trait_name, self_name) in self.compiler.modules.trait_impls().keys() {
             if self_name == &qualifier_name {
                 if let Some(ty) =
                     self.trait_associated_const_syn_type(trait_name, &const_name, &self_ty)
@@ -2839,7 +2839,7 @@ impl<'a, 'm> TypeInferenceCx<'a, 'm> {
                 }
             }
         }
-        for ((trait_name, self_name), _impl_item) in self.compiler.modules.primitives() {
+        for (trait_name, self_name) in self.compiler.modules.primitives().keys() {
             if self_name == &qualifier_name {
                 if let Some(ty) =
                     self.trait_associated_const_syn_type(trait_name, &const_name, &self_ty)
@@ -3385,12 +3385,12 @@ fn substitute_self_type(ty: &Type, self_ty: &Type) -> Type {
         }
         Type::Reference(reference) => {
             let mut reference = reference.clone();
-            reference.elem = Box::new(substitute_self_type(&reference.elem, self_ty));
+            *reference.elem = substitute_self_type(&reference.elem, self_ty);
             Type::Reference(reference)
         }
         Type::Ptr(ptr) => {
             let mut ptr = ptr.clone();
-            ptr.elem = Box::new(substitute_self_type(&ptr.elem, self_ty));
+            *ptr.elem = substitute_self_type(&ptr.elem, self_ty);
             Type::Ptr(ptr)
         }
         Type::Tuple(tuple) => {
@@ -3404,22 +3404,22 @@ fn substitute_self_type(ty: &Type, self_ty: &Type) -> Type {
         }
         Type::Array(array) => {
             let mut array = array.clone();
-            array.elem = Box::new(substitute_self_type(&array.elem, self_ty));
+            *array.elem = substitute_self_type(&array.elem, self_ty);
             Type::Array(array)
         }
         Type::Slice(slice) => {
             let mut slice = slice.clone();
-            slice.elem = Box::new(substitute_self_type(&slice.elem, self_ty));
+            *slice.elem = substitute_self_type(&slice.elem, self_ty);
             Type::Slice(slice)
         }
         Type::Paren(paren) => {
             let mut paren = paren.clone();
-            paren.elem = Box::new(substitute_self_type(&paren.elem, self_ty));
+            *paren.elem = substitute_self_type(&paren.elem, self_ty);
             Type::Paren(paren)
         }
         Type::Group(group) => {
             let mut group = group.clone();
-            group.elem = Box::new(substitute_self_type(&group.elem, self_ty));
+            *group.elem = substitute_self_type(&group.elem, self_ty);
             Type::Group(group)
         }
         _ => ty.clone(),
@@ -4002,12 +4002,12 @@ fn substitute_resolved_generics(ty: &Type, inference: &GenericArgInference) -> O
         }
         Type::Reference(reference) => {
             let mut result = reference.clone();
-            result.elem = Box::new(substitute_resolved_generics(&reference.elem, inference)?);
+            *result.elem = substitute_resolved_generics(&reference.elem, inference)?;
             Some(Type::Reference(result))
         }
         Type::Ptr(ptr) => {
             let mut result = ptr.clone();
-            result.elem = Box::new(substitute_resolved_generics(&ptr.elem, inference)?);
+            *result.elem = substitute_resolved_generics(&ptr.elem, inference)?;
             Some(Type::Ptr(result))
         }
         Type::Tuple(tuple) => {
@@ -4019,13 +4019,13 @@ fn substitute_resolved_generics(ty: &Type, inference: &GenericArgInference) -> O
         }
         Type::Array(array) => {
             let mut result = array.clone();
-            result.elem = Box::new(substitute_resolved_generics(&array.elem, inference)?);
+            *result.elem = substitute_resolved_generics(&array.elem, inference)?;
             result.len = substitute_resolved_const_expr(&array.len, inference)?;
             Some(Type::Array(result))
         }
         Type::Slice(slice) => {
             let mut result = slice.clone();
-            result.elem = Box::new(substitute_resolved_generics(&slice.elem, inference)?);
+            *result.elem = substitute_resolved_generics(&slice.elem, inference)?;
             Some(Type::Slice(result))
         }
         Type::ImplTrait(_) => None,
@@ -4084,18 +4084,18 @@ fn substitute_resolved_const_expr(expr: &Expr, inference: &GenericArgInference) 
         }
         Expr::Repeat(repeat) => {
             let mut result = repeat.clone();
-            result.expr = Box::new(substitute_resolved_const_expr(&repeat.expr, inference)?);
-            result.len = Box::new(substitute_resolved_const_expr(&repeat.len, inference)?);
+            *result.expr = substitute_resolved_const_expr(&repeat.expr, inference)?;
+            *result.len = substitute_resolved_const_expr(&repeat.len, inference)?;
             Some(Expr::Repeat(result))
         }
         Expr::Unary(unary) => {
             let mut result = unary.clone();
-            result.expr = Box::new(substitute_resolved_const_expr(&unary.expr, inference)?);
+            *result.expr = substitute_resolved_const_expr(&unary.expr, inference)?;
             Some(Expr::Unary(result))
         }
         Expr::Paren(paren) => {
             let mut result = paren.clone();
-            result.expr = Box::new(substitute_resolved_const_expr(&paren.expr, inference)?);
+            *result.expr = substitute_resolved_const_expr(&paren.expr, inference)?;
             Some(Expr::Paren(result))
         }
         _ => Some(expr.clone()),

--- a/cutile-compiler/src/specialization.rs
+++ b/cutile-compiler/src/specialization.rs
@@ -176,7 +176,7 @@ pub fn compute_spec(
         .map(|(&s, &d)| (s, d))
         .collect();
     sorted.sort();
-    spec.elements_disjoint = sorted.first().map_or(true, |(s, _)| *s > 0);
+    spec.elements_disjoint = sorted.first().is_none_or(|(s, _)| *s > 0);
     for w in sorted.windows(2) {
         if w[1].0 <= 0 || w[1].0 < w[0].0 * w[0].1 {
             spec.elements_disjoint = false;

--- a/cutile-compiler/src/specialization_tests.rs
+++ b/cutile-compiler/src/specialization_tests.rs
@@ -4,6 +4,7 @@
  */
 
 #[cfg(test)]
+#[allow(clippy::module_inception)]
 mod tests {
     use crate::specialization::*;
 

--- a/cutile-compiler/src/syn_utils.rs
+++ b/cutile-compiler/src/syn_utils.rs
@@ -121,7 +121,7 @@ impl SingleMetaList {
     pub fn from_attribute(attr: Attribute) -> Self {
         match attr.meta {
             Meta::List(meta_list) => {
-                let tokens = proc_macro2::TokenStream::from(meta_list.tokens.clone());
+                let tokens = meta_list.tokens.clone();
                 let mut result = syn::parse2::<SingleMetaList>(tokens).unwrap();
                 result.name = Some(meta_list.path.to_token_stream().to_string());
                 result.meta_list = Some(meta_list);
@@ -139,24 +139,20 @@ impl SingleMetaList {
     }
     /// Returns the attribute path as a single string.
     pub fn name_as_str(&self) -> Option<String> {
-        match &self.name {
-            Some(s) => Some(s.clone()),
-            None => None,
-        }
+        self.name.clone()
     }
     /// Returns the attribute path split by `::` separators.
     pub fn name_as_vec(&self) -> Option<Vec<&str>> {
-        match &self.name {
-            Some(s) => Some(s.as_str().split(" :: ").collect()),
-            None => None,
-        }
+        self.name
+            .as_ref()
+            .map(|s| s.as_str().split(" :: ").collect())
     }
     fn get_value(&self, name: &str) -> Option<&Expr> {
         for item in &self.variables {
             match item {
                 Meta::NameValue(name_value) => {
                     let meta_ident = name_value.path.get_ident();
-                    let meta_name = meta_ident.clone().unwrap().to_string();
+                    let meta_name = meta_ident.unwrap().to_string();
                     if name == meta_name {
                         return Some(&name_value.value);
                     }
@@ -266,10 +262,10 @@ impl Parse for SingleMetaList {
     }
 }
 
-impl Into<Vec<Attribute>> for SingleMetaList {
-    fn into(self) -> Vec<Attribute> {
+impl From<SingleMetaList> for Vec<Attribute> {
+    fn from(val: SingleMetaList) -> Self {
         let mut res = vec![];
-        for meta in self.variables {
+        for meta in val.variables {
             let attr: Attribute = parse_quote! {
                 #[noname(#meta)]
             };
@@ -280,7 +276,7 @@ impl Into<Vec<Attribute>> for SingleMetaList {
 }
 
 /// Removes all attributes whose path matches one of the given names.
-pub fn clear_attributes(attr_names: HashSet<&str>, attrs: &mut Vec<Attribute>) -> () {
+pub fn clear_attributes(attr_names: HashSet<&str>, attrs: &mut Vec<Attribute>) {
     // filter == keep
     *attrs = attrs
         .clone()
@@ -329,10 +325,7 @@ pub fn get_attribute(
 
 /// Looks up an attribute by full path and parses it as a [`SingleMetaList`].
 pub fn get_meta_list(attr_name: &str, outer_attrs: &Vec<Attribute>) -> Option<SingleMetaList> {
-    match get_attribute(attr_name, outer_attrs, false) {
-        Some(attr) => Some(SingleMetaList::from_attribute(attr)),
-        None => None,
-    }
+    get_attribute(attr_name, outer_attrs, false).map(SingleMetaList::from_attribute)
 }
 
 /// Like [`get_meta_list`] but matches only the last path segment.
@@ -340,10 +333,7 @@ pub fn get_meta_list_by_last_segment(
     last_seg: &str,
     outer_attrs: &Vec<Attribute>,
 ) -> Option<SingleMetaList> {
-    match get_attribute(last_seg, outer_attrs, true) {
-        Some(attr) => Some(SingleMetaList::from_attribute(attr)),
-        None => None,
-    }
+    get_attribute(last_seg, outer_attrs, true).map(SingleMetaList::from_attribute)
 }
 
 /// Finds the first `cuda_tile::*` attribute and parses it as a [`SingleMetaList`].
@@ -414,7 +404,7 @@ impl VarCGAParameter {
                 }
             }
             _ => {
-                panic!("Unexpected path expression {:#?}.", &ty_arr.len)
+                panic!("Unexpected path expression {:#?}.", ty_arr.len)
             }
         }
     }
@@ -483,7 +473,7 @@ impl CGAParameter {
                 }
             }
             _ => {
-                panic!("Unexpected path expression {:#?}.", &ty_arr.len)
+                panic!("Unexpected path expression {:#?}.", ty_arr.len)
             }
         }
     }
@@ -640,7 +630,7 @@ pub fn get_sig_output_type(sig: &Signature) -> Type {
 pub fn function_returns(fn_item: &ItemFn) -> bool {
     match &fn_item.sig.output {
         ReturnType::Type(_, return_type) => match &**return_type {
-            Type::Tuple(type_tuple) => type_tuple.elems.len() > 0,
+            Type::Tuple(type_tuple) => !type_tuple.elems.is_empty(),
             _ => true,
         },
         ReturnType::Default => false,
@@ -661,7 +651,7 @@ pub fn get_ident_from_path_expr(path_expr: &ExprPath) -> Ident {
 pub fn get_ident_from_expr(expr: &Expr) -> Option<Ident> {
     match expr {
         Expr::Path(path_expr) => Some(get_ident_from_path(&path_expr.path)),
-        Expr::Reference(ref_expr) => get_ident_from_expr(&*ref_expr.expr),
+        Expr::Reference(ref_expr) => get_ident_from_expr(&ref_expr.expr),
         _ => None,
     }
 }
@@ -771,7 +761,7 @@ pub fn get_supported_generic_params(generics: &Generics) -> Vec<(String, Option<
 }
 
 /// Removes lifetime arguments from angle-bracketed generic arguments in place.
-pub fn strip_generic_args_lifetimes(gen_args: &mut AngleBracketedGenericArguments) -> () {
+pub fn strip_generic_args_lifetimes(gen_args: &mut AngleBracketedGenericArguments) {
     let mut res = gen_args.args.clone();
     res.clear();
     for gen_arg in gen_args.args.iter() {
@@ -784,7 +774,7 @@ pub fn strip_generic_args_lifetimes(gen_args: &mut AngleBracketedGenericArgument
 }
 
 /// Removes lifetime parameters from generics in place.
-pub fn strip_generics_lifetimes(generics: &mut Generics) -> () {
+pub fn strip_generics_lifetimes(generics: &mut Generics) {
     let mut res = generics.params.clone();
     res.clear();
     for gen_param in generics.params.iter() {

--- a/cutile-compiler/src/type_aliases.rs
+++ b/cutile-compiler/src/type_aliases.rs
@@ -142,7 +142,7 @@ pub fn normalize_item_fn_param_type_aliases(
         let FnArg::Typed(PatType { ty, .. }) = arg else {
             continue;
         };
-        *ty = Box::new(normalize_type_aliases(ty, aliases)?);
+        **ty = normalize_type_aliases(ty, aliases)?;
     }
     Ok(item)
 }
@@ -186,12 +186,12 @@ fn normalize_type_aliases_inner(
         Type::Path(type_path) => normalize_path_type(type_path, aliases, stack),
         Type::Reference(type_ref) => {
             let mut out = type_ref.clone();
-            out.elem = Box::new(normalize_type_aliases_inner(&out.elem, aliases, stack)?);
+            *out.elem = normalize_type_aliases_inner(&out.elem, aliases, stack)?;
             Ok(Type::Reference(out))
         }
         Type::Ptr(type_ptr) => {
             let mut out = type_ptr.clone();
-            out.elem = Box::new(normalize_type_aliases_inner(&out.elem, aliases, stack)?);
+            *out.elem = normalize_type_aliases_inner(&out.elem, aliases, stack)?;
             Ok(Type::Ptr(out))
         }
         Type::Tuple(tuple) => {
@@ -203,22 +203,22 @@ fn normalize_type_aliases_inner(
         }
         Type::Array(array) => {
             let mut out = array.clone();
-            out.elem = Box::new(normalize_type_aliases_inner(&out.elem, aliases, stack)?);
+            *out.elem = normalize_type_aliases_inner(&out.elem, aliases, stack)?;
             Ok(Type::Array(out))
         }
         Type::Slice(slice) => {
             let mut out = slice.clone();
-            out.elem = Box::new(normalize_type_aliases_inner(&out.elem, aliases, stack)?);
+            *out.elem = normalize_type_aliases_inner(&out.elem, aliases, stack)?;
             Ok(Type::Slice(out))
         }
         Type::Paren(paren) => {
             let mut out = paren.clone();
-            out.elem = Box::new(normalize_type_aliases_inner(&out.elem, aliases, stack)?);
+            *out.elem = normalize_type_aliases_inner(&out.elem, aliases, stack)?;
             Ok(Type::Paren(out))
         }
         Type::Group(group) => {
             let mut out = group.clone();
-            out.elem = Box::new(normalize_type_aliases_inner(&out.elem, aliases, stack)?);
+            *out.elem = normalize_type_aliases_inner(&out.elem, aliases, stack)?;
             Ok(Type::Group(out))
         }
         _ => Ok(ty.clone()),
@@ -292,7 +292,7 @@ fn build_alias_substitution(
     }
 
     let mut subst = AliasSubstitution::default();
-    for (formal, actual) in formals.into_iter().zip(actual_args.into_iter()) {
+    for (formal, actual) in formals.into_iter().zip(actual_args) {
         match (formal, actual) {
             (GenericParam::Type(param), GenericArgument::Type(ty)) => {
                 subst.types.insert(param.ident.to_string(), ty);
@@ -352,12 +352,12 @@ fn substitute_type(
         }
         Type::Reference(type_ref) => {
             let mut out = type_ref.clone();
-            out.elem = Box::new(substitute_type(&out.elem, subst, aliases, stack)?);
+            *out.elem = substitute_type(&out.elem, subst, aliases, stack)?;
             Ok(Type::Reference(out))
         }
         Type::Ptr(type_ptr) => {
             let mut out = type_ptr.clone();
-            out.elem = Box::new(substitute_type(&out.elem, subst, aliases, stack)?);
+            *out.elem = substitute_type(&out.elem, subst, aliases, stack)?;
             Ok(Type::Ptr(out))
         }
         Type::Tuple(tuple) => {
@@ -369,23 +369,23 @@ fn substitute_type(
         }
         Type::Array(array) => {
             let mut out = array.clone();
-            out.elem = Box::new(substitute_type(&out.elem, subst, aliases, stack)?);
+            *out.elem = substitute_type(&out.elem, subst, aliases, stack)?;
             substitute_expr_in_place(&mut out.len, subst);
             Ok(Type::Array(out))
         }
         Type::Slice(slice) => {
             let mut out = slice.clone();
-            out.elem = Box::new(substitute_type(&out.elem, subst, aliases, stack)?);
+            *out.elem = substitute_type(&out.elem, subst, aliases, stack)?;
             Ok(Type::Slice(out))
         }
         Type::Paren(paren) => {
             let mut out = paren.clone();
-            out.elem = Box::new(substitute_type(&out.elem, subst, aliases, stack)?);
+            *out.elem = substitute_type(&out.elem, subst, aliases, stack)?;
             Ok(Type::Paren(out))
         }
         Type::Group(group) => {
             let mut out = group.clone();
-            out.elem = Box::new(substitute_type(&out.elem, subst, aliases, stack)?);
+            *out.elem = substitute_type(&out.elem, subst, aliases, stack)?;
             Ok(Type::Group(out))
         }
         _ => Ok(ty.clone()),

--- a/cutile-compiler/src/types.rs
+++ b/cutile-compiler/src/types.rs
@@ -204,7 +204,7 @@ impl TypeParamPrimitive {
             }
             _ => SourceLocation::unknown().jit_error_result(&format!(
                 "unsupported primitive type `{}`",
-                self.rust_ty.to_token_stream().to_string()
+                self.rust_ty.to_token_stream()
             )),
         }
     }
@@ -587,10 +587,11 @@ pub fn get_ptr_type_instance(
     };
     if is_element_type(&maybe_element_type, primitives) {
         Some((prefix, maybe_element_type))
-    } else if let Some(element_type) = generic_vars.inst_types.get(&maybe_element_type) {
-        Some((prefix, element_type.to_string()))
     } else {
-        None
+        generic_vars
+            .inst_types
+            .get(&maybe_element_type)
+            .map(|element_type| (prefix, element_type.to_string()))
     }
 }
 
@@ -607,12 +608,12 @@ pub fn get_cuda_tile_element_type_from_rust_primitive_str(
 
 /// Returns the Rust identifier string for a primitive type.
 pub fn get_rust_element_type_primitive(ty: &syn::Type) -> String {
-    let type_ident = get_type_ident(&ty);
+    let type_ident = get_type_ident(ty);
     assert!(
         type_ident.is_some(),
         "get_element_type_primitive failed for {ty:#?}"
     );
-    return type_ident.unwrap().to_string();
+    type_ident.unwrap().to_string()
 }
 
 /// Returns the CUDA Tile element type string for a Rust primitive type.
@@ -644,8 +645,8 @@ pub fn get_element_type_structured(
     let (_type_ident, type_generic_args) = get_ident_generic_args(ty);
     let mut element_type: Option<String> = None;
     for generic_arg in &type_generic_args.args {
-        match generic_arg {
-            GenericArgument::Type(type_param) => match type_param {
+        if let GenericArgument::Type(type_param) = generic_arg {
+            match type_param {
                 syn::Type::Path(type_path) => {
                     let ident_str = type_path.path.segments.last().unwrap().ident.to_string();
                     if get_primitives_attrs("ElementType", &ident_str, primitives).is_some() {
@@ -667,8 +668,7 @@ pub fn get_element_type_structured(
                     element_type = get_element_type_structured(&type_ref.elem, primitives)
                 }
                 _ => {}
-            },
-            _ => {}
+            }
         }
     }
     element_type
@@ -679,9 +679,7 @@ pub fn get_cuda_tile_element_type_structured(
     ty: &syn::Type,
     primitives: &HashMap<(String, String), ItemImpl>,
 ) -> Option<String> {
-    let Some(rust_element_type) = get_element_type_structured(ty, primitives) else {
-        return None;
-    };
+    let rust_element_type = get_element_type_structured(ty, primitives)?;
     get_cuda_tile_element_type_from_rust_primitive_str(&rust_element_type, primitives)
 }
 
@@ -716,7 +714,7 @@ pub fn parse_signed_literal_as_i32(expr: &Expr) -> i32 {
                 Lit::Int(int_lit) => int_lit.base10_parse().unwrap(),
                 _ => unimplemented!("Unexpected array element {expr:#?}"),
             };
-            return val;
+            val
         }
         Expr::Unary(unary_expr) => match unary_expr.op {
             UnOp::Neg(_) => match &*unary_expr.expr {
@@ -725,7 +723,7 @@ pub fn parse_signed_literal_as_i32(expr: &Expr) -> i32 {
                         Lit::Int(int_lit) => int_lit.base10_parse().unwrap(),
                         _ => unimplemented!("Unexpected array element {expr:#?}"),
                     };
-                    return -val;
+                    -val
                 }
                 _ => panic!("Unexpected unary expr {unary_expr:#?}"),
             },
@@ -787,9 +785,7 @@ pub fn get_type_mutability(ty: &Type) -> bool {
 
 /// Tries to extract a const generic array from a type's generic arguments.
 pub fn try_extract_cga(ty: &Type, generic_vars: &GenericVars) -> Option<Vec<i32>> {
-    let Some(mut type_generic_args) = maybe_generic_args(ty) else {
-        return None;
-    };
+    let mut type_generic_args = maybe_generic_args(ty)?;
     strip_generic_args_lifetimes(&mut type_generic_args);
     let mut result = None;
 
@@ -798,17 +794,14 @@ pub fn try_extract_cga(ty: &Type, generic_vars: &GenericVars) -> Option<Vec<i32>
             GenericArgument::Lifetime(_) => continue,
             GenericArgument::Type(type_param) => {
                 // Currently, this is either shape or element_type
-                match type_param {
-                    syn::Type::Path(type_path) => {
-                        let last_ident = type_path.path.segments.last().unwrap().ident.to_string();
-                        // println!("get_variadic_type_args: Type::Path: {}", last_ident);
-                        if generic_vars.inst_array.contains_key(&last_ident) {
-                            // This is something like Shape<D> for const generic array D: [i32; N].
-                            let array_instance = generic_vars.inst_array.get(&last_ident).unwrap();
-                            result = Some(array_instance.clone());
-                        }
+                if let syn::Type::Path(type_path) = type_param {
+                    let last_ident = type_path.path.segments.last().unwrap().ident.to_string();
+                    // println!("get_variadic_type_args: Type::Path: {}", last_ident);
+                    if generic_vars.inst_array.contains_key(&last_ident) {
+                        // This is something like Shape<D> for const generic array D: [i32; N].
+                        let array_instance = generic_vars.inst_array.get(&last_ident).unwrap();
+                        result = Some(array_instance.clone());
                     }
-                    _ => {}
                 }
             }
             GenericArgument::Const(const_expr) => {
@@ -934,7 +927,7 @@ pub fn try_extract_cga(ty: &Type, generic_vars: &GenericVars) -> Option<Vec<i32>
                                     Expr::Path(len_path) => {
                                         // This is something like Tensor<E, {[-1; N]}>
                                         let num_rep_var = len_path.to_token_stream().to_string();
-                                        if !generic_vars.get_i32(&num_rep_var).is_some() {
+                                        if generic_vars.get_i32(&num_rep_var).is_none() {
                                             panic!(
                                                 "Expected instance for generic argument {}",
                                                 num_rep_var

--- a/cutile-compiler/tests/compiler2_e2e.rs
+++ b/cutile-compiler/tests/compiler2_e2e.rs
@@ -131,7 +131,7 @@ fn test_empty_kernel_tileiras() {
     );
 
     // Run through tileiras.
-    let cubin = compile_tile_ir_module(&module, &gpu_name).unwrap();
+    let cubin = compile_tile_ir_module(&module, gpu_name).unwrap();
     println!("cubin: {} bytes", cubin.len());
     assert!(!cubin.is_empty(), "cubin image should be non-empty");
 }
@@ -164,7 +164,7 @@ fn assert_tileiras_accepts(module: &Module) {
         cutile_ir::decode_bytecode(&bytecode).unwrap()
     );
 
-    let cubin = compile_tile_ir_module(module, &gpu_name).unwrap();
+    let cubin = compile_tile_ir_module(module, gpu_name).unwrap();
     assert!(!cubin.is_empty(), "cubin image should be non-empty");
     println!("tileiras accepted ✓");
 }
@@ -535,7 +535,8 @@ fn build_print_kernel(with_token: bool) -> Module {
         shape: vec![],
         element_type: TileElementType::Scalar(ScalarType::F32),
     });
-    let (region_id, block_id, args) = build_single_block_region(&mut module, &[tile_f32.clone()]);
+    let (region_id, block_id, args) =
+        build_single_block_region(&mut module, std::slice::from_ref(&tile_f32));
     let mut operands = vec![args[0]];
     let mut token_count = 0;
     if with_token {

--- a/cutile-compiler/tests/jit_cache.rs
+++ b/cutile-compiler/tests/jit_cache.rs
@@ -324,7 +324,7 @@ fn capacity_holds_across_short_lived_processes() {
             .capacity_bytes(CAPACITY)
             .open()
             .unwrap();
-        store.put(&key(tag), &vec![tag; ENTRY_BYTES]).unwrap();
+        store.put(&key(tag), &[tag; ENTRY_BYTES]).unwrap();
     }
 
     // Collection lands the store on the low watermark (6553 B ≈ 32 entries) and

--- a/cutile-examples/Cargo.toml
+++ b/cutile-examples/Cargo.toml
@@ -28,3 +28,6 @@ cuda-async = { workspace = true }
 tokio = { workspace = true }
 candle-core = { workspace = true }
 candle-nn = { workspace = true }
+
+[lints]
+workspace = true

--- a/cutile-examples/examples/flash_attention.rs
+++ b/cutile-examples/examples/flash_attention.rs
@@ -6,7 +6,6 @@ extern crate core;
 
 use cuda_async::device_operation::{DeviceOp, Unzippable6};
 use cuda_core::Device;
-use cutile;
 use cutile::api::{randn, zeros};
 use cutile::error::Error;
 use cutile::tensor::{IntoPartition, Partition, Tensor, ToHostVec, Unpartition};
@@ -169,7 +168,7 @@ fn fmha(
     let out: Partition<Tensor<f32>> = zeros(&[b * h, m, d])
         .sync_on(&stream)?
         .partition([bbh, bm, d]);
-    assert_eq!(out.grid()?, ((b * h) as u32, (m / bm as usize) as u32, 1));
+    assert_eq!(out.grid()?, ((b * h) as u32, (m / bm) as u32, 1));
 
     let qk_scale = 1.0 / f32::sqrt(q.shape()[3] as f32);
 

--- a/cutile-examples/examples/gemm.rs
+++ b/cutile-examples/examples/gemm.rs
@@ -41,11 +41,7 @@ fn gemm<T: DType + std::fmt::Display>() -> Result<(), Error> {
     let stream = device.new_stream()?;
     let scale = 2usize.pow(10); // On the order of megabytes.
     let (bm, bn, bk) = (16, 16, 8);
-    let (m, n, k) = (
-        scale * bm as usize,
-        scale * bn as usize,
-        scale * bk as usize,
-    );
+    let (m, n, k) = (scale * bm, scale * bn, scale * bk as usize);
     let generics = vec![
         T::DTYPE.as_str().to_string(),
         bm.to_string(),

--- a/cutile-examples/examples/gemm_static.rs
+++ b/cutile-examples/examples/gemm_static.rs
@@ -51,11 +51,7 @@ fn gemm<T: DType + std::fmt::Display>() -> Result<(), Error> {
     let stream = device.new_stream()?;
     let scale = 2usize.pow(10); // On the order of megabytes.
     let (bm, bn, bk) = (16, 16, 8);
-    let (m, n, k) = (
-        scale * bm as usize,
-        scale * bn as usize,
-        scale * bk as usize,
-    );
+    let (m, n, k) = (scale * bm, scale * bn, scale * bk as usize);
     let generics = vec![
         T::DTYPE.as_str().to_string(),
         bm.to_string(),

--- a/cutile-examples/examples/scale_ptr.rs
+++ b/cutile-examples/examples/scale_ptr.rs
@@ -13,7 +13,6 @@
 //! The reshape/broadcast pattern avoids the ptr-to-int/int-to-ptr workaround
 //! that was previously required for PointerTile shape manipulation.
 
-use cutile;
 use cutile::api::{arange, zeros};
 use cutile::tensor::{Tensor, ToHostVec};
 use cutile::tile_kernel::TileKernel;

--- a/cutile-ir/Cargo.toml
+++ b/cutile-ir/Cargo.toml
@@ -15,3 +15,6 @@ thiserror = { workspace = true }
 
 [dev-dependencies]
 half = { workspace = true }
+
+[lints]
+workspace = true

--- a/cutile-ir/src/bytecode/encoding.rs
+++ b/cutile-ir/src/bytecode/encoding.rs
@@ -18,6 +18,12 @@ pub struct EncodingWriter {
     required_alignment: u64,
 }
 
+impl Default for EncodingWriter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl EncodingWriter {
     pub fn new() -> Self {
         Self {
@@ -270,7 +276,7 @@ fn convert_to_f8(
     // Handle special values.
     if f64_exp == 0x7FF {
         // Inf or NaN
-        if f64_man != 0 || (nan_only_all_ones && f64_man == 0) {
+        if f64_man != 0 || nan_only_all_ones {
             // NaN (or Inf mapped to NaN for formats without infinities)
             if nan_only_all_ones {
                 return (sign << 7) | ((max_exp as u8) << man_bits) | man_mask;

--- a/cutile-ir/src/ir/fmt.rs
+++ b/cutile-ir/src/ir/fmt.rs
@@ -1107,7 +1107,7 @@ impl<'a> ModulePrinter<'a> {
         let pad = " ".repeat(self.indent);
 
         // Operands: [lb, ub, step, init_values...]
-        let lb = op.operands.get(0).map(|v| v.index());
+        let lb = op.operands.first().map(|v| v.index());
         let ub = op.operands.get(1).map(|v| v.index());
         let step = op.operands.get(2).map(|v| v.index());
         let init_values = &op.operands[3.min(op.operands.len())..];
@@ -2709,7 +2709,7 @@ fn format_dense_i32_array(attr: &Attribute) -> String {
                 .collect();
             format!("[{}]", elems.join(", "))
         }
-        _ => format!("{}", format_attr(attr)),
+        _ => format_attr(attr).to_string(),
     }
 }
 
@@ -2762,7 +2762,7 @@ mod tests {
 
         // Build a function with addf and return.
         let (region_id, block_id, args) =
-            build_single_block_region(&mut module, &[tile_ty.clone()]);
+            build_single_block_region(&mut module, std::slice::from_ref(&tile_ty));
 
         let (add_id, add_results) = OpBuilder::new(Opcode::AddF, Location::Unknown)
             .operand(args[0])

--- a/cutile-ir/src/ir/types.rs
+++ b/cutile-ir/src/ir/types.rs
@@ -323,11 +323,7 @@ fn strip_prefix_suffix<'a>(s: &'a str, prefix: &str, _suffix: &str) -> Option<&'
         }
     }
     // No matching close — try without nesting (just strip last char if it's '>').
-    if after_prefix.ends_with('>') {
-        Some(&after_prefix[..after_prefix.len() - 1])
-    } else {
-        None
-    }
+    after_prefix.strip_suffix('>')
 }
 
 fn parse_scalar(s: &str) -> Option<ScalarType> {
@@ -374,7 +370,7 @@ fn parse_tile(inner: &str) -> Option<Type> {
             before
                 .trim_end_matches('x')
                 .split('x')
-                .map(|d| parse_dim(d))
+                .map(parse_dim)
                 .collect()
         };
         let ptr_inner_start = ptr_start + "ptr<".len();
@@ -428,7 +424,7 @@ fn parse_tensor_view(inner: &str) -> Option<Type> {
 
     let strides = if let Some(sp) = strides_part {
         let sp = sp.trim_start_matches('[').trim_end_matches(']');
-        sp.split(',').map(|s| parse_dim(s)).collect()
+        sp.split(',').map(parse_dim).collect()
     } else {
         vec![DYNAMIC; shape.len()]
     };

--- a/cutile-ir/tests/bytecode_13_3.rs
+++ b/cutile-ir/tests/bytecode_13_3.rs
@@ -23,9 +23,10 @@ fn build_kernel(
     build_body(&mut module, block_id, &args);
     let needs_return = {
         let block = module.block(block_id);
-        block.ops.last().map_or(true, |&last| {
-            !matches!(module.op(last).opcode, Opcode::Return)
-        })
+        block
+            .ops
+            .last()
+            .is_none_or(|&last| !matches!(module.op(last).opcode, Opcode::Return))
     };
     if needs_return {
         let (ret, _) = OpBuilder::new(Opcode::Return, Location::Unknown).build(&mut module);
@@ -115,7 +116,7 @@ impl<'a> Reader<'a> {
     }
 }
 
-fn section_payload<'a>(bytecode: &'a [u8], wanted: Section) -> &'a [u8] {
+fn section_payload(bytecode: &[u8], wanted: Section) -> &[u8] {
     let mut r = Reader::new(bytecode);
     assert_eq!(r.bytes(MAGIC.len()), MAGIC);
     let _major = r.byte();
@@ -272,10 +273,10 @@ fn mmaf_fast_acc_flag_tracks_boolean_value() {
 #[test]
 fn exp_encodes_13_3_default_rounding_mode() {
     let f32_tile = tile(&[4], ScalarType::F32);
-    let module = build_kernel("exp", &[f32_tile.clone()], |m, b, args| {
+    let module = build_kernel("exp", std::slice::from_ref(&f32_tile), |m, b, args| {
         let (op, _) = OpBuilder::new(Opcode::Exp, Location::Unknown)
             .operand(args[0])
-            .result(f32_tile)
+            .result(f32_tile.clone())
             .build(m);
         append_op(m, b, op);
     });

--- a/cutile-ir/tests/bytecode_compat.rs
+++ b/cutile-ir/tests/bytecode_compat.rs
@@ -9,6 +9,9 @@
 //! `cuda-tile/test/Bytecode/`) into Rust, exercising the same IR patterns
 //! through the `OpBuilder` API and verifying bytecode roundtrip.
 
+// Float literals such as 3.14159 are arbitrary test payloads, not approximations of pi.
+#![allow(clippy::approx_constant)]
+
 use cutile_ir::builder::{append_op, build_single_block_region, OpBuilder};
 use cutile_ir::bytecode::{Opcode, MAGIC};
 use cutile_ir::ir::*;
@@ -34,9 +37,10 @@ fn build_kernel(
     // Append return if not already present.
     let needs_return = {
         let block = module.block(block_id);
-        block.ops.last().map_or(true, |&last| {
-            !matches!(module.op(last).opcode, Opcode::Return)
-        })
+        block
+            .ops
+            .last()
+            .is_none_or(|&last| !matches!(module.op(last).opcode, Opcode::Return))
     };
     if needs_return {
         let (ret, _) = OpBuilder::new(Opcode::Return, Location::Unknown).build(&mut module);
@@ -66,9 +70,10 @@ fn add_entry(
     build_body(module, block_id, &args);
     let needs_return = {
         let block = module.block(block_id);
-        block.ops.last().map_or(true, |&last| {
-            !matches!(module.op(last).opcode, Opcode::Return)
-        })
+        block
+            .ops
+            .last()
+            .is_none_or(|&last| !matches!(module.op(last).opcode, Opcode::Return))
     };
     if needs_return {
         let (ret, _) = OpBuilder::new(Opcode::Return, Location::Unknown).build(module);
@@ -658,7 +663,7 @@ fn build_padding_test(padding: Option<PaddingValue>) -> Module {
         dim_map: vec![0],
         padding_value: padding,
     });
-    build_kernel(&name, &[ptr_ty.clone()], move |m, b, args| {
+    build_kernel(&name, std::slice::from_ref(&ptr_ty), move |m, b, args| {
         // make_tensor_view
         let (mtv, mtv_res) = OpBuilder::new(Opcode::MakeTensorView, Location::Unknown)
             .operand(args[0])
@@ -1011,10 +1016,10 @@ fn test_edge_case_many_parameters() {
             append_op(m, b, op);
             res[0]
         };
-        for i in 2..10 {
+        for &arg in args.iter().take(10).skip(2) {
             let (op, res) = OpBuilder::new(Opcode::AddI, Location::Unknown)
                 .operand(acc)
-                .operand(args[i])
+                .operand(arg)
                 .result(tile_i32())
                 .attr("overflow", Attribute::i32(0))
                 .build(m);
@@ -1510,7 +1515,7 @@ fn test_attrs_all_padding_values_combined() {
     add_entry(
         &mut module,
         "make_partition_view_op",
-        &[ptr_ty.clone()],
+        std::slice::from_ref(&ptr_ty),
         |m, b, args| {
             // make_tensor_view from pointer
             let (mtv, mtv_res) = OpBuilder::new(Opcode::MakeTensorView, Location::Unknown)

--- a/cutile-ir/tests/bytecode_validate.rs
+++ b/cutile-ir/tests/bytecode_validate.rs
@@ -518,75 +518,79 @@ fn load_store_with_tokens() {
         shape: vec![128],
     });
 
-    let module = build_kernel("load_store", &[tile_ptr_f32.clone()], |m, blk, args| {
-        // make_token
-        let (tok_op, tok_res) = OpBuilder::new(Opcode::MakeToken, Location::Unknown)
-            .result(token_ty())
-            .build(m);
-        append_op(m, blk, tok_op);
+    let module = build_kernel(
+        "load_store",
+        std::slice::from_ref(&tile_ptr_f32),
+        |m, blk, args| {
+            // make_token
+            let (tok_op, tok_res) = OpBuilder::new(Opcode::MakeToken, Location::Unknown)
+                .result(token_ty())
+                .build(m);
+            append_op(m, blk, tok_op);
 
-        // make_tensor_view
-        let (mtv, mtv_res) = OpBuilder::new(Opcode::MakeTensorView, Location::Unknown)
-            .operand(args[0])
-            .result(tv_ty.clone())
-            .attr(
-                "operandSegmentSizes",
-                Attribute::Array(vec![
-                    Attribute::Integer(1, i32_ty()),
-                    Attribute::Integer(0, i32_ty()),
-                    Attribute::Integer(0, i32_ty()),
-                ]),
-            )
-            .build(m);
-        append_op(m, blk, mtv);
+            // make_tensor_view
+            let (mtv, mtv_res) = OpBuilder::new(Opcode::MakeTensorView, Location::Unknown)
+                .operand(args[0])
+                .result(tv_ty.clone())
+                .attr(
+                    "operandSegmentSizes",
+                    Attribute::Array(vec![
+                        Attribute::Integer(1, i32_ty()),
+                        Attribute::Integer(0, i32_ty()),
+                        Attribute::Integer(0, i32_ty()),
+                    ]),
+                )
+                .build(m);
+            append_op(m, blk, mtv);
 
-        // make_partition_view
-        let (mpv, mpv_res) = OpBuilder::new(Opcode::MakePartitionView, Location::Unknown)
-            .operand(mtv_res[0])
-            .result(pv_ty.clone())
-            .build(m);
-        append_op(m, blk, mpv);
+            // make_partition_view
+            let (mpv, mpv_res) = OpBuilder::new(Opcode::MakePartitionView, Location::Unknown)
+                .operand(mtv_res[0])
+                .result(pv_ty.clone())
+                .build(m);
+            append_op(m, blk, mpv);
 
-        // load_view_tko
-        let idx = const_i32(m, blk, 0);
-        let (load, load_res) = OpBuilder::new(Opcode::LoadViewTko, Location::Unknown)
-            .operand(mpv_res[0]) // view
-            .operand(idx) // index
-            .operand(tok_res[0]) // token
-            .attr("memory_ordering_semantics", Attribute::Integer(0, i32_ty()))
-            .attr(
-                "operandSegmentSizes",
-                Attribute::Array(vec![
-                    Attribute::Integer(1, i32_ty()),
-                    Attribute::Integer(1, i32_ty()),
-                    Attribute::Integer(1, i32_ty()),
-                ]),
-            )
-            .result(tile_128_f32.clone())
-            .result(token_ty())
-            .build(m);
-        append_op(m, blk, load);
+            // load_view_tko
+            let idx = const_i32(m, blk, 0);
+            let (load, load_res) = OpBuilder::new(Opcode::LoadViewTko, Location::Unknown)
+                .operand(mpv_res[0]) // view
+                .operand(idx) // index
+                .operand(tok_res[0]) // token
+                .attr("memory_ordering_semantics", Attribute::Integer(0, i32_ty()))
+                .attr(
+                    "operandSegmentSizes",
+                    Attribute::Array(vec![
+                        Attribute::Integer(1, i32_ty()),
+                        Attribute::Integer(1, i32_ty()),
+                        Attribute::Integer(1, i32_ty()),
+                    ]),
+                )
+                .result(tile_128_f32.clone())
+                .result(token_ty())
+                .build(m);
+            append_op(m, blk, load);
 
-        // store_view_tko
-        let (store, _) = OpBuilder::new(Opcode::StoreViewTko, Location::Unknown)
-            .operand(load_res[0]) // tile
-            .operand(mpv_res[0]) // view
-            .operand(idx) // index
-            .operand(load_res[1]) // token
-            .attr("memory_ordering_semantics", Attribute::Integer(0, i32_ty()))
-            .attr(
-                "operandSegmentSizes",
-                Attribute::Array(vec![
-                    Attribute::Integer(1, i32_ty()),
-                    Attribute::Integer(1, i32_ty()),
-                    Attribute::Integer(1, i32_ty()),
-                    Attribute::Integer(1, i32_ty()),
-                ]),
-            )
-            .result(token_ty())
-            .build(m);
-        append_op(m, blk, store);
-    });
+            // store_view_tko
+            let (store, _) = OpBuilder::new(Opcode::StoreViewTko, Location::Unknown)
+                .operand(load_res[0]) // tile
+                .operand(mpv_res[0]) // view
+                .operand(idx) // index
+                .operand(load_res[1]) // token
+                .attr("memory_ordering_semantics", Attribute::Integer(0, i32_ty()))
+                .attr(
+                    "operandSegmentSizes",
+                    Attribute::Array(vec![
+                        Attribute::Integer(1, i32_ty()),
+                        Attribute::Integer(1, i32_ty()),
+                        Attribute::Integer(1, i32_ty()),
+                        Attribute::Integer(1, i32_ty()),
+                    ]),
+                )
+                .result(token_ty())
+                .build(m);
+            append_op(m, blk, store);
+        },
+    );
     validate_module(&module);
 }
 
@@ -702,19 +706,17 @@ fn expect_tileiras_rejects(bc: &[u8], name: &str, needle: &str) {
         .arg(&tmp)
         .output();
     let _ = std::fs::remove_file(&tmp);
-    match out {
-        Ok(out) => {
-            assert!(
-                !out.status.success(),
-                "{name}: tileiras unexpectedly accepted invalid debug info"
-            );
-            let stderr = String::from_utf8_lossy(&out.stderr);
-            assert!(
-                stderr.contains(needle),
-                "{name}: rejection reason changed:\n{stderr}"
-            );
-        }
-        Err(_) => {} // tileiras not installed
+    // `Err` means tileiras is not installed; the check is skipped.
+    if let Ok(out) = out {
+        assert!(
+            !out.status.success(),
+            "{name}: tileiras unexpectedly accepted invalid debug info"
+        );
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(
+            stderr.contains(needle),
+            "{name}: rejection reason changed:\n{stderr}"
+        );
     }
 }
 

--- a/cutile-ir/tests/decode_rejection.rs
+++ b/cutile-ir/tests/decode_rejection.rs
@@ -44,9 +44,10 @@ fn build_kernel(
     build_body(&mut module, block_id, &args);
     let needs_return = {
         let block = module.block(block_id);
-        block.ops.last().map_or(true, |&last| {
-            !matches!(module.op(last).opcode, Opcode::Return)
-        })
+        block
+            .ops
+            .last()
+            .is_none_or(|&last| !matches!(module.op(last).opcode, Opcode::Return))
     };
     if needs_return {
         let (ret, _) = OpBuilder::new(Opcode::Return, Location::Unknown).build(&mut module);

--- a/cutile-ir/tests/per_op_roundtrip.rs
+++ b/cutile-ir/tests/per_op_roundtrip.rs
@@ -9,6 +9,9 @@
 //! bytecode, and decodes to verify no errors. These are cheap (no GPU)
 //! and run with every `cargo test`.
 
+// Float literals such as 3.14159 are arbitrary test payloads, not approximations of pi.
+#![allow(clippy::approx_constant)]
+
 use cutile_ir::builder::{append_op, build_single_block_region, OpBuilder};
 use cutile_ir::bytecode::Opcode;
 use cutile_ir::ir::*;
@@ -29,9 +32,10 @@ fn build_kernel(
     // Append return if not already present.
     let needs_return = {
         let block = module.block(block_id);
-        block.ops.last().map_or(true, |&last| {
-            !matches!(module.op(last).opcode, Opcode::Return)
-        })
+        block
+            .ops
+            .last()
+            .is_none_or(|&last| !matches!(module.op(last).opcode, Opcode::Return))
     };
     if needs_return {
         let (ret, _) = OpBuilder::new(Opcode::Return, Location::Unknown).build(&mut module);
@@ -489,13 +493,17 @@ fn roundtrip_make_partition_view() {
         dim_map: vec![0],
         padding_value: None,
     });
-    let module = build_kernel("make_partition_view", &[tv_ty.clone()], |m, b, args| {
-        let (op, _) = OpBuilder::new(Opcode::MakePartitionView, Location::Unknown)
-            .operand(args[0])
-            .result(pv_ty.clone())
-            .build(m);
-        append_op(m, b, op);
-    });
+    let module = build_kernel(
+        "make_partition_view",
+        std::slice::from_ref(&tv_ty),
+        |m, b, args| {
+            let (op, _) = OpBuilder::new(Opcode::MakePartitionView, Location::Unknown)
+                .operand(args[0])
+                .result(pv_ty.clone())
+                .build(m);
+            append_op(m, b, op);
+        },
+    );
     assert_roundtrip(&module);
 }
 
@@ -509,7 +517,7 @@ fn roundtrip_if_op() {
         shape: vec![],
         element_type: TileElementType::Scalar(ScalarType::I1),
     });
-    let module = build_kernel("if_op", &[cond_ty.clone()], |m, b, args| {
+    let module = build_kernel("if_op", std::slice::from_ref(&cond_ty), |m, b, args| {
         // Build then region.
         let (then_region, then_block, _) = build_single_block_region(m, &[]);
         let (ret, _) = OpBuilder::new(Opcode::Yield, Location::Unknown).build(m);
@@ -669,7 +677,7 @@ fn roundtrip_permute() {
         shape: vec![128, 64],
         element_type: TileElementType::Scalar(ScalarType::F32),
     });
-    let module = build_kernel("permute", &[ty.clone()], |m, b, args| {
+    let module = build_kernel("permute", std::slice::from_ref(&ty), |m, b, args| {
         let (op, _) = OpBuilder::new(Opcode::Permute, Location::Unknown)
             .operand(args[0])
             .result(ty_t.clone())
@@ -984,7 +992,7 @@ fn roundtrip_get_tensor_shape() {
         shape: vec![DYNAMIC, DYNAMIC],
         strides: vec![DYNAMIC, 1],
     });
-    let module = build_kernel("gts", &[tv.clone()], |m, b, args| {
+    let module = build_kernel("gts", std::slice::from_ref(&tv), |m, b, args| {
         let (op, _) = OpBuilder::new(Opcode::GetTensorShape, Location::Unknown)
             .operand(args[0])
             .result(scalar_i32())
@@ -1007,7 +1015,7 @@ fn roundtrip_get_index_space_shape() {
         dim_map: vec![0],
         padding_value: None,
     });
-    let module = build_kernel("giss", &[pv.clone()], |m, b, args| {
+    let module = build_kernel("giss", std::slice::from_ref(&pv), |m, b, args| {
         let (op, _) = OpBuilder::new(Opcode::GetIndexSpaceShape, Location::Unknown)
             .operand(args[0])
             .result(scalar_i32())
@@ -2278,7 +2286,7 @@ fn roundtrip_make_partition_view_with_padding() {
         dim_map: vec![0],
         padding_value: Some(PaddingValue::Zero),
     });
-    let module = build_kernel("pv_pad", &[tv.clone()], |m, b, args| {
+    let module = build_kernel("pv_pad", std::slice::from_ref(&tv), |m, b, args| {
         let (op, _) = OpBuilder::new(Opcode::MakePartitionView, Location::Unknown)
             .operand(args[0])
             .result(pv.clone())

--- a/cutile-kernels/Cargo.toml
+++ b/cutile-kernels/Cargo.toml
@@ -12,3 +12,6 @@ readme = "README.md"
 [dependencies]
 cutile = { workspace = true }
 cutile-compiler = { workspace = true }
+
+[lints]
+workspace = true

--- a/cutile-macro/Cargo.toml
+++ b/cutile-macro/Cargo.toml
@@ -25,3 +25,6 @@ phf = { workspace = true }
 convert_case = { workspace = true }
 cutile-compiler = { workspace = true }
 sha2 = { workspace = true }
+
+[lints]
+workspace = true

--- a/cutile-macro/src/_module.rs
+++ b/cutile-macro/src/_module.rs
@@ -372,6 +372,10 @@ fn module_inner(
                 #![allow(nonstandard_style)]
                 #![allow(dead_code)]
                 #![allow(unused_variables)]
+                // Kernel source is a Rust subset with its own idioms (`a = a + b`,
+                // explicit closures for reduce regions, trailing `return`); clippy's
+                // host-Rust style lints do not apply to it.
+                #![allow(clippy::all)]
                 // Module asts and generated type data.
                 use #ast_path;
                 #ast_module_tokens
@@ -384,6 +388,8 @@ fn module_inner(
         quote! {
             pub mod #name {
                 #![allow(dead_code)]
+                // Kernel source is a Rust subset with its own idioms; see above.
+                #![allow(clippy::all)]
                 // Entry point dependencies.
                 // Use of this macro requires cutile,
                 // so all dependencies should be imported relative to cutile.

--- a/cutile-macro/src/rank_instantiation.rs
+++ b/cutile-macro/src/rank_instantiation.rs
@@ -1130,9 +1130,7 @@ impl RankInstantiator {
     /// Rewrite a free-fn signature (generics, args, return) and its body.
     pub fn rewrite_function(mut self, item: &ItemFn) -> Result<ItemFn, Error> {
         let mut item = item.clone();
-        if let Err(e) = rewrite_fn_sig(&mut item.sig, &self.bindings) {
-            return Err(e);
-        }
+        rewrite_fn_sig(&mut item.sig, &self.bindings)?;
         self.visit_block_mut(&mut item.block);
         self.into_result(item)
     }
@@ -1142,13 +1140,8 @@ impl RankInstantiator {
     pub fn rewrite_impl(mut self, item: &ItemImpl) -> Result<ItemImpl, Error> {
         let mut item = item.clone();
         let original_self_ty = (*item.self_ty).clone();
-        match rewrite_type_for_rank(&item.self_ty, &self.bindings) {
-            Ok(t) => *item.self_ty = t,
-            Err(e) => return Err(e),
-        }
-        if let Err(e) = rewrite_generics_for_rank(&mut item.generics, &self.bindings) {
-            return Err(e);
-        }
+        *item.self_ty = rewrite_type_for_rank(&item.self_ty, &self.bindings)?;
+        rewrite_generics_for_rank(&mut item.generics, &self.bindings)?;
         if let Some(trait_) = &mut item.trait_ {
             let path = &mut trait_.1;
             if path.segments.is_empty() {
@@ -1159,9 +1152,7 @@ impl RankInstantiator {
             }
             let last_seg = path.segments.last_mut().unwrap();
             if let PathArguments::AngleBracketed(path_args) = &mut last_seg.arguments {
-                if let Err(e) = rewrite_generic_args_for_rank(path_args, &self.bindings) {
-                    return Err(e);
-                }
+                rewrite_generic_args_for_rank(path_args, &self.bindings)?
             }
         }
 
@@ -1170,10 +1161,7 @@ impl RankInstantiator {
             match item_in_impl {
                 ImplItem::Type(type_impl) => {
                     let mut result = type_impl.clone();
-                    match rewrite_type_for_rank(&type_impl.ty, &self.bindings) {
-                        Ok(t) => result.ty = t,
-                        Err(e) => return Err(e),
-                    }
+                    result.ty = rewrite_type_for_rank(&type_impl.ty, &self.bindings)?;
                     impl_items.push(ImplItem::Type(result));
                 }
                 ImplItem::Const(c) => impl_items.push(ImplItem::Const(c.clone())),
@@ -1185,8 +1173,8 @@ impl RankInstantiator {
                     }
                     let mut result = fn_impl.clone();
                     self.rewrite_impl_method(&original_self_ty, &mut result);
-                    if self.error.is_some() {
-                        return Err(self.error.unwrap());
+                    if let Some(error) = self.error.take() {
+                        return Err(error);
                     }
                     impl_items.push(ImplItem::Fn(result));
                 }
@@ -1444,7 +1432,7 @@ pub fn instantiate_type_alias_for_rank(item: &ItemType) -> Result<ItemType, Erro
     let bindings = RankBindings::from_generics(&item.generics)?;
     let mut item = item.clone();
     rewrite_generics_for_rank(&mut item.generics, &bindings)?;
-    item.ty = Box::new(rewrite_type_for_rank(&item.ty, &bindings)?);
+    *item.ty = rewrite_type_for_rank(&item.ty, &bindings)?;
     Ok(item)
 }
 
@@ -1456,7 +1444,7 @@ pub fn instantiate_type_alias_for_rank(item: &ItemType) -> Result<ItemType, Erro
 pub fn instantiate_static_for_rank(item: &ItemStatic) -> Result<ItemStatic, Error> {
     let bindings = RankBindings::new();
     let mut item = item.clone();
-    item.ty = Box::new(rewrite_type_for_rank(&item.ty, &bindings)?);
+    *item.ty = rewrite_type_for_rank(&item.ty, &bindings)?;
     let concrete_type_ident = concrete_type_ident(&item.ty);
     let mut instantiator = RankInstantiator::new(bindings);
     instantiator.visit_expr_mut(&mut item.expr);

--- a/cutile-macro/src/shadow_dispatch.rs
+++ b/cutile-macro/src/shadow_dispatch.rs
@@ -482,10 +482,8 @@ impl RankPolyOpSpec {
         }
         // Rank-dependent non-shape arg types as trait generics (e.g. `Idx0`
         // for `idx: [i32; N]`). Caller's array literal pins them.
-        for slot in &self.rank_dep_arg_idents {
-            if let Some(id) = slot {
-                all_trait_params.push(quote! { #id });
-            }
+        for id in self.rank_dep_arg_idents.iter().flatten() {
+            all_trait_params.push(quote! { #id });
         }
         if let Some(ref out) = extra_out_trait_param {
             all_trait_params.push(out.clone());
@@ -570,7 +568,7 @@ impl RankPolyOpSpec {
         let mut return_concrete = rewrite_ty_for_rank(&self.return_type, combo, &self.cgas);
         for (orig, replacement) in self.dead_lifetimes.iter().zip(self.dead_lt_idents.iter()) {
             return_concrete =
-                replace_lifetimes_with(&return_concrete, &[orig.clone()], replacement);
+                replace_lifetimes_with(&return_concrete, std::slice::from_ref(orig), replacement);
         }
 
         let mut trait_instantiation_args: Vec<TokenStream2> = Vec::new();
@@ -778,10 +776,8 @@ impl RankPolyOpSpec {
             trait_args.push(quote! { #i });
         }
         // Rank-dep arg generics, matching trait declaration ordering.
-        for slot in &self.rank_dep_arg_idents {
-            if let Some(id) = slot {
-                trait_args.push(quote! { #id });
-            }
+        for id in self.rank_dep_arg_idents.iter().flatten() {
+            trait_args.push(quote! { #id });
         }
         if use_free_out {
             trait_args.push(quote! { #out_ident });
@@ -832,10 +828,8 @@ impl RankPolyOpSpec {
         for i in &extra_shape_generic_idents {
             all_wrapper_generics.push(quote! { #i });
         }
-        for slot in &self.rank_dep_arg_idents {
-            if let Some(id) = slot {
-                all_wrapper_generics.push(quote! { #id });
-            }
+        for id in self.rank_dep_arg_idents.iter().flatten() {
+            all_wrapper_generics.push(quote! { #id });
         }
         if use_free_out {
             all_wrapper_generics.push(quote! { #out_ident });
@@ -1227,12 +1221,12 @@ fn rewrite_literal_cgas_only(ty: &Type) -> Type {
         }
         Type::Reference(r) => {
             let mut new_r = r.clone();
-            new_r.elem = Box::new(rewrite_literal_cgas_only(&r.elem));
+            *new_r.elem = rewrite_literal_cgas_only(&r.elem);
             Type::Reference(new_r)
         }
         Type::Array(a) => {
             let mut new_a = a.clone();
-            new_a.elem = Box::new(rewrite_literal_cgas_only(&a.elem));
+            *new_a.elem = rewrite_literal_cgas_only(&a.elem);
             Type::Array(new_a)
         }
         Type::Tuple(t) => {
@@ -1354,12 +1348,12 @@ fn replace_lifetimes_with(ty: &Type, dead: &[String], replacement: &syn::Lifetim
                     new_r.lifetime = Some(replacement.clone());
                 }
             }
-            new_r.elem = Box::new(replace_lifetimes_with(&r.elem, dead, replacement));
+            *new_r.elem = replace_lifetimes_with(&r.elem, dead, replacement);
             Type::Reference(new_r)
         }
         Type::Array(a) => {
             let mut new_a = a.clone();
-            new_a.elem = Box::new(replace_lifetimes_with(&a.elem, dead, replacement));
+            *new_a.elem = replace_lifetimes_with(&a.elem, dead, replacement);
             Type::Array(new_a)
         }
         Type::Tuple(t) => {
@@ -1551,12 +1545,12 @@ fn rewrite_ty_for_rank(ty: &Type, combo: &RankCombo, cgas: &[CgaInfo]) -> Type {
         }
         Type::Reference(r) => {
             let mut new_r = r.clone();
-            new_r.elem = Box::new(rewrite_ty_for_rank(&r.elem, combo, cgas));
+            *new_r.elem = rewrite_ty_for_rank(&r.elem, combo, cgas);
             Type::Reference(new_r)
         }
         Type::Array(a) => {
             let mut new_a = a.clone();
-            new_a.elem = Box::new(rewrite_ty_for_rank(&a.elem, combo, cgas));
+            *new_a.elem = rewrite_ty_for_rank(&a.elem, combo, cgas);
             if let Expr::Path(ExprPath { path, .. }) = &a.len {
                 if let Some(ident) = path.get_ident() {
                     if let Some(rank) = combo.rank_of_length(ident) {
@@ -1766,7 +1760,7 @@ pub fn desugar_variadic_trait_decl(item: &ItemTrait) -> Result<TokenStream2, Err
     for param in &item.generics.params {
         let drop_it = matches!(
             param,
-            GenericParam::Const(c) if cga_idents.iter().any(|i| *i == c.ident)
+            GenericParam::Const(c) if cga_idents.contains(&c.ident)
         );
         if !drop_it {
             new_params.push(param.clone());
@@ -1964,7 +1958,7 @@ fn emit_variadic_trait_impl_for_rank(
     for param in &item.generics.params {
         let skip = matches!(
             param,
-            GenericParam::Const(c) if cga_idents.iter().any(|i| *i == c.ident)
+            GenericParam::Const(c) if cga_idents.contains(&c.ident)
         );
         if !skip {
             all_impl_params.push(quote! { #param });
@@ -2034,7 +2028,7 @@ fn rewrite_trait_method_for_rank_poly(
                 .map(|(i, _)| i);
             if let Some(i) = cga_idx {
                 if let CgaRole::ShapeBound { sh_ident } = &shape.roles[i] {
-                    pt.ty = Box::new(syn::parse_quote! { #sh_ident });
+                    *pt.ty = syn::parse_quote! { #sh_ident };
                 }
                 // Free CGAs aren't in args by definition (classify_cgas's
                 // post-condition), so reaching this branch with a Free role
@@ -2053,7 +2047,7 @@ fn rewrite_trait_method_for_rank_poly(
             } else {
                 syn::parse_quote! { Self::Out }
             };
-            *ret = Box::new(new_ret);
+            **ret = new_ret;
         }
     }
 }
@@ -2132,13 +2126,13 @@ fn rewrite_impl_method_body_for_rank(
         if let FnArg::Typed(pt) = arg {
             let new_ty = rewrite_ty_for_rank(&pt.ty, combo, cgas);
             let new_ty = bind_anon_lifetimes_to(&new_ty, recv_lt);
-            pt.ty = Box::new(new_ty);
+            *pt.ty = new_ty;
         }
     }
     if let ReturnType::Type(_, ret) = &mut new_sig.output {
         let new_ret = rewrite_ty_for_rank(ret, combo, cgas);
         let new_ret = bind_anon_lifetimes_to(&new_ret, recv_lt);
-        *ret = Box::new(new_ret);
+        **ret = new_ret;
     }
     let muted_args: Vec<TokenStream2> = new_sig
         .inputs
@@ -2197,12 +2191,12 @@ fn bind_anon_lifetimes_to(ty: &Type, lt: &syn::Lifetime) -> Type {
             if r.lifetime.is_none() {
                 new_r.lifetime = Some(lt.clone());
             }
-            new_r.elem = Box::new(bind_anon_lifetimes_to(&r.elem, lt));
+            *new_r.elem = bind_anon_lifetimes_to(&r.elem, lt);
             Type::Reference(new_r)
         }
         Type::Array(a) => {
             let mut new_a = a.clone();
-            new_a.elem = Box::new(bind_anon_lifetimes_to(&a.elem, lt));
+            *new_a.elem = bind_anon_lifetimes_to(&a.elem, lt);
             Type::Array(new_a)
         }
         Type::Tuple(t) => {
@@ -2234,11 +2228,7 @@ fn type_uses_lifetime(ty: &Type) -> bool {
                     for arg in ab.args.iter() {
                         match arg {
                             GenericArgument::Lifetime(_) => return true,
-                            GenericArgument::Type(t) => {
-                                if type_uses_lifetime(t) {
-                                    return true;
-                                }
-                            }
+                            GenericArgument::Type(t) if type_uses_lifetime(t) => return true,
                             _ => {}
                         }
                     }
@@ -2259,10 +2249,7 @@ fn filter_cuda_tile_attrs(attrs: &[syn::Attribute]) -> Vec<syn::Attribute> {
         .iter()
         .filter(|a| {
             let path = a.path();
-            !path
-                .segments
-                .first()
-                .is_some_and(|s| s.ident == "cuda_tile")
+            path.segments.first().is_none_or(|s| s.ident != "cuda_tile")
         })
         .cloned()
         .collect()

--- a/cutile/Cargo.toml
+++ b/cutile/Cargo.toml
@@ -38,3 +38,6 @@ once_cell = { workspace = true }
 tokio = { workspace = true }
 sha2 = { workspace = true }
 trybuild = { workspace = true }
+
+[lints]
+workspace = true

--- a/cutile/src/api.rs
+++ b/cutile/src/api.rs
@@ -833,7 +833,7 @@ pub fn randn_f16<const RANK: usize>(
             let res = value((Arc::new(src_tensor), dst))
                 .then(convert_apply)
                 .unzip();
-            res.1.unpartition().reshape(&shape.to_vec())
+            res.1.unpartition().reshape(shape.as_ref())
         })
     })
 }

--- a/cutile/src/tensor.rs
+++ b/cutile/src/tensor.rs
@@ -1043,7 +1043,7 @@ impl<T: DType> Tensor<T> {
         // spec_ptr, not cu_deviceptr: the sentinel satisfies every DType's
         // alignment (like a real >=256-aligned allocation) without panicking on meta.
         let alignment = align_of::<U>() as u64;
-        if alignment > 1 && self.storage.spec_ptr() % alignment != 0 {
+        if alignment > 1 && !self.storage.spec_ptr().is_multiple_of(alignment) {
             return tensor_error_result(
                 "Tensor storage alignment is incompatible with reinterpret target type.",
             );
@@ -1284,7 +1284,7 @@ impl<T: DType> Reshape for Tensor<T> {
     }
 }
 
-impl<'a, T: DType> Reshape for &'a Arc<Tensor<T>> {
+impl<T: DType> Reshape for &Arc<Tensor<T>> {
     type Output = Arc<Tensor<T>>;
     fn reshape(self, shape: &[usize]) -> Result<Arc<Tensor<T>>, Error> {
         self.reshape_shared(shape)
@@ -1519,7 +1519,7 @@ impl<'a, T: DType> PartitionMut<'a, T> for &'a mut Tensor<T> {
     }
 }
 
-impl<'a, T: DType> Partition<&'a mut Tensor<T>> {
+impl<T: DType> Partition<&mut Tensor<T>> {
     pub fn dtype_str(&self) -> &'static str {
         T::DTYPE.as_str()
     }
@@ -1803,7 +1803,7 @@ impl<T: DType> KernelOutputStored<T> for Partition<Tensor<T>> {
     }
 }
 
-impl<'a, T: DType> KernelOutputStored<T> for Partition<&'a mut Tensor<T>> {
+impl<T: DType> KernelOutputStored<T> for Partition<&mut Tensor<T>> {
     fn grid_bound(&self) -> Result<GridBound, Error> {
         let grid = KernelOutputStored::grid(self)?;
         Ok(if self.prefix_coverage {
@@ -1889,7 +1889,7 @@ impl<T: DType> KernelOutputStored<T> for MappedLaunchPartition<Partition<Tensor<
     }
 }
 
-impl<'a, T: DType> KernelOutputStored<T> for MappedLaunchPartition<Partition<&'a mut Tensor<T>>> {
+impl<T: DType> KernelOutputStored<T> for MappedLaunchPartition<Partition<&mut Tensor<T>>> {
     fn push_kernel_args(&self, launcher: &mut AsyncKernelLaunch) {
         self.partition.push_kernel_args(launcher);
     }
@@ -2031,7 +2031,7 @@ impl<T: DType> KernelInputStored for Arc<Tensor<T>> {
     }
 }
 
-impl<'a, T: DType + Sync> KernelInputStored for &'a Tensor<T> {
+impl<T: DType + Sync> KernelInputStored for &Tensor<T> {
     fn push_kernel_args(&self, launcher: &mut AsyncKernelLaunch) {
         unsafe {
             launcher.push_device_ptr(self.cu_deviceptr());

--- a/cutile/src/tile_kernel.rs
+++ b/cutile/src/tile_kernel.rs
@@ -1323,7 +1323,7 @@ impl<T: DType> KernelArgument for &Partition<Tensor<T>> {
 }
 
 /// Same as above but for borrowed mutable tensor partitions.
-impl<'a, T: DType> KernelArgument for &Partition<&'a mut Tensor<T>> {
+impl<T: DType> KernelArgument for &Partition<&mut Tensor<T>> {
     fn push_arg(self, launcher: &mut AsyncKernelLaunch) {
         unsafe {
             launcher.push_device_ptr(self.object.cu_deviceptr());

--- a/cutile/tests/autotune.rs
+++ b/cutile/tests/autotune.rs
@@ -160,7 +160,7 @@ fn record_end_to_end_with_real_l2_verification() {
                     "gate: wrong scale result".into(),
                 )));
             }
-            Ok(move |s: &std::sync::Arc<cuda_core::Stream>| launch(s).map_err(Into::into))
+            Ok(move |s: &std::sync::Arc<cuda_core::Stream>| launch(s))
         })
         .expect("tuning run");
 

--- a/cutile/tests/basics_and_inlining.rs
+++ b/cutile/tests/basics_and_inlining.rs
@@ -2,7 +2,6 @@
  * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-use cutile;
 use cutile_compiler::compiler::utils::CompileOptions;
 
 mod common;
@@ -485,7 +484,7 @@ fn compile_ir(function_name: &str, generics: &[String], strides: &[(&str, &[i32]
 }
 
 #[test]
-fn compile_inline_tensor_from_ptr_helper() -> () {
+fn compile_inline_tensor_from_ptr_helper() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir("inline_tensor_from_ptr_kernel", &["f32".to_string()], &[]);
         assert!(
@@ -497,7 +496,7 @@ fn compile_inline_tensor_from_ptr_helper() -> () {
 }
 
 #[test]
-fn compile_ptr_partition_load_helper() -> () {
+fn compile_ptr_partition_load_helper() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir("ptr_partition_load_kernel", &["f32".to_string()], &[]);
         assert!(
@@ -512,7 +511,7 @@ fn compile_ptr_partition_load_helper() -> () {
 }
 
 #[test]
-fn compile_shift_ops_kernel() -> () {
+fn compile_shift_ops_kernel() {
     common::with_test_stack(|| {
         let module_op_str =
             compile_ir("shift_ops_kernel", &[], &[("x", &[1][..]), ("z", &[1][..])]);
@@ -528,7 +527,7 @@ fn compile_shift_ops_kernel() -> () {
 }
 
 #[test]
-fn compile_ptr_partition_mut_store_helper() -> () {
+fn compile_ptr_partition_mut_store_helper() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir("ptr_partition_mut_store_kernel", &[], &[]);
         assert!(
@@ -543,7 +542,7 @@ fn compile_ptr_partition_mut_store_helper() -> () {
 }
 
 #[test]
-fn compile_partition_mut_store_rank3_loop() -> () {
+fn compile_partition_mut_store_rank3_loop() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir(
             "partition_mut_store_rank3_loop_kernel",
@@ -558,7 +557,7 @@ fn compile_partition_mut_store_rank3_loop() -> () {
 }
 
 #[test]
-fn compile_partition_mut_store_loaded_rank3_loop() -> () {
+fn compile_partition_mut_store_loaded_rank3_loop() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir(
             "partition_mut_store_loaded_rank3_loop_kernel",
@@ -573,7 +572,7 @@ fn compile_partition_mut_store_loaded_rank3_loop() -> () {
 }
 
 #[test]
-fn compile_inlining() -> () {
+fn compile_inlining() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir(
             "inlining_kernel",
@@ -592,7 +591,7 @@ fn compile_inlining() -> () {
 }
 
 #[test]
-fn compile_scalar_bool_condition() -> () {
+fn compile_scalar_bool_condition() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir(
             "scalar_bool_condition_kernel",
@@ -604,7 +603,7 @@ fn compile_scalar_bool_condition() -> () {
 }
 
 #[test]
-fn compile_basics() -> () {
+fn compile_basics() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir(
             "basics_kernel",
@@ -616,7 +615,7 @@ fn compile_basics() -> () {
 }
 
 #[test]
-fn compile_negative_constant() -> () {
+fn compile_negative_constant() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir(
             "negative_constant_kernel",
@@ -629,7 +628,7 @@ fn compile_negative_constant() -> () {
 }
 
 #[test]
-fn compile_ptr_tile_reshape() -> () {
+fn compile_ptr_tile_reshape() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir("ptr_tile_reshape_kernel", &[], &[]);
         println!("{module_op_str}");

--- a/cutile/tests/binary_math_ops.rs
+++ b/cutile/tests/binary_math_ops.rs
@@ -2,7 +2,6 @@
  * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-use cutile;
 use cutile_compiler::compiler::utils::CompileOptions;
 
 mod common;
@@ -118,7 +117,7 @@ fn compile_ir(function_name: &str, generics: &[String], strides: &[(&str, &[i32]
 }
 
 #[test]
-fn compile_minmax() -> () {
+fn compile_minmax() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir("minmax_kernel", &[128.to_string()], &[("output", &[1])]);
         println!("\n=== MIN/MAX MLIR ===\n{}", module_op_str);
@@ -140,7 +139,7 @@ fn compile_minmax() -> () {
 }
 
 #[test]
-fn compile_select() -> () {
+fn compile_select() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir("select_kernel", &[128.to_string()], &[("output", &[1])]);
         println!("\n=== SELECT MLIR ===\n{}", module_op_str);
@@ -159,7 +158,7 @@ fn compile_select() -> () {
 }
 
 #[test]
-fn compile_bf16_binary_arith() -> () {
+fn compile_bf16_binary_arith() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir(
             "bf16_binary_arith_kernel",
@@ -183,7 +182,7 @@ fn compile_bf16_binary_arith() -> () {
 }
 
 #[test]
-fn compile_addf_shadow_dispatch() -> () {
+fn compile_addf_shadow_dispatch() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir(
             "addf_shadow_dispatch_kernel",
@@ -199,7 +198,7 @@ fn compile_addf_shadow_dispatch() -> () {
 }
 
 #[test]
-fn compile_reshape_shadow_dispatch() -> () {
+fn compile_reshape_shadow_dispatch() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir(
             "reshape_shadow_dispatch_kernel",
@@ -215,7 +214,7 @@ fn compile_reshape_shadow_dispatch() -> () {
 }
 
 #[test]
-fn compile_reduce_sum_shadow_dispatch() -> () {
+fn compile_reduce_sum_shadow_dispatch() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir(
             "reduce_sum_shadow_dispatch_kernel",
@@ -234,7 +233,7 @@ fn compile_reduce_sum_shadow_dispatch() -> () {
 }
 
 #[test]
-fn compile_addf_shadow_dispatch_nested() -> () {
+fn compile_addf_shadow_dispatch_nested() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir(
             "addf_shadow_dispatch_nested_kernel",

--- a/cutile/tests/bitwise_and_bitcast_ops.rs
+++ b/cutile/tests/bitwise_and_bitcast_ops.rs
@@ -2,7 +2,6 @@
  * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-use cutile;
 use cutile_compiler::compiler::utils::CompileOptions;
 
 mod common;
@@ -65,7 +64,7 @@ fn compile_ir(function_name: &str, generics: &[String], strides: &[(&str, &[i32]
 }
 
 #[test]
-fn compile_bitwise_ops() -> () {
+fn compile_bitwise_ops() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir(
             "bitwise_ops_kernel",
@@ -91,7 +90,7 @@ fn compile_bitwise_ops() -> () {
 }
 
 #[test]
-fn compile_bitcast() -> () {
+fn compile_bitcast() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir("bitcast_kernel", &[128.to_string()], &[("output", &[1])]);
         println!("\n=== BITCAST MLIR ===\n{}", module_op_str);
@@ -106,7 +105,7 @@ fn compile_bitcast() -> () {
 }
 
 #[test]
-fn compile_shri_unsigned() -> () {
+fn compile_shri_unsigned() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir(
             "shri_unsigned_kernel",

--- a/cutile/tests/check_placement_ratchet.rs
+++ b/cutile/tests/check_placement_ratchet.rs
@@ -22,7 +22,6 @@
 //! Keep this corpus FROZEN: it is a measurement instrument, not a feature
 //! test. New behavior gets new tests elsewhere.
 
-use cutile;
 use cutile_compiler::compiler::utils::CompileOptions;
 
 mod common;

--- a/cutile/tests/checked_store_corpus.rs
+++ b/cutile/tests/checked_store_corpus.rs
@@ -19,7 +19,6 @@
 //! in `inferred_axis_bounds.rs`. There is no `partition_permuted_mut`, so the
 //! permuted case is only reachable through loads.
 
-use cutile;
 use cutile_compiler::compiler::utils::CompileOptions;
 
 mod common;

--- a/cutile/tests/common/mod.rs
+++ b/cutile/tests/common/mod.rs
@@ -41,6 +41,7 @@ pub fn cache_test_lock() -> MutexGuard<'static, ()> {
 /// - With reduce/scan operations: ~2.7 MB
 /// - With all unary math operations: ~5 MB (after adding absf, negf, negi, floor)
 /// - tensor_views module tests require a bit more headroom.
+///
 /// Using 8 MB provides an adequate safety margin for all tests.
 pub const TEST_STACK_SIZE: usize = 8_000_000; // 8 MB
 

--- a/cutile/tests/compile_error_quality.rs
+++ b/cutile/tests/compile_error_quality.rs
@@ -5,7 +5,6 @@
 
 //! Compile-only error-quality tests.
 
-use cutile;
 use cutile_compiler::ast::Module;
 use cutile_compiler::compiler::utils::CompileOptions;
 use cutile_compiler::error::JITError;

--- a/cutile/tests/control_flow_ops.rs
+++ b/cutile/tests/control_flow_ops.rs
@@ -309,7 +309,7 @@ fn compile_ir(function_name: &str, generics: &[String], strides: &[(&str, &[i32]
 }
 
 #[test]
-fn compile_control_flow_test() -> () {
+fn compile_control_flow_test() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir(
             "control_flow_test_kernel",
@@ -339,7 +339,7 @@ fn compile_control_flow_test() -> () {
 }
 
 #[test]
-fn execute_if_result_test() -> () {
+fn execute_if_result_test() {
     common::with_test_stack(|| {
         let arg: Tensor<i64> = ones(&[16]).sync().expect("Failed.");
         // If true, double and add 2.
@@ -360,7 +360,7 @@ fn execute_if_result_test() -> () {
 }
 
 #[test]
-fn execute_break_test() -> () {
+fn execute_break_test() {
     common::with_test_stack(|| {
         // break_test_kernel loads output, doubles it twice (loop runs 2 iterations then breaks),
         // and stores the result. Starting from 1.0, we expect 1.0 * 2 * 2 = 4.0.
@@ -378,7 +378,7 @@ fn execute_break_test() -> () {
 }
 
 #[test]
-fn compile_break_test() -> () {
+fn compile_break_test() {
     common::with_test_stack(|| {
         let module_op_str =
             compile_ir("break_test_kernel", &[128.to_string()], &[("output", &[1])]);
@@ -395,7 +395,7 @@ fn compile_break_test() -> () {
 }
 
 #[test]
-fn compile_while_loop_test() -> () {
+fn compile_while_loop_test() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir(
             "while_loop_test_kernel",
@@ -415,7 +415,7 @@ fn compile_while_loop_test() -> () {
 }
 
 #[test]
-fn compile_loop_test() -> () {
+fn compile_loop_test() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir(
             "infinite_loop_test_kernel",
@@ -435,7 +435,7 @@ fn compile_loop_test() -> () {
 }
 
 #[test]
-fn compile_step_by_test() -> () {
+fn compile_step_by_test() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir(
             "step_by_test_kernel",
@@ -456,7 +456,7 @@ fn compile_step_by_test() -> () {
 }
 
 #[test]
-fn compile_assume_test() -> () {
+fn compile_assume_test() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir(
             "assume_test_kernel",
@@ -484,7 +484,7 @@ fn compile_assume_test() -> () {
 }
 
 #[test]
-fn compile_assume_non_negative_test() -> () {
+fn compile_assume_non_negative_test() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir(
             "assume_non_negative_test_kernel",
@@ -507,7 +507,7 @@ fn compile_assume_non_negative_test() -> () {
 }
 
 #[test]
-fn compile_assume_div_by_test() -> () {
+fn compile_assume_div_by_test() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir(
             "assume_div_by_test_kernel",
@@ -530,7 +530,7 @@ fn compile_assume_div_by_test() -> () {
 }
 
 #[test]
-fn compile_assume_same_elements_test() -> () {
+fn compile_assume_same_elements_test() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir(
             "assume_same_elements_test_kernel",

--- a/cutile/tests/do_bench.rs
+++ b/cutile/tests/do_bench.rs
@@ -8,7 +8,6 @@
 use cuda_core::Device;
 use cutile::bench::{do_bench, do_bench_paired, BenchOptions};
 use cutile::prelude::*;
-use std::sync::Arc;
 use std::time::Duration;
 
 fn quick_opts() -> BenchOptions {

--- a/cutile/tests/dtype_float_ops.rs
+++ b/cutile/tests/dtype_float_ops.rs
@@ -10,7 +10,6 @@
 //! 4. Verify correctness on the host
 
 use cuda_core::{f8e4m3fn, f8e5m2};
-use cutile;
 use cutile::tensor::PartitionMut;
 use cutile::tile_kernel::{DeviceOp, ToHostVecOp};
 use half::{bf16, f16};

--- a/cutile/tests/element_type_zero.rs
+++ b/cutile/tests/element_type_zero.rs
@@ -11,6 +11,7 @@
 use cutile::core::{bf16, f16, f8e4m3fn, f8e5m2, tf32, ElementType};
 
 #[test]
+#[allow(clippy::assertions_on_constants)] // the constants are what is under test
 fn zero_values_match_expected() {
     assert_eq!(<f16 as ElementType>::ZERO, f16::ZERO);
     assert_eq!(<bf16 as ElementType>::ZERO, bf16::ZERO);
@@ -24,13 +25,14 @@ fn zero_values_match_expected() {
     assert_eq!(<u32 as ElementType>::ZERO, 0u32);
     assert_eq!(<i64 as ElementType>::ZERO, 0i64);
     assert_eq!(<u64 as ElementType>::ZERO, 0u64);
-    assert_eq!(<bool as ElementType>::ZERO, false);
+    assert!(!<bool as ElementType>::ZERO);
     assert_eq!(<tf32 as ElementType>::ZERO, tf32(0));
     assert_eq!(<f8e4m3fn as ElementType>::ZERO, f8e4m3fn(0));
     assert_eq!(<f8e5m2 as ElementType>::ZERO, f8e5m2(0));
 }
 
 #[test]
+#[allow(clippy::assertions_on_constants)] // the constants are what is under test
 fn zero_usable_in_const_context() {
     const F32_ZERO: f32 = <f32 as ElementType>::ZERO;
     const I32_ZERO: i32 = <i32 as ElementType>::ZERO;

--- a/cutile/tests/element_type_zero_jit.rs
+++ b/cutile/tests/element_type_zero_jit.rs
@@ -10,7 +10,6 @@
 //! `generic_args.inst_types` lookup was added to the Expr::Path branch in
 //! `compile_cuda_tile_op.rs`.
 
-use cutile;
 use cutile_compiler::compiler::utils::CompileOptions;
 
 mod common;

--- a/cutile/tests/error_quality.rs
+++ b/cutile/tests/error_quality.rs
@@ -6,7 +6,6 @@
 //! CPU integration tests for error message quality, formatting consistency,
 //! and source-location utilities that do not need CUDA runtime access.
 
-use cutile;
 use cutile_compiler::error::JITError;
 
 mod common;

--- a/cutile/tests/flash_attention_compile.rs
+++ b/cutile/tests/flash_attention_compile.rs
@@ -5,7 +5,6 @@
 
 //! Compile-only coverage for the example flash-attention kernels.
 
-use cutile;
 use cutile::compile_api::KernelCompiler;
 
 mod common;

--- a/cutile/tests/global_memory.rs
+++ b/cutile/tests/global_memory.rs
@@ -2,7 +2,6 @@
  * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-use cutile;
 use cutile_compiler::compiler::utils::CompileOptions;
 
 mod common;

--- a/cutile/tests/gpu/async_saxpy_unsafe.rs
+++ b/cutile/tests/gpu/async_saxpy_unsafe.rs
@@ -4,7 +4,7 @@
  */
 
 //! Smoke test: raw async compile-and-launch path via `compile_from_context`
-//! + `AsyncKernelLaunch`. Exercises the low-level async API that higher-
+//! and `AsyncKernelLaunch`. Exercises the low-level async API that higher-
 //! level kernel launchers wrap.
 
 use cuda_async::device_operation::{value, with_context, DeviceOp};

--- a/cutile/tests/gpu/audit_module_consts.rs
+++ b/cutile/tests/gpu/audit_module_consts.rs
@@ -17,7 +17,6 @@ use crate::common;
 /// uses it in a value position.
 #[cutile::module]
 mod const_helper_module {
-    use cutile::core::*;
 
     const N: i32 = 64;
 

--- a/cutile/tests/gpu/launcher_guards.rs
+++ b/cutile/tests/gpu/launcher_guards.rs
@@ -164,8 +164,7 @@ fn generics_must_match_pointer_element_types() {
             .generics(vec!["f16".to_string()])
             .grid((1, 1, 1))
             .sync()
-            .err()
-            .expect("f16 specialization over a DevicePointer<f32> must be rejected");
+            .expect_err("f16 specialization over a DevicePointer<f32> must be rejected");
         let msg = format!("{err}");
         assert!(msg.contains("element type mismatch"), "{msg}");
         assert!(msg.contains("DevicePointer<f32>"), "{msg}");

--- a/cutile/tests/gpu/num_tiles.rs
+++ b/cutile/tests/gpu/num_tiles.rs
@@ -44,7 +44,7 @@ mod kernels {
 }
 
 fn cdiv(n: usize, d: usize) -> usize {
-    (n + d - 1) / d
+    n.div_ceil(d)
 }
 
 /// Launches the axis-0 kernel on an input of shape `[m, n]` with tile `[bm, bn]`,

--- a/cutile/tests/gpu/tensor_guards.rs
+++ b/cutile/tests/gpu/tensor_guards.rs
@@ -67,9 +67,7 @@ fn reshape_op_rejects_shape_that_exceeds_storage() {
     // this returned a [32] tensor whose every later launch read 64 bytes past
     // the allocation (reproduced under compute-sanitizer).
     let result = api::ones::<f32>(&[16]).reshape(&[32]).sync();
-    let err = result
-        .err()
-        .expect("reshape to a larger element count must fail");
+    let err = result.expect_err("reshape to a larger element count must fail");
     let msg = format!("{err}");
     assert!(
         msg.contains("preserve tensor size"),
@@ -93,8 +91,7 @@ fn oversized_allocation_is_an_error_not_a_panic() {
     // 2^44 f32 elements = 64 TiB, beyond any device.
     let err = Tensor::<f32>::uninitialized(1usize << 44)
         .sync()
-        .err()
-        .expect("oversized allocation must fail");
+        .expect_err("oversized allocation must fail");
     let msg = format!("{err:?}");
     assert!(
         msg.contains("Driver"),

--- a/cutile/tests/inferred_axis_bounds.rs
+++ b/cutile/tests/inferred_axis_bounds.rs
@@ -17,7 +17,6 @@
 //! kernel places its checks exactly where its annotated twin does. That
 //! equality is the precondition for removing the annotations entirely.
 
-use cutile;
 use cutile_compiler::compiler::utils::CompileOptions;
 
 mod common;

--- a/cutile/tests/integer_ops.rs
+++ b/cutile/tests/integer_ops.rs
@@ -2,7 +2,6 @@
  * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-use cutile;
 use cutile::compile_api::KernelCompiler;
 use cutile_compiler::compiler::utils::CompileOptions;
 
@@ -90,7 +89,7 @@ fn compile_ir(function_name: &str, generics: &[String], strides: &[(&str, &[i32]
 }
 
 #[test]
-fn compile_maxi() -> () {
+fn compile_maxi() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir("maxi_kernel", &[128.to_string()], &[("output", &[1])]);
         println!("\n=== MAXI MLIR ===\n{}", module_op_str);
@@ -109,7 +108,7 @@ fn compile_maxi() -> () {
 }
 
 #[test]
-fn compile_mini() -> () {
+fn compile_mini() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir("mini_kernel", &[128.to_string()], &[("output", &[1])]);
         println!("\n=== MINI MLIR ===\n{}", module_op_str);
@@ -126,7 +125,7 @@ fn compile_mini() -> () {
 }
 
 #[test]
-fn compile_mulhii() -> () {
+fn compile_mulhii() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir("mulhii_kernel", &[128.to_string()], &[("output", &[1])]);
         println!("\n=== MULHII MLIR ===\n{}", module_op_str);
@@ -141,7 +140,7 @@ fn compile_mulhii() -> () {
 }
 
 #[test]
-fn compile_maxi_unsigned() -> () {
+fn compile_maxi_unsigned() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir(
             "maxi_unsigned_kernel",
@@ -164,7 +163,7 @@ fn compile_maxi_unsigned() -> () {
 }
 
 #[test]
-fn compile_named_integer_arithmetic() -> () {
+fn compile_named_integer_arithmetic() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir(
             "named_integer_arithmetic_kernel",
@@ -205,7 +204,7 @@ fn named_integer_arithmetic_serializes_bytecode() {
 }
 
 #[test]
-fn compile_cmpi() -> () {
+fn compile_cmpi() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir("cmpi_kernel", &[128.to_string()], &[("output", &[1])]);
         println!("\n=== CMPI MLIR ===\n{}", module_op_str);

--- a/cutile/tests/kernel_compiler.rs
+++ b/cutile/tests/kernel_compiler.rs
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use cutile;
 use cutile::compile_api::KernelCompiler;
 use cutile::cutile_compiler::cuda_tile_runtime_utils::{
     serialize_tile_ir_bytecode, tileiras_fingerprint, TileirasOptions,

--- a/cutile/tests/load_tile_like_examples.rs
+++ b/cutile/tests/load_tile_like_examples.rs
@@ -9,7 +9,6 @@
 //! instead of ascribing the returned tile type. These tests exercise the same
 //! JIT path without requiring a CUDA device.
 
-use cutile;
 use cutile_compiler::compiler::utils::CompileOptions;
 
 mod common;

--- a/cutile/tests/memory_and_atomic_ops.rs
+++ b/cutile/tests/memory_and_atomic_ops.rs
@@ -2,7 +2,6 @@
  * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-use cutile;
 use cutile_compiler::compiler::utils::CompileOptions;
 
 mod common;
@@ -568,7 +567,7 @@ fn compile_ir(function_name: &str, generics: &[String], strides: &[(&str, &[i32]
 }
 
 #[test]
-fn compile_join_tokens() -> () {
+fn compile_join_tokens() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir(
             "join_tokens_kernel",
@@ -602,7 +601,7 @@ fn compile_join_tokens() -> () {
 }
 
 #[test]
-fn compile_print_tko() -> () {
+fn compile_print_tko() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir("print_tko_kernel", &[128.to_string()], &[("output", &[1])]);
         println!("\n=== PRINT_TKO MLIR ===\n{}", module_op_str);
@@ -619,7 +618,7 @@ fn compile_print_tko() -> () {
 }
 
 #[test]
-fn compile_ptr_load_store() -> () {
+fn compile_ptr_load_store() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir(
             "ptr_load_store_kernel",
@@ -676,7 +675,7 @@ fn compile_ptr_load_store() -> () {
 }
 
 #[test]
-fn compile_load_ptr_weak() -> () {
+fn compile_load_ptr_weak() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir(
             "load_ptr_weak_kernel",
@@ -699,7 +698,7 @@ fn compile_load_ptr_weak() -> () {
 }
 
 #[test]
-fn compile_load_ptr_acquire() -> () {
+fn compile_load_ptr_acquire() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir(
             "load_ptr_acquire_kernel",
@@ -722,7 +721,7 @@ fn compile_load_ptr_acquire() -> () {
 }
 
 #[test]
-fn compile_load_ptr_with_token() -> () {
+fn compile_load_ptr_with_token() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir(
             "load_ptr_with_token_kernel",
@@ -750,7 +749,7 @@ fn compile_load_ptr_with_token() -> () {
 }
 
 #[test]
-fn compile_load_ptr_with_mask() -> () {
+fn compile_load_ptr_with_mask() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir(
             "load_ptr_with_mask_kernel",
@@ -778,7 +777,7 @@ fn compile_load_ptr_with_mask() -> () {
 }
 
 #[test]
-fn compile_store_ptr_release() -> () {
+fn compile_store_ptr_release() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir(
             "store_ptr_release_kernel",
@@ -801,7 +800,7 @@ fn compile_store_ptr_release() -> () {
 }
 
 #[test]
-fn compile_store_ptr_with_mask() -> () {
+fn compile_store_ptr_with_mask() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir(
             "store_ptr_with_mask_kernel",
@@ -828,7 +827,7 @@ fn compile_store_ptr_with_mask() -> () {
 }
 
 #[test]
-fn compile_atomic_rmw() -> () {
+fn compile_atomic_rmw() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir(
             "atomic_rmw_kernel",
@@ -863,7 +862,7 @@ fn compile_atomic_rmw() -> () {
 }
 
 #[test]
-fn compile_atomic_cas() -> () {
+fn compile_atomic_cas() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir(
             "atomic_cas_kernel",
@@ -899,7 +898,7 @@ fn compile_atomic_cas() -> () {
 }
 
 #[test]
-fn compile_atomic_cas_with_mask() -> () {
+fn compile_atomic_cas_with_mask() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir(
             "atomic_cas_with_mask_kernel",
@@ -927,7 +926,7 @@ fn compile_atomic_cas_with_mask() -> () {
 }
 
 #[test]
-fn compile_atomic_cas_acq_rel_sys() -> () {
+fn compile_atomic_cas_acq_rel_sys() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir(
             "atomic_cas_acq_rel_sys_kernel",
@@ -955,7 +954,7 @@ fn compile_atomic_cas_acq_rel_sys() -> () {
 }
 
 #[test]
-fn compile_atomic_and() -> () {
+fn compile_atomic_and() {
     common::with_test_stack(|| {
         let module_op_str =
             compile_ir("atomic_and_kernel", &[128.to_string()], &[("output", &[1])]);
@@ -979,7 +978,7 @@ fn compile_atomic_and() -> () {
 }
 
 #[test]
-fn compile_atomic_add() -> () {
+fn compile_atomic_add() {
     common::with_test_stack(|| {
         let module_op_str =
             compile_ir("atomic_add_kernel", &[128.to_string()], &[("output", &[1])]);
@@ -1003,7 +1002,7 @@ fn compile_atomic_add() -> () {
 }
 
 #[test]
-fn compile_atomic_max() -> () {
+fn compile_atomic_max() {
     common::with_test_stack(|| {
         let module_op_str =
             compile_ir("atomic_max_kernel", &[128.to_string()], &[("output", &[1])]);
@@ -1027,7 +1026,7 @@ fn compile_atomic_max() -> () {
 }
 
 #[test]
-fn compile_atomic_rmw_with_mask() -> () {
+fn compile_atomic_rmw_with_mask() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir(
             "atomic_rmw_with_mask_kernel",
@@ -1054,7 +1053,7 @@ fn compile_atomic_rmw_with_mask() -> () {
 }
 
 #[test]
-fn compile_atomic_rmw_with_token() -> () {
+fn compile_atomic_rmw_with_token() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir(
             "atomic_rmw_with_token_kernel",
@@ -1081,7 +1080,7 @@ fn compile_atomic_rmw_with_token() -> () {
 }
 
 #[test]
-fn compile_atomic_xchg() -> () {
+fn compile_atomic_xchg() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir(
             "atomic_xchg_kernel",
@@ -1108,7 +1107,7 @@ fn compile_atomic_xchg() -> () {
 }
 
 #[test]
-fn compile_padded_partition_view() -> () {
+fn compile_padded_partition_view() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir(
             "padded_partition_view_kernel",
@@ -1131,7 +1130,7 @@ fn compile_padded_partition_view() -> () {
 }
 
 #[test]
-fn compile_atomic_red_view_tko() -> () {
+fn compile_atomic_red_view_tko() {
     common::with_test_stack(|| {
         let module_op_str = common::compile_to_ir(
             atomic_red_view_module::__module_ast_self,
@@ -1180,7 +1179,7 @@ mod gather_scatter_view_module {
 }
 
 #[test]
-fn compile_make_gather_scatter_view() -> () {
+fn compile_make_gather_scatter_view() {
     common::with_test_stack(|| {
         let module_op_str = common::compile_to_ir(
             gather_scatter_view_module::__module_ast_self,
@@ -1229,7 +1228,7 @@ mod strided_view_module {
 }
 
 #[test]
-fn compile_make_strided_view() -> () {
+fn compile_make_strided_view() {
     common::with_test_stack(|| {
         let module_op_str = common::compile_to_ir(
             strided_view_module::__module_ast_self,
@@ -1281,7 +1280,7 @@ mod strided_view_permuted_module {
 }
 
 #[test]
-fn compile_strided_view_threads_dim_map() -> () {
+fn compile_strided_view_threads_dim_map() {
     common::with_test_stack(|| {
         let module_op_str = common::compile_to_ir(
             strided_view_permuted_module::__module_ast_self,

--- a/cutile/tests/num_tiles_jit.rs
+++ b/cutile/tests/num_tiles_jit.rs
@@ -10,7 +10,6 @@
 //! the axis-th result. No GPU execution — these tests only cover the
 //! DSL → IR lowering path.
 
-use cutile;
 use cutile_compiler::compiler::utils::CompileOptions;
 
 mod common;

--- a/cutile/tests/optimization_hints.rs
+++ b/cutile/tests/optimization_hints.rs
@@ -7,7 +7,6 @@
 // must keep working unchanged until it is removed.
 #![allow(deprecated)]
 
-use cutile;
 use cutile_compiler::compiler::utils::CompileOptions;
 
 mod common;

--- a/cutile/tests/partition_access_soundness.rs
+++ b/cutile/tests/partition_access_soundness.rs
@@ -10,7 +10,6 @@
 //! foreign mapped index against a permuted target must discharge against the
 //! REMAPPED root axis, not the logical coordinate.
 
-use cutile;
 use cutile_compiler::compiler::utils::CompileOptions;
 
 mod common;

--- a/cutile/tests/partition_index_schedules.rs
+++ b/cutile/tests/partition_index_schedules.rs
@@ -7,7 +7,6 @@
 // annotation path deliberately.
 #![allow(deprecated)]
 
-use cutile;
 use cutile_compiler::compiler::utils::CompileOptions;
 
 mod common;

--- a/cutile/tests/reduce_scan_ops.rs
+++ b/cutile/tests/reduce_scan_ops.rs
@@ -2,7 +2,6 @@
  * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-use cutile;
 use cutile_compiler::compiler::utils::CompileOptions;
 
 mod common;
@@ -110,7 +109,7 @@ fn compile_ir(function_name: &str, generics: &[String], strides: &[(&str, &[i32]
 }
 
 #[test]
-fn compile_scan_sum_test() -> () {
+fn compile_scan_sum_test() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir(
             "scan_sum_test_kernel",
@@ -142,7 +141,7 @@ fn compile_scan_sum_test() -> () {
 }
 
 #[test]
-fn compile_reduce_closure_test() -> () {
+fn compile_reduce_closure_test() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir(
             "reduce_closure_test_kernel",
@@ -177,7 +176,7 @@ fn compile_reduce_closure_test() -> () {
 }
 
 #[test]
-fn compile_reduce_product_closure_test() -> () {
+fn compile_reduce_product_closure_test() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir(
             "reduce_product_closure_test_kernel",
@@ -212,7 +211,7 @@ fn compile_reduce_product_closure_test() -> () {
 }
 
 #[test]
-fn compile_reduce_max_closure_test() -> () {
+fn compile_reduce_max_closure_test() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir(
             "reduce_max_closure_test_kernel",
@@ -247,7 +246,7 @@ fn compile_reduce_max_closure_test() -> () {
 }
 
 #[test]
-fn compile_scan_closure_test() -> () {
+fn compile_scan_closure_test() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir(
             "scan_closure_test_kernel",

--- a/cutile/tests/slice_non_divisible.rs
+++ b/cutile/tests/slice_non_divisible.rs
@@ -421,7 +421,7 @@ fn partition_load_bounds_check_static() {
     common::with_test_stack(|| {
         let n: usize = 1000;
         let b: usize = 128;
-        let nblocks = (n + b - 1) / b; // = 8
+        let nblocks = n.div_ceil(b); // = 8
         let generics = vec![b.to_string(), n.to_string(), nblocks.to_string()];
 
         let a: Arc<Tensor<f32>> = api::ones::<f32>(&[n]).sync().expect("alloc a").into();

--- a/cutile/tests/span_source_location.rs
+++ b/cutile/tests/span_source_location.rs
@@ -32,7 +32,6 @@
 //!    number, and column number — proving that `source_text()` correctly
 //!    preserves comments in the captured text.
 
-use cutile;
 use cutile_compiler::compiler::utils::CompileOptions;
 use cutile_compiler::error::JITError;
 

--- a/cutile/tests/specialization_bits.rs
+++ b/cutile/tests/specialization_bits.rs
@@ -2,7 +2,6 @@
  * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-use cutile;
 use cutile::api;
 use cutile::tile_kernel::{DeviceOp, TileKernel};
 use cutile_compiler::compiler::utils::CompileOptions;
@@ -76,7 +75,7 @@ fn compile_kernel(
     scalar_hints: &[(&str, &DivHint)],
     options: &CompileOptions,
 ) -> String {
-    let result = common::compile_to_ir(
+    common::compile_to_ir(
         __module_ast_self,
         "spec_test_module",
         name,
@@ -87,8 +86,7 @@ fn compile_kernel(
         None,
         options,
     )
-    .expect("Failed to compile");
-    result
+    .expect("Failed to compile")
 }
 
 // -- SpecializationBits produces correct assume_div_by in MLIR --

--- a/cutile/tests/tensor_and_matrix_ops.rs
+++ b/cutile/tests/tensor_and_matrix_ops.rs
@@ -2,7 +2,6 @@
  * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-use cutile;
 use cutile::cuda_core::{f4e2m1fnx2, f8e4m3fn};
 use cutile::prelude::{
     api, Arc, Device, DeviceOp, DeviceOpReshape, IntoPartition, Tensor, ToHostVec,
@@ -319,7 +318,7 @@ fn compile_ir(function_name: &str, generics: &[String], strides: &[(&str, &[i32]
 }
 
 #[test]
-fn compile_cat() -> () {
+fn compile_cat() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir("cat_kernel", &[], &[("output", &[8])]);
         println!("\n=== CAT MLIR ===\n{}", module_op_str);
@@ -338,7 +337,7 @@ fn compile_cat() -> () {
 }
 
 #[test]
-fn compile_extract() -> () {
+fn compile_extract() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir("extract_kernel", &[], &[("output", &[1])]);
         println!("\n=== EXTRACT MLIR ===\n{}", module_op_str);
@@ -353,7 +352,7 @@ fn compile_extract() -> () {
 }
 
 #[test]
-fn compile_mmai() -> () {
+fn compile_mmai() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir("mmai_kernel", &[], &[("output", &[16, 16])]);
         println!("\n=== MMAI MLIR ===\n{}", module_op_str);
@@ -376,7 +375,7 @@ fn compile_mmai() -> () {
 }
 
 #[test]
-fn compile_raw_mmai() -> () {
+fn compile_raw_mmai() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir("raw_mmai_kernel", &[], &[("output", &[16, 16])]);
         println!("\n=== RAW MMAI MLIR ===\n{}", module_op_str);
@@ -393,7 +392,7 @@ fn compile_raw_mmai() -> () {
 }
 
 #[test]
-fn compile_raw_mmaf() -> () {
+fn compile_raw_mmaf() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir("raw_mmaf_kernel", &[], &[("output", &[16, 16])]);
         println!("\n=== RAW MMAF MLIR ===\n{}", module_op_str);
@@ -406,7 +405,7 @@ fn compile_raw_mmaf() -> () {
 }
 
 #[test]
-fn compile_transpose_tile() -> () {
+fn compile_transpose_tile() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir(
             "transpose_tile_kernel",
@@ -421,7 +420,7 @@ fn compile_transpose_tile() -> () {
 }
 
 #[test]
-fn compile_nvfp4_pack_unpack() -> () {
+fn compile_nvfp4_pack_unpack() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir(
             "nvfp4_pack_unpack_kernel",
@@ -446,7 +445,7 @@ fn compile_nvfp4_pack_unpack() -> () {
 }
 
 #[test]
-fn compile_nvfp4_pack_unpack_2d() -> () {
+fn compile_nvfp4_pack_unpack_2d() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir(
             "nvfp4_pack_unpack_2d_kernel",
@@ -463,7 +462,7 @@ fn compile_nvfp4_pack_unpack_2d() -> () {
 }
 
 #[test]
-fn compile_nvfp4_u8_escape_unpack() -> () {
+fn compile_nvfp4_u8_escape_unpack() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir(
             "nvfp4_u8_escape_unpack_kernel",
@@ -488,7 +487,7 @@ fn compile_nvfp4_u8_escape_unpack() -> () {
 }
 
 #[test]
-fn compile_pack_unpack_2d_f16() -> () {
+fn compile_pack_unpack_2d_f16() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir(
             "pack_unpack_2d_f16_kernel",
@@ -504,7 +503,7 @@ fn compile_pack_unpack_2d_f16() -> () {
 }
 
 #[test]
-fn compile_cross_type_pack_unpack() -> () {
+fn compile_cross_type_pack_unpack() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir(
             "cross_type_pack_unpack_kernel",
@@ -520,7 +519,7 @@ fn compile_cross_type_pack_unpack() -> () {
 }
 
 #[test]
-fn compile_i32_packed_nibbles_to_i4_roundtrip() -> () {
+fn compile_i32_packed_nibbles_to_i4_roundtrip() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir(
             "i32_packed_nibbles_to_i4_roundtrip_kernel",
@@ -537,7 +536,7 @@ fn compile_i32_packed_nibbles_to_i4_roundtrip() -> () {
 }
 
 #[test]
-fn compile_raw_mmaf_scaled_nvfp4_from_i32_words() -> () {
+fn compile_raw_mmaf_scaled_nvfp4_from_i32_words() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir(
             "raw_mmaf_scaled_nvfp4_from_i32_words_kernel",
@@ -563,7 +562,7 @@ fn compile_raw_mmaf_scaled_nvfp4_from_i32_words() -> () {
 }
 
 #[test]
-fn compile_raw_mmaf_scaled_nvfp4() -> () {
+fn compile_raw_mmaf_scaled_nvfp4() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir(
             "raw_mmaf_scaled_nvfp4_kernel",
@@ -594,7 +593,7 @@ fn compile_raw_mmaf_scaled_nvfp4() -> () {
 }
 
 #[test]
-fn compile_raw_mmaf_scaled_nvfp4_e4_scale() -> () {
+fn compile_raw_mmaf_scaled_nvfp4_e4_scale() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir(
             "raw_mmaf_scaled_nvfp4_e4_scale_kernel",
@@ -615,7 +614,7 @@ fn compile_raw_mmaf_scaled_nvfp4_e4_scale() -> () {
 }
 
 #[test]
-fn execute_raw_mmaf_scaled_nvfp4_e4_scale() -> () {
+fn execute_raw_mmaf_scaled_nvfp4_e4_scale() {
     common::with_test_stack(|| {
         let gpu_name = get_gpu_name(0);
         if !supports_native_nvfp4(&gpu_name) {
@@ -677,7 +676,7 @@ fn execute_raw_mmaf_scaled_nvfp4_e4_scale() -> () {
 }
 
 #[test]
-fn compile_raw_mmaf_scaled_fp8() -> () {
+fn compile_raw_mmaf_scaled_fp8() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir(
             "raw_mmaf_scaled_fp8_kernel",
@@ -698,7 +697,7 @@ fn compile_raw_mmaf_scaled_fp8() -> () {
 }
 
 #[test]
-fn compile_batch_mmaf_scaled_fp8() -> () {
+fn compile_batch_mmaf_scaled_fp8() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir(
             "batch_mmaf_scaled_fp8_kernel",

--- a/cutile/tests/tensor_reinterpret.rs
+++ b/cutile/tests/tensor_reinterpret.rs
@@ -4,7 +4,6 @@
  */
 use std::sync::Arc;
 
-use cutile;
 use cutile::api;
 use cutile::tensor::{IntoPartition, ToHostVec};
 use cutile::tile_kernel::DeviceOp;
@@ -87,7 +86,7 @@ fn reinterpret_u8_to_i16_succeeds() {
 #[test]
 fn reinterpret_u8_boundaries_are_enforced() {
     common::with_test_stack(|| {
-        let valid_bits = vec![0x3f800000u32, 0x40000000u32];
+        let valid_bits = [0x3f800000u32, 0x40000000u32];
         let valid_bytes: Arc<Vec<u8>> = Arc::new(
             valid_bits
                 .iter()

--- a/cutile/tests/tensor_views.rs
+++ b/cutile/tests/tensor_views.rs
@@ -5,7 +5,6 @@
 use std::panic::{self, AssertUnwindSafe};
 use std::sync::Arc;
 
-use cutile;
 use cutile::api;
 use cutile::tensor::{IntoPartition, Reshape, ToHostVec};
 use cutile::tile_kernel::DeviceOp;
@@ -269,6 +268,7 @@ fn slice_chained() {
 }
 
 #[test]
+#[allow(clippy::reversed_empty_ranges)] // `5..3` is the rejected input under test
 fn slice_out_of_bounds_rejected() {
     common::with_test_stack(|| {
         let tensor = api::arange::<f32>(8).sync().expect("Failed.");

--- a/cutile/tests/trait_dispatch_probe.rs
+++ b/cutile/tests/trait_dispatch_probe.rs
@@ -48,31 +48,67 @@ pub struct Tensor_2<E, const D0: i32, const D1: i32>(PhantomData<E>);
 pub struct Tensor_3<E, const D0: i32, const D1: i32, const D2: i32>(PhantomData<E>);
 
 // Constructors so tests can build values without needing real DSL machinery.
+impl<E, const D0: i32> Default for Tile_1<E, D0> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<E, const D0: i32> Tile_1<E, D0> {
     pub fn new() -> Self {
         Self(PhantomData)
     }
 }
+impl<E, const D0: i32, const D1: i32> Default for Tile_2<E, D0, D1> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<E, const D0: i32, const D1: i32> Tile_2<E, D0, D1> {
     pub fn new() -> Self {
         Self(PhantomData)
     }
 }
+impl<E, const D0: i32, const D1: i32, const D2: i32> Default for Tile_3<E, D0, D1, D2> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<E, const D0: i32, const D1: i32, const D2: i32> Tile_3<E, D0, D1, D2> {
     pub fn new() -> Self {
         Self(PhantomData)
     }
 }
+impl<E, const D0: i32> Default for Tensor_1<E, D0> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<E, const D0: i32> Tensor_1<E, D0> {
     pub fn new() -> Self {
         Self(PhantomData)
     }
 }
+impl<E, const D0: i32, const D1: i32> Default for Tensor_2<E, D0, D1> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<E, const D0: i32, const D1: i32> Tensor_2<E, D0, D1> {
     pub fn new() -> Self {
         Self(PhantomData)
     }
 }
+impl<E, const D0: i32, const D1: i32, const D2: i32> Default for Tensor_3<E, D0, D1, D2> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<E, const D0: i32, const D1: i32, const D2: i32> Tensor_3<E, D0, D1, D2> {
     pub fn new() -> Self {
         Self(PhantomData)

--- a/cutile/tests/type_conversion_ops.rs
+++ b/cutile/tests/type_conversion_ops.rs
@@ -2,7 +2,6 @@
  * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-use cutile;
 use cutile::{api::*, tensor::*, tile_kernel::*};
 use cutile_compiler::compiler::utils::CompileOptions;
 use half::bf16;
@@ -120,7 +119,7 @@ use type_conversion_ops_module::bf16_to_f32_conversion_kernel;
 use type_conversion_ops_module::f32_to_bf16_conversion_kernel;
 
 #[test]
-fn compile_conversion_ops() -> () {
+fn compile_conversion_ops() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir(
             "conversion_ops_kernel",
@@ -147,7 +146,7 @@ fn compile_conversion_ops() -> () {
 }
 
 #[test]
-fn compile_ptr_conversion() -> () {
+fn compile_ptr_conversion() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir(
             "ptr_conversion_kernel",
@@ -174,7 +173,7 @@ fn compile_ptr_conversion() -> () {
 }
 
 #[test]
-fn compile_exti_unsigned() -> () {
+fn compile_exti_unsigned() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir(
             "exti_unsigned_kernel",
@@ -197,7 +196,7 @@ fn compile_exti_unsigned() -> () {
 }
 
 #[test]
-fn compile_bf16_conversion() -> () {
+fn compile_bf16_conversion() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir(
             "bf16_conversion_kernel",
@@ -218,7 +217,7 @@ fn compile_bf16_conversion() -> () {
 }
 
 #[test]
-fn compile_bf16_to_f32_load_tile_like() -> () {
+fn compile_bf16_to_f32_load_tile_like() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir(
             "bf16_to_f32_conversion_kernel",
@@ -246,7 +245,7 @@ fn compile_bf16_to_f32_load_tile_like() -> () {
 }
 
 #[test]
-fn compile_unannotated_load_tile_like() -> () {
+fn compile_unannotated_load_tile_like() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir(
             "unannotated_load_tile_like_kernel",
@@ -274,7 +273,7 @@ fn compile_unannotated_load_tile_like() -> () {
 }
 
 #[test]
-fn compile_explicit_conversion_ops() -> () {
+fn compile_explicit_conversion_ops() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir(
             "explicit_conversion_ops_kernel",
@@ -299,7 +298,7 @@ fn compile_explicit_conversion_ops() -> () {
 }
 
 #[test]
-fn execute_bf16_f32_roundtrip() -> () {
+fn execute_bf16_f32_roundtrip() {
     common::with_test_stack(|| {
         let input_host = Arc::new(vec![
             bf16::from_f32(-3.5),
@@ -330,7 +329,7 @@ fn execute_bf16_f32_roundtrip() -> () {
 }
 
 #[test]
-fn execute_bf16_to_f32_conversion() -> () {
+fn execute_bf16_to_f32_conversion() {
     common::with_test_stack(|| {
         let input_host = Arc::new(vec![
             bf16::from_f32(-3.5),
@@ -364,7 +363,7 @@ fn execute_bf16_to_f32_conversion() -> () {
 }
 
 #[test]
-fn execute_f32_to_bf16_conversion() -> () {
+fn execute_f32_to_bf16_conversion() {
     common::with_test_stack(|| {
         let input_host = Arc::new(vec![-3.5f32, -1.0, -0.0, 0.0, 0.125, 0.1, 1.1, 42.0]);
 

--- a/cutile/tests/type_inference_sanity.rs
+++ b/cutile/tests/type_inference_sanity.rs
@@ -2,7 +2,6 @@
  * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-use cutile;
 use cutile_compiler::compiler::utils::CompileOptions;
 use cutile_compiler::compiler::{CUDATileFunctionCompiler, CUDATileModules};
 

--- a/cutile/tests/unary_math_ops.rs
+++ b/cutile/tests/unary_math_ops.rs
@@ -2,7 +2,6 @@
  * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-use cutile;
 use cutile_compiler::compiler::utils::CompileOptions;
 
 mod common;
@@ -200,7 +199,7 @@ fn compile_ir(function_name: &str, generics: &[String], strides: &[(&str, &[i32]
 }
 
 #[test]
-fn compile_unary_math_ops() -> () {
+fn compile_unary_math_ops() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir(
             "unary_math_ops_kernel",
@@ -229,7 +228,7 @@ fn compile_unary_math_ops() -> () {
 }
 
 #[test]
-fn compile_integer_unary_ops() -> () {
+fn compile_integer_unary_ops() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir(
             "integer_unary_ops_kernel",
@@ -255,7 +254,7 @@ fn compile_integer_unary_ops() -> () {
 }
 
 #[test]
-fn compile_sqrt() -> () {
+fn compile_sqrt() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir("sqrt_kernel", &[128.to_string()], &[("output", &[1])]);
         println!("\n=== SQRT MLIR ===\n{}", module_op_str);
@@ -270,7 +269,7 @@ fn compile_sqrt() -> () {
 }
 
 #[test]
-fn compile_fma() -> () {
+fn compile_fma() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir("fma_kernel", &[128.to_string()], &[("output", &[1])]);
         println!("\n=== FMA MLIR ===\n{}", module_op_str);
@@ -285,7 +284,7 @@ fn compile_fma() -> () {
 }
 
 #[test]
-fn compile_pow() -> () {
+fn compile_pow() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir("pow_kernel", &[128.to_string()], &[("output", &[1])]);
         println!("\n=== POW MLIR ===\n{}", module_op_str);
@@ -300,7 +299,7 @@ fn compile_pow() -> () {
 }
 
 #[test]
-fn compile_atan2() -> () {
+fn compile_atan2() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir("atan2_kernel", &[128.to_string()], &[("output", &[1])]);
         println!("\n=== ATAN2 MLIR ===\n{}", module_op_str);
@@ -313,7 +312,7 @@ fn compile_atan2() -> () {
 }
 
 #[test]
-fn compile_exp2_ftz() -> () {
+fn compile_exp2_ftz() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir("exp2_ftz_kernel", &[128.to_string()], &[("output", &[1])]);
         println!("\n=== EXP2 FTZ MLIR ===\n{}", module_op_str);
@@ -330,7 +329,7 @@ fn compile_exp2_ftz() -> () {
 }
 
 #[test]
-fn compile_maxf_ftz() -> () {
+fn compile_maxf_ftz() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir("maxf_ftz_kernel", &[128.to_string()], &[("output", &[1])]);
         println!("\n=== MAXF FTZ MLIR ===\n{}", module_op_str);
@@ -347,7 +346,7 @@ fn compile_maxf_ftz() -> () {
 }
 
 #[test]
-fn compile_minf_ftz() -> () {
+fn compile_minf_ftz() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir("minf_ftz_kernel", &[128.to_string()], &[("output", &[1])]);
         println!("\n=== MINF FTZ MLIR ===\n{}", module_op_str);
@@ -416,7 +415,7 @@ fn compile_sqrt_ftz() {
 }
 
 #[test]
-fn compile_unary_math_ops_bf16() -> () {
+fn compile_unary_math_ops_bf16() {
     common::with_test_stack(|| {
         let module_op_str = compile_ir(
             "unary_math_ops_bf16_kernel",

--- a/cutile/tests/warmup.rs
+++ b/cutile/tests/warmup.rs
@@ -88,7 +88,7 @@ fn cache_key_different_tileiras_fingerprint() {
 #[test]
 fn cache_key_tileiras_stat_fallback_is_distinct() {
     let key_stat = default_key()
-        .tileiras_fingerprint("stat\0/usr/local/cuda/bin/tileiras\094855128\0170000000")
+        .tileiras_fingerprint("stat\x00/usr/local/cuda/bin/tileiras\x0094855128\x00170000000")
         .build();
     let key_version = default_key()
         .tileiras_fingerprint("release 13.3, V13.3.36")


### PR DESCRIPTION
Enforces `clippy::all` as an error across the workspace and fixes everything it flagged. Carries forward the lint policy from #19 and the compiler cleanup from #47 by @ur4t on top of current main.

- Lint policy lives in a `[workspace.lints]` table in the root `Cargo.toml`; every crate opts in with `[lints] workspace = true`, so a local `cargo clippy` enforces the same rules as CI. Allowed, as in #19: `missing_safety_doc`, `type_complexity`, `too_many_arguments`. Also allowed: `needless_range_loop` and `large_enum_variant` (invasive to fix in the compiler) and `single_range_in_vec_init` (`Tensor::slice` takes one `Range` per axis, so a single-element range array is the rank-1 case).
- Kernel source is exempt: `#[cutile::module]` now emits `#![allow(clippy::all)]` on the module it re-emits. Kernel code is a Rust subset with its own idioms (`a = a + b`, explicit closures for reduce regions, trailing `return`), and clippy's host-Rust suggestions either do not compile in the frontend or change what a test pins. This is also what keeps the deny sustainable for contributors writing kernels.
- CI's clippy step now checks `--workspace --exclude cuda-tile-rs --all-targets --all-features`; `cuda-tile-rs` stays out because it is outside `default-members` (its build compiles LLVM).
- The code changes are the lint fixes themselves, in host code only: mostly `single_match` to `if let`, `needless_return`, `needless_borrow`, `to_string` in format arguments and redundant clones, applied with `cargo clippy --fix` and reviewed hunk by hunk where they were not one-liners.
- Not taken from #19: dropping the `GraphNode: DeviceOp` supertrait and moving CI from nightly to stable.

No public API changes. Signatures are untouched apart from removing explicit `-> ()` and eliding impl lifetimes; the three `ptr_arg` suggestions on public parameters are pinned with a targeted allow instead. New impls are additive (`Default` for `EncodingWriter` and `StreamCallbackState`).

Verified on an RTX 5090 with CUDA 13.3: `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features` with zero warnings, `scripts/run_cpu_tests.sh`, `scripts/run_gpu_tests.sh`, and the cutile-kernels smoke suite.
