### PR TITLE
feat(cuda-core): add zero-copy PinnedHostMapping and DeviceAllocation bridge

### DIFF
--- a/cuda-async/src/device_buffer.rs
+++ b/cuda-async/src/device_buffer.rs
@@ -223,3 +223,17 @@ impl DeviceBuffer {
         self.device_id
     }
 }
+
+unsafe impl DeviceAllocation for cuda_core::PinnedHostMapping {
+    fn device_ptr(&self) -> CUdeviceptr {
+        self.device_ptr()
+    }
+
+    fn len_bytes(&self) -> usize {
+        self.len_bytes()
+    }
+
+    fn device_id(&self) -> usize {
+        self.device_id()
+    }
+}

--- a/cuda-core/src/lib.rs
+++ b/cuda-core/src/lib.rs
@@ -35,5 +35,5 @@ pub use simt::{
     DeviceCopy, DeviceLaunchLimits, DynamicSharedMemoryRequirement, EmbeddedModule,
     EmbeddedModuleError, KernelLaunchConfig, KernelLaunchContract, LaunchAxis, LaunchConfig1D,
     LaunchConfig2D, LaunchConfig3D, LaunchContractError, LaunchContractSpec, LaunchDimension,
-    PinnedHostBuffer, PreparedLaunch, StreamPriorityRange, SyncPolicy,
+    PinnedHostBuffer, PinnedHostMapping, PreparedLaunch, StreamPriorityRange, SyncPolicy,
 };

--- a/cuda-core/src/simt/memory.rs
+++ b/cuda-core/src/simt/memory.rs
@@ -223,3 +223,47 @@ pub unsafe fn malloc_host(num_bytes: usize) -> Result<*mut c_void, DriverError> 
 pub unsafe fn free_host(ptr: *mut c_void) -> Result<(), DriverError> {
     unsafe { cuda_bindings::cuMemFreeHost(ptr) }.result()
 }
+
+/// Page-locks and registers an existing host memory range with CUDA.
+///
+/// # Safety
+///
+/// - A CUDA context must be bound to the calling thread.
+/// - `ptr` must point to at least `num_bytes` of valid, allocated host memory.
+/// - `ptr` must remain allocated and must not be freed until [`host_unregister`] is called.
+pub unsafe fn host_register(
+    ptr: *mut c_void,
+    num_bytes: usize,
+    flags: std::ffi::c_uint,
+) -> Result<(), DriverError> {
+    unsafe { cuda_bindings::cuMemHostRegister_v2(ptr, num_bytes, flags) }.result()
+}
+
+/// Unregisters a host memory range previously registered with [`host_register`].
+///
+/// # Safety
+///
+/// - A CUDA context must be bound to the calling thread.
+/// - `ptr` must have been previously registered with [`host_register`].
+/// - No in-flight CUDA transfer or kernel may reference `ptr`.
+pub unsafe fn host_unregister(ptr: *mut c_void) -> Result<(), DriverError> {
+    unsafe { cuda_bindings::cuMemHostUnregister(ptr) }.result()
+}
+
+/// Retrieves the device pointer through which `ptr` can be accessed by the GPU.
+///
+/// # Safety
+///
+/// - A CUDA context must be bound to the calling thread.
+/// - `ptr` must have been previously registered with [`host_register`] using
+///   `CU_MEMHOSTREGISTER_DEVICEMAP`.
+pub unsafe fn host_get_device_pointer(
+    ptr: *mut c_void,
+    flags: std::ffi::c_uint,
+) -> Result<cuda_bindings::CUdeviceptr, DriverError> {
+    let mut dev_ptr = MaybeUninit::uninit();
+    unsafe {
+        cuda_bindings::cuMemHostGetDevicePointer_v2(dev_ptr.as_mut_ptr(), ptr, flags).result()?;
+        Ok(dev_ptr.assume_init())
+    }
+}

--- a/cuda-core/src/simt/mod.rs
+++ b/cuda-core/src/simt/mod.rs
@@ -42,6 +42,7 @@ pub mod memory;
 pub mod module;
 pub mod peer;
 pub mod pinned_host_buffer;
+pub mod pinned_host_mapping;
 pub mod stream;
 pub mod vmm;
 
@@ -59,6 +60,7 @@ pub use launch::{
 };
 pub use module::{ConstantHandle, CudaFunction, CudaModule};
 pub use pinned_host_buffer::PinnedHostBuffer;
+pub use pinned_host_mapping::PinnedHostMapping;
 pub use stream::CudaStream;
 
 // The remaining items of oxide's crate root are identical on both surfaces;

