### PR TITLE
fix(cutile): synchronize stream in to_host_vec before dropping owned tensor

### DIFF
--- a/cutile/src/api.rs
+++ b/cutile/src/api.rs
@@ -342,11 +342,14 @@ impl<T: DType> DeviceOp for CopyDeviceToHostVec<T> {
             unsafe {
                 memcpy_dtoh_async(host.as_mut_ptr(), cu_deviceptr, size, ctx.get_cuda_stream())
             }?;
+            // Synchronize the execution stream before dropping `self.tensor` (owned by `self`),
+            // ensuring the device read finishes before any asynchronous deallocation is
+            // enqueued on the deallocator stream (#252).
+            unsafe { ctx.get_cuda_stream().synchronize() }?;
         }
-        // SAFETY: `cuMemcpyDtoHAsync` into pageable host memory (a `Vec`'s
-        // heap buffer is pageable) returns only once the copy has completed,
-        // so all `size` elements are initialized here, and `size` is exactly
-        // the capacity reserved above.
+        // SAFETY: `cuMemcpyDtoHAsync` into pageable host memory followed by stream
+        // synchronization ensures the copy has completed, so all `size` elements
+        // are initialized here, and `size` is exactly the capacity reserved above.
         unsafe { host.set_len(size) };
         Ok(host)
     }

--- a/cutile/tests/gpu/tensor.rs
+++ b/cutile/tests/gpu/tensor.rs
@@ -48,3 +48,14 @@ fn from_raw_parts_rejects_shape_storage_mismatch() {
         )
     };
 }
+
+/// Regression test for #252: owned tensor `to_host_vec().sync_on(&stream)` must not race
+/// with asynchronous deallocation on the deallocator stream.
+#[test]
+fn to_host_vec_owned_sync_on_stream_order() {
+    let device = cuda_core::Device::new(0).expect("Failed to create device");
+    let stream = device.new_stream().expect("Failed to create stream");
+    let tensor = api::zeros::<u8>(&[1]).sync_on(&stream).expect("zeros failed");
+    let host = tensor.to_host_vec().sync_on(&stream).expect("to_host_vec failed");
+    assert_eq!(host, vec![0]);
+}


### PR DESCRIPTION
## Summary

Fixes #252.

Synchronizes the execution stream in `CopyDeviceToHostVec::execute` before dropping `self.tensor`, eliminating a stream-ordered race and use-after-free between the in-flight DtoH memcpy and asynchronous deallocation on the `deallocator_stream`.

## Root Cause

When copying an owned tensor to host memory via `tensor.to_host_vec().sync_on(&stream)`:
1. `CopyDeviceToHostVec` holds ownership of the source tensor via `self.tensor: Arc<Tensor<T>>`.
2. In `CopyDeviceToHostVec::execute`, `memcpy_dtoh_async` is enqueued on `ctx.get_cuda_stream()`.
3. `execute(self, &ctx)` consumes `self` by value, meaning `self` (and its inner `self.tensor`) is dropped at the return of `execute`.
4. Dropping the owned tensor triggers `DeviceBuffer::drop`, which immediately enqueues `cuMemFreeAsync` on the thread's `deallocator_stream`.
5. Because `deallocator_stream` does not establish an event wait on `ctx.get_cuda_stream()`, the free operation on `deallocator_stream` races with the in-flight copy on `ctx.get_cuda_stream()`, triggering a stream-ordered use-after-free flagged by Compute-Sanitizer (as reported in #252).

## Fix

By explicitly calling `ctx.get_cuda_stream().synchronize()` inside `CopyDeviceToHostVec::execute` before `self.tensor` is dropped:
- The device read on `ctx.get_cuda_stream()` is guaranteed to be 100% complete before any deallocation can be submitted to the `deallocator_stream`.
- Ensures the safety contract (`SAFETY: ... returns only once the copy has completed, so all size elements are initialized here`) holds deterministically across all stream configurations.

## Validation

- Added regression test `to_host_vec_owned_sync_on_stream_order` in `cutile/tests/gpu/tensor.rs` matching the reproduction snippet from #252.
