### PR TITLE
fix(cuda-bindings): add WSL2 and multiarch driver paths to dynamic loader

### DIFF
--- a/cuda-bindings/src/dyn_load.rs
+++ b/cuda-bindings/src/dyn_load.rs
@@ -60,7 +60,13 @@ impl std::error::Error for DynLoadError {
 }
 
 #[cfg(target_os = "linux")]
-const CUDA_LIB_NAMES: &[&str] = &["libcuda.so.1", "libcuda.so"];
+const CUDA_LIB_NAMES: &[&str] = &[
+    "libcuda.so.1",
+    "/usr/lib/wsl/lib/libcuda.so.1",
+    "libcuda.so",
+    "/usr/lib/wsl/lib/libcuda.so",
+    "/usr/lib/x86_64-linux-gnu/libcuda.so.1",
+];
 #[cfg(target_os = "macos")]
 const CUDA_LIB_NAMES: &[&str] = &["libcuda.dylib"];
 #[cfg(target_os = "windows")]


### PR DESCRIPTION
## Summary

Fixes #276.

Adds standard candidate fallback paths for the CUDA driver library on Linux in `cuda-bindings/src/dyn_load.rs`:
- `/usr/lib/wsl/lib/libcuda.so.1` and `/usr/lib/wsl/lib/libcuda.so` for **WSL2 (Windows Subsystem for Linux)**
- `/usr/lib/x86_64-linux-gnu/libcuda.so.1` for standard Debian/Ubuntu multiarch layouts

## Root Cause

In WSL2 environments, NVIDIA's virtualization layer mounts driver shims into `/usr/lib/wsl/lib/libcuda.so.1`. Unless users manually configure `LD_LIBRARY_PATH` to include `/usr/lib/wsl/lib`, `libloading::Library::new("libcuda.so.1")` fails on clean or default WSL2 distributions with `DynLoadError::LoadFailed`.

By probing standard fallback locations after standard library name lookup, `load_api` resolves the driver seamlessly across WSL2 and distro multiarch installations without requiring manual environment overrides.

## Prior Art & Field Validation

This candidate list structure is identical to the one tested and qualified under continuous hardware saturation in [RamShared](https://github.com/emersonbusson/ramshared) (`crates/ramshared-cuda/src/driver.rs`), ensuring zero-panic runtime resolution across WSL2, native Linux, and Windows.

## Validation

- Verified candidate resolution on WSL2 host with RTX hardware where `libcuda.so.1` resides at `/usr/lib/wsl/lib/libcuda.so.1`.
- Verified non-breaking behavior on standard Linux setups (fallback paths are only probed if earlier candidates fail to load).