--- a/cuda-core/src/simt/pinned_host_mapping.rs
+++ b/cuda-core/src/simt/pinned_host_mapping.rs
@@ -1,0 +1,248 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Zero-copy host memory registration for CUDA transfers and Tile kernels.
+//!
+//! [`PinnedHostMapping`] registers pre-allocated host memory using `cuMemHostRegister`.
+//! The memory is mapped directly into the CUDA device address space with zero copy,
+//! and automatically unregistered on drop.
+
+use std::fmt;
+use std::ops::{Deref, DerefMut};
+use std::ptr::NonNull;
+use std::slice;
+use std::sync::Arc;
+
+use crate::error::DriverError;
+use crate::simt::context::CudaContext;
+
+/// If set, the host memory is mapped into the address space of all CUDA contexts,
+/// not just the one that performed the registration.
+pub const CU_MEMHOSTREGISTER_PORTABLE: u32 = 0x01;
+
+/// If set, the host memory is mapped directly into the CUDA device address space
+/// and [`device_ptr`](PinnedHostMapping::device_ptr) can be used by kernels.
+pub const CU_MEMHOSTREGISTER_DEVICEMAP: u32 = 0x02;
+
+/// If set, the host memory is treated as I/O memory (e.g. PCIe MMIO or BARs).
+pub const CU_MEMHOSTREGISTER_IOMEMORY: u32 = 0x04;
+
+/// If set, the host memory is mapped read-only from the GPU's perspective.
+pub const CU_MEMHOSTREGISTER_READ_ONLY: u32 = 0x08;
+
+/// Owned registration token for page-locked host memory.
+///
+/// Backing host memory is registered via `cuMemHostRegister` and unregistered
+/// via `cuMemHostUnregister` on drop.
+pub struct PinnedHostMapping {
+    host_ptr: NonNull<u8>,
+    dev_ptr: cuda_bindings::CUdeviceptr,
+    len_bytes: usize,
+    device_id: usize,
+    ctx: Arc<CudaContext>,
+}
+
+unsafe impl Send for PinnedHostMapping {}
+unsafe impl Sync for PinnedHostMapping {}
+
+impl PinnedHostMapping {
+    /// Registers an existing caller-owned host memory buffer for zero-copy device access
+    /// using default flags (`CU_MEMHOSTREGISTER_DEVICEMAP`).
+    ///
+    /// # Safety
+    ///
+    /// - `host_ptr` must point to at least `len_bytes` of valid, allocated host memory.
+    /// - Backing host memory must remain valid and must not be freed while this mapping is alive.
+    pub unsafe fn new(
+        ctx: &Arc<CudaContext>,
+        host_ptr: NonNull<u8>,
+        len_bytes: usize,
+    ) -> Result<Self, DriverError> {
+        unsafe { Self::register(ctx, host_ptr, len_bytes, CU_MEMHOSTREGISTER_DEVICEMAP) }
+    }
+
+    /// Registers an existing caller-owned host memory buffer for zero-copy device access
+    /// with explicit registration flags.
+    ///
+    /// Note that `CU_MEMHOSTREGISTER_DEVICEMAP` is always set so that a device pointer
+    /// can be queried for kernels.
+    ///
+    /// # Safety
+    ///
+    /// - `host_ptr` must point to at least `len_bytes` of valid, allocated host memory.
+    /// - Backing host memory must remain valid and must not be freed while this mapping is alive.
+    pub unsafe fn register(
+        ctx: &Arc<CudaContext>,
+        host_ptr: NonNull<u8>,
+        len_bytes: usize,
+        flags: u32,
+    ) -> Result<Self, DriverError> {
+        if len_bytes == 0 {
+            return Err(DriverError(
+                cuda_bindings::cudaError_enum_CUDA_ERROR_INVALID_VALUE,
+            ));
+        }
+
+        let effective_flags = flags | CU_MEMHOSTREGISTER_DEVICEMAP;
+
+        ctx.bind_to_thread()?;
+        unsafe {
+            crate::simt::memory::host_register(
+                host_ptr.as_ptr().cast(),
+                len_bytes,
+                effective_flags,
+            )?;
+        }
+
+        let dev_ptr = unsafe {
+            match crate::simt::memory::host_get_device_pointer(host_ptr.as_ptr().cast(), 0) {
+                Ok(ptr) => ptr,
+                Err(e) => {
+                    let _ = crate::simt::memory::host_unregister(host_ptr.as_ptr().cast());
+                    return Err(e);
+                }
+            }
+        };
+
+        let device_id = ctx.device().ordinal() as usize;
+
+        Ok(Self {
+            host_ptr,
+            dev_ptr,
+            len_bytes,
+            device_id,
+            ctx: ctx.clone(),
+        })
+    }
+
+    /// Returns the mapped device pointer.
+    #[inline]
+    pub fn device_ptr(&self) -> cuda_bindings::CUdeviceptr {
+        self.dev_ptr
+    }
+
+    /// Number of bytes registered.
+    #[inline]
+    pub fn len_bytes(&self) -> usize {
+        self.len_bytes
+    }
+
+    /// Number of bytes registered (equivalent to [`len_bytes`](Self::len_bytes)).
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.len_bytes
+    }
+
+    /// Returns true if the mapping has zero length.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len_bytes == 0
+    }
+
+    /// Returns the device ordinal.
+    #[inline]
+    pub fn device_id(&self) -> usize {
+        self.device_id
+    }
+
+    /// Host pointer.
+    #[inline]
+    pub fn host_ptr(&self) -> NonNull<u8> {
+        self.host_ptr
+    }
+
+    /// Returns the host pointer as a raw const pointer.
+    #[inline]
+    pub fn as_ptr(&self) -> *const u8 {
+        self.host_ptr.as_ptr()
+    }
+
+    /// Returns the host pointer as a raw mut pointer.
+    #[inline]
+    pub fn as_mut_ptr(&mut self) -> *mut u8 {
+        self.host_ptr.as_ptr()
+    }
+
+    /// Returns the registered memory as a host byte slice.
+    #[inline]
+    pub fn as_slice(&self) -> &[u8] {
+        unsafe { slice::from_raw_parts(self.host_ptr.as_ptr(), self.len_bytes) }
+    }
+
+    /// Returns the registered memory as a mutable host byte slice.
+    #[inline]
+    pub fn as_mut_slice(&mut self) -> &mut [u8] {
+        unsafe { slice::from_raw_parts_mut(self.host_ptr.as_ptr(), self.len_bytes) }
+    }
+
+    /// Associated CUDA context.
+    #[inline]
+    pub fn context(&self) -> &Arc<CudaContext> {
+        &self.ctx
+    }
+}
+
+impl Drop for PinnedHostMapping {
+    fn drop(&mut self) {
+        if self.len_bytes != 0 {
+            self.ctx.record_err(self.ctx.bind_to_thread());
+            self.ctx.record_err(unsafe {
+                crate::simt::memory::host_unregister(self.host_ptr.as_ptr().cast())
+            });
+        }
+    }
+}
+
+impl fmt::Debug for PinnedHostMapping {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PinnedHostMapping")
+            .field("host_ptr", &self.host_ptr)
+            .field("dev_ptr", &self.dev_ptr)
+            .field("len_bytes", &self.len_bytes)
+            .field("device_id", &self.device_id)
+            .finish()
+    }
+}
+
+impl AsRef<[u8]> for PinnedHostMapping {
+    fn as_ref(&self) -> &[u8] {
+        self.as_slice()
+    }
+}
+
+impl AsMut<[u8]> for PinnedHostMapping {
+    fn as_mut(&mut self) -> &mut [u8] {
+        self.as_mut_slice()
+    }
+}
+
+impl Deref for PinnedHostMapping {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        self.as_slice()
+    }
+}
+
+impl DerefMut for PinnedHostMapping {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.as_mut_slice()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn register_rejects_zero_length() {
+        let dummy = NonNull::dangling();
+        // Zero-length must fail early without touching the driver.
+        let ctx = Arc::new(unsafe { std::mem::zeroed::<CudaContext>() });
+        let result = unsafe { PinnedHostMapping::register(&ctx, dummy, 0, 0) };
+        assert!(result.is_err());
+        std::mem::forget(ctx);
+    }
+}


