### PR TITLE
fix: make the drop_in_flight regression test independent of GPU speed

### DIFF
--- a/cuda-async/tests/drop_in_flight.rs
+++ b/cuda-async/tests/drop_in_flight.rs
@@ -6,19 +6,30 @@
 //! Dropping a `DeviceFuture` while its GPU work is in flight must not release
 //! the operation's output before the device has finished with it.
 //!
-//! The op enqueues a long chain of memsets and then records a CUDA event on
-//! the same stream, handing the event back inside its output. The output's
+//! The op enqueues a chain of memsets and then records a CUDA event on the
+//! same stream, handing the event back inside its output. The output's
 //! `Drop` queries that event: if the output were released early, the query
-//! would report the work still in flight. Requires a GPU.
+//! would report the work still in flight.
+//!
+//! The core test does not rely on GPU speed to keep that work in flight. Its
+//! op starts with a [`Gate`]: a `cuStreamWaitValue32` on a word of pinned
+//! host memory that a helper thread opens after a fixed delay. Until then
+//! nothing behind the gate can run, whatever the device's memset throughput
+//! or the inline-spin budget (`CUDA_ASYNC_SPIN_BUDGET_US`), so the first poll
+//! is guaranteed to find the work in flight and the drop is guaranteed to
+//! have to wait for it. Requires a GPU.
 
-use cuda_async::device_context::{global_policy, init_device_contexts};
+use cuda_async::device_context::{global_policy, init_device_contexts, with_device};
 use cuda_async::device_operation::{DeviceOp, ExecutionContext};
 use cuda_async::error::DeviceError;
 use cuda_core::Event;
 use std::future::{Future, IntoFuture};
+use std::mem::MaybeUninit;
 use std::pin::Pin;
+use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
+use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
 fn on_fresh_thread<F: FnOnce() + Send + 'static>(f: F) {
@@ -34,14 +45,107 @@ fn noop_waker() -> Waker {
     unsafe { Waker::from_raw(RawWaker::new(std::ptr::null(), &VTABLE)) }
 }
 
