### PR TITLE
docs: the launch-path performance entry belongs to 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [0.3.1] - 2026-09-02
+
+A single `cargo add cutile` now suffices, kernels gain Triton-parity
+program indexing and Rust-model raw pointers, and the experimental
+autotuner grows the pieces its first engine-scale consumer asked for.
 
 ### Performance
 
@@ -18,12 +22,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   (~108 -> single-digit allocations per launch). Evicting from the kernel
   cache invalidates every launch site, preserving the quiesce-then-clear
   contract.
-
-## [0.3.1] - 2026-09-02
-
-A single `cargo add cutile` now suffices, kernels gain Triton-parity
-program indexing and Rust-model raw pointers, and the experimental
-autotuner grows the pieces its first engine-scale consumer asked for.
 
 ### Breaking changes
 


### PR DESCRIPTION
The v0.3.1 tag moved to include #265 after the changelog section was cut; this moves the perf entry from Unreleased into the 0.3.1 section so the tagged changelog matches the tagged code.