### PR TITLE
fix: lifetime-brand CudaGraph so captured buffers cannot dangle or race

### DIFF
--- a/cuda-async/src/cuda_graph.rs
+++ b/cuda-async/src/cuda_graph.rs
@@ -16,13 +16,24 @@ const CU_STREAM_CAPTURE_MODE_RELAXED: sys::CUstreamCaptureMode = 2;
 
 /// A captured and instantiated CUDA graph, ready for replay.
 ///
-/// Created via [`CudaGraph::capture`], which runs a [`DeviceOp`] once on a
-/// capture stream, recording all GPU work into a graph. The graph can then
+/// Created via [`CudaGraph::capture`] or [`CudaGraph::scope`]. The graph can
 /// be replayed any number of times via [`launch`](CudaGraph::launch).
 ///
-/// All device pointers used by the operation are baked into the graph at capture
-/// time. To vary inputs between replays, pre-allocate an input buffer, pass it
-/// into the operation, and memcpy new data into that buffer before each launch.
+/// # Lifetime `'a`: captured buffers stay borrowed
+///
+/// The instantiated graph bakes in the **device pointers** of every buffer
+/// the captured work touches; a replay reads and writes those exact
+/// addresses. `'a` ties the graph to those buffers: everything the capture
+/// closure (or op) borrowed stays borrowed for as long as the graph value is
+/// used, so safe code cannot drop, move, or mutably alias a captured buffer
+/// while a replay could still happen, and cannot touch any of them while a
+/// [`GraphLaunch`] (which borrows the graph mutably) is in flight.
+///
+/// Outputs are only reachable after a completed replay: through the
+/// reference [`GraphLaunch::sync`]/[`sync_on`](GraphLaunch::sync_on) return,
+/// through [`outputs`](CudaGraph::outputs), or by consuming the graph with
+/// [`into_inner`](CudaGraph::into_inner) — each synchronizes before handing
+/// anything back.
 ///
 /// # Examples
 ///
@@ -34,18 +45,20 @@ const CU_STREAM_CAPTURE_MODE_RELAXED: sys::CUstreamCaptureMode = 2;
 ///
 /// // Capture: records the op's GPU work into a graph. Nothing has run yet.
 /// let mut graph = CudaGraph::capture(stream.clone(), forward_op)?;
-/// let bufs = graph.take_output().unwrap();
 ///
-/// // Replay loop.
+/// // Replay loop; the completed replay hands back the outputs.
 /// for _ in 0..n_tokens {
-///     // Optionally: copy new input into a pre-allocated buffer here.
-///     graph.launch().sync_on(&stream)?;
+///     // Optionally: graph.update(memcpy into a pre-allocated input) here.
+///     let bufs = graph.launch().sync_on(&stream)?;
 /// }
 /// ```
-pub struct CudaGraph<T> {
+pub struct CudaGraph<'a, T> {
     stream: Arc<Stream>,
     exec: Arc<GraphExecHandle>,
-    output: Option<T>,
+    output: T,
+    /// Keeps every capture-time borrow alive while the graph is in use; see
+    /// the type docs.
+    _captured: std::marker::PhantomData<&'a mut ()>,
 }
 
 /// Owns an instantiated CUDA graph: the `CUgraph` it was instantiated from
@@ -178,18 +191,19 @@ fn destroy_graph(cu_graph: sys::CUgraph) {
     }
 }
 