### PR DESCRIPTION
## Summary

This PR introduces zero-copy host memory registration via `cuMemHostRegister` and `cuMemHostUnregister`, exposing a safe RAII abstraction `PinnedHostMapping` in `cuda-core` and bridging it to `cuda-async` via `DeviceAllocation`.

## Motivation

When working with high-throughput streaming workloads, system page tiering, or pre-allocated userspace/OS buffers (e.g. hugepages, NUMA-pinned memory, kernel drivers), copying memory into `PinnedHostBuffer` adds unnecessary CPU overhead and allocation latency. `cuMemHostRegister` allows page-locking existing memory and obtaining a device-accessible pointer directly without copying.

## Changes

1. **`cuda-core`**:
   - Added `PinnedHostMapping` RAII struct that binds host memory via `host_register` and guarantees unregistration on drop.
   - Implemented `Deref<Target = [u8]>`, `DerefMut`, `AsRef<[u8]>`, and `AsMut<[u8]>`.
   - Provided constructors `PinnedHostMapping::new` and `PinnedHostMapping::register` with explicit flags (`CU_MEMHOSTREGISTER_*`).
   - Added low-level FFI helpers: `host_register`, `host_unregister`, and `host_get_device_pointer`.
2. **`cuda-async`**:
   - Implemented `DeviceAllocation` for `PinnedHostMapping`, enabling direct integration with async copy and stream execution pipelines.
3. **Soundness & Safety**:
   - Zero-length registration rejects early (`CUDA_ERROR_INVALID_VALUE`).
   - `CU_MEMHOSTREGISTER_DEVICEMAP` is ensured so that device pointer queries succeed reliably.
   - Context is bound to the thread during register and unregister.

## Validation

- `cargo fmt -- --check` passes cleanly.
- Unit test `tests::register_rejects_zero_length` validates early refusal contracts.
- Strictly additive API; zero breaking changes.