### PR TITLE
fix: lockstep-pin the crate family; CI semver checks

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -85,6 +85,52 @@ jobs:
           source "${HOME}/.cargo/env"
           ./scripts/run_cpu_tests.sh
 
+  # Breaking API changes must ship with the right version bump: compare each
+  # publishable crate's API against its latest crates.io release and fail the
+  # PR when a break arrives without one (the 0.3.0 -> 0.3.1 lesson). Same
+  # CUDA container as `build` because rustdoc needs the crates to compile.
+  semver-checks:
+    runs-on: linux-amd64-cpu16
+    container:
+      image: nvidia/cuda:13.3.0-devel-ubuntu24.04
+      env:
+        DEBIAN_FRONTEND: noninteractive
+    env:
+      CUDA_TOOLKIT_PATH: /usr/local/cuda
+    timeout-minutes: 30
+    steps:
+      - name: Install basic dependencies
+        run: |
+          apt update
+          apt install -y --no-install-recommends build-essential curl \
+            ca-certificates git cmake pkg-config libclang-dev zlib1g-dev \
+            libzstd-dev
+
+      - name: Clone repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Install Rust
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+          source "${HOME}/.cargo/env"
+          rustup default nightly
+
+      - name: Install cargo-semver-checks
+        run: |
+          source "${HOME}/.cargo/env"
+          cargo install cargo-semver-checks --locked
+
+      - name: Check API compatibility against crates.io
+        run: |
+          source "${HOME}/.cargo/env"
+          cargo semver-checks --workspace \
+            --exclude cuda-tile-rs \
+            --exclude cutile-examples \
+            --exclude cutile-benchmarks
+
   # The shared host-side crates (cuda-bindings, cuda-core, cuda-async)
   # support CUDA 13.0+, while the Tile stack requires 13.2+. This lane keeps
   # the 13.0 floor honest: compile-only, no GPU, no TileIR toolchain (13.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,16 +89,22 @@ sha2 = "0.10"
 once_cell = "1.19"
 
 # ── Intra-workspace ──────────────────────────────────────────────────────────
-cuda-bindings = { path = "cuda-bindings", version = "0.3.1" }
-cuda-core = { path = "cuda-core", version = "0.3.1" }
-cuda-async = { path = "cuda-async", version = "0.3.1" }
-cutile-compiler = { path = "cutile-compiler", version = "0.3.1" }
-cutile-macro = { path = "cutile-macro", version = "0.3.1" }
-cutile = { path = "cutile", version = "0.3.1" }
-cutile-kernels = { path = "cutile-kernels", version = "0.3.1" }
-cutile-examples = { path = "cutile-examples", version = "0.3.1" }
-cutile-ir = { path = "cutile-ir", version = "0.3.1" }
-cutile-benchmarks = { path = "cutile-benchmarks", version = "0.3.1" }
+cuda-bindings = { path = "cuda-bindings", version = "=0.3.1" }
+cuda-core = { path = "cuda-core", version = "=0.3.1" }
+cuda-async = { path = "cuda-async", version = "=0.3.1" }
+# Lockstep crates: the macro's generated code targets exact runtime items
+# (and the compiler's registry/ast contract), so a floating requirement lets
+# cargo pair an old runtime with a new macro and break the OLD published
+# crate for downstreams (candle CI, 2026-09-04: cutile 0.3.0 resolved
+# cutile-macro 0.3.1 and failed on 0.3.1-only symbols). Exact-pin, like
+# serde pins serde_derive.
+cutile-compiler = { path = "cutile-compiler", version = "=0.3.1" }
+cutile-macro = { path = "cutile-macro", version = "=0.3.1" }
+cutile = { path = "cutile", version = "=0.3.1" }
+cutile-kernels = { path = "cutile-kernels", version = "=0.3.1" }
+cutile-examples = { path = "cutile-examples", version = "=0.3.1" }
+cutile-ir = { path = "cutile-ir", version = "=0.3.1" }
+cutile-benchmarks = { path = "cutile-benchmarks", version = "=0.3.1" }
 
 # Lint policy shared by every workspace crate (`[lints] workspace = true`).
 [workspace.lints.rust]

--- a/cuda-core/Cargo.toml
+++ b/cuda-core/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 
 [dependencies]
 cuda-bindings = { workspace = true }
-cuda-core-derive = { version = "0.3", path = "../cuda-core-derive" }
+cuda-core-derive = { version = "=0.3.1", path = "../cuda-core-derive" }
 anyhow = { workspace = true }
 half = { workspace = true }
 oxide-artifacts = { version = "0.2.1", features = ["object-read"] }

--- a/cutile-kernels/Cargo.toml
+++ b/cutile-kernels/Cargo.toml
@@ -1,5 +1,7 @@
 [package]
 name = "cutile-kernels"
+# Internal kernel corpus; never published (semver-checks skips publish = false).
+publish = false
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
Two guards from the 0.3.0/0.3.1 incident (candle CI break, huggingface/candle#3959):

- **Exact-pin every intra-workspace dependency edge** (`=0.3.1`, serde-style): cutile 0.3.0 declared `cutile-macro = "0.3.0"` (floating `^0.3.0`), so publishing 0.3.1 let downstreams resolve cutile 0.3.0 with cutile-macro 0.3.1 — and the new macro emits code referencing 0.3.1-only runtime items, breaking the *old* published crate. With exact pins, generation skew is unresolvable instead of a downstream build break.
- **`cargo semver-checks` in PR CI**: each publishable crate's API is compared against its latest crates.io release, so a breaking change without the matching version bump fails the PR instead of shipping in a patch release.