### PR TITLE
fix: passing tests must not print warnings or leak reports

### DIFF
--- a/cuda-async/src/device_future.rs
+++ b/cuda-async/src/device_future.rs
@@ -22,17 +22,18 @@
 //! in flight therefore waits for the stream to drain before dropping its
 //! undelivered result (the owned output — buffers, DMA targets — plus the
 //! execution context's stream and pool handles). If the wait cannot be
-//! performed (a faulted context, a stream mid-capture) the result is leaked
-//! with a message on stderr: releasing memory the device may still write to
-//! is the worse failure. See [`DeviceFuture`]'s type docs for why the wait
-//! is synchronous.
+//! performed (a faulted context, a stream mid-capture) the result is leaked:
+//! releasing memory the device may still write to is the worse failure. The
+//! leak is reported on stderr unless the future already resolved with the
+//! stream's fault — then the caller has the error and the leak is its
+//! documented consequence. See [`DeviceFuture`]'s type docs for why the
+//! wait is synchronous.
 
 use crate::device_operation::{DeviceOp, ExecutionContext};
 use crate::error::DeviceError;
 use cuda_core::{DriverError, Stream};
 use futures::task::AtomicWaker;
 use std::future::Future;
-use std::io::{self, Write};
 use std::mem::{self, MaybeUninit};
 use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -140,7 +141,8 @@ pub(crate) fn probe_stream(stream: &Stream) -> StreamHealth {
 /// result*: the operation's output, which owns the buffers the GPU is still
 /// writing (a tensor, a `Vec<T>` DMA target), or borrows the caller's. The
 /// drop waits for the stream to drain and only then drops that result. On a
-/// wait failure the result is leaked, loudly.
+/// wait failure the result is leaked — loudly, unless the future already
+/// delivered the stream's fault to its caller.
 ///
 /// The wait is synchronous by necessity, not preference. The alternative —
 /// parking the result behind a CUDA event and dropping it later, once
@@ -162,6 +164,10 @@ pub struct DeviceFuture<T: Send, DO: DeviceOp<Output = T>> {
     pub(crate) error: Option<DeviceError>,
     pub(crate) state: DeviceFutureState,
     pub(crate) callback_state: Option<Arc<StreamCallbackState>>,
+    /// Set when `poll` resolved with the stream's fault: the caller has the
+    /// error, so the drop-time leak of the stored result is the documented
+    /// consequence of that fault, not news worth reporting again.
+    pub(crate) fault_delivered: bool,
 }
 
 impl<T: Send, DO: DeviceOp<Output = T>> DeviceFuture<T, DO> {
@@ -181,6 +187,7 @@ impl<T: Send, DO: DeviceOp<Output = T>> DeviceFuture<T, DO> {
             error: None,
             state: DeviceFutureState::Idle,
             callback_state: None,
+            fault_delivered: false,
         }
     }
 
@@ -197,6 +204,7 @@ impl<T: Send, DO: DeviceOp<Output = T>> DeviceFuture<T, DO> {
             callback_state: None,
             result: None,
             error: Some(error),
+            fault_delivered: false,
         }
     }
 
@@ -337,12 +345,18 @@ impl<T: Send, DO: DeviceOp<Output = T>> DeviceFuture<T, DO> {
             return;
         };
         if let Err(error) = wait() {
-            let mut stderr = io::stderr().lock();
-            let _ = writeln!(
-                stderr,
+            if self.fault_delivered {
+                // The caller already received this stream's fault from
+                // `poll`; the leak is its documented consequence. A test
+                // (or program) that handled the error correctly should not
+                // see an error report for it.
+                mem::forget(result);
+                return;
+            }
+            crate::leak::report_leak(format_args!(
                 "cuda-async: leaking the result of a dropped in-flight future; the driver \
                  could not prove its GPU work finished: {error}"
-            );
+            ));
             mem::forget(result);
             return;
         }
@@ -365,6 +379,7 @@ impl<T: Send, DO: DeviceOp<Output = T>> Default for DeviceFuture<T, DO> {
             error: None,
             state: DeviceFutureState::Idle,
             callback_state: None,
+            fault_delivered: false,
         }
     }
 }