-fn alloc_device(bytes: usize) -> u64 {
-    cuda_async::device_context::with_device(0, |device| device.bind_to_thread())
+fn bind_device() {
+    with_device(0, |device| device.bind_to_thread())
         .expect("device context")
         .expect("bind_to_thread failed");
-    let mut dptr = std::mem::MaybeUninit::uninit();
+}
+
+fn alloc_device(bytes: usize) -> u64 {
+    bind_device();
+    let mut dptr = MaybeUninit::uninit();
     let code = unsafe { cuda_bindings::cuMemAlloc_v2(dptr.as_mut_ptr(), bytes) };
     assert_eq!(code, 0, "cuMemAlloc failed: {code}");
     unsafe { dptr.assume_init() }
+}
+
+/// A host-controlled barrier at the head of a stream.
+///
+/// [`arm`](Gate::arm) enqueues a `cuStreamWaitValue32` on the gate's word, a
+/// page of pinned, device-mapped host memory; work submitted to the stream
+/// after that stays queued until [`open`](Gate::open) stores the release
+/// value. This is the host-mapped-flag mechanism the crate's completion
+/// reactor uses, in the other direction.
+struct Gate {
+    host: *mut u32,
+    dptr: cuda_bindings::CUdeviceptr,
+}
+
+// SAFETY: `host` is pinned, device-mapped memory owned by the gate for its
+// whole lifetime; the host side only touches it through atomics.
+unsafe impl Send for Gate {}
+unsafe impl Sync for Gate {}
+
+impl Gate {
+    /// Allocates a closed gate. Requires a current CUDA context on the
+    /// calling thread.
+    fn closed() -> Arc<Self> {
+        let mut host = MaybeUninit::uninit();
+        let flags =
+            cuda_bindings::CU_MEMHOSTALLOC_PORTABLE | cuda_bindings::CU_MEMHOSTALLOC_DEVICEMAP;
+        let code = unsafe {
+            cuda_bindings::cuMemHostAlloc(host.as_mut_ptr(), std::mem::size_of::<u32>(), flags)
+        };
+        assert_eq!(code, 0, "cuMemHostAlloc failed: {code}");
+        let host = unsafe { host.assume_init() } as *mut u32;
+        unsafe { AtomicU32::from_ptr(host) }.store(0, Ordering::SeqCst);
+        let mut dptr = MaybeUninit::uninit();
+        let code =
+            unsafe { cuda_bindings::cuMemHostGetDevicePointer_v2(dptr.as_mut_ptr(), host as _, 0) };
+        assert_eq!(code, 0, "cuMemHostGetDevicePointer failed: {code}");
+        Arc::new(Self {
+            host,
+            dptr: unsafe { dptr.assume_init() },
+        })
+    }
+
+    /// Enqueues the wait: everything submitted to `stream` after this call
+    /// stays queued until the gate is opened.
+    fn arm(&self, stream: cuda_bindings::CUstream) -> Result<(), DeviceError> {
+        // CUDA driver flag bindings have platform-dependent integer types, so
+        // the FFI call casts the flag as `_`.
+        let code = unsafe {
+            cuda_bindings::cuStreamWaitValue32_v2(
+                stream,
+                self.dptr,
+                1,
+                cuda_bindings::CUstreamWaitValue_flags_enum_CU_STREAM_WAIT_VALUE_GEQ as _,
+            )
+        };
+        if code != cuda_bindings::cudaError_enum_CUDA_SUCCESS {
+            return Err(DeviceError::Internal(format!(
+                "cuStreamWaitValue32 failed: {code}"
+            )));
+        }
+        Ok(())
+    }
+
+    /// Releases every stream waiting on the gate.
+    fn open(&self) {
+        unsafe { AtomicU32::from_ptr(self.host) }.store(1, Ordering::SeqCst);
+    }
+
+    /// Opens the gate from a helper thread once `delay` has elapsed.
+    fn open_after(self: &Arc<Self>, delay: Duration) -> JoinHandle<()> {
+        let gate = Arc::clone(self);
+        std::thread::spawn(move || {
+            std::thread::sleep(delay);
+            gate.open();
+        })
+    }
+}
+
+impl Drop for Gate {
+    fn drop(&mut self) {
+        // Every wait on the gate has passed by now: the test keeps its own
+        // handle until the gated stream has been synchronized. The last owner
+        // may be the opener thread, which never bound a context.
+        let _ = with_device(0, |device| device.bind_to_thread());
+        let code = unsafe { cuda_bindings::cuMemFreeHost(self.host as _) };
+        if !std::thread::panicking() {
+            assert_eq!(code, 0, "cuMemFreeHost failed: {code}");
+        }
+    }
 }
 
 /// What the output's `Drop` observed: whether the device had passed the
@@ -63,10 +167,12 @@ impl Drop for Tracked {
 }
 
 /// `passes` memsets of a `bytes` buffer, then an event recorded after them.
+/// With a `gate`, the whole chain waits behind it.
 struct SlowOp {
     dptr: u64,
     bytes: usize,
     passes: usize,
+    gate: Option<Arc<Gate>>,
     log: DropLog,
 }
 
@@ -74,6 +180,9 @@ impl DeviceOp for SlowOp {
     type Output = Tracked;
     unsafe fn execute(self, context: &ExecutionContext) -> Result<Tracked, DeviceError> {
         let stream = context.get_cuda_stream();
+        if let Some(gate) = &self.gate {
+            gate.arm(stream.cu_stream())?;
+        }
         for _ in 0..self.passes {
             let code =
                 cuda_bindings::cuMemsetD8Async(self.dptr, 0x5A, self.bytes, stream.cu_stream());
@@ -105,16 +214,29 @@ impl IntoFuture for SlowOp {
 }
 
 const BUF: usize = 64 << 20;
-/// ~64 MiB x 32 of memset: well past the 20 us inline-spin budget, so the
-/// first poll leaves the work in flight.
+/// ~64 MiB x 32 of memset: real device work behind each op's event. The
+/// ungated tests lean on it being far past the 20 us inline-spin budget; the
+/// core test does not, its gate holds the work back for as long as it needs.
 const PASSES: usize = 32;
+/// How long a gate stays closed. Generous, so the first poll happens while
+/// the gate is provably closed even on a loaded machine, and so a drop that
+/// waits measurably cannot finish before the gate opens.
+const GATE_DELAY: Duration = Duration::from_millis(200);
 
 fn slow_op(dptr: u64, log: &DropLog) -> SlowOp {
     SlowOp {
         dptr,
         bytes: BUF,
         passes: PASSES,
+        gate: None,
         log: Arc::clone(log),
+    }
+}
+
+fn gated_op(dptr: u64, log: &DropLog, gate: &Arc<Gate>) -> SlowOp {
+    SlowOp {
+        gate: Some(Arc::clone(gate)),
+        ..slow_op(dptr, log)
     }
 }
 
@@ -136,9 +258,13 @@ fn block_on_with_deadline<F: Future + Unpin>(mut future: F, deadline: Duration) 
     }
 }
 
-/// The core regression: poll once (work in flight), drop the future, and
-/// check that the output was released only after the device passed the
-/// event recorded behind the work.
+/// The core regression: poll once with the work provably in flight (held
+/// behind a closed gate), drop the future, and check that the output was
+/// released only after the device passed the event recorded behind the work.
+///
+/// The gate opens from a helper thread after `GATE_DELAY`, so a drop that
+/// waits cannot return before then, and one that does not is caught twice:
+/// it returns early, and its output's event reports the work still in flight.
 #[test]
 fn dropping_in_flight_future_releases_output_after_the_device_finished() {
     on_fresh_thread(|| {
@@ -146,15 +272,50 @@ fn dropping_in_flight_future_releases_output_after_the_device_finished() {
         let dptr = alloc_device(BUF);
         let log: DropLog = Arc::new(Mutex::new(Vec::new()));
 
+        // Bring up the completion path (reactor slab, scanner thread) on an
+        // ungated op, so the crate's one-time driver setup does not happen
+        // while a gate is closed.
+        let scratch: DropLog = Default::default();
+        block_on_with_deadline(
+            slow_op(dptr, &scratch).into_future(),
+            Duration::from_secs(30),
+        )
+        .expect("warm-up op failed");
+
         for _ in 0..4 {
-            let mut future = slow_op(dptr, &log).into_future();
+            let gate = Gate::closed();
+            let mut future = gated_op(dptr, &log, &gate).into_future();
             let waker = noop_waker();
             let mut cx = Context::from_waker(&waker);
-            assert!(
-                Pin::new(&mut future).poll(&mut cx).is_pending(),
-                "the op must still be in flight after the first poll"
-            );
+            let started = Instant::now();
+            let opener = gate.open_after(GATE_DELAY);
+            match Pin::new(&mut future).poll(&mut cx) {
+                Poll::Pending => {}
+                Poll::Ready(Ok(_)) => {
+                    let elapsed = started.elapsed();
+                    assert!(
+                        elapsed >= GATE_DELAY,
+                        "the first poll found the stream idle after {elapsed:?} with the gate \
+                         still closed: the gate did not hold the work back"
+                    );
+                    panic!(
+                        "the first poll resolved only once the gate had opened ({elapsed:?}): \
+                         the op was never left in flight (a huge CUDA_ASYNC_SPIN_BUDGET_US, or \
+                         CUDA_LAUNCH_BLOCKING, in the environment?)"
+                    );
+                }
+                Poll::Ready(Err(error)) => {
+                    panic!("the first poll failed instead of leaving the op in flight: {error}")
+                }
+            }
             drop(future);
+            let elapsed = started.elapsed();
+            assert!(
+                elapsed >= GATE_DELAY,
+                "the drop returned after {elapsed:?}, before the gate opened at {GATE_DELAY:?}: \
+                 it did not wait for the in-flight work"
+            );
+            opener.join().expect("gate opener thread panicked");
         }
 
         let log = log.lock().unwrap();


### PR DESCRIPTION
The core `drop_in_flight` test asserted that its first poll leaves the op in flight by enqueuing 2 GiB of memsets and betting that no GPU finishes them inside the 20 us inline-spin budget. The bet is lost whenever the stream is idle by the time the spin runs (a large `CUDA_ASYNC_SPIN_BUDGET_US`, a synchronous submission mode), and a failed first poll looks the same: all of them surfaced as the bare "the op must still be in flight after the first poll", with the poll's result discarded. Seen failing on a GPU host after #271 landed; #271 does not touch the polled path.

The op now starts with a gate: a `cuStreamWaitValue32` on a word of pinned, device-mapped host memory that a helper thread opens after a fixed delay (200 ms). Nothing behind it can run until then, so the first poll finds the work in flight by construction, and a drop that waits provably cannot return before the gate opens (now asserted), while one that does not is still caught by the output's event. A first poll that resolves or fails now reports what it returned and how long it took. The gate is the host-mapped-flag mechanism the completion reactor already relies on, used in the other direction; the sibling tests in the file keep the plain memset op.

Test-only change; no library code touched. Verified so far: the test target builds, `cargo clippy -p cuda-async --all-targets` and `cargo fmt --check` are clean. On a GPU host, all four `drop_in_flight` tests pass.
