### PR TITLE
feat(cutile): add reduce_xor, reduce_and, and reduce_or bitwise reductions

### DIFF
--- a/cutile-compiler/src/compiler/compile_intrinsic.rs
+++ b/cutile-compiler/src/compiler/compile_intrinsic.rs
@@ -1689,6 +1689,18 @@ impl<'m> CUDATileFunctionCompiler<'m> {
                             get_const_hex(&element_type, "one")?,
                             syn::parse_quote! { { curr * prev } },
                         ),
+                        "reduce_xor" => (
+                            get_const_hex(&element_type, "zero")?,
+                            syn::parse_quote! { { curr ^ prev } },
+                        ),
+                        "reduce_and" => (
+                            get_const_hex(&element_type, "all_ones")?,
+                            syn::parse_quote! { { curr & prev } },
+                        ),
+                        "reduce_or" => (
+                            get_const_hex(&element_type, "zero")?,
+                            syn::parse_quote! { { curr | prev } },
+                        ),
                         _ => {
                             return self.jit_error_result(
                                 &call_expr.span(),

--- a/cutile-compiler/src/compiler/shared_utils.rs
+++ b/cutile-compiler/src/compiler/shared_utils.rs
@@ -230,8 +230,77 @@ where
     fn one() -> Self;
     fn min() -> Self;
     fn max() -> Self;
+    fn all_ones() -> Self;
 }
 
+impl Integer for u8 {
+    fn zero() -> u8 {
+        0u8
+    }
+    fn one() -> u8 {
+        1u8
+    }
+    fn min() -> u8 {
+        u8::MIN
+    }
+    fn max() -> u8 {
+        u8::MAX
+    }
+    fn all_ones() -> u8 {
+        !0u8
+    }
+}
+impl Integer for i8 {
+    fn zero() -> i8 {
+        0i8
+    }
+    fn one() -> i8 {
+        1i8
+    }
+    fn min() -> i8 {
+        i8::MIN
+    }
+    fn max() -> i8 {
+        i8::MAX
+    }
+    fn all_ones() -> i8 {
+        -1i8
+    }
+}
+impl Integer for u16 {
+    fn zero() -> u16 {
+        0u16
+    }
+    fn one() -> u16 {
+        1u16
+    }
+    fn min() -> u16 {
+        u16::MIN
+    }
+    fn max() -> u16 {
+        u16::MAX
+    }
+    fn all_ones() -> u16 {
+        !0u16
+    }
+}
+impl Integer for i16 {
+    fn zero() -> i16 {
+        0i16
+    }
+    fn one() -> i16 {
+        1i16
+    }
+    fn min() -> i16 {
+        i16::MIN
+    }
+    fn max() -> i16 {
+        i16::MAX
+    }
+    fn all_ones() -> i16 {
+        -1i16
+    }
+}
 impl Integer for i32 {
     fn zero() -> i32 {
         0i32
@@ -244,6 +313,9 @@ impl Integer for i32 {
     }
     fn max() -> i32 {
         i32::MAX
+    }
+    fn all_ones() -> i32 {
+        -1i32
     }
 }
 impl Integer for i64 {
@@ -259,6 +331,9 @@ impl Integer for i64 {
     fn max() -> i64 {
         i64::MAX
     }
+    fn all_ones() -> i64 {
+        -1i64
+    }
 }
 impl Integer for u32 {
     fn zero() -> u32 {
@@ -273,6 +348,9 @@ impl Integer for u32 {
     fn max() -> u32 {
         u32::MAX
     }
+    fn all_ones() -> u32 {
+        !0u32
+    }
 }
 impl Integer for u64 {
     fn zero() -> u64 {
@@ -286,6 +364,9 @@ impl Integer for u64 {
     }
     fn max() -> u64 {
         u64::MAX
+    }
+    fn all_ones() -> u64 {
+        !0u64
     }
 }
 
@@ -307,6 +388,7 @@ fn get_integer_const<T: Integer>(const_str: &str) -> Result<String, JITError> {
         "one" => Ok(T::one().to_hex()),
         "min" => Ok(T::min().to_hex()),
         "max" => Ok(T::max().to_hex()),
+        "all_ones" => Ok(T::all_ones().to_hex()),
         _ => SourceLocation::unknown()
             .jit_error_result(&format!("Unsupported integer constant type {}.", const_str)),
     }
@@ -319,6 +401,10 @@ pub fn get_const_hex(rust_element_type_str: &str, const_str: &str) -> Result<Str
         "f16" => get_float_const::<f16>(const_str),
         "f32" => get_float_const::<f32>(const_str),
         "f64" => get_float_const::<f64>(const_str),
+        "u8" => get_integer_const::<u8>(const_str),
+        "i8" => get_integer_const::<i8>(const_str),
+        "u16" => get_integer_const::<u16>(const_str),
+        "i16" => get_integer_const::<i16>(const_str),
         "i32" => get_integer_const::<i32>(const_str),
         "i64" => get_integer_const::<i64>(const_str),
         "u32" => get_integer_const::<u32>(const_str),
@@ -1032,5 +1118,30 @@ pub fn update_type_meta(
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_const_hex_integers() {
+        assert_eq!(get_const_hex("u8", "zero").unwrap(), "0x0");
+        assert_eq!(get_const_hex("u8", "one").unwrap(), "0x1");
+        assert_eq!(get_const_hex("u8", "all_ones").unwrap(), "0xff");
+        assert_eq!(get_const_hex("i8", "all_ones").unwrap(), "0xff");
+        assert_eq!(get_const_hex("u16", "all_ones").unwrap(), "0xffff");
+        assert_eq!(get_const_hex("i16", "all_ones").unwrap(), "0xffff");
+        assert_eq!(get_const_hex("u32", "all_ones").unwrap(), "0xffffffff");
+        assert_eq!(get_const_hex("i32", "all_ones").unwrap(), "0xffffffff");
+        assert_eq!(
+            get_const_hex("u64", "all_ones").unwrap(),
+            "0xffffffffffffffff"
+        );
+        assert_eq!(
+            get_const_hex("i64", "all_ones").unwrap(),
+            "0xffffffffffffffff"
+        );
     }
 }

--- a/cutile/src/_core.rs
+++ b/cutile/src/_core.rs
@@ -1924,6 +1924,36 @@ pub mod core {
         unreachable!()
     }
 
+    /// Bitwise XOR reduction along `dim`. Useful for parity checks, page hashing, and CRC calculations.
+    #[cuda_tile::compiler_op(name = "reduce")]
+    #[cuda_tile::variadic_op(N = 6, M = 6)]
+    pub fn reduce_xor<E: ElementType, const S: [i32; N], const R: [i32; M]>(
+        x: Tile<E, S>,
+        dim: i32,
+    ) -> Tile<E, R> {
+        unreachable!()
+    }
+
+    /// Bitwise AND reduction along `dim`.
+    #[cuda_tile::compiler_op(name = "reduce")]
+    #[cuda_tile::variadic_op(N = 6, M = 6)]
+    pub fn reduce_and<E: ElementType, const S: [i32; N], const R: [i32; M]>(
+        x: Tile<E, S>,
+        dim: i32,
+    ) -> Tile<E, R> {
+        unreachable!()
+    }
+
+    /// Bitwise OR reduction along `dim`. Useful for zero-page detection and flag aggregation.
+    #[cuda_tile::compiler_op(name = "reduce")]
+    #[cuda_tile::variadic_op(N = 6, M = 6)]
+    pub fn reduce_or<E: ElementType, const S: [i32; N], const R: [i32; M]>(
+        x: Tile<E, S>,
+        dim: i32,
+    ) -> Tile<E, R> {
+        unreachable!()
+    }
+
     /// Prefix sum along `dim`. The compiler emits the addf/addi region.
     #[cuda_tile::op(name="cuda_tile.scan", params=["operand"])]
     #[cuda_tile::variadic_op(N = 6)]

--- a/cutile/tests/reduce_scan_ops.rs
+++ b/cutile/tests/reduce_scan_ops.rs
@@ -89,6 +89,36 @@ mod reduce_scan_ops_module {
         // Store the result
         output.store(prefix_products);
     }
+
+    #[cutile::entry()]
+    fn reduce_xor_test_kernel<const S: [i32; 2]>(
+        input: &mut Tensor<u32, S>,
+        output: &mut Tensor<u32, { [1, 1] }>,
+    ) {
+        let tile: Tile<u32, S> = load_tile_mut(input);
+        let reduced: Tile<u32, { [1, 1] }> = reduce_xor(tile, 1i32);
+        output.store(reduced);
+    }
+
+    #[cutile::entry()]
+    fn reduce_and_test_kernel<const S: [i32; 2]>(
+        input: &mut Tensor<u32, S>,
+        output: &mut Tensor<u32, { [1, 1] }>,
+    ) {
+        let tile: Tile<u32, S> = load_tile_mut(input);
+        let reduced: Tile<u32, { [1, 1] }> = reduce_and(tile, 1i32);
+        output.store(reduced);
+    }
+
+    #[cutile::entry()]
+    fn reduce_or_test_kernel<const S: [i32; 2]>(
+        input: &mut Tensor<u32, S>,
+        output: &mut Tensor<u32, { [1, 1] }>,
+    ) {
+        let tile: Tile<u32, S> = load_tile_mut(input);
+        let reduced: Tile<u32, { [1, 1] }> = reduce_or(tile, 1i32);
+        output.store(reduced);
+    }
 }
 
 use reduce_scan_ops_module::__module_ast_self;
@@ -283,5 +313,53 @@ fn compile_scan_closure_test() {
         );
 
         println!("\n✓ scan with closure (prefix product) operation verified");
+    });
+}
+
+#[test]
+fn compile_reduce_xor_test() {
+    common::with_test_stack(|| {
+        let module_op_str = compile_ir(
+            "reduce_xor_test_kernel",
+            &[8.to_string(), 16.to_string()],
+            &[("input", &[8, 16]), ("output", &[1, 1])],
+        );
+        assert!(
+            module_op_str.contains("reduce"),
+            "Expected reduce operation in MLIR output"
+        );
+        println!("\n✓ reduce_xor operation verified");
+    });
+}
+
+#[test]
+fn compile_reduce_and_test() {
+    common::with_test_stack(|| {
+        let module_op_str = compile_ir(
+            "reduce_and_test_kernel",
+            &[8.to_string(), 16.to_string()],
+            &[("input", &[8, 16]), ("output", &[1, 1])],
+        );
+        assert!(
+            module_op_str.contains("reduce"),
+            "Expected reduce operation in MLIR output"
+        );
+        println!("\n✓ reduce_and operation verified");
+    });
+}
+
+#[test]
+fn compile_reduce_or_test() {
+    common::with_test_stack(|| {
+        let module_op_str = compile_ir(
+            "reduce_or_test_kernel",
+            &[8.to_string(), 16.to_string()],
+            &[("input", &[8, 16]), ("output", &[1, 1])],
+        );
+        assert!(
+            module_op_str.contains("reduce"),
+            "Expected reduce operation in MLIR output"
+        );
+        println!("\n✓ reduce_or operation verified");
     });
 }


### PR DESCRIPTION
## Summary

This PR adds bitwise reductions (`reduce_xor`, `reduce_and`, and `reduce_or`) to the `cutile` DSL and compiler, and expands the compiler's `Integer` trait to support `u8`, `i8`, `u16`, `i16` along with `"all_ones"` identity constant generation.

## Motivation

Bitwise reductions across tile dimensions are fundamental for:
- Fast parity checking, RAID, CRC, and hash computations (`reduce_xor`).
- Mask validation and bit-flag assertions (`reduce_and`).
- Fast zero-block detection and non-zero page tagging (`reduce_or`).

Previously, only arithmetic reductions (`reduce_sum`, `reduce_prod`, `reduce_min`, `reduce_max`) were exposed as intrinsic operations in the compiler.

## Changes

1. **`cutile-compiler`**:
   - Extended `Integer` trait and `get_const_hex` in `shared_utils.rs` to support `u8`, `i8`, `u16`, `i16` and the `"all_ones"` identity constant (`!0`).
   - Lowered `reduce_xor`, `reduce_and`, and `reduce_or` intrinsics to `Opcode::Reduce` with their corresponding binary bitwise regions (`curr ^ prev`, `curr & prev`, `curr | prev`).
2. **`cutile`**:
   - Exposed `reduce_xor`, `reduce_and`, and `reduce_or` in `cutile::core` for `Tile<E, S>`.
3. **Tests**:
   - Added unit test `test_get_const_hex_integers` in `cutile-compiler` verifying integer identity constants across all bit widths.
   - Added Tile IR lowering tests `compile_reduce_xor_test`, `compile_reduce_and_test`, and `compile_reduce_or_test` in `cutile/tests/reduce_scan_ops.rs`.

## Validation

- `cargo fmt -- --check` passes cleanly across the workspace.
- CPU integration tests and lowering tests pass.
- Strictly additive API; zero breaking changes.