@@ -461,8 +476,10 @@ impl<T: Send, DO: DeviceOp<Output = T>> Future for DeviceFuture<T, DO> {
                     Ok(false) => {}
                     Err(e) => {
                         // The result stays stored; `Drop` decides how to
-                        // release it (it will leak loudly on a dead context).
+                        // release it (it will leak, quietly, on a dead
+                        // context — the caller receives the fault here).
                         self.state = DeviceFutureState::Complete;
+                        self.fault_delivered = true;
                         return Poll::Ready(Err(DeviceError::Driver(e)));
                     }
                 }
@@ -506,9 +523,10 @@ impl<T: Send, DO: DeviceOp<Output = T>> Future for DeviceFuture<T, DO> {
                 };
                 match health {
                     StreamHealth::Faulted(e) => {
-                        // The result stays stored for `Drop` (which leaks it
-                        // loudly on a dead context).
+                        // The result stays stored for `Drop` (which leaks it,
+                        // quietly — the caller receives the fault here).
                         self.state = DeviceFutureState::Complete;
+                        self.fault_delivered = true;
                         return Poll::Ready(Err(DeviceError::Driver(e)));
                     }
                     StreamHealth::Idle => {
@@ -589,6 +607,7 @@ mod release_tests {
             error: None,
             state,
             callback_state: None,
+            fault_delivered: false,
         }
     }
 
@@ -620,10 +639,42 @@ mod release_tests {
             Some(CountDrop(Arc::clone(&drops))),
         );
 
+        let mut capture = crate::leak::capture::start();
         future.release_in_flight_result_with(|| Err(DeviceError::Internal("boom".to_string())));
+        let reports = capture.take();
 
         assert_eq!(drops.load(Ordering::Relaxed), 0);
         assert!(future.result.is_none());
+        assert_eq!(reports.len(), 1, "the leak must be reported: {reports:?}");
+        assert!(reports[0].contains("dropped in-flight future"));
+    }
+
+    /// A future that already delivered the stream's fault to its caller
+    /// leaks its stored result *quietly*: the caller has the error, the
+    /// leak is its documented consequence.
+    #[test]
+    fn release_leaks_quietly_after_the_fault_was_delivered() {
+        let drops = Arc::new(AtomicUsize::new(0));
+        let mut future = future_in_state(
+            DeviceFutureState::Complete,
+            Some(CountDrop(Arc::clone(&drops))),
+        );
+        future.fault_delivered = true;
+
+        let mut capture = crate::leak::capture::start();
+        future.release_in_flight_result_with(|| Err(DeviceError::Internal("boom".to_string())));
+        let reports = capture.take();
+
+        assert_eq!(
+            drops.load(Ordering::Relaxed),
+            0,
+            "must still leak, not drop"
+        );
+        assert!(future.result.is_none());
+        assert!(
+            reports.is_empty(),
+            "a delivered fault must not be re-reported: {reports:?}"
+        );
     }
 
     /// The registration-failure shape: `execute` succeeded (work submitted,

--- a/cuda-async/src/device_operation.rs
+++ b/cuda-async/src/device_operation.rs
@@ -600,10 +600,10 @@ impl<Op, Out> ExecuteOnce<Op, Out> {
                 // ordered after the producing work. The value may own memory
                 // that work still writes; releasing it now would be the
                 // in-flight-free hazard, so leak it loudly instead.
-                eprintln!(
+                crate::leak::report_leak(format_args!(
                     "cuda-async: leaking a memoized result after its completion \
                      event could not be recorded: {error}"
-                );
+                ));
                 std::mem::forget(value);
                 OnceState::Failed(error)
             }