-impl<T: Send> CudaGraph<T> {
+impl<'a, T: Send> CudaGraph<'a, T> {
     /// Capture a [`DeviceOp`] into a replayable CUDA graph.
     ///
     /// Runs `op` once on `stream` in capture mode. All GPU work (kernel
     /// launches, memcpys, etc.) issued by the operation is *recorded* into a
     /// graph, not executed. The graph is then instantiated and uploaded.
     ///
-    /// The output `T` is available immediately via
-    /// [`take_output`](CudaGraph::take_output), but only its host-side
-    /// metadata (shapes, device pointers, handles) is meaningful: the GPU
-    /// data behind it is first computed when the graph is launched. Read it
-    /// after `graph.launch().sync_on(graph.stream())`.
+    /// The `op: 'a` bound keeps every buffer the op borrows alive and
+    /// exclusively held for as long as the graph is used (see the type
+    /// docs). The output `T` — typically the op's recovered buffers — is
+    /// held by the graph and only handed out after a completed replay
+    /// ([`GraphLaunch::sync`], [`outputs`](CudaGraph::outputs)) or when the
+    /// graph is consumed ([`into_inner`](CudaGraph::into_inner)).
     ///
     /// Capture holds the thread-local execution lock for the duration of
     /// `op`, so nested `.sync()` / `.sync_on()` / `.await` inside it return
@@ -198,7 +212,7 @@ impl<T: Send> CudaGraph<T> {
     /// propagates.
     pub fn capture(
         stream: Arc<Stream>,
-        op: impl DeviceOp<Output = T>,
+        op: impl DeviceOp<Output = T> + 'a,
     ) -> Result<Self, DeviceError> {
         let _execution_lock = crate::device_operation::acquire_execution_lock()?;
         let exec_ctx = ExecutionContext::new(stream.clone());
@@ -206,16 +220,9 @@ impl<T: Send> CudaGraph<T> {
         Ok(Self {
             stream,
             exec,
-            output: Some(output),
+            output,
+            _captured: std::marker::PhantomData,
         })
-    }
-
-    /// Take the output produced during the capture execution.
-    ///
-    /// Returns `Some(T)` on the first call, `None` thereafter. Use this to
-    /// recover intermediate buffers or inspect the initial result.
-    pub fn take_output(&mut self) -> Option<T> {
-        self.output.take()
     }
 
     /// Enqueue a [`GraphNode`] on the graph's stream without synchronizing.
@@ -296,10 +303,60 @@ impl<T: Send> CudaGraph<T> {
     /// complete before the graph runs **only when the launch is executed on
     /// [`stream`](CudaGraph::stream)** (same-stream ordering); on any other
     /// stream there is no ordering between them.
-    pub fn launch(&self) -> GraphLaunch {
-        GraphLaunch {
-            exec: Arc::clone(&self.exec),
-        }
+    pub fn launch(&mut self) -> GraphLaunch<'_, 'a, T> {
+        GraphLaunch { graph: self }
+    }
+
+    /// Like [`update`](CudaGraph::update), for an input buffer the graph
+    /// *owns* (part of its output handle `T`): `build` receives `&mut T`
+    /// and returns the refresh op — typically a memcpy into a pre-allocated
+    /// input — which is enqueued on the graph's stream without
+    /// synchronizing. Taking `&mut self` guarantees no replay is in flight
+    /// while the host-side handle is being used to build the op; the
+    /// enqueued work itself is ordered before any later replay on
+    /// [`stream`](CudaGraph::stream), exactly like `update`.
+    pub fn update_with<'s, N, F>(&'s mut self, build: F) -> Result<(), DeviceError>
+    where
+        F: FnOnce(&'s mut T) -> N,
+        N: GraphNode + DeviceOp<Output = ()> + 's,
+    {
+        let _execution_lock = crate::device_operation::acquire_execution_lock()?;
+        let ctx = ExecutionContext::new(self.stream.clone());
+        let op = build(&mut self.output);
+        // SAFETY: as in `update` — a `GraphNode` with no output, enqueued on
+        // the graph's stream; nothing observes it before stream order does.
+        unsafe { op.execute(&ctx) }
+    }
+
+    /// Replay once on the graph's own stream, block until complete, and
+    /// return the outputs. Shorthand for
+    /// `graph.launch().sync_on(graph.stream())`, which the borrow checker
+    /// cannot express directly (the launch borrows the graph mutably).
+    pub fn replay(&mut self) -> Result<&mut T, DeviceError> {
+        let stream = self.stream.clone();
+        self.launch().sync_on(&stream)
+    }
+
+    /// The captured outputs, after synchronizing the graph's stream.
+    ///
+    /// The synchronize guarantees no replay (or [`update`](CudaGraph::update))
+    /// issued on [`stream`](CudaGraph::stream) is still writing the buffers
+    /// behind `T` when the reference is handed out. A replay executed on a
+    /// *different* stream is not ordered by this call — complete it through
+    /// its own [`GraphLaunch::sync`]/[`sync_on`](GraphLaunch::sync_on)
+    /// instead (the launch's `&mut` borrow of the graph already prevents
+    /// calling this while one is pending).
+    pub fn outputs(&mut self) -> Result<&mut T, DeviceError> {
+        unsafe { self.stream.synchronize()? };
+        Ok(&mut self.output)
+    }
+
+    /// Consume the graph: synchronize its stream, destroy nothing that a
+    /// pending launch still shares, and return the captured outputs. This
+    /// ends the graph's borrow of every captured buffer.
+    pub fn into_inner(self) -> Result<T, DeviceError> {
+        unsafe { self.stream.synchronize()? };
+        Ok(self.output)
     }
 
     /// Returns a reference to the stream this graph was captured on.
@@ -308,22 +365,52 @@ impl<T: Send> CudaGraph<T> {
     }
 }
 
-/// A [`DeviceOp`] that replays a captured CUDA graph.
+/// One replay of a captured CUDA graph.
 ///
-/// Created by [`CudaGraph::launch`]. The graph executes on whichever stream
-/// the op is scheduled on (via `.sync_on(&stream)`, `.sync()`, or `.await`).
-/// Holds a shared reference to the instantiated graph, so it may outlive the
-/// [`CudaGraph`] that created it.
-pub struct GraphLaunch {
-    exec: Arc<GraphExecHandle>,
+/// Created by [`CudaGraph::launch`]. Borrows the graph **mutably** for the
+/// replay's duration, so while a replay is pending nothing else can touch
+/// the graph, its outputs, or (through the graph's `'a`) any captured
+/// buffer.
+///
+/// Completing the replay hands the outputs back:
+/// [`sync`](GraphLaunch::sync) / [`sync_on`](GraphLaunch::sync_on) return
+/// `&mut T` tied to the graph borrow, valid only after the synchronize.
+/// The launch also composes as a [`DeviceOp`] with `Output = ()` —
+/// `graph.launch().then(op)`, `.await` — which never exposes `T`; read the
+/// outputs afterwards via [`CudaGraph::outputs`], which synchronizes first.
+pub struct GraphLaunch<'g, 'a, T> {
+    graph: &'g mut CudaGraph<'a, T>,
 }
 
-impl DeviceOp for GraphLaunch {
+impl<'g, 'a, T: Send> GraphLaunch<'g, 'a, T> {
+    /// Replay on `stream`, block until complete, and return the outputs.
+    ///
+    /// Mirrors [`DeviceOp::sync_on`], with one addition: the completed
+    /// replay yields `&mut T`, the graph's captured outputs, which cannot be
+    /// reached before this synchronize returns.
+    pub fn sync_on(self, stream: &Arc<Stream>) -> Result<&'g mut T, DeviceError> {
+        let _execution_lock = crate::device_operation::acquire_execution_lock()?;
+        unsafe {
+            sys::cuGraphLaunch(self.graph.exec.cu_graph_exec, stream.cu_stream()).result()?;
+            stream.synchronize()?;
+        }
+        Ok(&mut self.graph.output)
+    }
+
+    /// Replay on a policy-chosen stream, block until complete, and return
+    /// the outputs. See [`sync_on`](GraphLaunch::sync_on).
+    pub fn sync(self) -> Result<&'g mut T, DeviceError> {
+        let stream = with_default_device_policy(|policy| policy.next_stream())??;
+        self.sync_on(&stream)
+    }
+}
+
+impl<'g, 'a, T: Send> DeviceOp for GraphLaunch<'g, 'a, T> {
     type Output = ();
 
     unsafe fn execute(self, context: &ExecutionContext) -> Result<(), DeviceError> {
         sys::cuGraphLaunch(
-            self.exec.cu_graph_exec,
+            self.graph.exec.cu_graph_exec,
             context.get_cuda_stream().cu_stream(),
         )
         .result()?;
@@ -331,9 +418,9 @@ impl DeviceOp for GraphLaunch {
     }
 }
 
-impl IntoFuture for GraphLaunch {
+impl<'g, 'a, T: Send> IntoFuture for GraphLaunch<'g, 'a, T> {
     type Output = Result<(), DeviceError>;
-    type IntoFuture = DeviceFuture<(), GraphLaunch>;
+    type IntoFuture = DeviceFuture<(), GraphLaunch<'g, 'a, T>>;
     fn into_future(self) -> Self::IntoFuture {
         match with_default_device_policy(|policy| {
             let stream = policy.next_stream()?;
@@ -430,6 +517,44 @@ impl IntoFuture for GraphLaunch {
 /// pre-allocated and passed in via borrows. No tensor created inside
 /// the scope means no tensor dropped inside the scope.
 ///
+/// ## Lifetimes make replay safe, not just capture
+///
+/// Capture-time ordering alone is not enough: the instantiated graph bakes
+/// in the *device pointers* of every recorded buffer, and a replay
+/// dereferences them long after `record`'s borrows have ended. The
+/// remaining obligations are carried by [`CudaGraph<'a, T>`]'s lifetime:
+///
+/// 1. **No use-after-free.** `scope`'s closure is bound `F: 'a`, so every
+///    buffer it captures outlives `'a`; the returned graph keeps `'a` alive
+///    at each of its uses. Dropping or moving a captured buffer while the
+///    graph can still replay is a borrow-check error.
+/// 2. **No aliased writes between replays.** The same borrow covers host or
+///    other-stream writes: taking `&mut` to a captured buffer while the
+///    graph lives is rejected.
+/// 3. **Nothing touches the buffers during a replay.** A replay borrows the
+///    graph mutably ([`CudaGraph::launch`] takes `&mut self`), so no other
+///    graph operation — including output reads — can overlap it.
+/// 4. **Outputs only after completion.** The closure's return value is held
+///    by the graph and handed out only through paths that synchronize
+///    first: [`GraphLaunch::sync`]/[`sync_on`](GraphLaunch::sync_on),
+///    [`CudaGraph::outputs`], [`CudaGraph::into_inner`].
+///
+/// Point 1 covers buffers the closure captures by reference. A buffer the
+/// closure *owns* (a pre-allocated tensor moved into a `move` closure) must
+/// be returned as part of `T`: the graph then owns it and the same
+/// guarantees apply. An owned buffer that is recorded against and then
+/// dropped when the closure returns is freed while the graph still holds
+/// its device address — the borrow checker cannot see that relationship,
+/// and a later replay is a use-after-free.
+///
+/// One boundary remains the caller's: a replay awaited through the
+/// `DeviceOp` composition path and *abandoned before completion* (the
+/// future dropped mid-flight) leaves GPU work running that the borrow
+/// system can no longer see once the graph itself is dropped. The shared
+/// exec handle keeps the graph objects alive for a pending launch, but the
+/// captured buffers' liveness then rests on the general stream-ordering
+/// contract of [`DeviceOp`], as with every other operation in this crate.
+///
 /// # What happens if you call other operations inside the closure
 ///
 /// While `s.record(op)` is the intended API, other operations inside
@@ -478,16 +603,25 @@ impl Scope {
     }
 }
 
-impl CudaGraph<()> {
+impl<'a, T: Send> CudaGraph<'a, T> {
     /// Capture a CUDA graph using a scoped closure.
     ///
     /// The closure receives a [`Scope`] for recording operations. Each
     /// `s.record(op)` records a graph node and consumes the op, releasing
-    /// borrows. A buffer written by one `record` call can be read by the
-    /// next.
+    /// borrows *within the scope*. A buffer written by one `record` call can
+    /// be read by the next.
     ///
-    /// Pre-allocate all buffers before calling this method — the graph
-    /// replays into the same device pointers.
+    /// The closure's return value `T` becomes the graph's output handle —
+    /// typically the recovered output buffers of the last `record` (or `()`
+    /// when the caller keeps its own handles). It is only reachable after a
+    /// completed replay; see [`CudaGraph`].
+    ///
+    /// The `F: 'a` bound is the lifetime half of the safety argument: every
+    /// reference the closure captures must outlive `'a`, and the returned
+    /// `CudaGraph<'a, T>` keeps `'a` alive for as long as the graph is used
+    /// — so the buffers whose device pointers the graph baked in can be
+    /// neither dropped, moved, nor mutably reborrowed while a replay can
+    /// still happen. Pre-allocate all buffers before calling this method.
     ///
     /// # Example
     ///
@@ -495,19 +629,21 @@ impl CudaGraph<()> {
     /// let mut output = api::zeros::<f32>(&[d]).sync_on(&stream)?;
     /// let weights = api::ones::<f32>(&[d]).sync_on(&stream)?;
     ///
-    /// let graph = CudaGraph::scope(&stream, |s| {
+    /// let mut graph = CudaGraph::scope(&stream, |s| {
     ///     s.record(kernel1((&mut output).partition([128]), &weights))?;
     ///     s.record(kernel2((&mut output).partition([64]), &weights))?;
     ///     Ok(())
     /// })?;
     ///
     /// graph.launch().sync_on(&stream)?;
+    /// // `output` is borrowed until `graph`'s last use.
     /// ```
     ///
-    /// See [`Scope`] for the safety proof and edge-case behavior.
+    /// See [`Scope`] for the capture-time safety proof and edge-case
+    /// behavior.
     pub fn scope<F>(stream: &Arc<Stream>, f: F) -> Result<Self, DeviceError>
     where
-        F: FnOnce(&Scope) -> Result<(), DeviceError>,
+        F: FnOnce(&Scope) -> Result<T, DeviceError> + 'a,
     {
         // The guard releases the lock on return and on unwind; `capture_on`
         // ends the capture itself before a panic propagates.
@@ -516,11 +652,12 @@ impl CudaGraph<()> {
             ctx: ExecutionContext::new(stream.clone()),
             _not_send: std::marker::PhantomData,
         };
-        let ((), exec) = capture_on(stream, || f(&scope))?;
+        let (output, exec) = capture_on(stream, || f(&scope))?;
         Ok(CudaGraph {
             stream: stream.clone(),
             exec,
-            output: Some(()),
+            output,
+            _captured: std::marker::PhantomData,
         })
     }
 }
@@ -540,18 +677,17 @@ impl CudaGraph<()> {
 /// use cuda_async::prelude::*;
 ///
 /// struct MyModel {
-///     graph: CudaGraph<Arc<Tensor<f32>>>,
+///     // The captured op owns `Arc` clones of its buffers: `'static`.
+///     graph: CudaGraph<'static, Arc<Tensor<f32>>>,
 ///     h_input: Tensor<f32>,
-///     output: Arc<Tensor<f32>>,
 /// }
 ///
 /// impl MyModel {
 ///     fn new(stream: Arc<Stream>) -> Result<Self, DeviceError> {
 ///         let h_input = api::zeros(&[d]).sync_on(&stream)?;
 ///         let forward_op = build_forward(h_input.clone().into());
-///         let mut graph = forward_op.graph_on(stream)?;
-///         let output = graph.take_output().unwrap();
-///         Ok(Self { graph, h_input, output })
+///         let graph = forward_op.graph_on(stream)?;
+///         Ok(Self { graph, h_input })
 ///     }
 /// }
 ///
@@ -565,8 +701,8 @@ impl CudaGraph<()> {
 ///         self.graph.update(
 ///             api::memcpy(&mut self.h_input, &input)
 ///         )?;
-///         self.graph.launch().sync_on(self.graph.stream())?;
-///         Ok(self.output.clone())
+///         let output = self.graph.replay()?;
+///         Ok(output.clone())
 ///     }
 /// }
 /// ```

--- a/cuda-async/src/device_operation.rs
+++ b/cuda-async/src/device_operation.rs
@@ -380,9 +380,12 @@ pub trait DeviceOp:
     }
     /// Capture this operation into a replayable [`CudaGraph`](crate::cuda_graph::CudaGraph)
     /// using the default device's scheduling policy to pick a stream.
-    fn graph(
+    fn graph<'a>(
         self,
-    ) -> Result<crate::cuda_graph::CudaGraph<<Self as DeviceOp>::Output>, DeviceError> {
+    ) -> Result<crate::cuda_graph::CudaGraph<'a, <Self as DeviceOp>::Output>, DeviceError>
+    where
+        Self: 'a,
+    {
         let stream = with_default_device_policy(|policy| policy.next_stream())??;
         self.graph_on(stream)
     }
@@ -392,10 +395,13 @@ pub trait DeviceOp:
     /// Executes the operation once on `stream` in capture mode, recording
     /// all GPU work. Returns a `CudaGraph<Self::Output>` containing the
     /// replayable graph and the initial output.
-    fn graph_on(
+    fn graph_on<'a>(
         self,
         stream: Arc<Stream>,
-    ) -> Result<crate::cuda_graph::CudaGraph<<Self as DeviceOp>::Output>, DeviceError> {
+    ) -> Result<crate::cuda_graph::CudaGraph<'a, <Self as DeviceOp>::Output>, DeviceError>
+    where
+        Self: 'a,
+    {
         crate::cuda_graph::CudaGraph::capture(stream, self)
     }
     /// Execute synchronously using the default device's scheduling policy.

--- a/cuda-async/tests/cuda_graph.rs
+++ b/cuda-async/tests/cuda_graph.rs
@@ -31,7 +31,7 @@ fn scope_empty_closure() {
         let device = cuda_core::Device::new(0).unwrap();
         let stream = device.new_stream().unwrap();
 
-        let graph = CudaGraph::scope(&stream, |_s| Ok(())).unwrap();
+        let mut graph = CudaGraph::scope(&stream, |_s| Ok(())).unwrap();
         graph.launch().sync_on(&stream).unwrap();
     });
 }
@@ -45,17 +45,17 @@ fn scope_records_value_ops() {
         let device = cuda_core::Device::new(0).unwrap();
         let stream = device.new_stream().unwrap();
 
-        let mut recorded = Vec::new();
-        let graph = CudaGraph::scope(&stream, |s| {
+        // Capture-time results come back as the graph's output handle: a
+        // closure-captured local would stay borrowed for the graph's whole
+        // life (by design), so return the data instead.
+        let mut graph = CudaGraph::scope(&stream, |s| {
             let a = s.record(value(42))?;
             let b = s.record(value("hello"))?;
-            recorded.push(a);
-            recorded.push(b.len() as i32);
-            Ok(())
+            Ok(vec![a, b.len() as i32])
         })
         .unwrap();
 
-        assert_eq!(recorded, vec![42, 5]);
+        assert_eq!(*graph.outputs().unwrap(), vec![42, 5]);
         graph.launch().sync_on(&stream).unwrap();
     });
 }
@@ -69,7 +69,7 @@ fn scope_error_propagation() {
         let device = cuda_core::Device::new(0).unwrap();
         let stream = device.new_stream().unwrap();
 
-        let result = CudaGraph::scope(&stream, |_s| {
+        let result = CudaGraph::<()>::scope(&stream, |_s| {
             Err(DeviceError::Internal("test error".into()))
         });
 
@@ -97,7 +97,7 @@ fn scope_panic_safety() {
         let stream = device.new_stream().unwrap();
 
         let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            CudaGraph::scope(&stream, |_s| {
+            CudaGraph::<()>::scope(&stream, |_s| {
                 panic!("intentional panic in scope");
             })
         }));
@@ -122,7 +122,7 @@ fn scope_multiple_launches() {
         let device = cuda_core::Device::new(0).unwrap();
         let stream = device.new_stream().unwrap();
 
-        let graph = CudaGraph::scope(&stream, |_s| Ok(())).unwrap();
+        let mut graph = CudaGraph::scope(&stream, |_s| Ok(())).unwrap();
 
         for _ in 0..10 {
             graph.launch().sync_on(&stream).unwrap();
@@ -168,13 +168,18 @@ fn scope_nested_execution_rejected() {
 }
 
 // ---------------------------------------------------------------------------
-// Launch lifetime: a GraphLaunch shares ownership of the instantiated graph
+// Launch lifetime: a GraphLaunch mutably borrows its graph, and the exec
+// handle is Arc-shared so a pending future can never dangle
 // ---------------------------------------------------------------------------
 
-/// `GraphLaunch` used to copy the raw `CUgraphExec`, so dropping the graph
-/// before replaying the launch ran a destroyed exec.
+/// A launch borrows the graph for the replay's duration; completing it hands
+/// back the captured outputs, and sequential replays each take a fresh
+/// borrow. (`GraphLaunch` once copied the raw `CUgraphExec` and could replay
+/// a destroyed exec; the borrow now makes graph-outlives-launch a
+/// compile-time fact, with the `Arc` exec handle as defense in depth for
+/// pending `DeviceOp` futures.)
 #[test]
-fn launch_outlives_its_graph() {
+fn launch_borrows_its_graph_and_returns_outputs() {
     if !has_gpu() {
         return;
     }
@@ -182,25 +187,18 @@ fn launch_outlives_its_graph() {
         let device = cuda_core::Device::new(0).unwrap();
         let stream = device.new_stream().unwrap();
 
-        let graph = CudaGraph::scope(&stream, |s| {
-            s.record(value(1))?;
-            Ok(())
-        })
-        .unwrap();
-        let launch = graph.launch();
-        drop(graph);
-        launch
+        let mut graph = CudaGraph::scope(&stream, |s| s.record(value(1))).unwrap();
+        let out = graph
+            .launch()
             .sync_on(&stream)
-            .expect("launch must keep the instantiated graph alive");
+            .expect("replay must complete");
+        assert_eq!(*out, 1);
 
-        // Several pending launches, replayed on different streams, after
-        // the graph is gone.
-        let graph = CudaGraph::capture(stream.clone(), value(3)).unwrap();
-        let a = graph.launch();
-        let b = graph.launch();
-        drop(graph);
-        a.sync_on(&stream).unwrap();
-        b.sync().unwrap();
+        // Sequential replays on different completion paths, then consume.
+        let mut graph = CudaGraph::capture(stream.clone(), value(3)).unwrap();
+        assert_eq!(*graph.launch().sync_on(&stream).unwrap(), 3);
+        assert_eq!(*graph.launch().sync().unwrap(), 3);
+        assert_eq!(graph.into_inner().unwrap(), 3);
     });
 }
 
@@ -217,7 +215,7 @@ fn capture_rejects_nested_execution() {
         let device = cuda_core::Device::new(0).unwrap();
         let stream = device.new_stream().unwrap();
 
-        let mut graph = CudaGraph::capture(
+        let graph = CudaGraph::capture(
             stream.clone(),
             value(1).then(|x| {
                 let nested = value(0).sync();
@@ -229,7 +227,7 @@ fn capture_rejects_nested_execution() {
             }),
         )
         .expect("capture failed");
-        assert_eq!(graph.take_output(), Some(1));
+        assert_eq!(graph.into_inner().unwrap(), 1);
     });
 }
 
@@ -256,7 +254,7 @@ fn capture_panic_ends_capture_and_releases_lock() {
         unsafe { stream.synchronize() }.expect("stream must not be left in capture mode");
         assert_eq!(value(2).sync_on(&stream).expect("lock must be free"), 2);
         let mut graph = CudaGraph::capture(stream.clone(), value(4)).expect("recapture");
-        assert_eq!(graph.take_output(), Some(4));
+        assert_eq!(*graph.outputs().unwrap(), 4);
     });
 }
 
@@ -314,12 +312,10 @@ fn graph_combinators_capture_and_replay() {
         let stream = device.new_stream().unwrap();
 
         let mut graph = value(5).graph_on(stream.clone()).expect("graph_on");
-        assert_eq!(graph.take_output(), Some(5));
-        graph.launch().sync_on(&stream).unwrap();
+        assert_eq!(*graph.launch().sync_on(&stream).unwrap(), 5);
 
         let mut graph = value(6).graph().expect("graph");
-        assert_eq!(graph.take_output(), Some(6));
-        graph.launch().sync().unwrap();
+        assert_eq!(*graph.launch().sync().unwrap(), 6);
 
         let panicked = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             value(())
@@ -348,9 +344,9 @@ fn update_runs_unit_graph_nodes() {
         let device = cuda_core::Device::new(0).unwrap();
         let stream = device.new_stream().unwrap();
 
-        let graph = CudaGraph::scope(&stream, |_s| Ok(())).unwrap();
+        let mut graph = CudaGraph::scope(&stream, |_s| Ok(())).unwrap();
         graph.update(value(())).expect("unit GraphNode");
-        graph.launch().sync_on(graph.stream()).unwrap();
+        graph.replay().unwrap();
 
         // `update` executes under the lock: from inside an executing region
         // it is rejected like any other nested execution.

--- a/cuda-async/tests/execution_lock.rs
+++ b/cuda-async/tests/execution_lock.rs
@@ -143,7 +143,7 @@ fn panic_inside_scope_releases_lock() {
         let device = cuda_core::Device::new(0).unwrap();
         let stream = device.new_stream().unwrap();
         let panicked = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            CudaGraph::scope(&stream, |_s| panic!("intentional panic in scope"))
+            CudaGraph::<()>::scope(&stream, |_s| panic!("intentional panic in scope"))
         }));
         assert!(panicked.is_err(), "the panic must propagate");
         assert_eq!(

--- a/cutile-examples/examples/cuda_graphs.rs
+++ b/cutile-examples/examples/cuda_graphs.rs
@@ -11,7 +11,9 @@
  * releasing borrows — so the same buffer can be written by one kernel
  * and read by the next.
  *
- * No Arc, no try_partition, no take_output, no SharedDeviceOp.
+ * No Arc, no try_partition, no SharedDeviceOp: the closure moves the
+ * pre-allocated buffers in and returns them as the graph's output, so the
+ * graph owns them for as long as it can replay.
  *
  * Usage:
  *   cargo run -p cutile-examples --example cuda_graphs
@@ -148,14 +150,23 @@ impl LayerBuffers {
 // Graph model — scoped capture
 // ═══════════════════════════════════════════════════════════════════════════════
 
-struct GraphModel {
-    graph: CudaGraph<()>,
+/// The buffers the captured graph reads and writes. The scope closure takes
+/// ownership of them and returns them as the graph's output, so the graph —
+/// not the model — owns them: they cannot be dropped, moved, or mutated
+/// while the graph can still replay.
+struct GraphBuffers {
     input: Tensor<f32>, // (d,) — copy new embedding here before launch
     buffers: Vec<LayerBuffers>,
 }
 
-impl GraphModel {
-    fn new(cfg: &Config, weights: &[LayerWeights], stream: &Arc<Stream>) -> Result<Self, Error> {
+/// `'w` is the borrow of the layer weights, which the graph captures by
+/// reference; the graph cannot outlive them.
+struct GraphModel<'w> {
+    graph: CudaGraph<'w, GraphBuffers>,
+}
+
+impl<'w> GraphModel<'w> {
+    fn new(cfg: &Config, weights: &'w [LayerWeights], stream: &Arc<Stream>) -> Result<Self, Error> {
         let mut input: Tensor<f32> = api::ones::<f32>(&[cfg.d]).sync_on(stream)?;
         let mut buffers: Vec<_> = (0..cfg.n_layers)
             .map(|_| LayerBuffers::allocate(cfg.d, stream))
@@ -163,41 +174,49 @@ impl GraphModel {
         unsafe { stream.synchronize() }?;
 
         // Capture the forward pass as a CUDA graph. Each s.record()
-        // records a graph node, releasing borrows between kernels.
-        let graph = CudaGraph::scope(stream, |s| {
+        // records a graph node, releasing borrows between kernels. The
+        // closure owns `input` and `buffers` (move) and returns them as
+        // the graph's output.
+        let d = cfg.d;
+        let block = cfg.block;
+        let bn = cfg.bn;
+        let eps = cfg.eps;
+        let rms_generics = cfg.rms_generics();
+        let mv_generics = cfg.mv_generics();
+        let graph = CudaGraph::scope(stream, move |s| {
             for (w, bufs) in weights.iter().zip(buffers.iter_mut()) {
                 // Create a (1,d) view of input for rms_norm. The view borrows
                 // input — after record consumes the op, the borrow is released.
-                let hidden_2d = input.view(&[1, cfg.d])?;
+                let hidden_2d = input.view(&[1, d])?;
 
                 // RMSNorm: hidden(1,d) → norm(1,d)
                 s.record(
                     rms_norm(
-                        (&mut bufs.norm).partition([1, cfg.d]),
+                        (&mut bufs.norm).partition([1, d]),
                         &hidden_2d,
                         &w.norm_w,
-                        cfg.eps,
+                        eps,
                     )
-                    .generics(cfg.rms_generics()),
+                    .generics(rms_generics.clone()),
                 )?;
                 // hidden_2d dropped — input no longer borrowed.
 
                 // Q projection: norm(1,d) @ wq^T → q(d,)
                 s.record(
-                    matvec((&mut bufs.q).partition([cfg.bn]), &bufs.norm, &w.wq)
-                        .generics(cfg.mv_generics()),
+                    matvec((&mut bufs.q).partition([bn]), &bufs.norm, &w.wq)
+                        .generics(mv_generics.clone()),
                 )?;
 
                 // O projection: q(1,d) @ wo^T → o(d,)
-                let q_2d = bufs.q.view(&[1, cfg.d])?;
+                let q_2d = bufs.q.view(&[1, d])?;
                 s.record(
-                    matvec((&mut bufs.o).partition([cfg.bn]), &q_2d, &w.wo)
-                        .generics(cfg.mv_generics()),
+                    matvec((&mut bufs.o).partition([bn]), &q_2d, &w.wo)
+                        .generics(mv_generics.clone()),
                 )?;
 
                 // Residual: hidden(d,) + o(d,) → residual(d,)
                 s.record(add(
-                    (&mut bufs.residual).partition([cfg.block]),
+                    (&mut bufs.residual).partition([block]),
                     &input,
                     &bufs.o,
                 ))?;
@@ -205,23 +224,23 @@ impl GraphModel {
                 // Copy residual into input for the next layer.
                 s.record(api::memcpy(&mut input, &bufs.residual))?;
             }
-            Ok(())
+            Ok(GraphBuffers { input, buffers })
         })?;
 
-        Ok(Self {
-            graph,
-            input,
-            buffers,
-        })
+        Ok(Self { graph })
     }
 
-    fn output(&self) -> &Tensor<f32> {
-        &self.buffers.last().unwrap().residual
+    /// Synchronizes the graph's stream, then hands out the output buffer.
+    fn output(&mut self) -> Result<&Tensor<f32>, DeviceError> {
+        Ok(&self.graph.outputs()?.buffers.last().unwrap().residual)
     }
 
     fn forward(&mut self, embedding: &Tensor<f32>) -> Result<(), DeviceError> {
-        self.graph.update(api::memcpy(&mut self.input, embedding))?;
-        self.graph.launch().sync_on(self.graph.stream())?;
+        // The graph owns `input`; `update_with` hands it back (no replay can
+        // be in flight) so the refresh memcpy can be built against it.
+        self.graph
+            .update_with(|b| api::memcpy(&mut b.input, embedding))?;
+        self.graph.replay()?;
         Ok(())
     }
 }
@@ -321,11 +340,7 @@ fn main() -> Result<(), Error> {
 
     // Graph path.
     model.forward(&test_input)?;
-    let graph_output: Vec<f32> = model
-        .output()
-        .dup()
-        .to_host_vec()
-        .sync_on(model.graph.stream())?;
+    let graph_output: Vec<f32> = model.output()?.dup().to_host_vec().sync_on(&stream)?;
 
     // Eager path.
     let eager_output = eager_forward(&cfg, &weights, &test_input, &stream)?;

--- a/cutile-examples/examples/cuda_graphs_deviceop.rs
+++ b/cutile-examples/examples/cuda_graphs_deviceop.rs
@@ -156,7 +156,9 @@ impl LayerBuffers {
 /// replays the graph. The output is read directly from the last layer's
 /// residual buffer.
 struct GraphModel {
-    graph: CudaGraph<()>,
+    // The captured op owns `Arc` clones of every buffer it touches, so the
+    // graph borrows nothing: `'static`.
+    graph: CudaGraph<'static, ()>,
     input: Tensor<f32>,
     output: Arc<Tensor<f32>>,
 }
@@ -206,7 +208,7 @@ impl GraphModel {
     /// Copy a new embedding into the input buffer and replay the graph.
     fn forward(&mut self, embedding: &Tensor<f32>) -> Result<(), DeviceError> {
         self.graph.update(api::memcpy(&mut self.input, embedding))?;
-        self.graph.launch().sync_on(self.graph.stream())?;
+        self.graph.replay()?;
         Ok(())
     }
 

--- a/cutile/tests/gpu/graph_scope_inputs.rs
+++ b/cutile/tests/gpu/graph_scope_inputs.rs
@@ -45,7 +45,7 @@ fn pre_allocated_inputs_record_and_replay() {
         let mut out = api::zeros::<f32>(&[8]).sync_on(&stream).expect("out");
         let mut out2 = api::zeros::<f32>(&[8]).sync_on(&stream).expect("out2");
 
-        let graph = CudaGraph::scope(&stream, |s| {
+        let mut graph = CudaGraph::scope(&stream, |s| {
             // `&mut` partition output, borrowed `&Tensor` and `Arc<Tensor>` inputs.
             s.record(add((&mut out).partition([8]), &a, ones.clone()))?;
             // A `&TensorView` input over a buffer written by the previous node.
@@ -57,6 +57,9 @@ fn pre_allocated_inputs_record_and_replay() {
 
         // Capture records; replay computes.
         graph.launch().sync_on(&stream).expect("graph launch");
+        // The graph borrows the captured buffers for as long as it lives;
+        // drop it to read them from the host.
+        drop(graph);
 
         let host: Vec<f32> = out.to_host_vec().sync_on(&stream).expect("out host");
         let expected: Vec<f32> = (0..8).map(|i| i as f32 + 1.0).collect();
@@ -65,5 +68,75 @@ fn pre_allocated_inputs_record_and_replay() {
         let host2: Vec<f32> = out2.to_host_vec().sync_on(&stream).expect("out2 host");
         let expected2: Vec<f32> = (0..8).map(|i| 2.0 * i as f32 + 1.0).collect();
         assert_eq!(host2, expected2, "out2 = out + arange");
+    });
+}
+
+/// The closure-owns-the-buffers pattern: the scope moves the buffers in and
+/// returns them as the graph's output `T`, giving a `CudaGraph<'static, _>`.
+/// Replays accumulate (out += a each launch, since out is also an input via
+/// a view), outputs are read through `replay`/`outputs`, and `into_inner`
+/// synchronizes and hands the buffers back.
+#[test]
+fn owned_outputs_replay_twice_and_into_inner() {
+    common::with_test_stack(|| {
+        let device = cuda_core::Device::new(0).expect("device");
+        let stream = device.new_stream().expect("stream");
+
+        let a = api::arange::<f32>(8).sync_on(&stream).expect("a");
+        let out = api::zeros::<f32>(&[8]).sync_on(&stream).expect("out");
+        let tmp = api::zeros::<f32>(&[8]).sync_on(&stream).expect("tmp");
+
+        let mut graph = CudaGraph::scope(&stream, move |s| {
+            let mut out = out;
+            let mut tmp = tmp;
+            // tmp = out + a; out = tmp — so each replay accumulates
+            // out += a.
+            s.record(add((&mut tmp).partition([8]), &out, &a))?;
+            s.record(api::memcpy(&mut out, &tmp))?;
+            // Every buffer the graph touches must be returned as part of
+            // `T` (or borrowed from outside): a closure-owned buffer that
+            // is dropped here would be freed while the graph still holds
+            // its device address.
+            Ok((out, a, tmp))
+        })
+        .expect("scope capture");
+
+        // Two sequential replays; `replay` synchronizes and hands the
+        // outputs back.
+        graph.replay().expect("first replay");
+        let bufs = graph.replay().expect("second replay");
+        let host: Vec<f32> = bufs
+            .0
+            .dup()
+            .to_host_vec()
+            .sync_on(&stream)
+            .expect("host after two replays");
+        let expected: Vec<f32> = (0..8).map(|i| 2.0 * i as f32).collect();
+        assert_eq!(host, expected, "two replays accumulate out = 2*a");
+
+        // An async replay completes before `outputs` hands the buffers out.
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("tokio runtime");
+        rt.block_on(async {
+            graph.launch().await.expect("async replay");
+        });
+        let host: Vec<f32> = graph
+            .outputs()
+            .expect("outputs after async replay")
+            .0
+            .dup()
+            .to_host_vec()
+            .sync_on(&stream)
+            .expect("host after async replay");
+        let expected: Vec<f32> = (0..8).map(|i| 3.0 * i as f32).collect();
+        assert_eq!(host, expected, "third (async) replay accumulates");
+
+        // `into_inner` synchronizes and returns ownership of the buffers.
+        let (out, a, tmp) = graph.into_inner().expect("into_inner");
+        drop((a, tmp));
+        let host: Vec<f32> = out.to_host_vec().sync_on(&stream).expect("final host");
+        assert_eq!(host, expected, "into_inner returns the buffers intact");
     });
 }

--- a/cutile/tests/ui.rs
+++ b/cutile/tests/ui.rs
@@ -20,6 +20,13 @@ fn ui() {
     // A launcher is only a `GraphNode` when its argument op is; an allocating
     // input (`api::zeros(..).partition(..)`) cannot be recorded into a scope.
     t.compile_fail("tests/ui/graph_scope_rejects_allocating_input.rs");
+    // Replay-time lifetime safety: a `CudaGraph<'a, T>` mutably borrows every
+    // captured buffer for `'a`, and a launch borrows the graph. Each case is
+    // one way safe code could otherwise reach a baked-in device address.
+    t.compile_fail("tests/ui/graph_captured_buffer_cannot_drop.rs");
+    t.compile_fail("tests/ui/graph_captured_buffer_cannot_move.rs");
+    t.compile_fail("tests/ui/graph_captured_buffer_no_mut_alias.rs");
+    t.compile_fail("tests/ui/graph_output_unreadable_during_async_replay.rs");
     // `#[cutile::entry(..)]` keys and literal kinds are checked at expansion:
     // a typo is no longer silently ignored, a non-literal no longer panics
     // inside the JIT at first launch.

--- a/cutile/tests/ui/graph_captured_buffer_cannot_drop.rs
+++ b/cutile/tests/ui/graph_captured_buffer_cannot_drop.rs
@@ -1,0 +1,20 @@
+// A `CudaGraph` borrows every buffer its captured ops touch for as long as
+// it lives: the instantiated executable bakes in their device addresses, so
+// dropping a captured buffer and replaying would be a use-after-free.
+// Dropping `out` while the graph can still launch must not compile.
+use cutile::cuda_async::cuda_graph::CudaGraph;
+use cutile::prelude::*;
+
+fn main() -> Result<(), Error> {
+    let device = Device::new(0)?;
+    let stream = device.new_stream()?;
+    let a = api::ones::<f32>(&[4]).sync_on(&stream)?;
+    let mut out = api::zeros::<f32>(&[4]).sync_on(&stream)?;
+    let mut graph = CudaGraph::scope(&stream, |s| {
+        s.record(api::memcpy(&mut out, &a))?;
+        Ok(())
+    })?;
+    drop(out);
+    graph.launch().sync()?;
+    Ok(())
+}

--- a/cutile/tests/ui/graph_captured_buffer_cannot_drop.stderr
+++ b/cutile/tests/ui/graph_captured_buffer_cannot_drop.stderr
@@ -1,0 +1,12 @@
+error[E0505]: cannot move out of `out` because it is borrowed
+  --> tests/ui/graph_captured_buffer_cannot_drop.rs:17:10
+   |
+13 |     let mut graph = CudaGraph::scope(&stream, |s| {
+   |                                               --- borrow of `out` occurs here
+14 |         s.record(api::memcpy(&mut out, &a))?;
+   |                                   --- borrow occurs due to use in closure
+...
+17 |     drop(out);
+   |          ^^^ move out of `out` occurs here
+18 |     graph.launch().sync()?;
+   |     ----- borrow later used here

--- a/cutile/tests/ui/graph_captured_buffer_cannot_move.rs
+++ b/cutile/tests/ui/graph_captured_buffer_cannot_move.rs
@@ -1,0 +1,20 @@
+// Moving a captured buffer while its `CudaGraph` can still replay must not
+// compile: the executable keeps the capture-time device address, and a move
+// lets the buffer be dropped (freed) through the new owner.
+use cutile::cuda_async::cuda_graph::CudaGraph;
+use cutile::prelude::*;
+
+fn main() -> Result<(), Error> {
+    let device = Device::new(0)?;
+    let stream = device.new_stream()?;
+    let a = api::ones::<f32>(&[4]).sync_on(&stream)?;
+    let mut out = api::zeros::<f32>(&[4]).sync_on(&stream)?;
+    let mut graph = CudaGraph::scope(&stream, |s| {
+        s.record(api::memcpy(&mut out, &a))?;
+        Ok(())
+    })?;
+    let stolen = out;
+    graph.launch().sync()?;
+    let _ = stolen;
+    Ok(())
+}

--- a/cutile/tests/ui/graph_captured_buffer_cannot_move.stderr
+++ b/cutile/tests/ui/graph_captured_buffer_cannot_move.stderr
@@ -1,0 +1,12 @@
+error[E0505]: cannot move out of `out` because it is borrowed
+  --> tests/ui/graph_captured_buffer_cannot_move.rs:16:18
+   |
+12 |     let mut graph = CudaGraph::scope(&stream, |s| {
+   |                                               --- borrow of `out` occurs here
+13 |         s.record(api::memcpy(&mut out, &a))?;
+   |                                   --- borrow occurs due to use in closure
+...
+16 |     let stolen = out;
+   |                  ^^^ move out of `out` occurs here
+17 |     graph.launch().sync()?;
+   |     ----- borrow later used here

--- a/cutile/tests/ui/graph_captured_buffer_no_mut_alias.rs
+++ b/cutile/tests/ui/graph_captured_buffer_no_mut_alias.rs
@@ -1,0 +1,20 @@
+// A buffer a `CudaGraph` writes is mutably borrowed by the graph for its
+// whole lifetime: taking another `&mut` to it (here, to enqueue an unrelated
+// write) while the graph can still replay must not compile — the write
+// could race with a replay in flight.
+use cutile::cuda_async::cuda_graph::CudaGraph;
+use cutile::prelude::*;
+
+fn main() -> Result<(), Error> {
+    let device = Device::new(0)?;
+    let stream = device.new_stream()?;
+    let a = api::ones::<f32>(&[4]).sync_on(&stream)?;
+    let mut out = api::zeros::<f32>(&[4]).sync_on(&stream)?;
+    let mut graph = CudaGraph::scope(&stream, |s| {
+        s.record(api::memcpy(&mut out, &a))?;
+        Ok(())
+    })?;
+    api::memcpy(&mut out, &a).sync_on(&stream)?;
+    graph.launch().sync()?;
+    Ok(())
+}

--- a/cutile/tests/ui/graph_captured_buffer_no_mut_alias.stderr
+++ b/cutile/tests/ui/graph_captured_buffer_no_mut_alias.stderr
@@ -1,0 +1,12 @@
+error[E0499]: cannot borrow `out` as mutable more than once at a time
+  --> tests/ui/graph_captured_buffer_no_mut_alias.rs:17:17
+   |
+13 |     let mut graph = CudaGraph::scope(&stream, |s| {
+   |                                               --- first mutable borrow occurs here
+14 |         s.record(api::memcpy(&mut out, &a))?;
+   |                                   --- first borrow occurs due to use of `out` in closure
+...
+17 |     api::memcpy(&mut out, &a).sync_on(&stream)?;
+   |                 ^^^^^^^^ second mutable borrow occurs here
+18 |     graph.launch().sync()?;
+   |     ----- first borrow later used here

--- a/cutile/tests/ui/graph_output_unreadable_during_async_replay.rs
+++ b/cutile/tests/ui/graph_output_unreadable_during_async_replay.rs
@@ -1,0 +1,23 @@
+// While an async replay is in flight, the graph's output handle must be
+// unreachable: `launch()` borrows the graph mutably for as long as the
+// launch (or its future) lives, so `outputs()` — which would hand out the
+// buffers the replay is concurrently writing — must not compile.
+use cutile::cuda_async::cuda_graph::CudaGraph;
+use cutile::prelude::*;
+use std::future::IntoFuture;
+
+fn main() -> Result<(), Error> {
+    let device = Device::new(0)?;
+    let stream = device.new_stream()?;
+    let a = api::ones::<f32>(&[4]).sync_on(&stream)?;
+    let out = api::zeros::<f32>(&[4]).sync_on(&stream)?;
+    let mut graph = CudaGraph::scope(&stream, move |s| {
+        let mut out = out;
+        s.record(api::memcpy(&mut out, &a))?;
+        Ok(out)
+    })?;
+    let replay = graph.launch().into_future();
+    let _peek = graph.outputs();
+    drop(replay);
+    Ok(())
+}

--- a/cutile/tests/ui/graph_output_unreadable_during_async_replay.stderr
+++ b/cutile/tests/ui/graph_output_unreadable_during_async_replay.stderr
@@ -1,0 +1,9 @@
+error[E0499]: cannot borrow `graph` as mutable more than once at a time
+  --> tests/ui/graph_output_unreadable_during_async_replay.rs:20:17
+   |
+19 |     let replay = graph.launch().into_future();
+   |                  ----- first mutable borrow occurs here
+20 |     let _peek = graph.outputs();
+   |                 ^^^^^ second mutable borrow occurs here
+21 |     drop(replay);
+   |          ------ first borrow later used here


### PR DESCRIPTION
**Breaking API changes (cuda-async):**
- `CudaGraph<T>` → `CudaGraph<'a, T>`: the graph mutably borrows every captured buffer for its lifetime, so dropping, moving, or writing one while the graph can still replay is now a compile error (previously a use-after-free / data race reachable in safe code).
- `take_output` removed: outputs are reachable only after a completed replay, via `outputs(&mut self)`, `into_inner(self)`, or the `&mut T` returned by `replay()` / `GraphLaunch::sync`.
- `launch` takes `&mut self` and returns `GraphLaunch<'_, 'a, T>`; the old `graph.launch().sync_on(graph.stream())` idiom becomes `graph.replay()`.
- `DeviceOp::graph`/`graph_on` gained a lifetime parameter (`where Self: 'a`).

New: `replay()`, `outputs()`, `into_inner()`, and `update_with()` (refresh an input buffer the graph owns). Self-referential graph structs migrate by moving buffers into the scope closure and returning them as `T` (see the updated `cuda_graphs` example). Compile-fail UI tests pin the rejected programs; GPU tests cover sequential/async replays and `into_inner`. cutile's public API is unchanged.