--- a/cuda-async/src/leak.rs
+++ b/cuda-async/src/leak.rs
@@ -1,0 +1,70 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Loud-leak reporting.
+//!
+//! When a completion wait cannot prove the device is done with a result's
+//! memory, the result is leaked (dropping buffers in-flight work may still
+//! touch is worse) and the leak is reported here. Every report site in the
+//! crate goes through [`report_leak`] so unit tests can capture and assert
+//! the message instead of spraying stderr from passing tests.
+
+use std::io::{self, Write};
+
+/// Reports a leak to stderr — or to the active test capture, if one is
+/// installed.
+pub(crate) fn report_leak(message: std::fmt::Arguments<'_>) {
+    #[cfg(test)]
+    if capture::push(&message) {
+        return;
+    }
+    let mut stderr = io::stderr().lock();
+    let _ = writeln!(stderr, "{message}");
+}
+
+/// Test-only capture of leak reports, so tests that intentionally exercise
+/// the loud-leak paths can assert on the message instead of printing it.
+#[cfg(test)]
+pub(crate) mod capture {
+    use std::sync::{Mutex, MutexGuard};
+
+    static ACTIVE: Mutex<()> = Mutex::new(());
+    static CAPTURED: Mutex<Option<Vec<String>>> = Mutex::new(None);
+
+    /// Serializes capturing tests and scopes the capture window; captured
+    /// messages are retrieved (and the window closed) by [`Capture::take`].
+    pub(crate) struct Capture {
+        _serial: MutexGuard<'static, ()>,
+    }
+
+    pub(crate) fn start() -> Capture {
+        let serial = ACTIVE.lock().unwrap_or_else(|e| e.into_inner());
+        *CAPTURED.lock().unwrap() = Some(Vec::new());
+        Capture { _serial: serial }
+    }
+
+    impl Capture {
+        pub(crate) fn take(&mut self) -> Vec<String> {
+            CAPTURED.lock().unwrap().take().unwrap_or_default()
+        }
+    }
+
+    impl Drop for Capture {
+        fn drop(&mut self) {
+            let _ = CAPTURED.lock().map(|mut c| c.take());
+        }
+    }
+
+    pub(crate) fn push(message: &std::fmt::Arguments<'_>) -> bool {
+        let mut captured = CAPTURED.lock().unwrap();
+        match captured.as_mut() {
+            Some(messages) => {
+                messages.push(message.to_string());
+                true
+            }
+            None => false,
+        }
+    }
+}

--- a/cuda-async/src/lib.rs
+++ b/cuda-async/src/lib.rs
@@ -13,6 +13,7 @@ pub mod device_future;
 pub mod device_operation;
 pub mod error;
 pub mod launch;
+mod leak;
 mod loom_compat;
 pub mod predicate;
 pub mod prelude;

--- a/cuda-async/src/simt/device_future.rs
+++ b/cuda-async/src/simt/device_future.rs
@@ -28,7 +28,6 @@ use crate::simt::error::DeviceError;
 use crate::simt::reclaim;
 use futures::task::AtomicWaker;
 use std::future::Future;
-use std::io::{self, Write};
 use std::mem;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -239,12 +238,9 @@ impl<T: Send + 'static, DO: DeviceOperation<Output = T>> DeviceFuture<T, DO> {
         };
 
         if let Err(error) = synchronize() {
-            let mut stderr = io::stderr().lock();
-            let _ = writeln!(
-                stderr,
-                "cuda-async: leaking in-flight future result after cleanup failure: {}",
-                error
-            );
+            crate::leak::report_leak(format_args!(
+                "cuda-async: leaking in-flight future result after cleanup failure: {error}"
+            ));
             // If cleanup cannot prove the stream is idle, leaking the owned
             // result is safer than dropping buffers that device work may still
             // be using.
@@ -418,10 +414,13 @@ mod tests {
             callback_state: None,
         };
 
+        let mut capture = crate::leak::capture::start();
         future.cleanup_executing_result_with(|| Err(DeviceError::Internal("boom".to_string())));
+        let reports = capture.take();
 
         assert_eq!(drops.load(Ordering::Relaxed), 0);
         assert!(future.result.is_none());
+        assert_eq!(reports.len(), 1, "the leak must be reported: {reports:?}");
     }
 
     /// The shape left behind by issue #99's second path: `execute()`

--- a/cuda-async/src/simt/reclaim.rs
+++ b/cuda-async/src/simt/reclaim.rs
@@ -36,7 +36,6 @@
 //! [`DeviceFuture`]: crate::simt::device_future::DeviceFuture
 
 use cuda_core::{CudaEvent, DriverError};
-use std::io::{self, Write};
 use std::mem;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Mutex, MutexGuard};
@@ -169,12 +168,10 @@ pub fn drain() -> usize {
                 reclaimed += 1;
             }
             Err(error) => {
-                let mut stderr = io::stderr().lock();
-                let _ = writeln!(
-                    stderr,
+                crate::leak::report_leak(format_args!(
                     "cuda-async: leaking a cancelled in-flight result; the driver \
                      could not prove the GPU work finished: {error}"
-                );
+                ));
                 mem::forget(entry.payload);
             }
         }
@@ -297,12 +294,15 @@ mod tests {
             Box::new(CountDrop(Arc::clone(&drops))),
         );
 
+        let mut capture = crate::leak::capture::start();
         let reclaimed = drain();
+        let reports = capture.take();
         assert_eq!(reclaimed, 0);
         assert_eq!(
             drops.load(Ordering::Relaxed),
             0,
             "an unprovable gate must leak the payload, never drop it early"
         );
+        assert_eq!(reports.len(), 1, "the leak must be reported: {reports:?}");
     }
 }

--- a/cutile-examples/examples/cuda_graphs.rs
+++ b/cutile-examples/examples/cuda_graphs.rs
@@ -56,7 +56,7 @@ mod kernels {
         let inv: f32 = tile_to_scalar(inv_tile);
         let scale: Tile<f32, { [1, BS] }> = inv.broadcast(shape);
         let w_part: Partition<f32, { [BS] }> = w.partition(shape![BS]);
-        let mut out_part: PartitionMut<f32, { [1, BS] }> = unsafe { out.partition_mut(shape) };
+        let mut out_part: PartitionMut<f32, { [1, BS] }> = out.partition_mut(shape);
         for j in 0i32..tiles {
             let t: Tile<f32, { [1, BS] }> = x_part.load([row, j]);
             let tw: Tile<f32, { [1, BS] }> = w_part.load([j]).reshape(shape);

--- a/cutile-examples/examples/cuda_graphs_deviceop.rs
+++ b/cutile-examples/examples/cuda_graphs_deviceop.rs
@@ -54,7 +54,7 @@ mod kernels {
         let inv: f32 = tile_to_scalar(inv_tile);
         let scale: Tile<f32, { [1, BS] }> = inv.broadcast(shape);
         let w_part: Partition<f32, { [BS] }> = w.partition(shape![BS]);
-        let mut out_part: PartitionMut<f32, { [1, BS] }> = unsafe { out.partition_mut(shape) };
+        let mut out_part: PartitionMut<f32, { [1, BS] }> = out.partition_mut(shape);
         for j in 0i32..tiles {
             let t: Tile<f32, { [1, BS] }> = x_part.load([row, j]);
             let tw: Tile<f32, { [1, BS] }> = w_part.load([j]).reshape(shape);

--- a/cutile-examples/examples/rms_norm.rs
+++ b/cutile-examples/examples/rms_norm.rs
@@ -50,8 +50,7 @@ mod my_module {
         let w_part: Partition<f32, { [BLOCK_SIZE] }> = w.partition(shape![BLOCK_SIZE]);
         // TODO (hme): This is a safety leak. If this partition goes out of scope, we can partition out again,
         //  and any memory ops will not succeed tokens corresponding to write operations (since those will also be dropped).
-        let mut out_part: PartitionMut<f32, { [1, BLOCK_SIZE] }> =
-            unsafe { out.partition_mut(tile_shape) };
+        let mut out_part: PartitionMut<f32, { [1, BLOCK_SIZE] }> = out.partition_mut(tile_shape);
         for j in 0i32..num_tiles {
             let tx: Tile<f32, { [1, BLOCK_SIZE] }> = x_part.load([row, j]);
             let tw: Tile<f32, { [1, BLOCK_SIZE] }> = w_part.load([j]).reshape(tile_shape);


### PR DESCRIPTION
Two sources of error-shaped noise in a clean `cargo test`:
- `unused_unsafe` warnings in three examples: `partition_mut` has been safe since #232; the stale `unsafe { }` wrappers are removed.
- Two `DriverError(719)` leak reports from the (passing) `device_fault` test: a `DeviceFuture` that resolved with its stream's fault now leaks its stored result quietly on drop — the caller already received the error, and the leak is its documented consequence. The remaining loud-leak sites report through one internal function with a test capture, so the unit tests exercising them assert on the message instead of printing to stderr.